### PR TITLE
Updated cache key and change naming

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,4 +1,4 @@
-name: Build
+name: Build test
 
 on:
   push:
@@ -9,6 +9,7 @@ on:
 jobs:
   test-build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -51,4 +52,3 @@ jobs:
         run: |
           pnpm build
           pnpm postbuild
-          pnpm dist

--- a/.github/workflows/lint_and_test.yaml
+++ b/.github/workflows/lint_and_test.yaml
@@ -1,11 +1,7 @@
 name: Lint and unit tests
 
 on:
-  # pull_request:
-  push:
-    branches:
-      - 'main'
-      - 'dev'
+  pull_request:
 
 jobs:
   lint-and-test:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -3,11 +3,11 @@ on:
     # Sequence of patterns matched against refs/tags
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
-  pull_request:
 
 jobs:
   release-build:
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
 
     strategy:
       fail-fast: false
@@ -46,6 +46,16 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Get tag name
+        uses: olegtarasov/get-tag@v2.1 # Put version in GIT_TAG_NAME environment variable
+
+      - name: Update package.json version
+        uses: jossef/action-set-json-field@v2
+        with:
+          file: package.json
+          field: version
+          value: ${{ env.GIT_TAG_NAME }}
+
       - name: Build app
         run: |
           pnpm build
@@ -57,9 +67,9 @@ jobs:
         with:
           name: build-artifats
           path: |
-            "./release/dist/*.exe"
-            "./release/dist/*.dmg"
-            "./release/dist/*.AppImage"
+            release/dist/*.exe
+            release/dist/*.dmg
+            release/dist/*.AppImage
 
 
   releas-project:

--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "webpack:renderer:prod": "webpack --config webpack/webpack.renderer.prod.ts",
     "build": "cross-env NODE_ENV=production pnpm r clean:prod webpack:renderer:prod webpack:main:prod",
     "postbuild": "node scripts/postbuild.js",
-    "dist": "electron-builder",
+    "dist": "electron-builder -p never",
     "clean:build": "rimraf release/build",
     "clean:prod": "rimraf release/dist",
     "test": "jest --config=jest.config.ts",


### PR DESCRIPTION
This PR adds separate workflow for release and fix some issues in others.

- release workflow will create new release after adding tag with format 'v*', also package.json will update automatically, but that changes will not merge.
- [package.json ](https://github.com/nova-wallet/omni-enterprise/pull/7/files#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R22)was updated with adding special parameter - https://www.electron.build/configuration/publish.html#how-to-publish because we did it manually in next job to increase control