### PR TITLE
Adding collecting detail info for coverage test

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:dataVerification": "jest --config=tests/integrations/jest.config.ts --group=dataVerification --json --outputFile=jest-results.json",
     "test:matrix": "jest --config=tests/integrations/jest.config.ts --group=matrix --json --outputFile=jest-results.json",
     "test:coverage": "npx jest --config=jest.config.ts --coverage --passWithNoTests | tee ./coverage.txt",
-    "test:coverage-new-files": "npx jest --config=jest.config.ts --coverage --changedSince=dev",
+    "test:coverage-new-files": "npx jest --config=jest.config.ts --coverage --changedSince=dev | tee ./coverage.txt",
     "lint": "cross-env NODE_ENV=production eslint . --ext=ts,tsx,js,jsx",
     "lint:fix": "pnpm lint --fix",
     "lint:translation-files": "cross-env NODE_ENV=production process.env.CHECK_TRANSLATION=true eslint ./src/shared/locale/ --ext=json --plugin i18n-json",


### PR DESCRIPTION
Currently it is hard to understood which files should be increased coverage:
<img width="864" alt="Screenshot 2022-10-05 at 17 42 39" src="https://user-images.githubusercontent.com/40560660/194063089-36de618f-2775-4c99-a46b-e247ef5b1a01.png">

This PR will add a table like that:
<img width="715" alt="Screenshot 2022-10-05 at 17 42 30" src="https://user-images.githubusercontent.com/40560660/194063129-9fdbd509-97fe-40e9-8801-c02a3f4918ab.png">
