### PR TITLE
Fix: Handle wrong provider 

### DIFF
--- a/src/renderer/services/network/networkService.ts
+++ b/src/renderer/services/network/networkService.ts
@@ -156,7 +156,7 @@ export const useNetwork = (): INetworkService => {
     const handler = async () => {
       console.log('🟢 connected ==> ', chainId);
 
-      const api = await ApiPromise.create({ provider });
+      const api = await ApiPromise.create({ provider, throwOnConnect: true, throwOnUnknown: true });
       if (!api) await provider.disconnect();
 
       updateConnectionState(
@@ -275,14 +275,14 @@ export const useNetwork = (): INetworkService => {
       provider.on('connected', async () => {
         let isNetworkMatch = false;
         try {
-          const api = await ApiPromise.create({ provider });
+          const api = await ApiPromise.create({ provider, throwOnConnect: true, throwOnUnknown: true });
           isNetworkMatch = genesisHash === api.genesisHash.toHex();
 
           api.disconnect().catch(console.warn);
-          provider.disconnect().catch(console.warn);
         } catch (error) {
           console.warn(error);
         }
+        provider.disconnect().catch(console.warn);
         resolve(isNetworkMatch ? RpcValidation.VALID : RpcValidation.WRONG_NETWORK);
       });
 


### PR DESCRIPTION
- Handle provider error more accurately
- Firefox/Chrome required additional parameters to throw an error