### PR TITLE
Changes for CI/CD to satisfy linter rules

### DIFF
--- a/.github/workflows/create_new_tag.yml
+++ b/.github/workflows/create_new_tag.yml
@@ -47,9 +47,10 @@ jobs:
         uses: ./.github/workflows/make-pull-request
         with:
           commit-path: package.json
-          commit-message: Release candidate - ${{ steps.bump.outputs.major }}.${{ steps.bump.outputs.minor }}.${{ steps.bump.outputs.patch }}
+          commit-message: 'ci: version in package.json'
           branch-name: rc/${{ steps.bump.outputs.major }}.${{ steps.bump.outputs.minor }}.${{ steps.bump.outputs.patch }}
           destination_branch: main
+          pr-title: Release candidate - ${{ steps.bump.outputs.major }}.${{ steps.bump.outputs.minor }}.${{ steps.bump.outputs.patch }}
           github-token: ${{ secrets.GITHUB_TOKEN }}
 
   create_new_tag:

--- a/.github/workflows/make-pull-request/action.yaml
+++ b/.github/workflows/make-pull-request/action.yaml
@@ -16,6 +16,9 @@ inputs:
     description: 'Name for destination branch'
     required: false
     default: 'dev'
+  pr-title:
+    description: 'Title for pull request'
+    required: true
   github-token:
     description: 'Token for making operations with GitHub'
     required: true
@@ -46,7 +49,7 @@ runs:
       with:
         source_branch: '${{ inputs.branch-name }}-${{github.run_number}}'
         destination_branch: ${{ inputs.destination_branch }}
-        pr_title: ${{ inputs.commit-message }}
+        pr_title: ${{ inputs.pr-title }}
         pr_body: |
           That pull-request was generated automatically 🤖
         pr_reviewer: "stepanLav,pgolovkin,tuul-wq,Asmadek"

--- a/.github/workflows/update_chains_file.yaml
+++ b/.github/workflows/update_chains_file.yaml
@@ -30,6 +30,7 @@ jobs:
         uses: ./.github/workflows/make-pull-request
         with:
           commit-path: src/renderer/services/network/common/*.json
-          commit-message: Update chains.json file
+          commit-message: "ci: chains.json file"
+          pr-title: "Update chains.json file"
           branch-name: update-chains-file
           github-token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This PR fixes problem with commit-linter for auto-generated PRs:
<img width="1076" alt="Screenshot 2022-12-16 at 17 05 59" src="https://user-images.githubusercontent.com/40560660/208115725-67292b40-7455-459f-b308-d0fd843de5d1.png">
