### PR TITLE
feat: block explorer link

### DIFF
--- a/src/renderer/components/common/ExplorerLink/ExplorerLink.tsx
+++ b/src/renderer/components/common/ExplorerLink/ExplorerLink.tsx
@@ -1,0 +1,35 @@
+import cn from 'classnames';
+import { encodeAddress } from '@polkadot/util-crypto';
+
+import { toPublicKey } from '@renderer/shared/utils/address';
+import { Icon } from '@renderer/components/ui';
+import { DefaultExplorer, ExplorerIcons } from '@renderer/components/common/Explorers/common/constants';
+import { Explorer } from '@renderer/domain/chain';
+import { useI18n } from '@renderer/context/I18nContext';
+
+interface Props {
+  explorer: Explorer;
+  address: string;
+  addressPrefix?: number;
+}
+
+const ExplorerLink = ({ explorer, address, addressPrefix }: Props) => {
+  const { t } = useI18n();
+  const { account, name } = explorer;
+
+  if (!account) return null;
+
+  return (
+    <a
+      className={cn('rounded-2lg flex items-center gap-x-2 p-2 select-none transition')}
+      href={account.replace('{address}', encodeAddress(toPublicKey(address) || '', addressPrefix))}
+      rel="noopener noreferrer"
+      target="_blank"
+    >
+      <Icon as="img" name={ExplorerIcons[name] || ExplorerIcons[DefaultExplorer]} size={16} />
+      {t('general.explorers.explorerButton', { name })}
+    </a>
+  );
+};
+
+export default ExplorerLink;

--- a/src/renderer/components/common/index.ts
+++ b/src/renderer/components/common/index.ts
@@ -15,6 +15,7 @@ import Expandable from './Expandable/Expandable';
 import Deposit from './Deposit/Deposit';
 import Badge from './Badge/Badge';
 import Fee from './Fee/Fee';
+import ExplorerLink from './ExplorerLink/ExplorerLink';
 
 export {
   AccountsList,
@@ -34,4 +35,5 @@ export {
   Message,
   Badge,
   Fee,
+  ExplorerLink,
 };

--- a/src/renderer/components/ui-redesign/Typography/index.ts
+++ b/src/renderer/components/ui-redesign/Typography/index.ts
@@ -1,0 +1,6 @@
+import CalloutText from './components/CalloutText';
+import BodyText from './components/BodyText';
+import SmallTitle from './components/SmallTitle';
+import TitleText from './components/TitleText';
+
+export { CalloutText, BodyText, SmallTitle, TitleText };

--- a/src/renderer/components/ui-redesign/index.ts
+++ b/src/renderer/components/ui-redesign/index.ts
@@ -1,0 +1,26 @@
+import Input from './Inputs/Input/Input';
+import PasswordInput from './Inputs/PasswordInput/PasswordInput';
+import InputHint from './InputHint/InputHint';
+import Button from './Buttons/Button/Button';
+import ButtonBack from './Buttons/ButtonBack/ButtonBack';
+import BaseModal from './Modals/BaseModal/BaseModal';
+import InfoPopover from './Popovers/InfoPopover/InfoPopover';
+import Popover from './Popovers/Popover/Popover';
+import InfoLink from './InfoLink/InfoLink';
+import { CalloutText, BodyText, SmallTitle, TitleText } from '@renderer/components/ui-redesign/Typography';
+
+export {
+  Input,
+  PasswordInput,
+  InputHint,
+  Button,
+  ButtonBack,
+  BaseModal,
+  InfoPopover,
+  Popover,
+  InfoLink,
+  CalloutText,
+  BodyText,
+  SmallTitle,
+  TitleText,
+};


### PR DESCRIPTION
## Block explorers link and export file for ui redesign
***
Figma: 
![image](https://user-images.githubusercontent.com/27145216/230921821-be5c8ff1-d9ce-40a1-a69b-96f07107620c.png)
***
ExplorerLink used in old Explorer component
![image](https://user-images.githubusercontent.com/27145216/230922001-14772536-5da4-4f01-8fc1-0ead1fd2358b.png)
***
it's more of a functional component inteded to be used with InfoPopover so I didn't add storybook entry