### PR TITLE
Feat: Root key blockexplorer links for onboarding

### DIFF
--- a/src/renderer/components/common/Explorers/Explorers.tsx
+++ b/src/renderer/components/common/Explorers/Explorers.tsx
@@ -31,6 +31,7 @@ const Explorers = ({ explorers, address, addressPrefix, header, className }: Pro
       {({ open }) => (
         <div className={cn('relative', open && 'z-10', className)}>
           <Menu.Button
+            data-testid={`explorers-${address}`}
             className="flex items-center w-5 h-5 rounded-full hover:bg-primary hover:text-white transition"
             onClick={scrollToMenu}
           >

--- a/src/renderer/screens/Onboarding/Parity/StepThree/StepThree.test.tsx
+++ b/src/renderer/screens/Onboarding/Parity/StepThree/StepThree.test.tsx
@@ -2,10 +2,10 @@ import { render, screen, act } from '@testing-library/react';
 import { hexToU8a } from '@polkadot/util';
 
 import { SeedInfo } from '@renderer/components/common/QrCode/QrReader/common/types';
-import { CryptoTypeString } from '@renderer/domain/shared-kernel';
+import { CryptoTypeString, CryptoType } from '@renderer/domain/shared-kernel';
 import StepThree from './StepThree';
 import { Chain } from '@renderer/domain/chain';
-import { TEST_ADDRESS } from '@renderer/shared/utils/constants';
+import { TEST_ACCOUNT_ID, TEST_ADDRESS } from '@renderer/shared/utils/constants';
 
 jest.mock('@renderer/context/I18nContext', () => ({
   useI18n: jest.fn().mockReturnValue({
@@ -41,27 +41,55 @@ jest.mock('@renderer/services/network/chainsService', () => ({
 }));
 
 describe('screens/Onboard/Parity/StepThree', () => {
-  test('should render component', async () => {
-    const data: SeedInfo[] = [
-      {
-        name: 'test wallet',
-        multiSigner: { MultiSigner: CryptoTypeString.SR25519, public: new Uint8Array([0]) },
-        derivedKeys: [
-          {
-            address: TEST_ADDRESS,
-            derivationPath: '//test',
-            encryption: 1,
-            genesisHash: hexToU8a('0x00'),
-          },
-        ],
-      },
-    ];
+  const WND_ADDRESS = '5CGQ7BPJZZKNirQgVhzbX9wdkgbnUHtJ5V7FkMXdZeVbXyr9';
+  const qrData: SeedInfo[] = [
+    {
+      name: 'test wallet',
+      multiSigner: { MultiSigner: CryptoTypeString.SR25519, public: hexToU8a(TEST_ACCOUNT_ID) },
+      derivedKeys: [
+        {
+          address: '5E7TYrCi6Yc2rZkU1x9hERoJSMyN3vDgNPmt3RFMtYBpzC1o',
+          derivationPath: '//test',
+          encryption: CryptoType.ED25519,
+          genesisHash: new Uint8Array([0]),
+        },
+      ],
+    },
+  ];
 
+  test('should render component', async () => {
     await act(async () => {
-      render(<StepThree qrData={data} onNextStep={() => {}} />);
+      render(<StepThree qrData={qrData} onNextStep={() => {}} />);
     });
 
     const inputs = screen.getAllByRole('textbox');
-    expect(inputs.length).toBe(5);
+    expect(inputs).toHaveLength(5);
+  });
+
+  test('should render 1 root 1 derived', async () => {
+    await act(async () => {
+      render(<StepThree qrData={qrData} onNextStep={() => {}} />);
+    });
+
+    const root = screen.getByDisplayValue('5CGQ7BPJZZ...XdZeVbXyr9');
+    const derived = screen.getByDisplayValue('5E7TYrCi6Y...FMtYBpzC1o');
+    expect(root).toBeInTheDocument();
+    expect(derived).toBeInTheDocument();
+  });
+
+  test('should lead to root block explorers', async () => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+
+    await act(async () => {
+      render(<StepThree qrData={qrData} onNextStep={() => {}} />);
+    });
+
+    const button = screen.getByTestId(`explorers-${TEST_ADDRESS}`);
+    await act(async () => button.click());
+
+    const links = screen.getAllByRole('menuitem');
+    expect(links).toHaveLength(2);
+    expect(links[0]).toHaveAttribute('href', `https://subscan.io/account/${WND_ADDRESS}`);
+    expect(links[1]).toHaveAttribute('href', `https://sub.id/${WND_ADDRESS}`);
   });
 });

--- a/src/renderer/screens/Onboarding/Parity/StepThreeSingle/StepThreeSingle.tsx
+++ b/src/renderer/screens/Onboarding/Parity/StepThreeSingle/StepThreeSingle.tsx
@@ -75,7 +75,7 @@ const StepThreeSingle = ({ qrData, onNextStep }: Props) => {
       onSubmit={handleSubmit(handleCreateAccount)}
     >
       <h2 className="text-2xl leading-relaxed font-normal text-neutral-variant text-center">
-        {t('onboarding.paritySigner.addSingleParitySignerDescription1')}
+        {t('onboarding.paritySigner.addSingleParitySignerDescription')}
       </h2>
       <div className="flex gap-10">
         <div className="flex flex-col w-[480px] h-[310px] p-4 bg-white shadow-surface rounded-2lg">

--- a/src/shared/locale/en.json
+++ b/src/shared/locale/en.json
@@ -182,7 +182,7 @@
       "accountsExistTitle": "These <strong>accounts</strong> already exist!",
       "addAccount": "Add new accounts",
       "addByParitySignerLabel": "Add wallet by Parity Signer",
-      "addSingleParitySignerDescription1": "Here is your account scanned from Parity Signer",
+      "addSingleParitySignerDescription": "Here is your account scanned from Parity Signer",
       "autoFillAccountsListButton": "Autofill account names",
       "checkAddress": "Check address",
       "chooseCameraLabel": "Please choose one to continue",

--- a/src/shared/locale/ru.json
+++ b/src/shared/locale/ru.json
@@ -182,7 +182,7 @@
       "accountsExistTitle": "These <strong>accounts</strong> already exist!",
       "addAccount": "Добавить кошелёк",
       "addByParitySignerLabel": "Добавить Parity Signer кошелёк",
-      "addSingleParitySignerDescription1": "Here is your account scanned from Parity Signer",
+      "addSingleParitySignerDescription": "Ваши отсканированные аккаунты из Parity Signer",
       "autoFillAccountsListButton": "Autofill account names",
       "checkAddress": "Проверить адрес",
       "chooseCameraLabel": "Выберите камеру, чтобы продолжить",


### PR DESCRIPTION
- Show root key with prefix 42
- Added 2 block explorer links for root account instead of `<AccountList />`

<img width="491" alt="image" src="https://user-images.githubusercontent.com/8149541/233660158-0979ec77-6071-4818-be7c-a5c2ef775eae.png">
