### PR TITLE
feat: adding cron schedule for chains updater

### DIFF
--- a/.github/workflows/update_chains_file.yaml
+++ b/.github/workflows/update_chains_file.yaml
@@ -7,6 +7,8 @@ on:
       required: true
       type: string
       default: 'v5'
+  schedule:
+    - cron: '0 8 * * 1'
 
 jobs:
   update-chains-file:


### PR DESCRIPTION
This PR adds cron task to run update-chains workflow each week in Moonday:

https://crontab.guru/#0_8_*_*_1