### PR TITLE
feat: adding payload to matrix events

### DIFF
--- a/src/renderer/context/MatrixContext/MatrixContext.tsx
+++ b/src/renderer/context/MatrixContext/MatrixContext.tsx
@@ -77,7 +77,7 @@ export const MatrixProvider = ({ children }: PropsWithChildren) => {
 
   const onInvite = async (payload: InvitePayload) => {
     try {
-      console.info('💛 ===> onInvite');
+      console.info('💛 ===> onInvite', payload);
 
       const { roomId, content } = payload;
       const { accountId, threshold, signatories, accountName, creatorAccountId } = content.mstAccount;
@@ -182,7 +182,7 @@ export const MatrixProvider = ({ children }: PropsWithChildren) => {
   };
 
   const onMultisigEvent = async ({ type, content }: MultisigPayload, extras: SpektrExtras) => {
-    console.info('🚀 === onMultisigEvent - ', type);
+    console.info('🚀 === onMultisigEvent - ', type, '\n Content: ', content);
 
     if (!validateMatrixEvent(content, extras)) return;
 


### PR DESCRIPTION
This PR add payload in logs for matrix events.

MST operation:
<img width="300" alt="Screenshot 2023-05-17 at 10 45 52" src="https://github.com/nova-wallet/omni-enterprise/assets/40560660/b5de2bf4-2f30-43d8-8fa8-c072a0c65c80">

Invite to room:
<img width="300" alt="Screenshot 2023-05-17 at 10 47 33" src="https://github.com/nova-wallet/omni-enterprise/assets/40560660/858c9082-cb51-4fc3-868c-b1e355472048">
