### PR TITLE
fix: duplicate resolution strategy score check

### DIFF
--- a/src/renderer/context/MatrixContext/MatrixContext.tsx
+++ b/src/renderer/context/MatrixContext/MatrixContext.tsx
@@ -152,7 +152,7 @@ export const MatrixProvider = ({ children }: PropsWithChildren) => {
     signerAccountId: AccountId,
   ) => {
     const { accountName, creatorAccountId } = extras.mstAccount;
-    const stayInRoom = toAddress(signerAccountId, { prefix: 42 }) < toAddress(creatorAccountId, { prefix: 42 });
+    const stayInRoom = toAddress(signerAccountId, { prefix: 42 }) > toAddress(creatorAccountId, { prefix: 42 });
 
     try {
       if (stayInRoom) {


### PR DESCRIPTION
1.       1. If `Score(MultisigAccount#creatorAccountId in SS58 with prefix=42) < Score(spektr_extras#invite#creatorAccountId in SS58 with prefix=42)` then the room should be updated.