### PR TITLE
Adding shasum to release distr

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -82,10 +82,10 @@ jobs:
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
       
-      - name: Rename Linux artifact
+      - name: Rename Linux distr # In order to show that we do not support ARM yet.
         run: rename 's/\.AppImage$/_x86_64.AppImage/' *.AppImage
       
-      - name: Generate checksum
+      - name: 🔐 Generate checksum
         run: |
           for filename in Nova.Spektr*; do
               shasum -a 256 "$filename" | awk '{print $1}' | tr -d '\n' > "${filename}.sha256"


### PR DESCRIPTION
That PR adds:
- Rename Nova.Spektr-0.0.0.Appimage to Nova.Spektr-0.0.0_x86_64.Appimage
- Recursive generation `shasum -a 256` for all distributive and attach it to release artefacts.
-- Also, it removes new line from the file by `tr -d '\n'` in order to use it in scripts without problems