### PR TITLE
fix: confirmation screen

### DIFF
--- a/src/renderer/screens/Operations/components/TransactionAmount.tsx
+++ b/src/renderer/screens/Operations/components/TransactionAmount.tsx
@@ -21,7 +21,7 @@ const TransactionAmount = ({ tx, ...balanceProps }: Props & BalanceProps) => {
     getChainById(tx.chainId).then((chain) => setAssets(chain?.assets || []));
   }, []);
 
-  const asset = getAssetById(tx.args.asset, assets);
+  const asset = getAssetById(tx.args.assetId, assets);
   const value = getTransactionAmount(tx);
 
   if (!asset || !value) return null;

--- a/src/renderer/screens/Transfer/components/TransferForm.tsx
+++ b/src/renderer/screens/Transfer/components/TransferForm.tsx
@@ -134,7 +134,7 @@ export const TransferForm = ({ api, chainId, account, signer, asset, nativeToken
       args: {
         dest: toAddress(destination, { prefix: addressPrefix }),
         value: formatAmount(amount, asset.precision),
-        asset: getAssetId(asset),
+        assetId: getAssetId(asset),
       },
     };
   };

--- a/src/renderer/services/transaction/transactionService.ts
+++ b/src/renderer/services/transaction/transactionService.ts
@@ -78,7 +78,7 @@ export const useTransaction = (): ITransactionService => {
     [TransactionType.ASSET_TRANSFER]: (transaction, info, options) => {
       return methods.assets.transfer(
         {
-          id: transaction.args.asset,
+          id: transaction.args.assetId,
           target: transaction.args.dest,
           amount: transaction.args.value,
         },
@@ -91,7 +91,7 @@ export const useTransaction = (): ITransactionService => {
         {
           dest: transaction.args.dest,
           amount: transaction.args.value,
-          currencyId: transaction.args.asset,
+          currencyId: transaction.args.assetId,
         },
         info,
         options,


### PR DESCRIPTION
1Use `assetId` everywhere for asset id parameter naming