### PR TITLE
fix: get balances for ORML

### DIFF
--- a/src/renderer/services/network/common/chains/chains.json
+++ b/src/renderer/services/network/common/chains/chains.json
@@ -379,7 +379,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0081",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000000000",
           "transfersEnabled": true
         },
@@ -394,7 +394,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x0082",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -409,7 +409,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/RMRK.svg",
         "typeExtras": {
           "currencyIdScale": "0x050000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -424,7 +424,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Bifrost_(BNC).svg",
         "typeExtras": {
           "currencyIdScale": "0x00a8",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "8000000000",
           "transfersEnabled": true
         },
@@ -439,7 +439,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0083",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "500000000",
           "transfersEnabled": true
         },
@@ -454,7 +454,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Phala_(PHA).svg",
         "typeExtras": {
           "currencyIdScale": "0x00aa",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "40000000000",
           "transfersEnabled": true
         },
@@ -469,7 +469,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x00ab",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "133330000",
           "transfersEnabled": true
         },
@@ -484,7 +484,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x00ac",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "660000",
           "transfersEnabled": true
         },
@@ -498,7 +498,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Taiga_(TAI).svg",
         "typeExtras": {
           "currencyIdScale": "0x0084",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -512,7 +512,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vsKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x00a9",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -526,7 +526,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/taiKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0300000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -541,7 +541,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Quartz_(QTZ).svg",
         "typeExtras": {
           "currencyIdScale": "0x050200",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000000",
           "transfersEnabled": true
         },
@@ -556,7 +556,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonriver_(MOVR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050300",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000",
           "transfersEnabled": true
         },
@@ -570,7 +570,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/HKO.svg",
         "typeExtras": {
           "currencyIdScale": "0x050400",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -585,7 +585,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Crust_Shadow_(CSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x050500",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -600,7 +600,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x050700",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -615,7 +615,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Calamari_(KMA).svg",
         "typeExtras": {
           "currencyIdScale": "0x050a00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -630,7 +630,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Integritee_Parachain_(TEER).svg",
         "typeExtras": {
           "currencyIdScale": "0x050800",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -644,7 +644,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KICO_(KICO).svg",
         "typeExtras": {
           "currencyIdScale": "0x050600",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000",
           "transfersEnabled": true
         },
@@ -659,7 +659,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Bit.Country_Pioneer_(NEER).svg",
         "typeExtras": {
           "currencyIdScale": "0x050900",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -674,7 +674,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Basilisk_(BSX).svg",
         "typeExtras": {
           "currencyIdScale": "0x050b00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -689,7 +689,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Altair_(AIR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050c00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -704,7 +704,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Genshiro_(GENS).svg",
         "typeExtras": {
           "currencyIdScale": "0x050e00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -719,7 +719,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/EQD.svg",
         "typeExtras": {
           "currencyIdScale": "0x050f00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000000000",
           "transfersEnabled": true
         },
@@ -734,7 +734,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Crab_(CRAB).svg",
         "typeExtras": {
           "currencyIdScale": "0x050d00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000000",
           "transfersEnabled": true
         },
@@ -991,7 +991,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x0204",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1006,7 +1006,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/RMRK.svg",
         "typeExtras": {
           "currencyIdScale": "0x0209",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -1021,7 +1021,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Zenlink_(ZLK).svg",
         "typeExtras": {
           "currencyIdScale": "0x0207",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -1036,7 +1036,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Karura_(KAR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0206",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1051,7 +1051,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0302",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1065,7 +1065,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vsKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0404",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1080,7 +1080,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0800",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -1095,7 +1095,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonriver_(MOVR).svg",
         "typeExtras": {
           "currencyIdScale": "0x020a",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -1110,7 +1110,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Phala_(PHA).svg",
         "typeExtras": {
           "currencyIdScale": "0x0208",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "40000000000",
           "transfersEnabled": true
         },
@@ -1124,7 +1124,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0104",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1914,7 +1914,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/BIT.svg",
         "typeExtras": {
           "currencyIdScale": "0x030000000000000000",
-          "currencyIdType": "bit_country_primitives.FungibleTokenId",
+          "currencyIdType": "BitCountryPrimitivesFungibleTokenId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1974,7 +1974,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0003",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "500000000",
           "transfersEnabled": true
         },
@@ -1989,7 +1989,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0001",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -2004,7 +2004,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2019,7 +2019,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lcDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x040d000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2034,7 +2034,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonbeam_(GLMR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -2049,7 +2049,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/PARA.svg",
         "typeExtras": {
           "currencyIdScale": "0x050100",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -2063,7 +2063,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Tapio_(TAP).svg",
         "typeExtras": {
           "currencyIdScale": "0x0004",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -2077,7 +2077,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/tDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0300000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2092,7 +2092,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050400",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000",
           "transfersEnabled": true
         },
@@ -2107,7 +2107,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Astar_(ASTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050200",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -2122,7 +2122,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Equilibrium_(EQ).svg",
         "typeExtras": {
           "currencyIdScale": "0x050700",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000",
           "transfersEnabled": true
         },
@@ -2137,7 +2137,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x050300",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100",
           "transfersEnabled": true
         },
@@ -2152,7 +2152,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x050c00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -2851,7 +2851,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2866,7 +2866,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2881,7 +2881,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x000a",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2896,7 +2896,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0102000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2911,7 +2911,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0103000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2926,7 +2926,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2940,7 +2940,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -2954,7 +2954,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC-USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000b0103000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -2968,7 +2968,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-KINT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -3658,7 +3658,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3673,7 +3673,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x0001",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3688,7 +3688,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3703,7 +3703,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3718,7 +3718,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3733,7 +3733,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x000a",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3748,7 +3748,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3763,7 +3763,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0102000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -4317,7 +4317,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonbeam_(GLMR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0801",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -4332,7 +4332,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0800",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000",
           "transfersEnabled": true
         },
@@ -4347,7 +4347,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0802",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -4809,7 +4809,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/GM_(GM).svg",
         "typeExtras": {
           "currencyIdScale": "0x01",
-          "currencyIdType": "gm_chain_runtime.Coooooins",
+          "currencyIdType": "GmChainRuntimeCoooooins",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -4823,7 +4823,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/GN.svg",
         "typeExtras": {
           "currencyIdScale": "0x02",
-          "currencyIdType": "gm_chain_runtime.Coooooins",
+          "currencyIdType": "GmChainRuntimeCoooooins",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5098,7 +5098,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0100",
-          "currencyIdType": "pendulum_runtime.currency.CurrencyId",
+          "currencyIdType": "PendulumRuntimeCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },

--- a/src/renderer/services/network/common/chains/chains_dev.json
+++ b/src/renderer/services/network/common/chains/chains_dev.json
@@ -424,7 +424,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0081",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000000000",
           "transfersEnabled": true
         },
@@ -439,7 +439,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x0082",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -454,7 +454,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/RMRK.svg",
         "typeExtras": {
           "currencyIdScale": "0x050000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -469,7 +469,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Bifrost_(BNC).svg",
         "typeExtras": {
           "currencyIdScale": "0x00a8",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "8000000000",
           "transfersEnabled": true
         },
@@ -484,7 +484,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0083",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "500000000",
           "transfersEnabled": true
         },
@@ -499,7 +499,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Phala_(PHA).svg",
         "typeExtras": {
           "currencyIdScale": "0x00aa",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "40000000000",
           "transfersEnabled": true
         },
@@ -514,7 +514,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x00ab",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "133330000",
           "transfersEnabled": true
         },
@@ -529,7 +529,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x00ac",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "660000",
           "transfersEnabled": true
         },
@@ -543,7 +543,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Taiga_(TAI).svg",
         "typeExtras": {
           "currencyIdScale": "0x0084",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -557,7 +557,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vsKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x00a9",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -571,7 +571,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/taiKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0300000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -586,7 +586,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Quartz_(QTZ).svg",
         "typeExtras": {
           "currencyIdScale": "0x050200",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000000",
           "transfersEnabled": true
         },
@@ -601,7 +601,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonriver_(MOVR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050300",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000",
           "transfersEnabled": true
         },
@@ -615,7 +615,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/HKO.svg",
         "typeExtras": {
           "currencyIdScale": "0x050400",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -630,7 +630,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Crust_Shadow_(CSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x050500",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -645,7 +645,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x050700",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -660,7 +660,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Calamari_(KMA).svg",
         "typeExtras": {
           "currencyIdScale": "0x050a00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -675,7 +675,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Integritee_Parachain_(TEER).svg",
         "typeExtras": {
           "currencyIdScale": "0x050800",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -689,7 +689,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KICO_(KICO).svg",
         "typeExtras": {
           "currencyIdScale": "0x050600",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000",
           "transfersEnabled": true
         },
@@ -704,7 +704,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Bit.Country_Pioneer_(NEER).svg",
         "typeExtras": {
           "currencyIdScale": "0x050900",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -719,7 +719,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Basilisk_(BSX).svg",
         "typeExtras": {
           "currencyIdScale": "0x050b00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -734,7 +734,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Altair_(AIR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050c00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -749,7 +749,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Genshiro_(GENS).svg",
         "typeExtras": {
           "currencyIdScale": "0x050e00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -764,7 +764,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/EQD.svg",
         "typeExtras": {
           "currencyIdScale": "0x050f00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000000000",
           "transfersEnabled": true
         },
@@ -779,7 +779,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Crab_(CRAB).svg",
         "typeExtras": {
           "currencyIdScale": "0x050d00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000000000",
           "transfersEnabled": true
         },
@@ -1037,7 +1037,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x0204",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1052,7 +1052,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/RMRK.svg",
         "typeExtras": {
           "currencyIdScale": "0x0209",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -1067,7 +1067,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Zenlink_(ZLK).svg",
         "typeExtras": {
           "currencyIdScale": "0x0207",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -1082,7 +1082,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Karura_(KAR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0206",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1097,7 +1097,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0302",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1111,7 +1111,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vsKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0404",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1126,7 +1126,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0800",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -1141,7 +1141,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonriver_(MOVR).svg",
         "typeExtras": {
           "currencyIdScale": "0x020a",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -1156,7 +1156,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Phala_(PHA).svg",
         "typeExtras": {
           "currencyIdScale": "0x0208",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "40000000000",
           "transfersEnabled": true
         },
@@ -1170,7 +1170,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/vKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0104",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -1240,7 +1240,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1255,7 +1255,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1270,7 +1270,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x000a",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1285,7 +1285,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0102000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1300,7 +1300,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0103000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1315,7 +1315,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1329,7 +1329,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -1343,7 +1343,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC-USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000b0103000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -1357,7 +1357,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-KINT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -1372,7 +1372,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1387,7 +1387,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x0001",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -1402,7 +1402,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2229,7 +2229,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/BIT.svg",
         "typeExtras": {
           "currencyIdScale": "0x030000000000000000",
-          "currencyIdType": "bit_country_primitives.FungibleTokenId",
+          "currencyIdType": "BitCountryPrimitivesFungibleTokenId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -2289,7 +2289,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0003",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "500000000",
           "transfersEnabled": true
         },
@@ -2304,7 +2304,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0001",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -2319,7 +2319,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2334,7 +2334,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lcDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x040d000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2349,7 +2349,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonbeam_(GLMR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -2364,7 +2364,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/PARA.svg",
         "typeExtras": {
           "currencyIdScale": "0x050100",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000",
           "transfersEnabled": true
         },
@@ -2378,7 +2378,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Tapio_(TAP).svg",
         "typeExtras": {
           "currencyIdScale": "0x0004",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -2392,7 +2392,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/tDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0300000000",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000",
           "transfersEnabled": true
         },
@@ -2407,7 +2407,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050400",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000",
           "transfersEnabled": true
         },
@@ -2422,7 +2422,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Astar_(ASTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x050200",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100000000000000000",
           "transfersEnabled": true
         },
@@ -2437,7 +2437,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Equilibrium_(EQ).svg",
         "typeExtras": {
           "currencyIdScale": "0x050700",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000",
           "transfersEnabled": true
         },
@@ -2452,7 +2452,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x050300",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "100",
           "transfersEnabled": true
         },
@@ -2467,7 +2467,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/DAI.svg",
         "typeExtras": {
           "currencyIdScale": "0x0254a37a01cd75b616d63e0ab665bffdb0143c52ae",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000000000000000",
           "transfersEnabled": true
         },
@@ -2482,7 +2482,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x050c00",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "10000",
           "transfersEnabled": true
         },
@@ -2564,7 +2564,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "acala_primitives.currency.CurrencyId",
+          "currencyIdType": "AcalaPrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000"
         },
         "name": "Polkadot"
@@ -3871,7 +3871,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Interlay_(INTR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0002",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3886,7 +3886,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/iBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x0001",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3901,7 +3901,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3916,7 +3916,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3931,7 +3931,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3946,7 +3946,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kusama_(KSM).svg",
         "typeExtras": {
           "currencyIdScale": "0x000a",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3961,7 +3961,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lDOT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -3976,7 +3976,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0102000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -4551,7 +4551,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Moonbeam_(GLMR).svg",
         "typeExtras": {
           "currencyIdScale": "0x0801",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000000000",
           "transfersEnabled": true
         },
@@ -4566,7 +4566,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0800",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000000",
           "transfersEnabled": true
         },
@@ -4581,7 +4581,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0802",
-          "currencyIdType": "node_primitives.currency.CurrencyId",
+          "currencyIdType": "NodePrimitivesCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -5147,7 +5147,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/GM_(GM).svg",
         "typeExtras": {
           "currencyIdScale": "0x01",
-          "currencyIdType": "gm_chain_runtime.Coooooins",
+          "currencyIdType": "GmChainRuntimeCoooooins",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5161,7 +5161,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/GN.svg",
         "typeExtras": {
           "currencyIdScale": "0x02",
-          "currencyIdType": "gm_chain_runtime.Coooooins",
+          "currencyIdType": "GmChainRuntimeCoooooins",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5516,7 +5516,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Polkadot_(DOT).svg",
         "typeExtras": {
           "currencyIdScale": "0x0100",
-          "currencyIdType": "pendulum_runtime.currency.CurrencyId",
+          "currencyIdType": "PendulumRuntimeCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -5531,7 +5531,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101",
-          "currencyIdType": "pendulum_runtime.currency.CurrencyId",
+          "currencyIdType": "PendulumRuntimeCurrencyCurrencyId",
           "existentialDeposit": "1000",
           "transfersEnabled": true
         },
@@ -5608,7 +5608,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/Kintsugi_(KINT).svg",
         "typeExtras": {
           "currencyIdScale": "0x000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5622,7 +5622,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5636,7 +5636,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/lKSM.svg",
         "typeExtras": {
           "currencyIdScale": "0x0102000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5650,7 +5650,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x0103000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5664,7 +5664,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/aUSD.svg",
         "typeExtras": {
           "currencyIdScale": "0x0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": true
         },
@@ -5678,7 +5678,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-kBTC.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000b",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -5692,7 +5692,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/kBTC-USDT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000b0101000000",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },
@@ -5706,7 +5706,7 @@
         "icon": "https://raw.githubusercontent.com/nova-wallet/nova-spektr-utils/main/icons/v1/assets/white/KSM-KINT.svg",
         "typeExtras": {
           "currencyIdScale": "0x03000a000c",
-          "currencyIdType": "interbtc_primitives.CurrencyId",
+          "currencyIdType": "InterbtcPrimitivesCurrencyId",
           "existentialDeposit": "0",
           "transfersEnabled": false
         },


### PR DESCRIPTION
The problem was with types for ORML queries. There should be not just a bytes but decoded with a special type.
This PR has to be merged together with https://github.com/novasamatech/nova-spektr-utils/pull/17