### PR TITLE
fix: change release type to draft

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,7 @@ jobs:
           name: 'Release ${{ steps.get_version.outputs.VERSION }}'
           tag_name: ${{ github.ref }}
           generate_release_notes: true
+          draft: true
           files: |
             *.dmg
             *.exe


### PR DESCRIPTION
That PR changes release type to "draft" when it will be created.

doc:
https://github.com/softprops/action-gh-release/tree/v1/#inputs