### PR TITLE
Fix: Payee of destination

### DIFF
--- a/src/renderer/screens/Operations/components/Details.tsx
+++ b/src/renderer/screens/Operations/components/Details.tsx
@@ -125,12 +125,12 @@ const Details = ({ tx, account, connection, isCardDetails = true }: Props) => {
 
       {transaction?.args.payee && (
         <DetailRow label={t('operation.details.payee')} className={valueClass}>
-          {transaction.args.payee.account ? (
+          {transaction.args.payee.Account ? (
             <AddressWithExplorers
               explorers={explorers}
               addressFont={AddressStyle}
               type="short"
-              address={transaction.args.payee.account}
+              address={transaction.args.payee.Account}
               addressPrefix={addressPrefix}
               wrapperClassName="-mr-2 min-w-min"
             />

--- a/src/renderer/screens/Operations/components/Operation.tsx
+++ b/src/renderer/screens/Operations/components/Operation.tsx
@@ -7,20 +7,22 @@ import { useToggle } from '@renderer/shared/hooks';
 import { MultisigAccount } from '@renderer/domain/account';
 import { FootnoteText, IconButton, Chain } from '@renderer/components/ui-redesign';
 import TransactionAmount from './TransactionAmount';
-import { MultisigTransactionDS } from '@renderer/services/storage';
 import OperationStatus from './OperationStatus';
 import OperationFullInfo from './OperationFullInfo';
 import { getTransactionAmount } from '@renderer/screens/Operations/common/utils';
+import { MultisigTransaction } from '@renderer/domain/transaction';
 
 type Props = {
-  tx: MultisigTransactionDS;
+  tx: MultisigTransaction;
   account?: MultisigAccount;
 };
 
 const Operation = ({ tx, account }: Props) => {
   const { dateLocale } = useI18n();
   const [isRowShown, toggleRow] = useToggle();
+
   const { dateCreated, chainId, events, transaction, description, status } = tx;
+
   const approvals = events.filter((e) => e.status === 'SIGNED');
 
   return (


### PR DESCRIPTION
- `transaction.args.payee` can have `{ Account: %address% }`

<img width="761" alt="image" src="https://github.com/novasamatech/nova-spektr/assets/8149541/d696e766-608a-45e5-9f76-554dbf50ac1e">
