### PR TITLE
fix: animation pause on click disabled

### DIFF
--- a/src/renderer/components/ui-redesign/Animation/Animation.tsx
+++ b/src/renderer/components/ui-redesign/Animation/Animation.tsx
@@ -13,7 +13,7 @@ export type Props = {
   className?: string;
 };
 
-const Animation = ({ name, width = 80, height = 80, loop = false, autoplay = false, className }: Props) => {
+const Animation = ({ name, width = 80, height = 80, loop = false, autoplay = true, className }: Props) => {
   const defaultOptions = {
     loop,
     autoplay,
@@ -25,7 +25,7 @@ const Animation = ({ name, width = 80, height = 80, loop = false, autoplay = fal
 
   return (
     <div className={className}>
-      <Lottie options={defaultOptions} height={height} width={width} />
+      <Lottie options={defaultOptions} isClickToPauseDisabled={true} height={height} width={width} />
     </div>
   );
 };


### PR DESCRIPTION
1. there is a warning in the log:
```
[1] 2023/06/29 23:45:19.042 [staging#1.0.1]-renderer [warn]  > Warning: componentWillUpdate has been renamed, and is not recommended for use. See https://reactjs.org/link/unsafe-component-lifecycles for details.
[1] 
[1] * Move data fetching code or side effects to componentDidUpdate.
[1] * Rename componentWillUpdate to UNSAFE_componentWillUpdate to suppress this warning in non-strict mode. In React 18.x, only the UNSAFE_ name will work. To rename all deprecated lifecycles to their new names, you can run `npx react-codemod rename-unsafe-lifecycles` in your project source folder.
[1] 
[1] Please update the following components: Lottie
```
2. use the property `isClickToPauseDisabled`  https://github.com/chenqingspring/react-lottie/issues/81
3. set `autoplay` to `true`, why was it `false`?