### PR TITLE
feat: add latest release description and zip for mac

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -64,6 +64,10 @@ jobs:
             release/dist/*.exe
             release/dist/*.dmg
             release/dist/*.AppImage
+            release/dist/latest.yml
+            release/dist/latest-mac.yml
+            release/dist/latest-linux.yml
+            release/dist/*mac.zip
 
   releas-project:
     name: Release Nova Spektr build-project
@@ -81,14 +85,14 @@ jobs:
       - name: Get the version
         id: get_version
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\//}
-      
+
       - name: Rename Linux distr # In order to show that we do not support ARM yet.
         run: |
           original=$(find . -name "Nova*.AppImage" -type f)
           filename="${original%.*}"
           new="$filename"_x86_64.AppImage
           mv "$original" "$new"
-      
+
       - name: 🔐 Generate checksum
         run: |
           for filename in Nova*; do


### PR DESCRIPTION
Add latest release description and zip for mac. This is required for the electron auto-update start.
1. yaml files for each platform with release metadata https://www.electron.build/auto-update#file-generated-and-uploaded-in-addition
2. zip archives for mac build is required https://www.electron.build/auto-update#quick-setup-guide