### PR TITLE
fix: add additional step in release build

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,6 +92,15 @@ jobs:
           filename="${original%.*}"
           new="$filename"_x86_64.AppImage
           mv "$original" "$new"
+      
+      - name: Replace space by "-"
+        run: |
+          for file in *; do
+            if [ -f "$file" ]; then
+              new_name=$(echo "$file" | tr ' ' '-')
+              mv "$file" "$new_name"
+            fi
+          done
 
       - name: 🔐 Generate checksum
         run: |


### PR DESCRIPTION
That PR adds additional step which will rename all artefacts in order to replace "space" with "-". 
Demo:

https://github.com/novasamatech/nova-spektr/assets/40560660/18a74c34-f10b-4062-bf19-2e431ae0613c

