### PR TITLE
CI. Release workflow fix: add skip if file name wasn't changed

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -98,7 +98,9 @@ jobs:
           for file in *; do
             if [ -f "$file" ]; then
               new_name=$(echo "$file" | tr ' ' '-')
-              mv "$file" "$new_name"
+              if [ "$new_name" != "$file" ]; then # Skip files with no spaces
+                mv "$file" "$new_name"
+              fi
             fi
           done
 


### PR DESCRIPTION
That command behave different in linux github image which leads to problem:
`mv: 'latest-linux.yml' and 'latest-linux.yml' are the same file`