### PR TITLE
Fix: Approve xcm

### DIFF
--- a/src/renderer/entities/chain/ui/XcmChains/XcmChains.tsx
+++ b/src/renderer/entities/chain/ui/XcmChains/XcmChains.tsx
@@ -11,7 +11,7 @@ type Props = {
 
 export const XcmChains = ({ chainIdFrom, chainIdTo, className }: Props) => {
   if (!chainIdTo) {
-    return <ChainTitle chainId={chainIdFrom} showChainName={false} />;
+    return <ChainTitle chainId={chainIdFrom} className={className} />;
   }
 
   return (

--- a/src/renderer/entities/signatory/ui/SelectableSignatory/SelectableSignatory.tsx
+++ b/src/renderer/entities/signatory/ui/SelectableSignatory/SelectableSignatory.tsx
@@ -27,7 +27,6 @@ export const SelectableSignatory = <T extends any>({
 
   const { getLiveBalance } = useBalance();
   const popoverItems = useAddressInfo(address, explorers, true);
-
   const balance = getLiveBalance(toAccountId(address), chainId, asset.assetId.toString());
 
   return (

--- a/src/renderer/features/operation/sign/ui/VaultSigning/VaultSigning.tsx
+++ b/src/renderer/features/operation/sign/ui/VaultSigning/VaultSigning.tsx
@@ -26,7 +26,6 @@ export const VaultSigning = ({
   const [countdown, resetCountdown] = useCountdown(api);
   const [unsignedTxs, setUnsignedTxs] = useState<UnsignedTransaction[]>([]);
   const [txPayloads, setTxPayloads] = useState<Uint8Array[]>([]);
-
   const [validationError, setValidationError] = useState<ValidationErrors>();
 
   const isScanStep = !unsignedTxs.length && !txPayloads.length;
@@ -38,7 +37,7 @@ export const VaultSigning = ({
     }
   }, [countdown]);
 
-  const handleSignature = async (data: string | string[]) => {
+  const handleSignature = async (data: string | string[]): Promise<void> => {
     const isMultishard = Array.isArray(data);
     const signatures = isMultishard ? (data as HexString[]) : [data as HexString];
     const accountIds = isMultiframe ? accounts.map((t) => t.accountId) : [(signatory || accounts[0])?.accountId];
@@ -75,43 +74,45 @@ export const VaultSigning = ({
     setTxPayloads([]);
   };
 
-  const ScanStep = (
-    <div className="w-[440px] px-5 py-4">
-      {isMultiframe ? (
-        <ScanMultiframeQr
-          api={api}
-          addressPrefix={addressPrefix}
-          countdown={countdown}
-          accounts={accounts}
-          transactions={transactions}
-          chainId={chainId}
-          onGoBack={onGoBack}
-          onResetCountdown={resetCountdown}
-          onResult={(unsignedTx, payloads) => {
-            setUnsignedTxs(unsignedTx);
-            setTxPayloads(payloads);
-          }}
-        />
-      ) : (
-        <ScanSingleframeQr
-          api={api}
-          addressPrefix={addressPrefix}
-          countdown={countdown}
-          account={signatory || accounts[0]}
-          transaction={transactions[0]}
-          chainId={chainId}
-          onGoBack={onGoBack}
-          onResetCountdown={resetCountdown}
-          onResult={(unsignedTx, payload) => {
-            setUnsignedTxs([unsignedTx]);
-            setTxPayloads([payload]);
-          }}
-        />
-      )}
-    </div>
-  );
+  if (isScanStep) {
+    return (
+      <div className="w-[440px] px-5 py-4">
+        {isMultiframe ? (
+          <ScanMultiframeQr
+            api={api}
+            addressPrefix={addressPrefix}
+            countdown={countdown}
+            accounts={accounts}
+            transactions={transactions}
+            chainId={chainId}
+            onGoBack={onGoBack}
+            onResetCountdown={resetCountdown}
+            onResult={(unsignedTx, payloads) => {
+              setUnsignedTxs(unsignedTx);
+              setTxPayloads(payloads);
+            }}
+          />
+        ) : (
+          <ScanSingleframeQr
+            api={api}
+            addressPrefix={addressPrefix}
+            countdown={countdown}
+            account={signatory || accounts[0]}
+            transaction={transactions[0]}
+            chainId={chainId}
+            onGoBack={onGoBack}
+            onResetCountdown={resetCountdown}
+            onResult={(unsignedTx, payload) => {
+              setUnsignedTxs([unsignedTx]);
+              setTxPayloads([payload]);
+            }}
+          />
+        )}
+      </div>
+    );
+  }
 
-  const SignStep = (
+  return (
     <div className="flex flex-col items-center gap-y-2.5 w-[440px] rounded-b-lg bg-black">
       <QrReaderWrapper
         isMultiFrame={isMultiframe}
@@ -122,10 +123,4 @@ export const VaultSigning = ({
       />
     </div>
   );
-
-  if (isScanStep) {
-    return ScanStep;
-  }
-
-  return SignStep;
 };

--- a/src/renderer/pages/Operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/pages/Operations/components/ActionSteps/Confirmation.tsx
@@ -15,7 +15,7 @@ type Props = {
   connection: ExtendedChain;
   feeTx?: Transaction;
 };
-const Confirmation = ({ tx, account, connection, feeTx }: Props) => {
+export const Confirmation = ({ tx, account, connection, feeTx }: Props) => {
   const { t } = useI18n();
 
   const iconName = getIconName(tx.transaction);
@@ -53,5 +53,3 @@ const Confirmation = ({ tx, account, connection, feeTx }: Props) => {
     </div>
   );
 };
-
-export default Confirmation;

--- a/src/renderer/pages/Operations/components/modals/AccountSelectModal/AccountSelectModal.tsx
+++ b/src/renderer/pages/Operations/components/modals/AccountSelectModal/AccountSelectModal.tsx
@@ -3,13 +3,14 @@ import { useI18n } from '@renderer/app/providers';
 import { AccountDS } from '@renderer/shared/api/storage';
 import { Chain } from '@renderer/entities/chain';
 import { SelectableAccount } from './SelectableAccount';
+import { cnTw } from '@renderer/shared/lib/utils';
 
 type Props = {
   isOpen: boolean;
-  onClose: () => void;
-  onSelect: (account: AccountDS) => void;
-  accounts: AccountDS[];
   chain: Chain;
+  accounts: AccountDS[];
+  onSelect: (account: AccountDS) => void;
+  onClose: () => void;
 };
 
 const AccountSelectModal = ({ isOpen, onClose, onSelect, accounts, chain }: Props) => {
@@ -24,7 +25,7 @@ const AccountSelectModal = ({ isOpen, onClose, onSelect, accounts, chain }: Prop
       panelClass="w-[368px]"
       onClose={onClose}
     >
-      <ul className="mt-1 max-h-[332px] overflow-y-auto">
+      <ul className={cnTw('mt-1', accounts.length > 7 && 'max-h-[332px] overflow-y-auto')}>
         {accounts.map((a) => (
           <li key={a.id}>
             <SelectableAccount

--- a/src/renderer/pages/Operations/components/modals/RejectTx.tsx
+++ b/src/renderer/pages/Operations/components/modals/RejectTx.tsx
@@ -11,10 +11,10 @@ import { ExtendedChain } from '@renderer/entities/network';
 import { Address, HexString, Timepoint } from '@renderer/domain/shared-kernel';
 import { toAddress, transferableAmount, getAssetById } from '@renderer/shared/lib/utils';
 import { getModalTransactionTitle } from '../../common/utils';
-import { Submit } from '../ActionSteps/Submit';
 import { useBalance } from '@renderer/entities/asset';
 import RejectReasonModal from './RejectReasonModal';
-import Confirmation from '@renderer/pages/Operations/components/ActionSteps/Confirmation';
+import { Submit } from '../ActionSteps/Submit';
+import { Confirmation } from '../ActionSteps/Confirmation';
 import { Signing } from '@renderer/features/operation';
 import { OperationTitle } from '@renderer/components/common';
 import {
@@ -70,7 +70,7 @@ const RejectTx = ({ tx, account, connection }: Props) => {
       api: connection.api,
       chainId: tx.chainId,
       transaction: rejectTx,
-      assetId: nativeAsset?.assetId.toString(),
+      assetId: nativeAsset.assetId.toString(),
       getBalance,
       getTransactionFee,
     });

--- a/src/renderer/pages/Operations/components/modals/SignatorySelectModal.tsx
+++ b/src/renderer/pages/Operations/components/modals/SignatorySelectModal.tsx
@@ -4,46 +4,44 @@ import { AccountDS } from '@renderer/shared/api/storage';
 import { Asset } from '@renderer/entities/asset';
 import { Chain } from '@renderer/entities/chain';
 import { SelectableSignatory } from '@renderer/entities/signatory';
+import { cnTw } from '@renderer/shared/lib/utils';
 
 type Props = {
   isOpen: boolean;
+  chain: Chain;
+  nativeAsset: Asset;
+  accounts: AccountDS[];
   onClose: () => void;
   onSelect: (account: AccountDS) => void;
-  accounts: AccountDS[];
-  chain: Chain;
-  asset?: Asset;
 };
 
-const SignatorySelectModal = ({ isOpen, onClose, onSelect, accounts, asset, chain }: Props) => {
+export const SignatorySelectModal = ({ isOpen, onClose, onSelect, accounts, nativeAsset, chain }: Props) => {
   const { t } = useI18n();
 
   return (
     <BaseModal
       closeButton
+      panelClass="w-[420px]"
       isOpen={isOpen}
       title={t('operation.selectSignatory')}
-      panelClass="w-[420px]"
       onClose={onClose}
     >
-      <ul className="mt-1 max-h-[332px] overflow-y-scroll">
-        {asset &&
-          accounts.map((a) => (
-            <li key={a.id}>
-              <SelectableSignatory
-                accountId={a.accountId}
-                addressPrefix={chain.addressPrefix}
-                name={a.name}
-                asset={asset}
-                chainId={chain.chainId}
-                explorers={chain.explorers}
-                value={a}
-                onSelected={onSelect}
-              />
-            </li>
-          ))}
+      <ul className={cnTw('mt-1', accounts.length > 7 && 'max-h-[332px] overflow-y-auto')}>
+        {accounts.map((account) => (
+          <li key={account.id}>
+            <SelectableSignatory
+              accountId={account.accountId}
+              addressPrefix={chain.addressPrefix}
+              name={account.name}
+              asset={nativeAsset}
+              chainId={chain.chainId}
+              explorers={chain.explorers}
+              value={account}
+              onSelected={onSelect}
+            />
+          </li>
+        ))}
       </ul>
     </BaseModal>
   );
 };
-
-export default SignatorySelectModal;

--- a/src/renderer/shared/lib/utils/balance.ts
+++ b/src/renderer/shared/lib/utils/balance.ts
@@ -90,9 +90,10 @@ export const formatBalance = (balance = '0', precision = 0): FormattedBalance =>
 export const totalAmount = (balance?: Balance): string => {
   if (!balance) return ZERO_BALANCE;
 
-  const { free = ZERO_BALANCE, reserved = ZERO_BALANCE } = balance;
+  const bnFree = new BN(balance.free || ZERO_BALANCE);
+  const bnReserved = new BN(balance.reserved || ZERO_BALANCE);
 
-  return new BN(free).add(new BN(reserved)).toString();
+  return bnFree.add(bnReserved).toString();
 };
 
 export const lockedAmount = ({ locked = [] }: Balance): string => {
@@ -105,9 +106,8 @@ export const lockedAmount = ({ locked = [] }: Balance): string => {
 export const transferableAmount = (balance?: Balance): string => {
   if (!balance) return ZERO_BALANCE;
 
-  const { free = ZERO_BALANCE, frozen = ZERO_BALANCE } = balance;
-  const bnFree = new BN(free);
-  const bnFrozen = new BN(frozen);
+  const bnFree = new BN(balance.free || ZERO_BALANCE);
+  const bnFrozen = new BN(balance.frozen || ZERO_BALANCE);
 
   return bnFree.gt(bnFrozen) ? bnFree.sub(bnFrozen).toString() : ZERO_BALANCE;
 };


### PR DESCRIPTION
- Correct filter of WOW accounts on `Approve modal`
- Info popover for Approve signatories can drop out until you pass more that 7 accounts (same logic from on Validators modal)

<img width="588" alt="image" src="https://github.com/novasamatech/nova-spektr/assets/8149541/a4bc466a-06b5-4dc1-81a3-a03ee19b166f">
