### PR TITLE
feat: custom menu

### DIFF
--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -1,5 +1,5 @@
 import { join } from 'path';
-import { BrowserWindow, shell } from 'electron';
+import { BrowserWindow, shell, Menu } from 'electron';
 import log, { LogFile } from 'electron-log';
 import windowStateKeeper from 'electron-window-state';
 import * as path from 'path';
@@ -8,6 +8,7 @@ import * as fs from 'fs';
 import { ENVIRONMENT } from '@shared/constants';
 import { APP_CONFIG } from '../../app.config';
 import { createWindow } from './factories/create';
+import { buildMenuTemplate } from '@main/vectormenu';
 
 const { MAIN, TITLE } = APP_CONFIG;
 log.initialize({ preload: true });
@@ -82,6 +83,7 @@ export async function MainWindow() {
 
     window.show();
   });
+  Menu.setApplicationMenu(buildMenuTemplate());
   mainWindowState.manage(window);
 
   return window;

--- a/src/main/vectormenu.ts
+++ b/src/main/vectormenu.ts
@@ -1,6 +1,6 @@
 import { app, shell, Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
 
-import { PLATFORM } from '@shared/constants';
+import { ENVIRONMENT, PLATFORM } from '@shared/constants';
 
 export function buildMenuTemplate(): Menu {
   const template: Array<MenuItemConstructorOptions | MenuItem> = [
@@ -79,10 +79,6 @@ export function buildMenuTemplate(): Menu {
           role: 'togglefullscreen',
           label: 'Toggle Full Screen',
         },
-        {
-          role: 'toggleDevTools',
-          label: 'Toggle Developer Tools',
-        },
       ],
     },
     {
@@ -108,12 +104,22 @@ export function buildMenuTemplate(): Menu {
         {
           label: 'Nova Spektr Help',
           click(): void {
-            shell.openExternal('https://wiki.novaspektr.io/');
+            shell.openExternal('https://docs.novaspektr.io/');
           },
         },
       ],
     },
   ];
+
+  if (ENVIRONMENT.IS_STAGE || ENVIRONMENT.IS_DEV) {
+    const viewSubmenu = template[1].submenu as MenuItemConstructorOptions[];
+    if (viewSubmenu) {
+      viewSubmenu.push({
+        role: 'toggleDevTools',
+        label: 'Toggle Developer Tools',
+      });
+    }
+  }
 
   // macOS has specific menu conventions...
   if (PLATFORM.IS_MAC) {

--- a/src/main/vectormenu.ts
+++ b/src/main/vectormenu.ts
@@ -1,0 +1,182 @@
+import { app, shell, Menu, MenuItem, MenuItemConstructorOptions } from 'electron';
+
+import { PLATFORM } from '@shared/constants';
+
+export function buildMenuTemplate(): Menu {
+  const template: Array<MenuItemConstructorOptions | MenuItem> = [
+    {
+      label: 'Edit',
+      accelerator: 'e',
+      submenu: [
+        {
+          role: 'undo',
+          label: 'Undo',
+        },
+        {
+          role: 'redo',
+          label: 'Redo',
+        },
+        { type: 'separator' },
+        {
+          role: 'cut',
+          label: 'Cut',
+        },
+        {
+          role: 'copy',
+          label: 'Copy',
+        },
+        {
+          role: 'paste',
+          label: 'Paste',
+        },
+        {
+          role: 'pasteAndMatchStyle',
+          label: 'Paste and Match Style',
+        },
+        {
+          role: 'delete',
+          label: 'Delete',
+        },
+        {
+          role: 'selectAll',
+          label: 'Select All',
+        },
+      ],
+    },
+    {
+      label: 'View',
+      accelerator: 'V',
+      submenu: [
+        { type: 'separator' },
+        {
+          role: 'resetZoom',
+          accelerator: 'CmdOrCtrl+Num0',
+          visible: false,
+        },
+        {
+          role: 'zoomIn',
+          accelerator: 'CmdOrCtrl+NumAdd',
+          visible: false,
+        },
+        {
+          role: 'zoomOut',
+          accelerator: 'CmdOrCtrl+NumSub',
+          visible: false,
+        },
+        {
+          role: 'resetZoom',
+          label: 'Actual Size',
+        },
+        {
+          role: 'zoomIn',
+          label: 'Zoom In',
+        },
+        {
+          role: 'zoomOut',
+          label: 'Zoom Out',
+        },
+        {
+          role: 'togglefullscreen',
+          label: 'Toggle Full Screen',
+        },
+        {
+          role: 'toggleDevTools',
+          label: 'Toggle Developer Tools',
+        },
+      ],
+    },
+    {
+      label: 'Window',
+      accelerator: 'w',
+      role: 'window',
+      submenu: [
+        {
+          role: 'minimize',
+          label: 'Minimize',
+        },
+        {
+          role: 'close',
+          label: 'Close',
+        },
+      ],
+    },
+    {
+      label: 'Help',
+      accelerator: 'h',
+      role: 'help',
+      submenu: [
+        {
+          label: 'Nova Spektr Help',
+          click(): void {
+            shell.openExternal('https://wiki.novaspektr.io/');
+          },
+        },
+      ],
+    },
+  ];
+
+  // macOS has specific menu conventions...
+  if (PLATFORM.IS_MAC) {
+    template.unshift({
+      // first macOS menu is the name of the app
+      role: 'appMenu',
+      label: app.name,
+      submenu: [
+        {
+          role: 'about',
+          label: 'About Nova Spektr',
+        },
+        { type: 'separator' },
+        {
+          role: 'hide',
+          label: 'Hide',
+        },
+        {
+          role: 'hideOthers',
+          label: 'Hide Others',
+        },
+        {
+          role: 'unhide',
+          label: 'Unhide',
+        },
+        { type: 'separator' },
+        {
+          role: 'quit',
+          label: 'Quit',
+        },
+      ],
+    });
+
+    // Window menu.
+    // This also has specific functionality on macOS
+    template[3].submenu = [
+      {
+        label: 'Close',
+        accelerator: 'CmdOrCtrl+W',
+        role: 'close',
+      },
+      {
+        label: 'Minimize',
+        accelerator: 'CmdOrCtrl+M',
+        role: 'minimize',
+      },
+      {
+        label: 'Zoom',
+        role: 'zoom',
+      },
+    ];
+  } else {
+    template.unshift({
+      label: 'File',
+      accelerator: 'f',
+      submenu: [
+        {
+          role: 'quit',
+          label: 'Quit',
+        },
+      ],
+    });
+  }
+
+  return Menu.buildFromTemplate(template);
+}

--- a/src/main/vectormenu.ts
+++ b/src/main/vectormenu.ts
@@ -3,7 +3,7 @@ import { app, shell, Menu, MenuItem, MenuItemConstructorOptions } from 'electron
 import { ENVIRONMENT, PLATFORM } from '@shared/constants';
 
 export function buildMenuTemplate(): Menu {
-  const template: Array<MenuItemConstructorOptions | MenuItem> = [
+  const template: MenuItemConstructorOptions[] | MenuItem[] = [
     {
       label: 'Edit',
       accelerator: 'e',


### PR DESCRIPTION
@stepanLav this PR has to be tested on Windows, Mac, Linux.
`Nova Spektr` should be in the menu but not the `nova-spektr`.