### PR TITLE
fix: use default max nominations

### DIFF
--- a/src/renderer/entities/network/lib/common/utils.ts
+++ b/src/renderer/entities/network/lib/common/utils.ts
@@ -1,6 +1,6 @@
 import { ExtendedChain } from './types';
 import { ConnectionType } from '@renderer/shared/core';
-import type { ChainOptions } from '@renderer/shared/core';
+import type { ChainId, ChainOptions } from '@renderer/shared/core';
 
 export const isPolkadot = (chainName: string): boolean => {
   return chainName === 'Polkadot';
@@ -8,6 +8,10 @@ export const isPolkadot = (chainName: string): boolean => {
 
 export const isKusama = (chainName: string): boolean => {
   return chainName === 'Kusama';
+};
+
+export const isKusamaChainId = (chainId: ChainId): boolean => {
+  return chainId === '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
 };
 
 export const isTestnet = (chainOptions?: ChainOptions[]): boolean => {

--- a/src/renderer/entities/staking/lib/common/constants.ts
+++ b/src/renderer/entities/staking/lib/common/constants.ts
@@ -9,3 +9,6 @@ export const INTEREST_IDEAL = INFLATION_IDEAL / STAKED_PORTION_IDEAL;
 
 export const DECAY_RATE = 0.05;
 export const DAYS_IN_YEAR = 365;
+
+export const KUSAMA_MAX_NOMINATORS = 24;
+export const DEFAULT_MAX_NOMINATORS = 16;

--- a/src/renderer/entities/staking/lib/validatorsService.ts
+++ b/src/renderer/entities/staking/lib/validatorsService.ts
@@ -8,6 +8,8 @@ import { AccountId32 } from '@polkadot/types/interfaces';
 import { getValidatorsApy } from './apyCalculator';
 import { IValidatorsService, ValidatorMap } from './common/types';
 import type { Address, ChainId, EraIndex, Identity, SubIdentity, Validator } from '@renderer/shared/core';
+import { isKusamaChainId } from '@renderer/entities/network';
+import { DEFAULT_MAX_NOMINATORS, KUSAMA_MAX_NOMINATORS } from './common/constants';
 
 export const useValidators = (): IValidatorsService => {
   /**
@@ -71,8 +73,18 @@ export const useValidators = (): IValidatorsService => {
     }, {});
   };
 
+  const getDefaultValidatorsAmount = (api: ApiPromise): number => {
+    if (isKusamaChainId(api.genesisHash.toHex())) return KUSAMA_MAX_NOMINATORS;
+
+    return DEFAULT_MAX_NOMINATORS;
+  };
+
   const getMaxValidators = (api: ApiPromise): number => {
-    return api.consts.staking.maxNominations.toNumber();
+    if (api.consts.staking.maxNominations) {
+      return api.consts.staking.maxNominations.toNumber();
+    } else {
+      return getDefaultValidatorsAmount(api);
+    }
   };
 
   const getIdentities = async (


### PR DESCRIPTION
* fix: use default max nominations if `api.consts.staking.maxNominations` doesn't exist