### PR TITLE
Fix: windows hotkey

### DIFF
--- a/src/renderer/pages/Onboarding/Vault/ManageDynamicDerivations/ManageDynamicDerivations.tsx
+++ b/src/renderer/pages/Onboarding/Vault/ManageDynamicDerivations/ManageDynamicDerivations.tsx
@@ -7,10 +7,10 @@ import { u8aToHex } from '@polkadot/util';
 
 import { useI18n, useStatusContext } from '@app/providers';
 import { SeedInfo } from '@renderer/components/common/QrCode/common/types';
-import { IS_WINDOWS, toAddress, dictionary } from '@shared/lib/utils';
+import { toAddress, dictionary, IS_MAC } from '@shared/lib/utils';
 import type { ChainAccount, ChainId, ShardAccount, DraftAccount } from '@shared/core';
 import { VaultInfoPopover } from './VaultInfoPopover';
-import { useAltKeyPressed, useToggle } from '@shared/lib/hooks';
+import { useAltOrCtrlKeyPressed, useToggle } from '@shared/lib/hooks';
 import { manageDynamicDerivationsModel } from './model/manage-dynamic-derivations-model';
 import { chainsService } from '@entities/network';
 import { RootAccount, accountUtils } from '@entities/wallet';
@@ -39,7 +39,7 @@ type Props = {
 export const ManageDynamicDerivations = ({ seedInfo, onBack, onComplete }: Props) => {
   const { t } = useI18n();
   const { showStatus } = useStatusContext();
-  const isAltPressed = useAltKeyPressed();
+  const isAltPressed = useAltOrCtrlKeyPressed();
 
   const accordions = useRef<Record<string, { el: null | HTMLButtonElement; isOpen: boolean }>>({});
 
@@ -115,19 +115,20 @@ export const ManageDynamicDerivations = ({ seedInfo, onBack, onComplete }: Props
     toggleConstructorModal();
   };
 
-  const button = IS_WINDOWS ? (
-    <>
-      <HelpText as="span" className="text-text-tertiary">
-        {t('onboarding.vault.hotkeyAlt')}
-      </HelpText>
-      <Icon name="hotkeyAlt" />
-    </>
-  ) : (
+  const button = IS_MAC ? (
     <>
       <HelpText as="span" className="text-text-tertiary">
         {t('onboarding.vault.hotkeyOption')}
       </HelpText>
       <Icon name="hotkeyOption" />
+    </>
+  ) : (
+    <>
+      <HelpText as="span" className="text-text-tertiary">
+        {t('onboarding.vault.hotkeyCtrl')}
+      </HelpText>
+      {/* TODO: update to ctrl Icon when ready */}
+      <Icon name="hotkeyAlt" />
     </>
   );
 

--- a/src/renderer/shared/api/translation/locales/en.json
+++ b/src/renderer/shared/api/translation/locales/en.json
@@ -337,7 +337,7 @@
       "addressColumn": "Address",
       "altHint": "Hold <button /> to see the details",
       "fillNamesButton": "Autofill account names",
-      "hotkeyAlt": "Alt",
+      "hotkeyCtrl": "Ctrl",
       "hotkeyOption": "Option",
       "importButton": "Import",
       "info": {

--- a/src/renderer/shared/lib/hooks/index.ts
+++ b/src/renderer/shared/lib/hooks/index.ts
@@ -6,4 +6,4 @@ export { useCountdown } from './useCountdown';
 export { useScrollTo } from './useScrollTo';
 export { useTaskQueue } from './useTaskQueue';
 export { useModalClose } from './useModalClose';
-export { useAltKeyPressed } from './useAltKeyPressed';
+export { useAltOrCtrlKeyPressed } from './useAltOrCtrlKeyPressed';

--- a/src/renderer/shared/lib/hooks/useAltOrCtrlKeyPressed.ts
+++ b/src/renderer/shared/lib/hooks/useAltOrCtrlKeyPressed.ts
@@ -1,21 +1,23 @@
 import { useEffect, useState } from 'react';
 
+import { IS_MAC } from '@shared/lib/utils';
+
 /**
- * Returns a boolean indicating whether the alt key is currently pressed.
+ * Returns a boolean indicating whether the alt key (for macOS) or control key (for Windows and Linux) is currently pressed.
  *
  * @return {boolean} A boolean indicating whether the alt key is currently pressed.
  */
-export const useAltKeyPressed = (): boolean => {
+export const useAltOrCtrlKeyPressed = (): boolean => {
   const [keyPressed, setKeyPressed] = useState<boolean>(false);
 
-  const downHandler = ({ altKey }: KeyboardEvent) => {
-    if (altKey) {
+  const downHandler = ({ altKey, ctrlKey }: KeyboardEvent) => {
+    if (IS_MAC ? altKey : ctrlKey) {
       setKeyPressed(true);
     }
   };
 
-  const upHandler = ({ altKey }: KeyboardEvent) => {
-    if (!altKey) setKeyPressed(false);
+  const upHandler = ({ altKey, ctrlKey }: KeyboardEvent) => {
+    if (IS_MAC ? !altKey : !ctrlKey) setKeyPressed(false);
   };
 
   useEffect(() => {

--- a/src/renderer/shared/lib/utils/browser.ts
+++ b/src/renderer/shared/lib/utils/browser.ts
@@ -18,4 +18,4 @@ export const getOperatingSystem = (): string => {
   return 'Unknown';
 };
 
-export const IS_WINDOWS = getOperatingSystem() === 'Windows';
+export const IS_MAC = getOperatingSystem() === 'macOS';


### PR DESCRIPTION
Changed `useAltKeyPressed` to `useAltOrCtrlKeyPressed` so on Windows and Linux it uses Ctrl key instead of Alt