### PR TITLE
Fix: Remove PV root account from staking rewards destination options

### DIFF
--- a/src/renderer/pages/Staking/Operations/common/utils.tsx
+++ b/src/renderer/pages/Staking/Operations/common/utils.tsx
@@ -1,13 +1,12 @@
 import { BN } from '@polkadot/util';
 import cn from 'classnames';
 import { ReactNode } from 'react';
-import { keyBy } from 'lodash';
 
 import { AccountAddress, accountUtils, WalletIcon, walletUtils } from '@entities/wallet';
 import { DropdownOption } from '@shared/ui/Dropdowns/common/types';
 import { AssetBalance } from '@entities/asset';
 import { ExplorerLink, FootnoteText } from '@shared/ui';
-import { Explorer } from '@shared/core';
+import { ChainId, Explorer } from '@shared/core';
 import { InfoSection } from '@shared/ui/Popovers/InfoPopover/InfoPopover';
 import type {
   Address,
@@ -27,6 +26,7 @@ import {
   unlockingAmount,
   redeemableAmount,
   getAccountExplorer,
+  dictionary,
 } from '@shared/lib/utils';
 
 export const validateBalanceForFee = (balance: AccountBalance | string, fee: string): boolean => {
@@ -246,8 +246,10 @@ export const getExplorers = (address: Address, explorers: Explorer[] = []): [Inf
   return [{ items: explorersContent }];
 };
 
-export const filterPvRootAccounts = (accounts: Account[], wallets: Wallet[]) => {
-  const walletById = keyBy(wallets, 'id');
+export const getDestinationAccounts = (accounts: Account[], wallets: Wallet[], chainId: ChainId) => {
+  const walletsMap = dictionary(wallets, 'id', walletUtils.isPolkadotVault);
 
-  return accounts.filter((a) => !accountUtils.isBaseAccount(a) || !walletUtils.isPolkadotVault(walletById[a.walletId]));
+  return accounts.filter(
+    (a) => (!accountUtils.isBaseAccount(a) || !walletsMap[a.walletId]) && accountUtils.isChainIdMatch(a, chainId),
+  );
 };

--- a/src/renderer/pages/Staking/Operations/common/utils.tsx
+++ b/src/renderer/pages/Staking/Operations/common/utils.tsx
@@ -1,8 +1,9 @@
 import { BN } from '@polkadot/util';
 import cn from 'classnames';
 import { ReactNode } from 'react';
+import { keyBy } from 'lodash';
 
-import { AccountAddress, WalletIcon } from '@entities/wallet';
+import { AccountAddress, accountUtils, WalletIcon, walletUtils } from '@entities/wallet';
 import { DropdownOption } from '@shared/ui/Dropdowns/common/types';
 import { AssetBalance } from '@entities/asset';
 import { ExplorerLink, FootnoteText } from '@shared/ui';
@@ -243,4 +244,10 @@ export const getExplorers = (address: Address, explorers: Explorer[] = []): [Inf
   }));
 
   return [{ items: explorersContent }];
+};
+
+export const filterPvRootAccounts = (accounts: Account[], wallets: Wallet[]) => {
+  const walletById = keyBy(wallets, 'id');
+
+  return accounts.filter((a) => !accountUtils.isBaseAccount(a) || !walletUtils.isPolkadotVault(walletById[a.walletId]));
 };

--- a/src/renderer/pages/Staking/Operations/components/OperationForm/OperationForm.tsx
+++ b/src/renderer/pages/Staking/Operations/components/OperationForm/OperationForm.tsx
@@ -8,7 +8,7 @@ import { useI18n } from '@app/providers';
 import { validateAddress } from '@shared/lib/utils';
 import { RadioOption } from '@shared/ui/RadioGroup/common/types';
 import { DropdownOption, ComboboxOption } from '@shared/ui/Dropdowns/common/types';
-import { getPayoutAccountOption } from '../../common/utils';
+import { filterPvRootAccounts, getPayoutAccountOption } from '../../common/utils';
 import type { Asset, Address, ChainId, AccountId } from '@shared/core';
 import { RewardsDestination } from '@shared/core';
 import { walletModel, accountUtils } from '@entities/wallet';
@@ -80,13 +80,16 @@ export const OperationForm = ({
 }: Props) => {
   const { t } = useI18n();
   const dbAccounts = useUnit(walletModel.$accounts);
+  const dbWallets = useUnit(walletModel.$wallets);
 
   const destinations = getDestinations(t);
 
   const [activePayout, setActivePayout] = useState<Address>('');
   const [payoutAccounts, setPayoutAccounts] = useState<ComboboxOption<Address>[]>([]);
 
-  const destAccounts = dbAccounts.filter((a) => accountUtils.isChainIdMatch(a, chainId));
+  const destAccounts = filterPvRootAccounts(dbAccounts, dbWallets).filter((a) =>
+    accountUtils.isChainIdMatch(a, chainId),
+  );
   const payoutIds = destAccounts.map((a) => a.accountId);
   const balances = useAssetBalances({
     accountIds: payoutIds,

--- a/src/renderer/pages/Staking/Operations/components/OperationForm/OperationForm.tsx
+++ b/src/renderer/pages/Staking/Operations/components/OperationForm/OperationForm.tsx
@@ -8,7 +8,7 @@ import { useI18n } from '@app/providers';
 import { validateAddress } from '@shared/lib/utils';
 import { RadioOption } from '@shared/ui/RadioGroup/common/types';
 import { DropdownOption, ComboboxOption } from '@shared/ui/Dropdowns/common/types';
-import { filterPvRootAccounts, getPayoutAccountOption } from '../../common/utils';
+import { getDestinationAccounts, getPayoutAccountOption } from '../../common/utils';
 import type { Asset, Address, ChainId, AccountId } from '@shared/core';
 import { RewardsDestination } from '@shared/core';
 import { walletModel, accountUtils } from '@entities/wallet';
@@ -87,9 +87,7 @@ export const OperationForm = ({
   const [activePayout, setActivePayout] = useState<Address>('');
   const [payoutAccounts, setPayoutAccounts] = useState<ComboboxOption<Address>[]>([]);
 
-  const destAccounts = filterPvRootAccounts(dbAccounts, dbWallets).filter((a) =>
-    accountUtils.isChainIdMatch(a, chainId),
-  );
+  const destAccounts = getDestinationAccounts(dbAccounts, dbWallets, chainId);
   const payoutIds = destAccounts.map((a) => a.accountId);
   const balances = useAssetBalances({
     accountIds: payoutIds,


### PR DESCRIPTION
Changes:
- Removed polkadot vault's root account from available options for staking rewards destination