### PR TITLE
Fix: active wallet select after forgetting last wallet

### DIFF
--- a/src/renderer/entities/wallet/model/wallet-model.ts
+++ b/src/renderer/entities/wallet/model/wallet-model.ts
@@ -8,6 +8,7 @@ import { modelUtils } from '../lib/model-utils';
 import { accountUtils } from '../lib/account-utils';
 
 const $wallets = createStore<Wallet[]>([]);
+console.log($wallets.getState());
 const $activeWallet = $wallets.map((wallets) => wallets.find((w) => w.isActive));
 
 const $accounts = createStore<Account[]>([]);
@@ -108,12 +109,12 @@ const walletSelectedFx = createEffect(async ({ prevId, nextId }: SelectParams): 
   }
 
   // TODO: consider using Dexie transaction() | Task --> https://app.clickup.com/t/8692uyemn
-  const [prevWallet, nextWallet] = await Promise.all([
+  const [, nextWallet] = await Promise.all([
     storageService.wallets.update(prevId, { isActive: false }),
     storageService.wallets.update(nextId, { isActive: true }),
   ]);
 
-  return prevWallet && nextWallet ? nextId : undefined;
+  return nextWallet ? nextId : undefined;
 });
 
 const multisigWalletUpdatedFx = createEffect(

--- a/src/renderer/entities/wallet/model/wallet-model.ts
+++ b/src/renderer/entities/wallet/model/wallet-model.ts
@@ -8,7 +8,6 @@ import { modelUtils } from '../lib/model-utils';
 import { accountUtils } from '../lib/account-utils';
 
 const $wallets = createStore<Wallet[]>([]);
-console.log($wallets.getState());
 const $activeWallet = $wallets.map((wallets) => wallets.find((w) => w.isActive));
 
 const $accounts = createStore<Account[]>([]);


### PR DESCRIPTION
Check for updating previously selected wallet in db prevented new wallet from being selected.