### PR TITLE
feat: adding ignore path for pr tests

### DIFF
--- a/.github/workflows/ci_lint.yaml
+++ b/.github/workflows/ci_lint.yaml
@@ -1,0 +1,18 @@
+name: Lint code
+
+on:
+  pull_request:
+
+jobs:
+  lint-and-test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: ⚙️ Install dependencies
+        uses: ./.github/workflows/install-pnpm
+
+      - name: 📝 Check by linter
+        run: pnpm lint

--- a/.github/workflows/ci_lint.yaml
+++ b/.github/workflows/ci_lint.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  lint-and-test:
+  lint:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/pull_request_coverage_report.yaml
+++ b/.github/workflows/pull_request_coverage_report.yaml
@@ -2,16 +2,8 @@ name: Coverage report for pull request
 
 on:
   pull_request:
-    paths-ignore:
-      - '**/*.md'
-      - '**/*.yml'
-      - '**/*.yaml'
-      - '**/*.json'
-      - '**/jest.config.ts'
-      - '.gitignore'
-      - '.github/**'
-      - 'scripts/**'
-      - 'tests/**'
+    paths:
+      - 'src/**'
 
 jobs:
   test-coverage:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -4,7 +4,7 @@ on:
   pull_request:
 
 jobs:
-  lint-and-test:
+  unit-tests:
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -1,4 +1,4 @@
-name: Lint and unit tests
+name: Run unit tests
 
 on:
   pull_request:
@@ -13,9 +13,6 @@ jobs:
 
       - name: ⚙️ Install dependencies
         uses: ./.github/workflows/install-pnpm
-
-      - name: 📝 Check by linter
-        run: pnpm lint
 
       - name: 🧪 Run tests
         run: pnpm test

--- a/jest.config.pr.ts
+++ b/jest.config.pr.ts
@@ -6,6 +6,7 @@ const config: Config = {
   testPathIgnorePatterns: [
     '<rootDir>/src/renderer/entities/.*/ui',
     '<rootDir>/src/renderer/features/.*/ui',
+    '<rootDir>/tests/'
   ],
 };
 

--- a/jest.config.pr.ts
+++ b/jest.config.pr.ts
@@ -1,0 +1,12 @@
+import type { Config } from 'jest';
+import baseConfig from './jest.config.ts'; // import your existing config
+
+const config: Config = {
+  ...baseConfig,
+  testPathIgnorePatterns: [
+    '<rootDir>/src/renderer/entities/.*/ui',
+    '<rootDir>/src/renderer/features/.*/ui',
+  ],
+};
+
+export default config;

--- a/jest.config.pr.ts
+++ b/jest.config.pr.ts
@@ -1,6 +1,6 @@
 import type { Config } from 'jest';
 
-import baseConfig from './jest.config.ts'; // import your existing config
+import baseConfig from './jest.config.ts';
 
 const config: Config = {
   ...baseConfig,

--- a/jest.config.pr.ts
+++ b/jest.config.pr.ts
@@ -1,4 +1,5 @@
 import type { Config } from 'jest';
+
 import baseConfig from './jest.config.ts'; // import your existing config
 
 const config: Config = {
@@ -6,7 +7,7 @@ const config: Config = {
   testPathIgnorePatterns: [
     '<rootDir>/src/renderer/entities/.*/ui',
     '<rootDir>/src/renderer/features/.*/ui',
-    '<rootDir>/tests/'
+    '<rootDir>/tests/',
   ],
 };
 

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "test:dataVerification": "jest --config=tests/integrations/jest.config.ts --group=dataVerification --json --outputFile=jest-results.json",
     "test:matrix": "jest --config=tests/integrations/jest.config.ts --group=matrix --json --outputFile=jest-results.json",
     "test:coverage": "jest --config=jest.config.ts --coverage --passWithNoTests | tee ./coverage.txt",
-    "test:coverage-new-files": "jest --config=jest.config.ts --coverage --changedSince=dev | tee ./coverage.txt",
+    "test:coverage-new-files": "jest --config=jest.config.pr.ts --coverage --changedSince=dev ; exitCode=$? ; echo $exitCode | tee ./coverage.txt ; exit $exitCode",
 
     "lint": "eslint . --ext=js,ts,tsx,json",
     "lint:fix": "pnpm lint --fix",


### PR DESCRIPTION
That PR:
- separate lint run and unit test run in order to start testing early (previous it runs only after linting)
- Fail run if coverage lover than 50%, setup in jest.config file, current is:
```js
coverageThreshold: {
    global: {
      branches: 50,
      functions: 50,
      lines: 50,
      statements: 50,
    },
  },
```

- Added to exclude path for tests:
'<rootDir>/src/renderer/entities/.*/ui',
'<rootDir>/src/renderer/features/.*/ui',
'<rootDir>/tests/',

Tested by:
failed - https://github.com/novasamatech/nova-spektr/actions/runs/7347678612/job/20004505820?pr=1347
<img width="300" alt="Screenshot 2023-12-28 at 15 41 03" src="https://github.com/novasamatech/nova-spektr/assets/40560660/a2afdc3f-5815-4ae1-ac2c-173ef6ccae6e">

success - https://github.com/novasamatech/nova-spektr/actions/runs/7347590966/job/20004275829
<img width="300" alt="Screenshot 2023-12-28 at 15 40 41" src="https://github.com/novasamatech/nova-spektr/assets/40560660/253d01de-ad3d-443d-84d3-ac2a0fd01467">

Can't merge on failure:
<img width="300" alt="Screenshot 2023-12-28 at 15 42 00" src="https://github.com/novasamatech/nova-spektr/assets/40560660/d745b055-b725-4a55-8a60-251e17cdd243">
