### PR TITLE
Feat: remove delegated wallets on wallet forget

### DIFF
--- a/src/renderer/features/wallets/ForgetWallet/index.ts
+++ b/src/renderer/features/wallets/ForgetWallet/index.ts
@@ -1,1 +1,2 @@
+export { forgetWalletModel } from './model/forget-wallet-model';
 export { ForgetWalletModal } from './ui/ForgetWalletModal';

--- a/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
@@ -80,9 +80,6 @@ const proxiedWallet = {
 };
 
 describe('features/ForgetModel', () => {
-  beforeEach(() => {
-    global.TextEncoder = TextEncoder;
-  });
   test('should call success calback after wallet delete', async () => {
     const spyCallback = jest.fn();
     storageService.wallets.delete = jest.fn();

--- a/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
@@ -112,7 +112,7 @@ describe('features/ForgetModel', () => {
     await allSettled(forgetWalletModel.events.callbacksChanged, { scope, params: { onDeleteFinished: () => {} } });
     await allSettled(forgetWalletModel.events.forgetWallet, { scope, params: wallet });
 
-    expect(spyDeleteWallet).toBeCalledWith(2);
+    expect(spyDeleteWallet).toBeCalledWith(1);
     expect(spyDeleteAccounts).toBeCalledWith([1, 2]);
   });
 

--- a/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
@@ -1,5 +1,5 @@
 import { allSettled, fork } from 'effector';
-import { TextEncoder } from 'node:util';
+
 
 import {
   Account,

--- a/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/__tests__/forget-wallet-model.test.ts
@@ -1,6 +1,5 @@
 import { allSettled, fork } from 'effector';
 
-
 import {
   Account,
   AccountType,
@@ -80,6 +79,10 @@ const proxiedWallet = {
 };
 
 describe('features/ForgetModel', () => {
+  beforeEach(() => {
+    jest.restoreAllMocks();
+  });
+
   test('should call success calback after wallet delete', async () => {
     const spyCallback = jest.fn();
     storageService.wallets.delete = jest.fn();
@@ -114,8 +117,8 @@ describe('features/ForgetModel', () => {
   });
 
   test('should delete proxied accounts, wallets and proxyGroups', async () => {
-    storageService.proxies.deleteAll = (ids: number[]) => new Promise((resolve) => resolve(ids));
-    storageService.proxyGroups.deleteAll = (ids: number[]) => new Promise((resolve) => resolve(ids));
+    jest.spyOn(storageService.proxies, 'deleteAll').mockResolvedValue([1]);
+    jest.spyOn(storageService.proxyGroups, 'deleteAll').mockResolvedValue([1]);
 
     const scope = fork({
       values: new Map()

--- a/src/renderer/features/wallets/ForgetWallet/model/forget-wallet-model.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/forget-wallet-model.ts
@@ -7,7 +7,6 @@ import { accountUtils, walletModel, walletUtils } from '@entities/wallet';
 import { balanceModel } from '@entities/balance';
 import { useForgetMultisig } from '@entities/multisig';
 import { proxyModel } from '@entities/proxy';
-import { wcDetailsModel } from '@widgets/WalletDetails/model/wc-details-model';
 
 const { deleteMultisigTxs } = useForgetMultisig();
 
@@ -15,14 +14,15 @@ export type Callbacks = {
   onDeleteFinished: () => void;
 };
 
+const forgetWallet = createEvent<Wallet>();
+const forgetSimpleWallet = createEvent<Wallet>();
+const forgetMultisigWallet = createEvent<Wallet>();
+const forgetWcWallet = createEvent<Wallet>();
+
 const $callbacks = createStore<Callbacks | null>(null);
 const callbacksApi = createApi($callbacks, {
   callbacksChanged: (state, props: Callbacks) => ({ ...state, ...props }),
 });
-
-const forgetWallet = createEvent<Wallet>();
-const forgetSimpleWallet = createEvent<Wallet>();
-const forgetMultisigWallet = createEvent<Wallet>();
 
 const deleteMultisigOperationsFx = createEffect(async (account: MultisigAccount): Promise<void> => {
   try {
@@ -83,7 +83,7 @@ split({
 });
 
 sample({
-  clock: [forgetWallet, wcDetailsModel.events.forgetButtonClicked],
+  clock: [forgetWallet, forgetWcWallet],
   source: {
     accounts: walletModel.$accounts,
     proxies: proxyModel.$proxies,
@@ -137,6 +137,7 @@ sample({
 export const forgetWalletModel = {
   events: {
     forgetWallet,
+    forgetWcWallet,
     callbacksChanged: callbacksApi.callbacksChanged,
   },
 };

--- a/src/renderer/widgets/WalletDetails/ui/wallets/WalletConnectDetails.tsx
+++ b/src/renderer/widgets/WalletDetails/ui/wallets/WalletConnectDetails.tsx
@@ -28,7 +28,7 @@ import { ProxiesList } from '../components/ProxiesList';
 import { walletProviderModel } from '../../model/wallet-provider-model';
 import { NoProxiesAction } from '../components/NoProxiesAction';
 import { WalletConnectAccounts } from '../components/WalletConnectAccounts';
-import { forgetWalletModel } from "@features/wallets/ForgetWallet";
+import { forgetWalletModel } from '@features/wallets/ForgetWallet';
 
 type Props = {
   wallet: WalletConnectWallet;

--- a/src/renderer/widgets/WalletDetails/ui/wallets/WalletConnectDetails.tsx
+++ b/src/renderer/widgets/WalletDetails/ui/wallets/WalletConnectDetails.tsx
@@ -28,6 +28,7 @@ import { ProxiesList } from '../components/ProxiesList';
 import { walletProviderModel } from '../../model/wallet-provider-model';
 import { NoProxiesAction } from '../components/NoProxiesAction';
 import { WalletConnectAccounts } from '../components/WalletConnectAccounts';
+import { forgetWalletModel } from "@features/wallets/ForgetWallet";
 
 type Props = {
   wallet: WalletConnectWallet;
@@ -59,6 +60,7 @@ export const WalletConnectDetails = ({ wallet, accounts, onClose }: Props) => {
 
   const handleForgetWallet = () => {
     wcDetailsModel.events.forgetButtonClicked(wallet);
+    forgetWalletModel.events.forgetWcWallet(wallet);
     toggleConfirmForget();
   };
 


### PR DESCRIPTION
## Changes:
- Updated `forget-wallet-model` to remove delegated wallets and accounts, proxies and proxyGroups connected to forgotten wallet