### PR TITLE
fix: ignore old matrix rooms

### DIFF
--- a/src/renderer/app/providers/context/MatrixContext/MatrixContext.tsx
+++ b/src/renderer/app/providers/context/MatrixContext/MatrixContext.tsx
@@ -213,12 +213,12 @@ export const MatrixProvider = ({ children }: PropsWithChildren) => {
     }
   };
 
-  const onMultisigEvent = async ({ type, content, sender }: MultisigPayload, extras: SpektrExtras) => {
+  const onMultisigEvent = async ({ type, content, sender }: MultisigPayload, extras: SpektrExtras | undefined) => {
     console.info('🚀 === onMultisigEvent - ', type, '\n Content: ', content);
 
     if (!validateMatrixEvent(content, extras)) return;
 
-    const multisigAccount = accountsRef.current.find((a) => a.accountId === extras.mstAccount.accountId);
+    const multisigAccount = accountsRef.current.find((a) => a.accountId === extras?.mstAccount.accountId);
     if (!multisigAccount || !accountUtils.isMultisigAccount(multisigAccount)) return;
 
     const multisigTx = await getMultisigTx(
@@ -245,8 +245,10 @@ export const MatrixProvider = ({ children }: PropsWithChildren) => {
 
   const validateMatrixEvent = <T extends BaseMultisigPayload>(
     { callData, callHash, senderAccountId }: T,
-    extras: SpektrExtras,
+    extras: SpektrExtras | undefined,
   ): boolean => {
+    if (!extras) return false;
+
     const { accountId, threshold, signatories } = extras.mstAccount;
     const senderIsSignatory = signatories.some((accountId) => accountId === senderAccountId);
     const mstAccountIsValid = accountId === accountUtils.getMultisigAccountId(signatories, threshold);

--- a/src/renderer/shared/api/matrix/lib/types.ts
+++ b/src/renderer/shared/api/matrix/lib/types.ts
@@ -196,7 +196,7 @@ type GeneralCallbacks = {
 };
 
 export type MultisigCallbacks = {
-  onMultisigEvent: (payload: MultisigPayload, extras: SpektrExtras) => Promise<void>;
+  onMultisigEvent: (payload: MultisigPayload, extras: SpektrExtras | undefined) => Promise<void>;
 };
 
 export type Callbacks = GeneralCallbacks & MultisigCallbacks;

--- a/src/renderer/shared/api/matrix/service/matrix.ts
+++ b/src/renderer/shared/api/matrix/service/matrix.ts
@@ -1002,7 +1002,7 @@ export class Matrix implements ISecureMessenger {
    * @param room the room itself
    * @return {Object}
    */
-  private getSpektrTopic(room: Room): SpektrExtras {
+  private getSpektrTopic(room: Room): SpektrExtras | undefined {
     // on invite user only sees stripped state, which has '' as state key for all events
     const strippedStateKey = '';
 

--- a/src/renderer/shared/api/matrix/service/matrix.ts
+++ b/src/renderer/shared/api/matrix/service/matrix.ts
@@ -407,7 +407,7 @@ export class Matrix implements ISecureMessenger {
       const isJoinedRoom = room.getMyMembership() === Membership.JOIN;
       if (!isSpektrRoom || !isJoinedRoom) return false;
 
-      return !accountId || this.getSpektrTopic(room).mstAccount.accountId === accountId;
+      return !accountId || this.getSpektrTopic(room)?.mstAccount?.accountId === accountId;
     });
   }
 


### PR DESCRIPTION
* add optional chaining for checking spektr topik data in matrix rooms 