### PR TITLE
fix: correct proxied accounts to remove

### DIFF
--- a/src/renderer/features/proxies/workers/proxy-worker.ts
+++ b/src/renderer/features/proxies/workers/proxy-worker.ts
@@ -221,7 +221,6 @@ async function getProxies({
         ep.accountId === p.accountId &&
         ep.chainId === p.chainId &&
         ep.proxyAccountId === p.proxyAccountId &&
-        ep.proxyVariant === p.proxyVariant &&
         ep.delay === p.delay &&
         ep.proxyType === p.proxyType,
     );


### PR DESCRIPTION
* don't check proxy variant when check proxied accounts to remove, because we don't get it yet