### PR TITLE
fix: remove coverage report

### DIFF
--- a/.github/workflows/pull_request_coverage_report.yaml
+++ b/.github/workflows/pull_request_coverage_report.yaml
@@ -1,9 +1,11 @@
 name: Coverage report for pull request
 
 on:
-  pull_request:
-    paths:
-      - 'src/**'
+  # Temporary remove coverage tests for PRs
+  # pull_request:
+  #   paths:
+  #     - 'src/**'
+  workflow_dispatch:
 
 jobs:
   test-coverage:


### PR DESCRIPTION
Since it's being ignored, I suggest removing it so as not to keep the workflow red all the time