### PR TITLE
Improve proxy-worker performance

### DIFF
--- a/src/renderer/features/proxies/workers/__tests__/proxy-worker.test.ts
+++ b/src/renderer/features/proxies/workers/__tests__/proxy-worker.test.ts
@@ -121,28 +121,26 @@ describe('features/proxies/workers/proxy-worker', () => {
       proxyType: 'Governance',
     };
 
-    set(state.apis, '0x01.query.proxy.proxies.keys', () => [
-      {
-        args: [
-          {
-            toHex: () => newProxy.proxiedAccountId,
-          },
-        ],
-      },
-    ]);
-    set(state.apis, '0x01.rpc.state.queryStorageAt', () => [
+    set(state.apis, '0x01.query.proxy.proxies.entries', () => [
       [
         {
-          toHuman: () => [
+          args: [
             {
-              delegate: newProxy.accountId,
-              proxyType: newProxy.proxyType,
-              delay: newProxy.delay,
+              toHex: () => newProxy.proxiedAccountId,
             },
           ],
         },
         {
-          toHuman: () => '1,002,050,000,000',
+          toHuman: () => [
+            [
+              {
+                delegate: newProxy.accountId,
+                proxyType: newProxy.proxyType,
+                delay: newProxy.delay,
+              },
+            ],
+            '1,002,050,000,000',
+          ],
         },
       ],
     ]);
@@ -326,28 +324,26 @@ describe('features/proxies/workers/proxy-worker', () => {
       proxyVariant: ProxyVariant.NONE,
     };
 
-    set(state.apis, '0x01.query.proxy.proxies.keys', () => [
-      {
-        args: [
-          {
-            toHex: () => '0x02',
-          },
-        ],
-      },
-    ]);
-    set(state.apis, '0x01.rpc.state.queryStorageAt', () => [
+    set(state.apis, '0x01.query.proxy.proxies.entries', () => [
       [
         {
-          toHuman: () => [
+          args: [
             {
-              delegate: '0x01',
-              proxyType: 'Governance',
-              delay: 0,
+              toHex: () => '0x02',
             },
           ],
         },
         {
-          toHuman: () => '1,002,050,000,000',
+          toHuman: () => [
+            [
+              {
+                delegate: '0x01',
+                proxyType: 'Governance',
+                delay: 0,
+              },
+            ],
+            '1,002,050,000,000',
+          ],
         },
       ],
     ]);

--- a/src/renderer/features/proxies/workers/proxy-worker.ts
+++ b/src/renderer/features/proxies/workers/proxy-worker.ts
@@ -204,7 +204,6 @@ async function getProxies({
         console.log(`proxy-worker ${api.genesisHash}: proxy error`, e);
       }
     });
-
   } catch (e) {
     console.log(`proxy-worker ${api.genesisHash}: error in getProxies`, e);
   }

--- a/src/renderer/features/proxies/workers/proxy-worker.ts
+++ b/src/renderer/features/proxies/workers/proxy-worker.ts
@@ -129,15 +129,13 @@ async function getProxies({
   }
 
   try {
-    const keys = await api.query.proxy.proxies.keys();
-
-    const proxiesRequests = keys.map(async (key) => {
+    const entries = await api.query.proxy.proxies.entries();
+    entries.forEach(([key, value]) => {
       try {
-        const proxyData = (await api.rpc.state.queryStorageAt([key])) as any;
-
+        const proxyData = value.toHuman() as any;
         const proxiedAccountId = key.args[0].toHex();
 
-        proxyData[0][0].toHuman().forEach((account: any) => {
+        proxyData[0].forEach((account: any) => {
           const newProxy: NoID<ProxyAccount> = {
             chainId,
             proxiedAccountId,
@@ -171,11 +169,11 @@ async function getProxies({
           }
 
           if (needToAddProxiedAccount) {
-            deposits.deposits[proxiedAccountId] = proxyData[0][1].toHuman();
+            deposits.deposits[proxiedAccountId] = proxyData[1];
           }
         });
 
-        proxyData[0][0].toHuman().forEach((account: any) => {
+        proxyData[0].forEach((account: any) => {
           const newProxy: NoID<ProxyAccount> = {
             chainId,
             proxiedAccountId,
@@ -199,7 +197,7 @@ async function getProxies({
           }
 
           if (needToAddProxyAccount) {
-            deposits.deposits[proxiedAccountId] = proxyData[0][1].toHuman();
+            deposits.deposits[proxiedAccountId] = proxyData[1];
           }
         });
       } catch (e) {
@@ -207,7 +205,6 @@ async function getProxies({
       }
     });
 
-    await Promise.all(proxiesRequests);
   } catch (e) {
     console.log(`proxy-worker ${api.genesisHash}: error in getProxies`, e);
   }


### PR DESCRIPTION
That PR change logic for proxy-worker in network interaction. That use [entries](https://polkadot.js.org/docs/api/start/api.query.other#map-keys--entries) to receive data from the network.


Found a problem with number of messages, sent by worker's wss connection:

It's an initialisation of one worker - 1711 storage queries:
<img width="300" alt="Screenshot 2024-04-22 at 17 20 10" src="https://github.com/novasamatech/nova-spektr/assets/40560660/4cec0359-ba9c-4dea-a786-22b99868b30b">

The same worker with entries - 16 requests, by 1000 entities and pagination 
<img width="300" alt="Screenshot 2024-04-22 at 17 38 52" src="https://github.com/novasamatech/nova-spektr/assets/40560660/026d487f-ef75-4a3e-b3ac-9f36b4f9c74a">


<details>
  <summary>Some measures</summary>

approach with keys:
<img width="300" alt="dev" src="https://github.com/novasamatech/nova-spektr/assets/40560660/586ae0ee-5541-4699-ac5f-5bf46246d7c6">

approach with entries:
<img width="300" alt="entries" src="https://github.com/novasamatech/nova-spektr/assets/40560660/ec6ad136-009b-4549-84cf-78c7a95e517a">

</details>