### PR TITLE
fix: correct create pure proxy wallet

### DIFF
--- a/src/renderer/features/proxies/model/proxies-model.ts
+++ b/src/renderer/features/proxies/model/proxies-model.ts
@@ -315,7 +315,8 @@ sample({
   filter: (_, data) => Boolean(data && data.wallets.length && data.accounts.length),
   fn: (wallets, data) => {
     const accountsMap = dictionary(data.accounts, 'walletId');
-    const newWallets = data.wallets.map((wallet) => ({ ...wallet, accounts: accountsMap[wallet.id] } as Wallet));
+
+    const newWallets = data.wallets.map((wallet) => ({ ...wallet, accounts: [accountsMap[wallet.id]] } as Wallet));
 
     return wallets.concat(newWallets);
   },


### PR DESCRIPTION
* use array for accounts when create pure proxied 

Fixed bug: wallet details for new pure proxied doesn't opened after creation until app will be restarted