### PR TITLE
fix: changed labels for accounts and wallets on confirmation screens

### DIFF
--- a/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
@@ -49,7 +49,7 @@ export const Confirmation = ({ onGoBack, secondaryActionButton, hideSignButton }
               <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('transfer.senderAccount')}>
+            <DetailRow label={t('transfer.senderProxiedAccount')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
@@ -43,7 +43,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
               <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('transfer.senderAccount')}>
+            <DetailRow label={t('transfer.senderProxiedAccount')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
@@ -69,7 +69,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
@@ -72,7 +72,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Nominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Nominate/ui/Confirmation.tsx
@@ -56,7 +56,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Payee/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Payee/ui/Confirmation.tsx
@@ -55,7 +55,7 @@ export const Confirmation = ({ onGoBack, secondaryActionButton, hideSignButton }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
@@ -48,7 +48,7 @@ export const Confirmation = ({ onGoBack, secondaryActionButton, hideSignButton }
               <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('transfer.senderAccount')}>
+            <DetailRow label={t('transfer.senderProxiedAccount')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain!.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/RemovePureProxied/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/RemovePureProxied/ui/Confirmation.tsx
@@ -49,7 +49,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
               <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('transfer.senderAccount')}>
+            <DetailRow label={t('transfer.senderProxiedAccount')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain!.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
@@ -58,7 +58,7 @@ export const Confirmation = ({ onGoBack, secondaryActionButton, hideSignButton }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
@@ -56,7 +56,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
               <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('transfer.senderAccount')}>
+            <DetailRow label={t('transfer.senderProxiedAccount')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
@@ -94,7 +94,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
               <FootnoteText className="pr-2">{initiatorWallet.name}</FootnoteText>
             </DetailRow>
 
-            <DetailRow label={t('proxy.details.account')}>
+            <DetailRow label={t('proxy.details.sender')}>
               <AddressWithExplorers
                 type="short"
                 explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
@@ -60,7 +60,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
@@ -58,7 +58,7 @@ export const Confirmation = ({ secondaryActionButton, hideSignButton, onGoBack }
                 <FootnoteText className="pr-2">{proxiedWallet.name}</FootnoteText>
               </DetailRow>
 
-              <DetailRow label={t('transfer.senderAccount')}>
+              <DetailRow label={t('transfer.senderProxiedAccount')}>
                 <AddressWithExplorers
                   type="short"
                   explorers={confirmStore.chain.explorers}

--- a/src/renderer/shared/api/translation/locales/en.json
+++ b/src/renderer/shared/api/translation/locales/en.json
@@ -682,12 +682,12 @@
     "details": {
       "accessType": "Access type",
       "account": "Account",
-      "sender": "Sender",
       "accountProxied": "Account (proxied)",
       "delegateTo": "Delegate to",
       "grantAccessType": "Grant access type",
       "revokeAccessType": "Revoke access type",
       "revokeFor": "Revoke for",
+      "sender": "Sender",
       "signatory": "Signatory",
       "wallet": "Wallet",
       "walletProxied": "Wallet (proxied)"
@@ -1165,8 +1165,8 @@
     "requiredDescriptionError": "Description is required",
     "requiredRecipientError": "Please enter recipient address",
     "senderAccount": "Sender account",
-    "senderProxiedAccount": "Account (proxied)",
     "senderLabel": "Sender",
+    "senderProxiedAccount": "Account (proxied)",
     "senderProxiedWallet": "Wallet (proxied)",
     "signatoryLabel": "Signatory",
     "signingAccount": "Signing account",

--- a/src/renderer/shared/api/translation/locales/en.json
+++ b/src/renderer/shared/api/translation/locales/en.json
@@ -659,7 +659,7 @@
   },
   "proxy": {
     "addProxy": {
-      "accountLabel": "Your account",
+      "accountLabel": "Account",
       "accountPlaceholder": "Select account",
       "balanceAlertMultisig": "To pay proxy deposit with selected account",
       "balanceAlertRegular": "To pay proxy deposit and network fee with selected account",
@@ -681,14 +681,15 @@
     },
     "details": {
       "accessType": "Access type",
-      "account": "Your account",
+      "account": "Account",
+      "sender": "Sender",
       "accountProxied": "Account (proxied)",
       "delegateTo": "Delegate to",
       "grantAccessType": "Grant access type",
       "revokeAccessType": "Revoke access type",
       "revokeFor": "Revoke for",
       "signatory": "Signatory",
-      "wallet": "Your wallet",
+      "wallet": "Wallet",
       "walletProxied": "Wallet (proxied)"
     },
     "names": {
@@ -1164,8 +1165,9 @@
     "requiredDescriptionError": "Description is required",
     "requiredRecipientError": "Please enter recipient address",
     "senderAccount": "Sender account",
+    "senderProxiedAccount": "Account (proxied)",
     "senderLabel": "Sender",
-    "senderProxiedWallet": "Sender wallet (proxied)",
+    "senderProxiedWallet": "Wallet (proxied)",
     "signatoryLabel": "Signatory",
     "signingAccount": "Signing account",
     "signingWallet": "Signing wallet",


### PR DESCRIPTION
Changed some inconsistent translations on confirmation screens, mainly for wallets and accounts.