### PR TITLE
fix: remove symbol from vote history

### DIFF
--- a/src/renderer/shared/api/translation/locales/en.json
+++ b/src/renderer/shared/api/translation/locales/en.json
@@ -451,7 +451,7 @@
       "listColumnVotingPower": "Voting power",
       "listEmptyState": "No one voted here",
       "title": "Vote history",
-      "totalVotesCount": "{value} votes {symbol}",
+      "totalVotesCount": "{value} votes",
       "totalVotesCountConviction": "{value} × {conviction}",
       "viewVoteHistory": "View vote history"
     },


### PR DESCRIPTION
Before:
<img width="1136" alt="Screenshot 2024-08-06 at 13 38 05" src="https://github.com/user-attachments/assets/43d26138-5b0c-45e8-9797-52875af75c31">

After:
<img width="1464" alt="Screenshot 2024-08-06 at 13 51 03" src="https://github.com/user-attachments/assets/b9469ab7-8983-4f69-a2b5-fa60e2d76d45">
