### PR TITLE
Fix: Desktop layout

### DIFF
--- a/src/renderer/features/governance/components/ReferendumDetails/ReferendumDetailsDialog.tsx
+++ b/src/renderer/features/governance/components/ReferendumDetails/ReferendumDetailsDialog.tsx
@@ -65,7 +65,7 @@ export const ReferendumDetailsDialog = ({ chain, referendum, onVoteRequest, onCl
       isOpen={isModalOpen}
       title={title || t('governance.referendums.referendumTitle', { index: referendum.referendumId })}
       contentClass="min-h-0 h-full w-full bg-main-app-background overflow-y-auto"
-      panelClass="flex flex-col w-[944px] h-[678px]"
+      panelClass="flex flex-col w-[954px] h-[678px]"
       headerClass="pl-5 pr-3 py-4 shrink-0"
       closeButton
       onClose={closeModal}


### PR DESCRIPTION
closes #2045

Chromium based browsers have a different behavior than Firefox with the scrollbars. Adding 10px to the wrapping container fixed the issue. I tested on Firefox too.

![image](https://github.com/user-attachments/assets/bc3bc3a5-e30b-400d-b529-eaa078022aba)
