### PR TITLE
chore: added restriction for using cnTw with single string argument

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -283,7 +283,7 @@ module.exports = {
           // },
           {
             message: 'Unnecessary cnTw usage, use simple string instead.',
-            selector: 'CallExpression[callee.name="cnTw"][arguments.length=1][arguments.0.type=\'Literal\']',
+            selector: 'CallExpression[callee.name="cnTw"][arguments.length=1][arguments.0.type="Literal"]',
           },
         ],
 

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -281,6 +281,10 @@ module.exports = {
           //   selector:
           //     'CallExpression:has(MemberExpression:has([property.name="forEach"])):has([arguments.0.type="ArrowFunctionExpression"])',
           // },
+          {
+            message: 'Unnecessary cnTw usage, use simple string instead.',
+            selector: 'CallExpression[callee.name="cnTw"][arguments.length=1][arguments.0.type=\'Literal\']',
+          },
         ],
 
         // TODO remove after no-restricted-syntax for for..of will be enabled

--- a/src/renderer/entities/wallet/ui/Cards/WalletCardSm.tsx
+++ b/src/renderer/entities/wallet/ui/Cards/WalletCardSm.tsx
@@ -42,7 +42,7 @@ export const WalletCardSm = ({ wallet, className, iconSize = 16, onClick, onInfo
           {wallet.name}
         </FootnoteText>
       </button>
-      <IconButton className={cnTw('absolute right-2')} name="details" size={16} onClick={handleClick(onInfoClick)} />
+      <IconButton className="absolute right-2" name="details" size={16} onClick={handleClick(onInfoClick)} />
     </div>
   );
 };

--- a/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 
 import { useI18n } from '@app/providers';
 import { useToggle } from '@shared/lib/hooks';
-import { cnTw, formatAmount } from '@shared/lib/utils';
+import { formatAmount } from '@shared/lib/utils';
 import { Button, CaptionText, DetailRow, FootnoteText, Icon, Tooltip } from '@shared/ui';
 import { AssetBalance } from '@entities/asset';
 import { SignButton } from '@entities/operations';
@@ -70,7 +70,7 @@ export const Confirmation = ({
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="stakeMoreConfirm" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={amountValue}
               asset={confirmStore.asset}

--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
@@ -3,7 +3,7 @@ import { type ReactNode } from 'react';
 
 import { useI18n } from '@app/providers';
 import { useToggle } from '@shared/lib/hooks';
-import { cnTw, formatAmount } from '@shared/lib/utils';
+import { formatAmount } from '@shared/lib/utils';
 import { Button, CaptionText, DetailRow, FootnoteText, Icon, Tooltip } from '@shared/ui';
 import { AssetBalance } from '@entities/asset';
 import { SignButton } from '@entities/operations';
@@ -83,7 +83,7 @@ export const Confirmation = ({
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="startStakingConfirm" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={amountValue}
               asset={confirmStore.asset}

--- a/src/renderer/features/operations/OperationsConfirm/Delegate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Delegate/ui/Confirmation.tsx
@@ -4,7 +4,7 @@ import { type ReactNode } from 'react';
 import { Trans } from 'react-i18next';
 
 import { useI18n } from '@app/providers';
-import { cnTw, formatAmount } from '@shared/lib/utils';
+import { formatAmount } from '@shared/lib/utils';
 import { Button, CaptionText, DetailRow, FootnoteText, HeadlineText, Icon, LargeTitleText, Tooltip } from '@shared/ui';
 import { LockPeriodDiff, ValueIndicator, votingService } from '@/entities/governance';
 import { AssetBalance } from '@entities/asset';
@@ -76,7 +76,7 @@ export const Confirmation = ({
       <div className="mb-2 flex flex-col items-center gap-y-3">
         <Icon className="text-icon-default" name="addDelegationConfirm" size={60} />
 
-        <div className={cnTw('flex flex-col items-center gap-y-1')}>
+        <div className="flex flex-col items-center gap-y-1">
           <LargeTitleText>
             <Trans
               t={t}

--- a/src/renderer/features/operations/OperationsConfirm/Referendum/Vote/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Referendum/Vote/ui/Confirmation.tsx
@@ -3,7 +3,7 @@ import { useStoreMap, useUnit } from 'effector-react';
 import { type ReactNode } from 'react';
 
 import { useI18n } from '@/app/providers';
-import { cnTw, formatAsset } from '@/shared/lib/utils';
+import { formatAsset } from '@/shared/lib/utils';
 import { Button, DetailRow, HeadlineText, Icon } from '@/shared/ui';
 import { AssetBalance } from '@/entities/asset';
 import { BalanceDiff, LockPeriodDiff, voteTransactionService, votingService } from '@/entities/governance';
@@ -52,7 +52,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
       <div className="mb-2 flex flex-col items-center gap-y-3">
         <Icon className="text-icon-default" name="voteMst" size={60} />
 
-        <div className={cnTw('flex flex-col items-center gap-y-1')}>
+        <div className="flex flex-col items-center gap-y-1">
           <AssetBalance
             value={votingService.calculateVotingPower(amount, conviction)}
             asset={confirm.meta.asset}

--- a/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
@@ -58,7 +58,7 @@ export const Confirmation = ({ id = 0, onGoBack, secondaryActionButton, hideSign
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="returnToStakeConfirm" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={confirmStore.amount}
               asset={confirmStore.asset}

--- a/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
@@ -2,7 +2,6 @@ import { useStoreMap } from 'effector-react';
 import { type ReactNode } from 'react';
 
 import { useI18n } from '@app/providers';
-import { cnTw } from '@shared/lib/utils';
 import { Button, DetailRow, FootnoteText, Icon, Tooltip } from '@shared/ui';
 import { AssetBalance } from '@entities/asset';
 import { ChainTitle } from '@entities/chain';
@@ -60,7 +59,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
       <div className="mb-2 flex flex-col items-center gap-y-3">
         <Icon className="text-icon-default" name={isXcm ? 'crossChainConfirm' : 'transferConfirm'} size={60} />
 
-        <div className={cnTw('flex flex-col items-center gap-y-1')}>
+        <div className="flex flex-col items-center gap-y-1">
           <AssetBalance
             value={confirmStore.amount}
             asset={confirmStore.asset}

--- a/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
@@ -64,7 +64,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="unstakeConfirm" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={confirmStore.amount}
               asset={confirmStore.asset}

--- a/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
@@ -58,7 +58,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="redeemConfirm" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={confirmStore.amount}
               asset={confirmStore.asset}

--- a/src/renderer/pages/Operations/components/TransactionAmount.tsx
+++ b/src/renderer/pages/Operations/components/TransactionAmount.tsx
@@ -19,7 +19,7 @@ export const TransactionAmount = ({ tx, className }: Props) => {
   }
 
   return (
-    <div className={cnTw('flex flex-col items-center gap-y-1')}>
+    <div className="flex flex-col items-center gap-y-1">
       <AssetBalance
         value={value}
         asset={asset}

--- a/src/renderer/shared/ui/Slider/Slider.tsx
+++ b/src/renderer/shared/ui/Slider/Slider.tsx
@@ -100,7 +100,7 @@ export const Slider = memo(
               minStepsBetweenThumbs={1}
               onValueChange={handleChange}
             >
-              <RadixSlider.Track className={cnTw('relative block h-2 w-full bg-icon-blue-line')}>
+              <RadixSlider.Track className="relative block h-2 w-full bg-icon-blue-line">
                 <RadixSlider.Range className="absolute block h-full bg-primary-button-background-default ps-2" />
               </RadixSlider.Track>
 

--- a/src/renderer/widgets/CreateWallet/ui/MultisigWallet/components/ConfirmSignatories.tsx
+++ b/src/renderer/widgets/CreateWallet/ui/MultisigWallet/components/ConfirmSignatories.tsx
@@ -1,6 +1,6 @@
 import { useI18n } from '@app/providers';
 import { type Chain, WalletType } from '@shared/core';
-import { RootExplorers, cnTw } from '@shared/lib/utils';
+import { RootExplorers } from '@shared/lib/utils';
 import { FootnoteText, HelpText, SmallTitleText } from '@shared/ui';
 import { ContactItem, ExplorersPopover } from '@entities/wallet';
 import { type ExtendedAccount, type ExtendedContact, type ExtendedWallet } from '../common/types';
@@ -20,7 +20,7 @@ export const ConfirmSignatories = ({ chain, wallets = [], accounts = [], contact
   const explorers = chain ? chain.explorers : RootExplorers;
 
   return (
-    <div className={cnTw('flex max-h-full flex-1 flex-col')}>
+    <div className="flex max-h-full flex-1 flex-col">
       <SmallTitleText className="mb-4 py-2">{t('createMultisigAccount.selectedSignatoriesTitle')}</SmallTitleText>
 
       <div className="flex flex-1 flex-col gap-y-2 overflow-y-auto">

--- a/src/renderer/widgets/UnlockModal/ui/UnlockConfirmation.tsx
+++ b/src/renderer/widgets/UnlockModal/ui/UnlockConfirmation.tsx
@@ -67,7 +67,7 @@ export const UnlockConfirmation = ({ id = 0, hideSignButton, secondaryActionButt
         <div className="mb-2 flex flex-col items-center gap-y-3">
           <Icon className="text-icon-default" name="unlockMst" size={60} />
 
-          <div className={cnTw('flex flex-col items-center gap-y-1')}>
+          <div className="flex flex-col items-center gap-y-1">
             <AssetBalance
               value={amount}
               asset={asset}


### PR DESCRIPTION
Now expressions like `cnTw('absolute flex')` are restricted