### PR TITLE
Fix: custom delegation checks and prefix in delegate address

### DIFF
--- a/src/renderer/features/governance/components/Delegations/DelegateTitle.tsx
+++ b/src/renderer/features/governance/components/Delegations/DelegateTitle.tsx
@@ -1,7 +1,10 @@
+import { useUnit } from 'effector-react';
+
 import { type DelegateAccount } from '@/shared/api/governance';
 import { cnTw } from '@/shared/lib/utils';
 import { HeadlineText, IconButton, Truncate } from '@/shared/ui';
 import { ExplorersPopover } from '@/entities/wallet';
+import { networkSelectorModel } from '../../model/networkSelector';
 
 type Props = {
   delegate: DelegateAccount;
@@ -9,6 +12,8 @@ type Props = {
 };
 
 export const DelegateTitle = ({ delegate, className }: Props) => {
+  const chain = useUnit(networkSelectorModel.$governanceChain);
+
   const delegateTitle = delegate.name || <Truncate ellipsis="..." start={4} end={4} text={delegate.accountId} />;
 
   return (
@@ -21,6 +26,7 @@ export const DelegateTitle = ({ delegate, className }: Props) => {
               contextClassName="left-0"
               button={<IconButton className="ml-2 flex" name="info" />}
               address={delegate.address}
+              addressPrefix={chain?.addressPrefix}
             />
           </span>
         )}

--- a/src/renderer/widgets/DelegationModal/model/delegation-model.ts
+++ b/src/renderer/widgets/DelegationModal/model/delegation-model.ts
@@ -5,7 +5,7 @@ import { readonly } from 'patronum';
 
 import { type DelegateAccount } from '@/shared/api/governance';
 import { type Address } from '@/shared/core';
-import { Step, includesMultiple, toAccountId, toAddress, validateAddress } from '@/shared/lib/utils';
+import { Step, includesMultiple, toAccountId, validateAddress } from '@/shared/lib/utils';
 import { votingService } from '@/entities/governance';
 import { walletModel } from '@/entities/wallet';
 import {
@@ -92,15 +92,11 @@ const $customError = combine(
   ({ delegate, votes, wallet, chain }): DelegationErrors | null => {
     if (!wallet || !chain || !delegate || !validateAddress(delegate)) return DelegationErrors.INVALID_ADDRESS;
 
-    const isSameAccount = wallet.accounts.some((a) => a.accountId === toAccountId(delegate));
+    const isOwnAccount = wallet.accounts.some((a) => a.accountId === toAccountId(delegate));
 
-    if (isSameAccount) return DelegationErrors.YOUR_ACCOUNT;
+    if (isOwnAccount) return DelegationErrors.YOUR_ACCOUNT;
 
-    const delegations = delegate && votes[delegate] ? Object.keys(votes[delegate]) : [];
-
-    const isAlreadyDelegated = wallet.accounts.every((a) =>
-      delegations.some((d) => d === toAddress(a.accountId, { prefix: chain.addressPrefix })),
-    );
+    const isAlreadyDelegated = Object.keys(votes).some((v) => toAccountId(v) === toAccountId(delegate));
 
     if (isAlreadyDelegated) return DelegationErrors.ALREADY_DELEGATED;
 


### PR DESCRIPTION
closes #2100

It also solves the address encoding in the explorer menu
![image](https://github.com/user-attachments/assets/cb15504f-0c1c-42e3-b39a-02d5c3adf3d7)
![image](https://github.com/user-attachments/assets/d4bbc3ea-71f9-4751-af92-ee09bb82f651)
