### PR TITLE
refector: referendums zod migration

### DIFF
--- a/src/renderer/entities/governance/lib/__tests__/claimScheduleService.test.ts
+++ b/src/renderer/entities/governance/lib/__tests__/claimScheduleService.test.ts
@@ -10,12 +10,11 @@ import {
   type TrackInfo,
   type Voting,
 } from '@/shared/core';
-import { ReferendumType } from '@/shared/core';
 import { claimScheduleService } from '../claimScheduleService';
 
 describe('claimScheduleService', () => {
   test('should handle empty case', () => {
-    const referendums: Referendum[] = [{ type: ReferendumType.Approved, referendumId: '123' } as ApprovedReferendum];
+    const referendums: Referendum[] = [{ type: 'Approved', referendumId: '123' } as ApprovedReferendum];
     const tracks: Record<TrackId, TrackInfo> = {};
     const trackLocks: Record<TrackId, BN> = {};
     const votingByTrack: Record<TrackId, Voting> = {};
@@ -34,7 +33,7 @@ describe('claimScheduleService', () => {
   });
 
   test('should handle single claimable', () => {
-    const referendums: Referendum[] = [{ type: ReferendumType.Approved, referendumId: '123' } as ApprovedReferendum];
+    const referendums: Referendum[] = [{ type: 'Approved', referendumId: '123' } as ApprovedReferendum];
     const votingByTrack: Record<TrackId, CastingVoting> = {
       0: {
         type: 'Casting',
@@ -153,8 +152,8 @@ describe('claimScheduleService', () => {
 
   test('should take max between two locks with same time', () => {
     const referendums: Referendum[] = [
-      { type: ReferendumType.Approved, referendumId: '12' } as ApprovedReferendum,
-      { type: ReferendumType.Approved, referendumId: '22' } as ApprovedReferendum,
+      { type: 'Approved', referendumId: '12' } as ApprovedReferendum,
+      { type: 'Approved', referendumId: '22' } as ApprovedReferendum,
     ];
 
     const votingByTrack: Record<TrackId, CastingVoting> = {
@@ -202,7 +201,7 @@ describe('claimScheduleService', () => {
   });
 
   test('should handle rejigged prior', () => {
-    const referendums: Referendum[] = [{ type: ReferendumType.Approved, referendumId: '123' } as ApprovedReferendum];
+    const referendums: Referendum[] = [{ type: 'Approved', referendumId: '123' } as ApprovedReferendum];
 
     const votingByTrack: Record<TrackId, CastingVoting> = {
       0: {
@@ -244,8 +243,8 @@ describe('claimScheduleService', () => {
 
   test('should fold several claimable to one', () => {
     const referendums: ApprovedReferendum[] = [
-      { type: ReferendumType.Approved, referendumId: '0', since: 1100, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '1', since: 1000, submissionDeposit: null },
+      { type: 'Approved', referendumId: '0', since: 1100, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '1', since: 1000, submissionDeposit: null, decisionDeposit: null },
     ];
 
     const votingByTrack: Record<TrackId, CastingVoting> = {
@@ -304,9 +303,9 @@ describe('claimScheduleService', () => {
 
   test('should include shadowed actions', () => {
     const referendums: ApprovedReferendum[] = [
-      { type: ReferendumType.Approved, referendumId: '1', since: 1000, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '2', since: 1100, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '3', since: 1200, submissionDeposit: null },
+      { type: 'Approved', referendumId: '1', since: 1000, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '2', since: 1100, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '3', since: 1200, submissionDeposit: null, decisionDeposit: null },
     ];
 
     const votingByTrack: Record<TrackId, CastingVoting> = {
@@ -539,9 +538,9 @@ describe('claimScheduleService', () => {
 
   test('pending should be sorted by remaining time', () => {
     const referendums: ApprovedReferendum[] = [
-      { type: ReferendumType.Approved, referendumId: '0', since: 1100, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '1', since: 1300, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '2', since: 1200, submissionDeposit: null },
+      { type: 'Approved', referendumId: '0', since: 1100, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '1', since: 1300, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '2', since: 1200, submissionDeposit: null, decisionDeposit: null },
     ];
     const votingByTrack: Record<TrackId, CastingVoting> = {
       0: {
@@ -600,8 +599,8 @@ describe('claimScheduleService', () => {
 
   test('gap should not be covered by its track locks', () => {
     const referendums: ApprovedReferendum[] = [
-      { type: ReferendumType.Approved, referendumId: '5', since: 1500, submissionDeposit: null },
-      { type: ReferendumType.Approved, referendumId: '13', since: 2000, submissionDeposit: null },
+      { type: 'Approved', referendumId: '5', since: 1500, submissionDeposit: null, decisionDeposit: null },
+      { type: 'Approved', referendumId: '13', since: 2000, submissionDeposit: null, decisionDeposit: null },
     ];
 
     const votingByTrack: Record<TrackId, CastingVoting> = {
@@ -770,7 +769,7 @@ describe('claimScheduleService', () => {
 
   test('delegate plus voting case', () => {
     const referendums: ApprovedReferendum[] = [
-      { type: ReferendumType.Approved, referendumId: '0', since: 1100, submissionDeposit: null },
+      { type: 'Approved', referendumId: '0', since: 1100, submissionDeposit: null, decisionDeposit: null },
     ];
     const votingByTrack: Record<TrackId, DelegatingVoting | CastingVoting> = {
       0: {

--- a/src/renderer/entities/governance/lib/governanceService.ts
+++ b/src/renderer/entities/governance/lib/governanceService.ts
@@ -1,190 +1,86 @@
 import { type ApiPromise } from '@polkadot/api';
-import {
-  type FrameSupportPreimagesBounded,
-  type PalletReferendaCurve,
-  type PalletReferendaDeposit,
-  type PalletReferendaReferendumInfoConvictionVotingTally,
-} from '@polkadot/types/lookup';
-import { type BN, BN_ZERO } from '@polkadot/util';
+import { type BN } from '@polkadot/util';
 
 import {
   type Address,
-  type Deposit,
-  type LinearDecreasingCurve,
-  type ReciprocalCurve,
   type Referendum,
   type ReferendumId,
-  ReferendumType,
-  type SteppedDecreasingCurve,
   type TrackId,
   type TrackInfo,
   type VotingCurve,
 } from '@/shared/core';
+import { type ReferendaCurve, referendaPallet } from '@/shared/pallet/referenda';
+import { convictionVotingPallet } from '@shared/pallet/convictionVoting';
 
 export const governanceService = {
   getReferendums,
-  getReferendum,
   getTrackLocks,
   getTracks,
 };
 
-function getProposalHex(proposal: FrameSupportPreimagesBounded) {
-  if (proposal.isInline) {
-    return proposal.asInline.toHex();
-  }
-  if (proposal.isLookup) {
-    return proposal.asLookup.toHex();
-  }
-  if (proposal.isLegacy) {
-    return proposal.asLegacy.toHex();
-  }
-
-  return '';
-}
-
-const mapDeposit = (deposit: PalletReferendaDeposit | null): Deposit | null => {
-  if (!deposit) return null;
-
-  return {
-    who: deposit.who.toString(),
-    amount: deposit.amount.toBn(),
-  };
-};
-
-const mapReferendum = (
-  referendumId: ReferendumId,
-  palette: PalletReferendaReferendumInfoConvictionVotingTally,
-): Referendum | null => {
-  if (palette.isOngoing) {
-    const ongoing = palette.asOngoing;
-    const deciding = ongoing.deciding.unwrapOr(null);
-    const decisionDeposit = ongoing.decisionDeposit.unwrapOr(null);
-    const submissionDeposit = ongoing.submissionDeposit;
-    const proposal = getProposalHex(ongoing.proposal);
-
-    return {
-      referendumId,
-      type: ReferendumType.Ongoing,
-      track: ongoing.track.toString(),
-      proposal,
-      submitted: ongoing.submitted.toNumber(),
-      enactment: {
-        value: ongoing.enactment.isAfter ? ongoing.enactment.asAfter.toBn() : ongoing.enactment.asAt.toBn(),
-        type: ongoing.enactment.type,
-      },
-      inQueue: ongoing.inQueue.toPrimitive(),
-      deciding: deciding
-        ? {
-            since: deciding.since.toNumber(),
-            confirming: deciding.confirming.unwrapOr(BN_ZERO).toNumber(),
-          }
-        : null,
-      tally: {
-        ayes: ongoing.tally.ayes.toBn(),
-        nays: ongoing.tally.nays.toBn(),
-        support: ongoing.tally.support.toBn(),
-      },
-      decisionDeposit: mapDeposit(decisionDeposit),
-      submissionDeposit: mapDeposit(submissionDeposit),
-    };
-  }
-
-  if (palette.isRejected) {
-    const referendum = palette.asRejected;
-    const [since, submissionDeposit] = referendum;
-
-    return {
-      referendumId,
-      type: ReferendumType.Rejected,
-      since: since.toNumber(),
-      submissionDeposit: mapDeposit(submissionDeposit.unwrapOr(null)),
-    };
-  }
-
-  if (palette.isApproved) {
-    const referendum = palette.asApproved;
-    const [since, submissionDeposit] = referendum;
-
-    return {
-      referendumId,
-      type: ReferendumType.Approved,
-      since: since.toNumber(),
-      submissionDeposit: mapDeposit(submissionDeposit.unwrapOr(null)),
-    };
-  }
-
-  if (palette.isCancelled) {
-    const referendum = palette.asCancelled;
-    const [since, submissionDeposit] = referendum;
-
-    return {
-      referendumId,
-      type: ReferendumType.Cancelled,
-      since: since.toNumber(),
-      submissionDeposit: mapDeposit(submissionDeposit.unwrapOr(null)),
-    };
-  }
-
-  if (palette.isTimedOut) {
-    const referendum = palette.asTimedOut;
-    const [since, submissionDeposit] = referendum;
-
-    return {
-      referendumId,
-      type: ReferendumType.TimedOut,
-      since: since.toNumber(),
-      submissionDeposit: mapDeposit(submissionDeposit.unwrapOr(null)),
-    };
-  }
-
-  if (palette.isKilled) {
-    return {
-      referendumId,
-      type: ReferendumType.Killed,
-      since: palette.asKilled.toNumber(),
-    };
-  }
-
-  return null;
-};
-
-async function getReferendums(api: ApiPromise): Promise<Referendum[]> {
-  const referendums = await api.query.referenda.referendumInfoFor.entries();
-
+async function getReferendums(api: ApiPromise, ids?: ReferendumId[]): Promise<Referendum[]> {
+  const referendums = await referendaPallet.storage.referendumInfoFor('governance', api, ids);
   const result: Referendum[] = [];
 
-  for (const [refIndex, option] of referendums) {
-    if (option.isNone) continue;
+  for (const { id, info } of referendums) {
+    if (!info) continue;
 
-    const pallet = option.unwrap();
-    const referendumId = refIndex.args[0].toString();
-    const referendum = mapReferendum(referendumId, pallet);
+    const referendumId = id.toString();
+    let mappedReferemdum: Referendum;
 
-    if (referendum) {
-      result.push(referendum);
+    switch (info.type) {
+      case 'Ongoing':
+        mappedReferemdum = {
+          referendumId,
+          type: info.type,
+          track: info._.track.toString(),
+          proposal: info._.proposal._,
+          submitted: info._.submitted,
+          enactment: {
+            value: info._.enactment._,
+            type: info._.enactment.type,
+          },
+          inQueue: info._.inQueue,
+          deciding: info._.deciding,
+          tally: info._.tally,
+          decisionDeposit: info._.decisionDeposit,
+          submissionDeposit: info._.submissionDeposit,
+        };
+        break;
+      case 'Approved':
+      case 'Rejected':
+      case 'Cancelled':
+      case 'TimedOut':
+        mappedReferemdum = {
+          type: info.type,
+          referendumId,
+          since: info._.since,
+          submissionDeposit: info._.submitionDeposit,
+          decisionDeposit: info._.decisionDeposit,
+        };
+        break;
+      case 'Killed':
+        mappedReferemdum = {
+          type: info.type,
+          referendumId,
+          since: info._,
+        };
+        break;
     }
+
+    result.push(mappedReferemdum);
   }
 
   return result;
 }
 
-async function getReferendum(id: ReferendumId, api: ApiPromise): Promise<Referendum | null> {
-  const palette = await api.query.referenda.referendumInfoFor(parseInt(id));
-
-  if (palette.isNone) {
-    return null;
-  }
-
-  return mapReferendum(id, palette.unwrap());
-}
-
 async function getTrackLocks(api: ApiPromise, addresses: Address[]): Promise<Record<Address, Record<TrackId, BN>>> {
-  const tuples = await api.query.convictionVoting.classLocksFor.multi(addresses);
+  const tuples = await convictionVotingPallet.storage.classLocksFor(api, addresses);
   const result: Record<Address, Record<TrackId, BN>> = {};
 
   for (const [index, locks] of tuples.entries()) {
     const lockData = locks.reduce<Record<TrackId, BN>>((acc, lock) => {
-      acc[lock[0].toString()] = lock[1].toBn();
+      acc[lock.track] = lock.amount;
 
       return acc;
     }, {});
@@ -196,33 +92,20 @@ async function getTrackLocks(api: ApiPromise, addresses: Address[]): Promise<Rec
 }
 
 function getTracks(api: ApiPromise): Record<TrackId, TrackInfo> {
-  const tracks = api.consts.referenda.tracks;
+  const tracks = referendaPallet.consts.tracks('governance', api);
 
   const result: Record<TrackId, TrackInfo> = {};
 
-  for (const [index, track] of tracks) {
-    let minApproval: VotingCurve | undefined;
-    let minSupport: VotingCurve | undefined;
+  for (const { track, info } of tracks) {
+    const minApproval = mapCurve(info.minApproval);
+    const minSupport = mapCurve(info.minSupport);
 
-    if (track.minApproval.isLinearDecreasing) minApproval = getLinearDecreasing(track.minApproval);
-    if (track.minSupport.isLinearDecreasing) minSupport = getLinearDecreasing(track.minSupport);
-
-    if (track.minApproval.isSteppedDecreasing) minApproval = getSteppedDecreasing(track.minApproval);
-    if (track.minSupport.isSteppedDecreasing) minSupport = getSteppedDecreasing(track.minSupport);
-
-    if (track.minApproval.isReciprocal) minApproval = getReciprocal(track.minApproval);
-    if (track.minSupport.isReciprocal) minSupport = getReciprocal(track.minSupport);
-
-    if (!minApproval || !minSupport) {
-      throw new Error('Approval curve not found');
-    }
-
-    result[index.toString()] = {
-      name: track.name.toString(),
-      maxDeciding: track.maxDeciding.toBn(),
-      decisionDeposit: track.decisionDeposit.toBn(),
-      preparePeriod: track.preparePeriod.toNumber(),
-      decisionPeriod: track.decisionPeriod.toNumber(),
+    result[track.toString()] = {
+      name: info.name,
+      maxDeciding: info.maxDeciding,
+      decisionDeposit: info.decisionDeposit,
+      preparePeriod: info.preparePeriod,
+      decisionPeriod: info.decisionPeriod,
       minApproval,
       minSupport,
     };
@@ -231,36 +114,29 @@ function getTracks(api: ApiPromise): Record<TrackId, TrackInfo> {
   return result;
 }
 
-function getLinearDecreasing(approval: PalletReferendaCurve): LinearDecreasingCurve {
-  const linearDecreasing = approval.asLinearDecreasing;
-
-  return {
-    type: 'LinearDecreasing',
-    length: linearDecreasing.length,
-    floor: linearDecreasing.floor,
-    ceil: linearDecreasing.ceil,
-  };
-}
-
-function getSteppedDecreasing(approval: PalletReferendaCurve): SteppedDecreasingCurve {
-  const steppedDecreasing = approval.asSteppedDecreasing;
-
-  return {
-    type: 'SteppedDecreasing',
-    begin: steppedDecreasing.begin,
-    end: steppedDecreasing.end,
-    period: steppedDecreasing.period,
-    step: steppedDecreasing.step,
-  };
-}
-
-function getReciprocal(approval: PalletReferendaCurve): ReciprocalCurve {
-  const reciprocal = approval.asReciprocal;
-
-  return {
-    type: 'Reciprocal',
-    factor: reciprocal.factor,
-    xOffset: reciprocal.xOffset,
-    yOffset: reciprocal.yOffset,
-  };
-}
+const mapCurve = (value: ReferendaCurve): VotingCurve => {
+  switch (value.type) {
+    case 'LinearDecreasing':
+      return {
+        type: 'LinearDecreasing',
+        length: value._.length,
+        floor: value._.floor,
+        ceil: value._.ceil,
+      };
+    case 'SteppedDecreasing':
+      return {
+        type: 'SteppedDecreasing',
+        begin: value._.begin,
+        end: value._.end,
+        period: value._.period,
+        step: value._.step,
+      };
+    case 'Reciprocal':
+      return {
+        type: 'Reciprocal',
+        factor: value._.factor,
+        xOffset: value._.xOffset,
+        yOffset: value._.yOffset,
+      };
+  }
+};

--- a/src/renderer/entities/governance/lib/governanceService.ts
+++ b/src/renderer/entities/governance/lib/governanceService.ts
@@ -55,7 +55,7 @@ async function getReferendums(api: ApiPromise, ids?: ReferendumId[]): Promise<Re
           type: info.type,
           referendumId,
           since: info._.since,
-          submissionDeposit: info._.submitionDeposit,
+          submissionDeposit: info._.submissionDeposit,
           decisionDeposit: info._.decisionDeposit,
         };
         break;

--- a/src/renderer/entities/governance/lib/governanceService.ts
+++ b/src/renderer/entities/governance/lib/governanceService.ts
@@ -33,18 +33,18 @@ async function getReferendums(api: ApiPromise, ids?: ReferendumId[]): Promise<Re
         mappedReferemdum = {
           referendumId,
           type: info.type,
-          track: info._.track.toString(),
-          proposal: info._.proposal._,
-          submitted: info._.submitted,
+          track: info.data.track.toString(),
+          proposal: info.data.proposal.data,
+          submitted: info.data.submitted,
           enactment: {
-            value: info._.enactment._,
-            type: info._.enactment.type,
+            value: info.data.enactment.data,
+            type: info.data.enactment.type,
           },
-          inQueue: info._.inQueue,
-          deciding: info._.deciding,
-          tally: info._.tally,
-          decisionDeposit: info._.decisionDeposit,
-          submissionDeposit: info._.submissionDeposit,
+          inQueue: info.data.inQueue,
+          deciding: info.data.deciding,
+          tally: info.data.tally,
+          decisionDeposit: info.data.decisionDeposit,
+          submissionDeposit: info.data.submissionDeposit,
         };
         break;
       case 'Approved':
@@ -54,16 +54,16 @@ async function getReferendums(api: ApiPromise, ids?: ReferendumId[]): Promise<Re
         mappedReferemdum = {
           type: info.type,
           referendumId,
-          since: info._.since,
-          submissionDeposit: info._.submissionDeposit,
-          decisionDeposit: info._.decisionDeposit,
+          since: info.data.since,
+          submissionDeposit: info.data.submissionDeposit,
+          decisionDeposit: info.data.decisionDeposit,
         };
         break;
       case 'Killed':
         mappedReferemdum = {
           type: info.type,
           referendumId,
-          since: info._,
+          since: info.data,
         };
         break;
     }
@@ -119,24 +119,24 @@ const mapCurve = (value: ReferendaCurve): VotingCurve => {
     case 'LinearDecreasing':
       return {
         type: 'LinearDecreasing',
-        length: value._.length,
-        floor: value._.floor,
-        ceil: value._.ceil,
+        length: value.data.length,
+        floor: value.data.floor,
+        ceil: value.data.ceil,
       };
     case 'SteppedDecreasing':
       return {
         type: 'SteppedDecreasing',
-        begin: value._.begin,
-        end: value._.end,
-        period: value._.period,
-        step: value._.step,
+        begin: value.data.begin,
+        end: value.data.end,
+        period: value.data.period,
+        step: value.data.step,
       };
     case 'Reciprocal':
       return {
         type: 'Reciprocal',
-        factor: value._.factor,
-        xOffset: value._.xOffset,
-        yOffset: value._.yOffset,
+        factor: value.data.factor,
+        xOffset: value.data.xOffset,
+        yOffset: value.data.yOffset,
       };
   }
 };

--- a/src/renderer/entities/governance/lib/governanceSubscribeService.ts
+++ b/src/renderer/entities/governance/lib/governanceSubscribeService.ts
@@ -75,16 +75,16 @@ function subscribeVotingFor(
             type: 'Delegating',
             address,
             track: trackId,
-            balance: convictionVoting._.balance,
-            conviction: convictionVoting._.conviction,
-            target: toAddress(convictionVoting._.target),
-            prior: convictionVoting._.prior,
+            balance: convictionVoting.data.balance,
+            conviction: convictionVoting.data.conviction,
+            target: toAddress(convictionVoting.data.target),
+            prior: convictionVoting.data.prior,
           };
           break;
         }
         case 'Casting': {
           const votes: Record<ReferendumId, AccountVote> = {};
-          for (const { referendum, vote } of convictionVoting._.votes) {
+          for (const { referendum, vote } of convictionVoting.data.votes) {
             const referendumId = referendum.toString();
 
             switch (vote.type) {
@@ -92,25 +92,25 @@ function subscribeVotingFor(
                 votes[referendumId] = {
                   type: 'Standard',
                   vote: {
-                    aye: vote._.vote.isAye,
-                    conviction: vote._.vote.conviction.type,
+                    aye: vote.data.vote.isAye,
+                    conviction: vote.data.vote.conviction.type,
                   },
-                  balance: vote._.balance,
+                  balance: vote.data.balance,
                 };
                 break;
               case 'Split':
                 votes[referendumId] = {
                   type: 'Split',
-                  aye: vote._.aye,
-                  nay: vote._.nay,
+                  aye: vote.data.aye,
+                  nay: vote.data.nay,
                 };
                 break;
               case 'SplitAbstain':
                 votes[referendumId] = {
                   type: 'SplitAbstain',
-                  aye: vote._.aye,
-                  nay: vote._.nay,
-                  abstain: vote._.abstain,
+                  aye: vote.data.aye,
+                  nay: vote.data.nay,
+                  abstain: vote.data.abstain,
                 };
                 break;
             }
@@ -121,7 +121,7 @@ function subscribeVotingFor(
             track: trackId,
             address,
             votes,
-            prior: convictionVoting._.prior,
+            prior: convictionVoting.data.prior,
           };
         }
       }

--- a/src/renderer/entities/governance/lib/referendumService.ts
+++ b/src/renderer/entities/governance/lib/referendumService.ts
@@ -4,7 +4,6 @@ import {
   type KilledReferendum,
   type OngoingReferendum,
   type Referendum,
-  ReferendumType,
   type RejectedReferendum,
   type TimedOutReferendum,
 } from '@/shared/core';
@@ -21,27 +20,27 @@ export const referendumService = {
 };
 
 function isOngoing(referendum: Referendum): referendum is OngoingReferendum {
-  return referendum.type === ReferendumType.Ongoing;
+  return referendum.type === 'Ongoing';
 }
 
 function isRejected(referendum: Referendum): referendum is RejectedReferendum {
-  return referendum.type === ReferendumType.Rejected;
+  return referendum.type === 'Rejected';
 }
 
 function isApproved(referendum: Referendum): referendum is ApprovedReferendum {
-  return referendum.type === ReferendumType.Approved;
+  return referendum.type === 'Approved';
 }
 
 function isCompleted(referendum: Referendum): referendum is CompletedReferendum {
-  return referendum.type !== ReferendumType.Ongoing;
+  return referendum.type !== 'Ongoing';
 }
 
 function isTimedOut(referendum: Referendum): referendum is TimedOutReferendum {
-  return referendum.type === ReferendumType.TimedOut;
+  return referendum.type === 'TimedOut';
 }
 
 function isKilled(referendum: Referendum): referendum is KilledReferendum {
-  return referendum.type === ReferendumType.Killed;
+  return referendum.type === 'Killed';
 }
 
 // waiting for deposit, deciding, passing

--- a/src/renderer/entities/governance/model/approveThreshold.ts
+++ b/src/renderer/entities/governance/model/approveThreshold.ts
@@ -72,7 +72,10 @@ sample({
   source: $approvalThresholds,
   fn: (thresholds, { params, result }) => ({
     ...thresholds,
-    [params.chain.chainId]: result,
+    [params.chain.chainId]: {
+      ...(thresholds[params.chain.chainId] ?? {}),
+      ...result,
+    },
   }),
   target: $approvalThresholds,
 });

--- a/src/renderer/entities/governance/model/supportThreshold.ts
+++ b/src/renderer/entities/governance/model/supportThreshold.ts
@@ -80,7 +80,10 @@ sample({
   source: $supportThresholds,
   fn: (thresholds, { params, result }) => ({
     ...thresholds,
-    [params.chain.chainId]: result,
+    [params.chain.chainId]: {
+      ...(thresholds[params.chain.chainId] ?? {}),
+      ...result,
+    },
   }),
   target: $supportThresholds,
 });

--- a/src/renderer/entities/governance/model/voting.ts
+++ b/src/renderer/entities/governance/model/voting.ts
@@ -19,9 +19,7 @@ const {
   received: receiveVoting,
   unsubscribe: unsubscribeVoting,
 } = createSubscriber<VotingParams, VotingMap>(({ api, tracks, addresses }, cb) => {
-  return governanceSubscribeService.subscribeVotingFor(api, tracks, addresses, (voting) => {
-    if (voting) cb(voting);
-  });
+  return governanceSubscribeService.subscribeVotingFor(api, tracks, addresses, cb);
 });
 
 const $voting = createStore<VotingMap>({});

--- a/src/renderer/features/governance/aggregates/details.ts
+++ b/src/renderer/features/governance/aggregates/details.ts
@@ -2,8 +2,6 @@ import { combine, sample } from 'effector';
 import { createGate } from 'effector-react';
 
 import { type Chain, type Referendum } from '@shared/core';
-import { nonNullable } from '@shared/lib/utils';
-import { referendumModel } from '@entities/governance';
 import { permissionUtils, walletModel } from '@entities/wallet';
 import { descriptionsModel } from '../model/description';
 import { networkSelectorModel } from '../model/networkSelector';
@@ -33,18 +31,6 @@ sample({
     descriptionsModel.events.requestDescription,
     timelineModel.events.requestTimeline,
   ],
-});
-
-sample({
-  clock: flow.open,
-  source: networkSelectorModel.$network,
-  filter: nonNullable,
-  fn: (network, { referendum }) => ({
-    api: network!.api,
-    chain: network!.chain,
-    referendumId: referendum.referendumId,
-  }),
-  target: referendumModel.events.requestReferendum,
 });
 
 export const detailsAggregate = {

--- a/src/renderer/features/governance/components/ReferendumDetails/VotingStatus.tsx
+++ b/src/renderer/features/governance/components/ReferendumDetails/VotingStatus.tsx
@@ -79,13 +79,11 @@ export const VotingStatus = ({
       )}
 
       {canVote && nonNullable(asset) && nonNullable(vote) && referendumService.isOngoing(referendum) && (
-        <Button className="w-full" disabled={!hasAccount || !canVote} onClick={onRevoteRequest}>
-          {t('governance.referendum.revote')}
-        </Button>
-      )}
-
-      {canVote && nonNullable(asset) && nonNullable(referendum.vote) && referendumService.isOngoing(referendum) && (
         <div className="flex w-full flex-col justify-stretch gap-4">
+          <Button className="w-full" disabled={!hasAccount || !canVote} onClick={onRevoteRequest}>
+            {t('governance.referendum.revote')}
+          </Button>
+
           <Button className="w-full" pallet="secondary" onClick={onRemoveVoteRequest}>
             {t('governance.referendum.remove')}
           </Button>

--- a/src/renderer/features/governance/components/VotingStatusBadge/VotingStatusBadge.tsx
+++ b/src/renderer/features/governance/components/VotingStatusBadge/VotingStatusBadge.tsx
@@ -1,6 +1,7 @@
 import { useI18n } from '@app/providers';
-import { type CompletedReferendum, type OngoingReferendum, ReferendumType } from '@shared/core';
+import { type CompletedReferendum, type OngoingReferendum, type ReferendumType } from '@shared/core';
 import { OperationStatus } from '@shared/ui';
+import { referendumService } from '@entities/governance';
 
 type Props = {
   passing?: boolean;
@@ -8,19 +9,19 @@ type Props = {
 };
 
 const statusesMap: Record<
-  Exclude<ReferendumType, ReferendumType.Ongoing | ReferendumType.Approved>,
+  Exclude<ReferendumType, 'Ongoing' | 'Approved'>,
   { text: string; pallet: 'default' | 'success' | 'error' }
 > = {
-  [ReferendumType.Rejected]: { text: 'governance.referendums.rejected', pallet: 'error' },
-  [ReferendumType.Cancelled]: { text: 'governance.referendums.cancelled', pallet: 'default' },
-  [ReferendumType.Killed]: { text: 'governance.referendums.killed', pallet: 'error' },
-  [ReferendumType.TimedOut]: { text: 'governance.referendums.timedOut', pallet: 'default' },
+  Rejected: { text: 'governance.referendums.rejected', pallet: 'error' },
+  Cancelled: { text: 'governance.referendums.cancelled', pallet: 'default' },
+  Killed: { text: 'governance.referendums.killed', pallet: 'error' },
+  TimedOut: { text: 'governance.referendums.timedOut', pallet: 'default' },
 };
 
 export const VotingStatusBadge = ({ passing, referendum }: Props) => {
   const { t } = useI18n();
 
-  if (referendum.type === ReferendumType.Ongoing) {
+  if (referendumService.isOngoing(referendum)) {
     const isPassing = passing ?? false;
 
     return (
@@ -30,7 +31,7 @@ export const VotingStatusBadge = ({ passing, referendum }: Props) => {
     );
   }
 
-  if (referendum.type === ReferendumType.Approved) {
+  if (referendumService.isApproved(referendum)) {
     // TODO implement
     const isExecuted = false;
 

--- a/src/renderer/features/governance/model/timeline.ts
+++ b/src/renderer/features/governance/model/timeline.ts
@@ -3,31 +3,12 @@ import { combine, createEffect, createEvent, createStore, sample } from 'effecto
 import { produce } from 'immer';
 import { readonly } from 'patronum';
 
-import {
-  type GovernanceApi,
-  type ReferendumTimelineRecord,
-  type ReferendumTimelineRecordStatus,
-} from '@shared/api/governance';
-import {
-  type Chain,
-  type ChainId,
-  type CompletedReferendum,
-  type Referendum,
-  type ReferendumId,
-  ReferendumType,
-} from '@shared/core';
+import { type GovernanceApi, type ReferendumTimelineRecord } from '@shared/api/governance';
+import { type Chain, type ChainId, type Referendum, type ReferendumId } from '@shared/core';
 import { getCreatedDateFromApi, nonNullable } from '@shared/lib/utils';
 import { governanceModel, referendumService } from '@entities/governance';
 
 import { networkSelectorModel } from './networkSelector';
-
-const referendumTimelineStatus: Record<CompletedReferendum['type'], ReferendumTimelineRecordStatus> = {
-  [ReferendumType.Killed]: 'Killed',
-  [ReferendumType.Cancelled]: 'Cancelled',
-  [ReferendumType.Rejected]: 'Rejected',
-  [ReferendumType.Approved]: 'Approved',
-  [ReferendumType.TimedOut]: 'TimedOut',
-};
 
 const $timelines = createStore<
   Record<ChainId, Record<ReferendumId, { onChain: ReferendumTimelineRecord[]; offChain: ReferendumTimelineRecord[] }>>
@@ -125,7 +106,7 @@ const requestOnChainTimelineFx = createEffect<RequestOnTimelineParams, Referendu
     }
 
     return getCreatedDateFromApi(referendum.since, api).then((time) => [
-      { date: new Date(time), status: referendumTimelineStatus[referendum.type] },
+      { date: new Date(time), status: referendum.type },
     ]);
   },
 );

--- a/src/renderer/pages/Basket/lib/prepareTransactions.ts
+++ b/src/renderer/pages/Basket/lib/prepareTransactions.ts
@@ -602,9 +602,9 @@ async function prepareRevokeDelegationTransaction({
     transferable,
 
     account: account!,
-    balance: delegation ? delegation._.balance.toString() : coreTxs[0].args.balance,
-    conviction: delegation ? delegation._.conviction : votingService.getConviction(coreTxs[0].args.conviction),
-    target: delegation ? toAddress(delegation._.target, { prefix: chain.addressPrefix }) : coreTxs[0].args.target,
+    balance: delegation ? delegation.data.balance.toString() : coreTxs[0].args.balance,
+    conviction: delegation ? delegation.data.conviction : votingService.getConviction(coreTxs[0].args.conviction),
+    target: delegation ? toAddress(delegation.data.target, { prefix: chain.addressPrefix }) : coreTxs[0].args.target,
     tracks: coreTxs.map((t: Transaction) => t.args.track),
     description: '',
     locks,

--- a/src/renderer/pages/Governance/lib/__tests__/governancePageUtils.test.ts
+++ b/src/renderer/pages/Governance/lib/__tests__/governancePageUtils.test.ts
@@ -1,6 +1,6 @@
 import { BN_ZERO } from '@polkadot/util';
 
-import { type OngoingReferendum, ReferendumType } from '@shared/core';
+import { type OngoingReferendum } from '@shared/core';
 import { type AggregatedReferendum, VoteStatus } from '@features/governance';
 import { governancePageUtils } from '../governancePageUtils';
 
@@ -16,7 +16,7 @@ const someVote = {
 describe('pages/Governance/lib/governancePageUtils', () => {
   const referendums: AggregatedReferendum[] = [
     {
-      type: ReferendumType.Approved,
+      type: 'Approved',
       referendumId: '111',
       since: 0,
       title: 'Referendum Title 1',
@@ -24,9 +24,10 @@ describe('pages/Governance/lib/governancePageUtils', () => {
       supportThreshold: null,
       vote: null,
       submissionDeposit: null,
+      decisionDeposit: null,
     },
     {
-      type: ReferendumType.Approved,
+      type: 'Approved',
       referendumId: '222',
       since: 0,
       title: 'Referendum Title 2',
@@ -34,6 +35,7 @@ describe('pages/Governance/lib/governancePageUtils', () => {
       supportThreshold: null,
       vote: null,
       submissionDeposit: null,
+      decisionDeposit: null,
     },
   ];
 
@@ -46,7 +48,7 @@ describe('pages/Governance/lib/governancePageUtils', () => {
           }
         : null,
       votedByDelegate: isVotedByDelegate ? 'delegate address' : null,
-      type: ReferendumType.Ongoing,
+      type: 'Ongoing',
       track: '1',
     } as AggregatedReferendum<OngoingReferendum>;
   };
@@ -56,7 +58,7 @@ describe('pages/Governance/lib/governancePageUtils', () => {
       voter: '',
       vote: someVote,
     },
-    type: ReferendumType.Ongoing,
+    type: 'Ongoing',
     track: '1',
   } as AggregatedReferendum<OngoingReferendum>;
 

--- a/src/renderer/pages/Operations/common/utils.ts
+++ b/src/renderer/pages/Operations/common/utils.ts
@@ -257,8 +257,9 @@ export const getUndelegationData = async (
   const delegation = votes.find((vote) => vote.type === 'Delegating');
 
   return {
-    votes: delegation && votingService.calculateVotingPower(delegation._.balance, delegation._.conviction).toString(),
-    target: delegation && toAddress(delegation._.target),
+    votes:
+      delegation && votingService.calculateVotingPower(delegation.data.balance, delegation.data.conviction).toString(),
+    target: delegation && toAddress(delegation.data.target),
   };
 };
 

--- a/src/renderer/shared/core/index.ts
+++ b/src/renderer/shared/core/index.ts
@@ -99,11 +99,11 @@ export type {
   LinearDecreasingCurve,
 } from './types/track';
 
-export { ReferendumType } from './types/referendum';
 export type {
   Deposit,
   Tally,
   ReferendumId,
+  ReferendumType,
   ApprovedReferendum,
   RejectedReferendum,
   OngoingReferendum,

--- a/src/renderer/shared/core/types/referendum.ts
+++ b/src/renderer/shared/core/types/referendum.ts
@@ -6,7 +6,7 @@ import { type TrackId } from './track';
 export type ReferendumId = string;
 
 export type OngoingReferendum = {
-  type: ReferendumType.Ongoing;
+  type: 'Ongoing';
   referendumId: ReferendumId;
   track: TrackId;
   proposal: string;
@@ -15,46 +15,50 @@ export type OngoingReferendum = {
   decisionDeposit: Deposit | null;
   inQueue: boolean;
   enactment: {
-    value: BN;
+    value: number;
     type: 'At' | 'After';
   };
   deciding: {
     since: BlockHeight;
-    confirming: BlockHeight;
+    confirming: BlockHeight | null;
   } | null;
   tally: Tally;
 };
 
 export type RejectedReferendum = {
-  type: ReferendumType.Rejected;
+  type: 'Rejected';
   referendumId: ReferendumId;
   since: BlockHeight;
   submissionDeposit: Deposit | null;
+  decisionDeposit: Deposit | null;
 };
 
 export type ApprovedReferendum = {
-  type: ReferendumType.Approved;
+  type: 'Approved';
   referendumId: ReferendumId;
   since: BlockHeight;
   submissionDeposit: Deposit | null;
+  decisionDeposit: Deposit | null;
 };
 
 export type CancelledReferendum = {
-  type: ReferendumType.Cancelled;
+  type: 'Cancelled';
   referendumId: ReferendumId;
   since: BlockHeight;
   submissionDeposit: Deposit | null;
+  decisionDeposit: Deposit | null;
 };
 
 export type TimedOutReferendum = {
-  type: ReferendumType.TimedOut;
+  type: 'TimedOut';
   referendumId: ReferendumId;
   since: BlockHeight;
   submissionDeposit: Deposit | null;
+  decisionDeposit: Deposit | null;
 };
 
 export type KilledReferendum = {
-  type: ReferendumType.Killed;
+  type: 'Killed';
   referendumId: ReferendumId;
   since: BlockHeight;
 };
@@ -67,15 +71,7 @@ export type CompletedReferendum =
   | KilledReferendum;
 
 export type Referendum = OngoingReferendum | CompletedReferendum;
-
-export const enum ReferendumType {
-  Rejected = 'rejected',
-  Approved = 'approved',
-  Ongoing = 'ongoing',
-  Cancelled = 'cancelled',
-  TimedOut = 'timedOut',
-  Killed = 'killed',
-}
+export type ReferendumType = 'Ongoing' | 'Approved' | 'Rejected' | 'Cancelled' | 'TimedOut' | 'Killed';
 
 export type Tally = {
   ayes: BN;

--- a/src/renderer/shared/core/types/track.ts
+++ b/src/renderer/shared/core/types/track.ts
@@ -6,7 +6,7 @@ export type TrackId = string;
 
 export type TrackInfo = {
   name: string;
-  maxDeciding: BN;
+  maxDeciding: BlockHeight;
   decisionDeposit: BN;
   preparePeriod: BlockHeight;
   decisionPeriod: BlockHeight;

--- a/src/renderer/shared/pallet/referenda/schema.ts
+++ b/src/renderer/shared/pallet/referenda/schema.ts
@@ -125,7 +125,7 @@ export const referendaReferendumStatusRankedCollectiveTally = pjsSchema.object({
 export type ReferendaReferendumInfoCompletedTally = z.infer<typeof referendaReferendumInfoCompletedTally>;
 export const referendaReferendumInfoCompletedTally = pjsSchema.tuppleMap(
   ['since', pjsSchema.blockHeight],
-  ['submitionDeposit', pjsSchema.optional(referendaDeposit)],
+  ['submissionDeposit', pjsSchema.optional(referendaDeposit)],
   ['decisionDeposit', pjsSchema.optional(referendaDeposit)],
 );
 

--- a/src/renderer/shared/polkadotjs-helpers/createPagedRequest.ts
+++ b/src/renderer/shared/polkadotjs-helpers/createPagedRequest.ts
@@ -1,0 +1,38 @@
+import { type StorageEntryBaseAt } from '@polkadot/api/types';
+
+import { substrateRpcPool } from '../api/substrate-helpers';
+import { nullable } from '../lib/utils';
+
+type Params = {
+  query: StorageEntryBaseAt<'promise', VoidFunction>;
+  pageSize: number;
+};
+
+export async function* createPagedRequest({ query, pageSize }: Params) {
+  let lastPageSize = pageSize;
+  let startKey: any = undefined;
+
+  while (lastPageSize === pageSize) {
+    yield substrateRpcPool
+      .call(() =>
+        query.entriesPaged({
+          args: [],
+          pageSize,
+          startKey,
+        }),
+      )
+      .then((res) => {
+        const lastResult = res.at(-1);
+        if (nullable(lastResult)) {
+          lastPageSize = 0;
+
+          return res;
+        }
+
+        lastPageSize = res.length;
+        startKey = lastResult[0];
+
+        return res;
+      });
+  }
+}

--- a/src/renderer/shared/polkadotjs-helpers/index.ts
+++ b/src/renderer/shared/polkadotjs-helpers/index.ts
@@ -1,5 +1,7 @@
+import { createPagedRequest } from './createPagedRequest';
 import { subscribeSystemEvents } from './subscribeSystemEvents';
 
 export const polkadotjsHelpers = {
   subscribeSystemEvents,
+  createPagedRequest,
 };

--- a/src/renderer/shared/polkadotjs-helpers/index.ts
+++ b/src/renderer/shared/polkadotjs-helpers/index.ts
@@ -1,7 +1,9 @@
 import { createPagedRequest } from './createPagedRequest';
+import { subscribeExtrinsics } from './subscribeExtrinsics';
 import { subscribeSystemEvents } from './subscribeSystemEvents';
 
 export const polkadotjsHelpers = {
   subscribeSystemEvents,
+  subscribeExtrinsics,
   createPagedRequest,
 };

--- a/src/renderer/shared/polkadotjs-helpers/subscribeExtrinsics.ts
+++ b/src/renderer/shared/polkadotjs-helpers/subscribeExtrinsics.ts
@@ -1,0 +1,21 @@
+import { type ApiPromise } from '@polkadot/api';
+import { type GenericExtrinsic } from '@polkadot/types';
+
+type Params = {
+  api: ApiPromise;
+  name: string[];
+};
+
+export const subscribeExtrinsics = ({ api, name }: Params, fn: (extrinsic: GenericExtrinsic) => unknown) => {
+  const methodsMap = Object.fromEntries(name.map((x) => [x, true]));
+
+  return api.rpc.chain.subscribeAllHeads((header) => {
+    api.rpc.chain.getBlock(header.hash).then((body) => {
+      for (const extrinsic of body.block.extrinsics) {
+        if (extrinsic.meta.name.toString() in methodsMap) {
+          fn(extrinsic);
+        }
+      }
+    });
+  });
+};

--- a/src/renderer/shared/polkadotjs-helpers/subscribeExtrinsics.ts
+++ b/src/renderer/shared/polkadotjs-helpers/subscribeExtrinsics.ts
@@ -7,12 +7,12 @@ type Params = {
 };
 
 export const subscribeExtrinsics = ({ api, name }: Params, fn: (extrinsic: GenericExtrinsic) => unknown) => {
-  const methodsMap = Object.fromEntries(name.map((x) => [x, true]));
+  const methodsMap = new Set(name);
 
   return api.rpc.chain.subscribeAllHeads((header) => {
     api.rpc.chain.getBlock(header.hash).then((body) => {
       for (const extrinsic of body.block.extrinsics) {
-        if (extrinsic.meta.name.toString() in methodsMap) {
+        if (methodsMap.has(extrinsic.meta.name.toString())) {
           fn(extrinsic);
         }
       }

--- a/src/renderer/shared/polkadotjs-helpers/subscribeSystemEvents.ts
+++ b/src/renderer/shared/polkadotjs-helpers/subscribeSystemEvents.ts
@@ -12,11 +12,11 @@ export const subscribeSystemEvents = (
   fn: (event: Event) => unknown,
 ) => {
   const isValidEvent = (event: Event) => {
-    const isCorrectSection = event.section === section;
+    const isCorrectSection = event.section.toString() === section;
     if (!methods || methods.length === 0) {
       return isCorrectSection;
     }
-    const isCorrectMethod = methods.some((method) => method === event.method);
+    const isCorrectMethod = methods.includes(event.method);
 
     return isCorrectSection && isCorrectMethod;
   };

--- a/src/renderer/shared/polkadotjs-schemas/structs.ts
+++ b/src/renderer/shared/polkadotjs-schemas/structs.ts
@@ -104,7 +104,7 @@ export const enumValueSchema = <const Map extends Record<string, z.ZodTypeAny>>(
   type EnumVariant = {
     [K in keyof Map]: {
       type: K;
-      _: z.infer<Map[K]>;
+      data: z.infer<Map[K]>;
     };
   }[keyof Map];
 
@@ -125,7 +125,7 @@ export const enumValueSchema = <const Map extends Record<string, z.ZodTypeAny>>(
 
         return {
           type,
-          _: result,
+          data: result,
         } as EnumVariant;
       }
 
@@ -150,7 +150,7 @@ export const enumValueLooseSchema = <const Map extends Record<string, z.ZodTypeA
   type EnumVariant = {
     [K in keyof Map]: {
       type: K;
-      _: z.infer<Map[K]>;
+      data: z.infer<Map[K]>;
     };
   }[keyof Map];
 
@@ -171,7 +171,7 @@ export const enumValueLooseSchema = <const Map extends Record<string, z.ZodTypeA
 
         return {
           type,
-          _: result,
+          data: result,
         } as EnumVariant;
       }
 

--- a/src/renderer/widgets/RemoveVoteModal/aggregates/removeVoteModal.ts
+++ b/src/renderer/widgets/RemoveVoteModal/aggregates/removeVoteModal.ts
@@ -13,7 +13,6 @@ import {
 } from '@shared/core';
 import { Step, nonNullable, nullable, toAddress } from '@shared/lib/utils';
 import { basketModel } from '@entities/basket';
-import { referendumModel } from '@entities/governance';
 import { transactionBuilder } from '@entities/transaction';
 import { accountUtils, walletModel, walletUtils } from '@entities/wallet';
 import { lockPeriodsModel, locksModel, votingAggregate } from '@/features/governance';
@@ -268,18 +267,6 @@ sample({
 sample({
   clock: removeVoteConfirmModel.events.submitFinished,
   target: locksModel.events.subscribeLocks,
-});
-
-sample({
-  clock: removeVoteConfirmModel.events.submitFinished,
-  source: flow.state,
-  filter: ({ referendum, chain, api }) => nonNullable(referendum) && nonNullable(chain) && nonNullable(api),
-  fn: ({ referendum, chain, api }) => ({
-    api: api!,
-    chain: chain!,
-    referendumId: referendum!.referendumId,
-  }),
-  target: referendumModel.events.requestReferendum,
 });
 
 sample({

--- a/src/renderer/widgets/VoteModal/aggregates/voteModal.ts
+++ b/src/renderer/widgets/VoteModal/aggregates/voteModal.ts
@@ -6,7 +6,7 @@ import { type PathType, Paths } from '@/shared/routes';
 import { type AccountVote, type BasketTransaction, type OngoingReferendum } from '@shared/core';
 import { Step, isStep, nonNullable, nullable, toAddress } from '@shared/lib/utils';
 import { basketModel } from '@entities/basket';
-import { referendumModel, votingService } from '@entities/governance';
+import { votingService } from '@entities/governance';
 import {
   delegationAggregate,
   lockPeriodsModel,
@@ -223,21 +223,6 @@ sample({
 sample({
   clock: voteConfirmModel.events.submitFinished,
   target: locksModel.events.subscribeLocks,
-});
-
-sample({
-  clock: voteConfirmModel.events.submitFinished,
-  source: {
-    referendum: voteFormAggregate.$referendum,
-    network: networkSelectorModel.$network,
-  },
-  filter: ({ referendum, network }) => nonNullable(referendum) && nonNullable(network),
-  fn: ({ referendum, network }) => ({
-    chain: network!.chain,
-    api: network!.api,
-    referendumId: referendum!.referendumId,
-  }),
-  target: referendumModel.events.requestReferendum,
 });
 
 sample({


### PR DESCRIPTION
* Moved referendum requests to the new `pallet` transport system
* Switched referenda subscription from throttling to system events + extrinsic parsing
* Small cleanup