### PR TITLE
fix: signatory name input

### DIFF
--- a/src/renderer/widgets/CreateWallet/ui/MultisigWallet/components/SelectSignatories.tsx
+++ b/src/renderer/widgets/CreateWallet/ui/MultisigWallet/components/SelectSignatories.tsx
@@ -20,7 +20,8 @@ export const SelectSignatories = () => {
       <div className="flex flex-col gap-2">
         {signatories.map((value, index) => (
           <Signatory
-            key={`${value.name}-${value.address}`}
+            // TODO: Address and name maybe not unique by user input
+            key={value.address}
             signatoryIndex={index}
             isOwnAccount={index === 0}
             signatoryName={value.name}


### PR DESCRIPTION
* use address as key for signatory (use name lead to rerender on change name and lost focus)