### PR TITLE
Fix: All wallets in Signatory selector

### DIFF
--- a/src/renderer/features/wallets/WalletSelect/lib/wallet-select-utils.ts
+++ b/src/renderer/features/wallets/WalletSelect/lib/wallet-select-utils.ts
@@ -2,7 +2,12 @@ import { type Wallet, type WalletFamily, WalletType } from '@/shared/core';
 import { includes } from '@/shared/lib/utils';
 import { walletUtils } from '@/entities/wallet';
 
-const getWalletByGroups = (wallets: Wallet[], query = ''): Record<WalletFamily, Wallet[]> => {
+export const walletSelectUtils = {
+  getWalletByGroups,
+  getFirstWallet,
+};
+
+function getWalletByGroups(wallets: Wallet[], query = ''): Record<WalletFamily, Wallet[]> {
   const accumulator: Record<WalletFamily, Wallet[]> = {
     [WalletType.POLKADOT_VAULT]: [],
     [WalletType.MULTISIG]: [],
@@ -28,13 +33,8 @@ const getWalletByGroups = (wallets: Wallet[], query = ''): Record<WalletFamily, 
 
     return acc;
   }, accumulator);
-};
+}
 
-const getFirstWallet = (wallets: Wallet[]) => {
+function getFirstWallet(wallets: Wallet[]): Wallet | null {
   return Object.values(getWalletByGroups(wallets)).flat().at(0) ?? null;
-};
-
-export const walletSelectUtils = {
-  getWalletByGroups,
-  getFirstWallet,
-};
+}

--- a/src/renderer/features/wallets/WalletSelect/lib/wallet-select-utils.ts
+++ b/src/renderer/features/wallets/WalletSelect/lib/wallet-select-utils.ts
@@ -2,12 +2,7 @@ import { type Wallet, type WalletFamily, WalletType } from '@/shared/core';
 import { includes } from '@/shared/lib/utils';
 import { walletUtils } from '@/entities/wallet';
 
-export const walletSelectUtils = {
-  getWalletByGroups,
-  getFirstWallet,
-};
-
-function getWalletByGroups(wallets: Wallet[], query = ''): Record<WalletFamily, Wallet[]> {
+const getWalletByGroups = (wallets: Wallet[], query = ''): Record<WalletFamily, Wallet[]> => {
   const accumulator: Record<WalletFamily, Wallet[]> = {
     [WalletType.POLKADOT_VAULT]: [],
     [WalletType.MULTISIG]: [],
@@ -33,8 +28,13 @@ function getWalletByGroups(wallets: Wallet[], query = ''): Record<WalletFamily, 
 
     return acc;
   }, accumulator);
-}
+};
 
-function getFirstWallet(wallets: Wallet[]): Wallet | null {
+const getFirstWallet = (wallets: Wallet[]): Wallet | null => {
   return Object.values(getWalletByGroups(wallets)).flat().at(0) ?? null;
-}
+};
+
+export const walletSelectUtils = {
+  getWalletByGroups,
+  getFirstWallet,
+};

--- a/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
+++ b/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
@@ -146,9 +146,9 @@ const Group = ({ title, children }: PropsWithChildren<GroupProps>) => {
   if (Children.count(children) === 0) return null;
 
   return (
-    <Ariakit.ComboboxGroup>
+    <Ariakit.ComboboxGroup className="mb-1 last:mb-0">
       <Ariakit.ComboboxGroupLabel>
-        <div className="px-3 py-1 text-help-text text-text-secondary">{title}</div>
+        <div className="mb-1 px-3 py-1 text-help-text text-text-secondary">{title}</div>
       </Ariakit.ComboboxGroupLabel>
       {children}
     </Ariakit.ComboboxGroup>

--- a/src/renderer/widgets/CreateWallet/ui/MultisigWallet/SelectSignatoriesThreshold.tsx
+++ b/src/renderer/widgets/CreateWallet/ui/MultisigWallet/SelectSignatoriesThreshold.tsx
@@ -5,7 +5,7 @@ import { type FormEvent, useState } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable } from '@/shared/lib/utils';
 import { Alert, Button, InputHint, SmallTitleText } from '@/shared/ui';
-import { Box, Select } from '@/shared/ui-kit';
+import { Box, Field, Select } from '@/shared/ui-kit';
 import { walletModel } from '@/entities/wallet';
 import { Step } from '../../lib/types';
 import { flowModel } from '../../model/flow-model';
@@ -113,23 +113,25 @@ export const SelectSignatoriesThreshold = () => {
             <Alert.Item withDot={false}>{t('createMultisigAccount.notEmptySignatoryName')}</Alert.Item>
           </Alert>
         </div>
-        <div className="flex items-center gap-x-4">
+        <div className="flex gap-x-4">
           <Box width="300px">
-            <Select
-              placeholder={t('createMultisigAccount.thresholdPlaceholder')}
-              value={(threshold.value || '').toString()}
-              invalid={threshold.hasError()}
-              disabled={[0, 1].includes(signatories.length)}
-              onChange={(value) => threshold.onChange(Number(value))}
-            >
-              {Array.from({ length: signatories.length - 1 }, (_, index) => (
-                <Select.Item key={index} value={(index + 2).toString()}>
-                  {index + 2}
-                </Select.Item>
-              ))}
-            </Select>
+            <Field text={t('createMultisigAccount.thresholdName')}>
+              <Select
+                placeholder={t('createMultisigAccount.thresholdPlaceholder')}
+                value={(threshold.value || '').toString()}
+                invalid={threshold.hasError()}
+                disabled={[0, 1].includes(signatories.length)}
+                onChange={(value) => threshold.onChange(Number(value))}
+              >
+                {Array.from({ length: signatories.length - 1 }, (_, index) => (
+                  <Select.Item key={index} value={(index + 2).toString()}>
+                    {index + 2}
+                  </Select.Item>
+                ))}
+              </Select>
+            </Field>
           </Box>
-          <InputHint className="flex-1 pt-5" active>
+          <InputHint active className="mt-8.5 flex-1">
             {t('createMultisigAccount.thresholdHint')}
           </InputHint>
         </div>
@@ -176,12 +178,7 @@ export const SelectSignatoriesThreshold = () => {
           </Alert>
         </div>
         <div className="mt-auto flex items-center justify-between">
-          <Button
-            variant="text"
-            onClick={() => {
-              flowModel.events.stepChanged(Step.NAME_NETWORK);
-            }}
-          >
+          <Button variant="text" onClick={() => flowModel.events.stepChanged(Step.NAME_NETWORK)}>
             {t('createMultisigAccount.backButton')}
           </Button>
           <div className="mt-auto flex items-center justify-end">


### PR DESCRIPTION
- Show all accounts for all wallets (allow duplicates)
- Use `address_walletId` as a Combobox value
- Fixed awkward search (now use account address and name instead of wallet name)
- Added `Threshold` lost label

closes #2711 

<img width="792" alt="image" src="https://github.com/user-attachments/assets/4a56d280-f0cb-47db-b59c-e79c06c6cc9f">
