### PR TITLE
Fix: Correct payee

### DIFF
--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
@@ -116,6 +116,7 @@ export const Confirmation = ({
           </DetailRow>
 
           <hr className="w-full border-filter-border pr-2" />
+
           <DetailRow label={t('staking.confirmation.rewardsDestinationLabel')}>
             {confirmStore.destination ? (
               <Account accountId={toAccountId(confirmStore.destination)} chain={confirmStore.chain} variant="short" />

--- a/src/renderer/pages/Operations/common/utils.ts
+++ b/src/renderer/pages/Operations/common/utils.ts
@@ -120,11 +120,14 @@ export const getDestination = (
 export const getPayee = (tx: MultisigTransaction): { Account: Address } | string | undefined => {
   if (!tx.transaction) return undefined;
 
-  if (isProxyTransaction(tx.transaction)) {
-    return tx.transaction.args.transaction.args.payee;
+  const args = isProxyTransaction(tx.transaction) ? tx.transaction.args.transaction.args : tx.transaction.args;
+
+  // Bond + Nominate
+  if (args.transactions?.at(0)) {
+    return args.transactions.at(0).args.payee;
   }
 
-  return tx.transaction.args.payee;
+  return args.payee;
 };
 
 export const getDelegate = (tx: MultisigTransaction): Address | undefined => {

--- a/src/renderer/pages/Operations/common/utils.ts
+++ b/src/renderer/pages/Operations/common/utils.ts
@@ -122,8 +122,7 @@ export const getPayee = (tx: MultisigTransaction): { Account: Address } | string
 
   const args = isProxyTransaction(tx.transaction) ? tx.transaction.args.transaction.args : tx.transaction.args;
 
-  // Bond + Nominate
-  if (args.transactions?.at(0)) {
+  if (tx.transaction.type === TransactionType.BATCH_ALL) {
     return args.transactions.at(0).args.payee;
   }
 

--- a/src/renderer/pages/Operations/components/Details.tsx
+++ b/src/renderer/pages/Operations/components/Details.tsx
@@ -315,10 +315,10 @@ export const Details = ({ tx, account, extendedChain, signatory }: Props) => {
       {payee && (
         <DetailRow
           label={t('operation.details.payee')}
-          className={typeof payee === 'string' ? 'pr-0' : 'text-text-secondary'}
+          className={cnTw('text-text-secondary', { 'pr-0': typeof payee === 'string' })}
         >
           {typeof payee === 'string' ? (
-            payee
+            t('staking.confirmation.restakeRewards')
           ) : (
             <AddressWithExplorers
               explorers={explorers}

--- a/src/renderer/pages/Operations/components/Details.tsx
+++ b/src/renderer/pages/Operations/components/Details.tsx
@@ -411,7 +411,7 @@ export const Details = ({ tx, account, extendedChain, signatory }: Props) => {
               value={delegationVotes}
               asset={defaultAsset}
               showSymbol={false}
-            ></AssetBalance>
+            />
           </FootnoteText>
         </DetailRow>
       )}
@@ -424,7 +424,7 @@ export const Details = ({ tx, account, extendedChain, signatory }: Props) => {
               value={undelegationVotes}
               asset={defaultAsset}
               showSymbol={false}
-            ></AssetBalance>
+            />
           </FootnoteText>
         </DetailRow>
       )}

--- a/src/renderer/pages/Operations/components/OperationCardDetails.tsx
+++ b/src/renderer/pages/Operations/components/OperationCardDetails.tsx
@@ -360,9 +360,12 @@ export const OperationCardDetails = ({ tx, account, extendedChain }: Props) => {
       )}
 
       {payee && (
-        <DetailRow label={t('operation.details.payee')} className={valueClass}>
+        <DetailRow
+          label={t('operation.details.payee')}
+          className={cnTw(valueClass, { 'pr-0': typeof payee === 'string' })}
+        >
           {typeof payee === 'string' ? (
-            payee
+            t('staking.confirmation.restakeRewards')
           ) : (
             <AddressWithExplorers
               type="short"


### PR DESCRIPTION
- Get correct `payee` for Bond + Nominate operation

closes #2710 

<img width="445" alt="image" src="https://github.com/user-attachments/assets/c1b609eb-40fa-441f-a0c7-58c673ded12d">
