### PR TITLE
feat: implemented special api for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -106,6 +106,7 @@
     "effector": "23.2.3",
     "effector-forms": "2.0.0-next.1",
     "effector-react": "23.2.1",
+    "effector-storage": "7.1.0",
     "electron": "32.2.0",
     "electron-log": "5.2.0",
     "electron-store": "8.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -128,6 +128,9 @@ importers:
       effector-react:
         specifier: 23.2.1
         version: 23.2.1(effector@23.2.3)(react@18.3.1)
+      effector-storage:
+        specifier: 7.1.0
+        version: 7.1.0(effector@23.2.3)
       electron:
         specifier: 32.2.0
         version: 32.2.0
@@ -5149,6 +5152,11 @@ packages:
     peerDependencies:
       effector: ^23.0.0
       react: '>=16.8.0 <19.0.0'
+
+  effector-storage@7.1.0:
+    resolution: {integrity: sha512-l5+RR48g7ZKUldElHnJSkzPwiMeyoO7D+C/xM6g4MVHpM9Waty8HMuIas+udSXYE1Tf9i8xm/AGBhdRrMm2FIA==}
+    peerDependencies:
+      effector: ^22.4.0 || ^23.0.0
 
   effector@23.2.3:
     resolution: {integrity: sha512-nBk3pzdJKT/Sn3OhLUurZoxKXUBd+iqiYHNoBRDFc8EE/vXp2JPNsickX59ZjlDbsWZwTMCVV3tovxjRo+vMGQ==}
@@ -16295,6 +16303,10 @@ snapshots:
       effector: 23.2.3
       react: 18.3.1
       use-sync-external-store: 1.2.0(react@18.3.1)
+
+  effector-storage@7.1.0(effector@23.2.3):
+    dependencies:
+      effector: 23.2.3
 
   effector@23.2.3: {}
 

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -7,6 +7,7 @@ import { createRoot } from 'react-dom/client';
 import { ErrorBoundary } from 'react-error-boundary';
 import { HashRouter } from 'react-router-dom';
 
+import { resetFeatureStatuses, updateFeatureStatus } from '@/shared/config/features';
 import { I18Provider } from '@/shared/i18n';
 import { isElectron } from '@/shared/lib/utils';
 import { FallbackScreen } from '@/shared/ui';
@@ -15,6 +16,22 @@ import { APP_CONFIG } from '../../../app.config';
 import { LoadingDelay, controlledLazy, suspenseDelay } from './DelayedSuspense';
 import { ElectronSplashScreen } from './components/ElectronSplashScreen/ElectronSplashScreen';
 import { WebSplashScreen } from './components/WebSplashScreen/WebSplashScreen';
+
+declare global {
+  interface Window {
+    __spectr_config: {
+      enableFeature(name: string): void;
+      disableFeature(name: string): void;
+      resetFeatureConfig(): void;
+    };
+  }
+}
+
+window.__spectr_config = {
+  enableFeature: (name) => updateFeatureStatus([name, true]),
+  disableFeature: (name) => updateFeatureStatus([name, false]),
+  resetFeatureConfig: () => resetFeatureStatuses(),
+};
 
 const CLEAR_LOADING_TIMEOUT = 700;
 const DIRTY_LOADING_TIMEOUT = 2000;
@@ -64,8 +81,7 @@ if (!container) {
 
 document.body.style.minWidth = `${APP_CONFIG.MAIN.WINDOW.WIDTH}px`;
 
-createRoot(container).render(<Root />);
-
 // NOTE: React 18 Strict mode renders twice in DEV mode
 // which leads to errors in components that use camera
 // https://reactjs.org/docs/strict-mode.html#ensuring-reusable-state
+createRoot(container).render(<Root />);

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -19,7 +19,7 @@ import { WebSplashScreen } from './components/WebSplashScreen/WebSplashScreen';
 
 declare global {
   interface Window {
-    __spectr_config: {
+    __spektr_config: {
       enableFeature(name: string): void;
       disableFeature(name: string): void;
       resetFeatureConfig(): void;
@@ -27,7 +27,7 @@ declare global {
   }
 }
 
-window.__spectr_config = {
+window.__spektr_config = {
   enableFeature: (name) => updateFeatureStatus([name, true]),
   disableFeature: (name) => updateFeatureStatus([name, false]),
   resetFeatureConfig: () => resetFeatureStatuses(),

--- a/src/renderer/shared/config/features/index.ts
+++ b/src/renderer/shared/config/features/index.ts
@@ -1,18 +1,37 @@
-import { createStore } from 'effector';
-import { readonly } from 'patronum';
+import { createEvent, createStore, sample } from 'effector';
+import { persist } from 'effector-storage/session';
 
 import { isDev } from '@/shared/lib/utils';
 
-export const $features = readonly(
-  createStore({
-    assets: true,
-    staking: true,
-    governance: true,
-    // TODO: Dev only
-    fellowship: isDev(),
-    operations: true,
-    contacts: true,
-    notifications: true,
-    settings: true,
-  }),
-);
+export const updateFeatureStatus = createEvent<[feature: string, status: boolean]>();
+export const resetFeatureStatuses = createEvent();
+
+export const $features = createStore({
+  assets: true,
+  staking: true,
+  governance: true,
+  // TODO: Dev only
+  fellowship: isDev(),
+  operations: true,
+  contacts: true,
+  notifications: true,
+  settings: true,
+});
+
+persist({
+  key: 'feature-toggle',
+  store: $features,
+});
+
+sample({
+  clock: updateFeatureStatus,
+  source: $features,
+  filter: (features, [feature]) => feature in features,
+  fn: (features, [feature, status]) => ({ ...features, [feature]: status }),
+  target: $features,
+});
+
+sample({
+  clock: resetFeatureStatuses,
+  target: $features.reinit,
+});


### PR DESCRIPTION
New api `window.__spektr_config`. Now it should help with testing new feature, hidden under feature toggle.

For example, you can call `__spektr_config.enableFeature('fellowship')` to start fellowship feature. This change will be valid within the user session (it's stored in `SessionStorage`).