### PR TITLE
feat: add validation logic tests

### DIFF
--- a/src/renderer/features/operations/OperationsValidation/lib/transfer-rules.ts
+++ b/src/renderer/features/operations/OperationsValidation/lib/transfer-rules.ts
@@ -32,9 +32,9 @@ export const TransferRules = {
       errorText: 'transfer.noSignatoryError',
       source,
       validator: (signatory: Account | null, _: any, isMultisig: boolean) => {
-        if (!signatory || !isMultisig) return true;
+        if (!isMultisig) return true;
 
-        return Object.keys(signatory).length > 0;
+        return signatory !== null && Object.keys(signatory).length > 0;
       },
     }),
     notEnoughTokens: (source: Store<TransferSignatoryFeeStore>) => ({

--- a/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
+++ b/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
@@ -1,7 +1,7 @@
 import { createStore } from 'effector';
 import { describe, expect, it } from 'vitest';
 
-import { type Asset, AssetType, type Chain } from '@/shared/core';
+import { type Account, type Asset, AssetType, type Chain, ChainOptions } from '@/shared/core';
 import { ZERO_BALANCE } from '@/shared/lib/utils';
 import { TransferRules } from '@/features/operations/OperationsValidation/lib/transfer-rules';
 import {
@@ -18,7 +18,7 @@ const createTestAsset = (): Asset => ({
   type: AssetType.NATIVE,
 });
 
-const createTestChain = (): Chain => ({
+const createTestChain = (ethChain: boolean = false): Chain => ({
   chainId: '0x0000000000000000000000000000000000000000000000000000000000000000',
   specName: 'polkadot',
   name: 'Polkadot',
@@ -26,9 +26,12 @@ const createTestChain = (): Chain => ({
   nodes: [],
   icon: '',
   addressPrefix: 0,
+  options: ethChain ? [ChainOptions.ETHEREUM_BASED] : [],
 });
 
 describe('Transfer Validation Rules', () => {
+  const defaultConfig = { withFormatAmount: false };
+
   describe('Account Validation', () => {
     it('should pass when proxy has enough native balance for fee', () => {
       const transferAccountStore: TransferAccountStore = {
@@ -77,13 +80,13 @@ describe('Transfer Validation Rules', () => {
     it('should pass when signatory is selected for multisig', () => {
       const store = createStore(true);
       const rule = TransferRules.signatory.noSignatorySelected(store);
-      expect(rule.validator(null, {}, true)).toBe(true);
+      expect(rule.validator({ address: 'some-address' } as unknown as Account, {}, true)).toBe(true);
     });
 
     it('should fail when no signatory is selected for multisig', () => {
       const store = createStore(true);
       const rule = TransferRules.signatory.noSignatorySelected(store);
-      expect(rule.validator(null, {}, false)).toBe(false);
+      expect(rule.validator(null, {}, true)).toBe(false);
     });
 
     it('should pass when signatory has enough balance for fee and deposit', () => {
@@ -99,11 +102,24 @@ describe('Transfer Validation Rules', () => {
       expect(rule.validator(null, {}, transferSignatoryFeeStore)).toBe(true);
     });
 
-    it('should fail when signatory has insufficient balance for fee and deposit', () => {
+    it('should fail when signatory has insufficient balance for deposit', () => {
       const transferSignatoryFeeStore: TransferSignatoryFeeStore = {
-        fee: '1000000000',
+        fee: '0',
         isMultisig: true,
-        multisigDeposit: '1000000000',
+        multisigDeposit: '2000000000',
+        balance: '1000000000',
+      };
+      const store = createStore<TransferSignatoryFeeStore>(transferSignatoryFeeStore);
+
+      const rule = TransferRules.signatory.notEnoughTokens(store);
+      expect(rule.validator(null, {}, transferSignatoryFeeStore)).toBe(false);
+    });
+
+    it('should fail when signatory has insufficient balance for fee', () => {
+      const transferSignatoryFeeStore: TransferSignatoryFeeStore = {
+        fee: '2000000000',
+        isMultisig: true,
+        multisigDeposit: '0',
         balance: '1000000000',
       };
       const store = createStore<TransferSignatoryFeeStore>(transferSignatoryFeeStore);
@@ -116,23 +132,62 @@ describe('Transfer Validation Rules', () => {
   describe('Destination Validation', () => {
     it('should pass when destination is provided', () => {
       const rule = TransferRules.destination.required;
-      expect(rule.validator('5Hjdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjh')).toBe(true);
+      expect(rule.validator('13mAjFVjFDpfa42k2dLdSnUyrSzK8vAySsoudnxX2EKVtfaq')).toBe(true);
     });
 
     it('should fail when destination is empty', () => {
       const rule = TransferRules.destination.required;
-      expect(rule.validator('')).toBe(false);
+      expect(rule.validator(undefined)).toBe(false);
     });
 
-    it('should pass when destination address is valid for chain', () => {
+    it('should pass when destination address is valid for Substrate chain', () => {
       const chain = createTestChain();
       const store = createStore(chain);
       const rule = TransferRules.destination.incorrectRecipient(store);
 
-      expect(rule.validator('5Hjdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjh', {}, chain)).toBe(true);
+      expect(rule.validator('13mAjFVjFDpfa42k2dLdSnUyrSzK8vAySsoudnxX2EKVtfaq', {}, chain)).toBe(true);
     });
 
-    it('should fail when destination address is invalid for chain', () => {
+    it('should fail when destination address is invalid for Substrate chain', () => {
+      const chain = createTestChain();
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('invalid-address', {}, chain)).toBe(false);
+    });
+    it('should pass when destination address is valid for ETH chain - no checksum', () => {
+      const chain = createTestChain(true);
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('0xc4d9aa77d94c36d737c5a25f5cdd0fcc7baef963', {}, chain)).toBe(true);
+    });
+
+    it('should pass when destination address is valid for ETH chain - checksum', () => {
+      const chain = createTestChain(true);
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('0xC4d9Aa77d94c36D737c5A25F5CdD0FCC7BAEf963', {}, chain)).toBe(true);
+    });
+
+    it('should fail when destination address is eth for substrate', () => {
+      const chain = createTestChain();
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('0xC4d9Aa77d94c36D737c5A25F5CdD0FCC7BAEf963', {}, chain)).toBe(false);
+    });
+
+    it('should fail when destination address is substrate for eth', () => {
+      const chain = createTestChain(true);
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('13mAjFVjFDpfa42k2dLdSnUyrSzK8vAySsoudnxX2EKVtfaq', {}, chain)).toBe(false);
+    });
+
+    it('should fail when destination address is invalid', () => {
       const chain = createTestChain();
       const store = createStore(chain);
       const rule = TransferRules.destination.incorrectRecipient(store);
@@ -172,7 +227,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.notEnoughBalance(store);
+      const rule = TransferRules.amount.notEnoughBalance(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(true);
     });
 
@@ -186,7 +241,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.notEnoughBalance(store);
+      const rule = TransferRules.amount.notEnoughBalance(store, defaultConfig);
       expect(rule.validator('2000000000', {}, storeState)).toBe(false);
     });
 
@@ -207,7 +262,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(true);
     });
 
@@ -228,7 +283,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(false);
     });
 
@@ -249,7 +304,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(true);
     });
 
@@ -270,7 +325,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(false);
     });
 
@@ -291,7 +346,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(true);
     });
 
@@ -312,7 +367,7 @@ describe('Transfer Validation Rules', () => {
       };
       const store = createStore(storeState);
 
-      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store);
+      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(false);
     });
   });

--- a/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
+++ b/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
@@ -3,7 +3,7 @@ import { describe, expect, it } from 'vitest';
 
 import { type Asset, AssetType, type Chain } from '@/shared/core';
 import { ZERO_BALANCE } from '@/shared/lib/utils';
-import { TransferRules } from '@/features/operations/OperationsValidation';
+import { TransferRules } from '@/features/operations/OperationsValidation/lib/transfer-rules';
 import {
   type TransferAccountStore,
   type TransferSignatoryFeeStore,

--- a/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
+++ b/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
@@ -1,0 +1,319 @@
+import { createStore } from 'effector';
+import { describe, expect, it } from 'vitest';
+
+import { type Asset, AssetType, type Chain } from '@/shared/core';
+import { ZERO_BALANCE } from '@/shared/lib/utils';
+import { TransferRules } from '@/features/operations/OperationsValidation';
+import {
+  type TransferAccountStore,
+  type TransferSignatoryFeeStore,
+} from '@/features/operations/OperationsValidation/types/types';
+
+const createTestAsset = (): Asset => ({
+  assetId: 0,
+  symbol: 'DOT',
+  precision: 10,
+  name: 'Polkadot',
+  icon: { monochrome: '', colored: '' },
+  type: AssetType.NATIVE,
+});
+
+const createTestChain = (): Chain => ({
+  chainId: '0x0000000000000000000000000000000000000000000000000000000000000000',
+  specName: 'polkadot',
+  name: 'Polkadot',
+  assets: [createTestAsset()],
+  nodes: [],
+  icon: '',
+  addressPrefix: 0,
+});
+
+describe('Transfer Validation Rules', () => {
+  describe('Account Validation', () => {
+    it('should pass when proxy has enough native balance for fee', () => {
+      const transferAccountStore: TransferAccountStore = {
+        fee: '1000000000',
+        isProxy: true,
+        proxyBalance: { balance: '0', native: '2000000000' },
+      };
+      const store = createStore<TransferAccountStore>(transferAccountStore);
+
+      const rule = TransferRules.account.noProxyFee(store);
+      expect(rule.validator(null, {}, transferAccountStore)).toBe(true);
+    });
+
+    it('should fail when proxy has insufficient native balance for fee', () => {
+      const transferAccountStore: TransferAccountStore = {
+        fee: '2000000000',
+        isProxy: true,
+        proxyBalance: { balance: '0', native: '1000000000' },
+      };
+      const store = createStore<TransferAccountStore>(transferAccountStore);
+
+      const rule = TransferRules.account.noProxyFee(store);
+      expect(rule.validator(null, {}, transferAccountStore)).toBe(false);
+    });
+
+    it('should pass when not using proxy', () => {
+      const transferAccountStore: TransferAccountStore = {
+        fee: '1000000000',
+        isProxy: false,
+        proxyBalance: { balance: '0', native: '0' },
+      };
+      const store = createStore<TransferAccountStore>(transferAccountStore);
+
+      const rule = TransferRules.account.noProxyFee(store);
+      expect(rule.validator(null, {}, transferAccountStore)).toBe(true);
+    });
+  });
+
+  describe('Signatory Validation', () => {
+    it('should pass when no signatory is required', () => {
+      const store = createStore(false);
+      const rule = TransferRules.signatory.noSignatorySelected(store);
+      expect(rule.validator(null, {}, false)).toBe(true);
+    });
+
+    it('should pass when signatory is selected for multisig', () => {
+      const store = createStore(true);
+      const rule = TransferRules.signatory.noSignatorySelected(store);
+      expect(rule.validator(null, {}, true)).toBe(true);
+    });
+
+    it('should fail when no signatory is selected for multisig', () => {
+      const store = createStore(true);
+      const rule = TransferRules.signatory.noSignatorySelected(store);
+      expect(rule.validator(null, {}, false)).toBe(false);
+    });
+
+    it('should pass when signatory has enough balance for fee and deposit', () => {
+      const transferSignatoryFeeStore: TransferSignatoryFeeStore = {
+        fee: '1000000000',
+        isMultisig: true,
+        multisigDeposit: '1000000000',
+        balance: '3000000000',
+      };
+      const store = createStore<TransferSignatoryFeeStore>(transferSignatoryFeeStore);
+
+      const rule = TransferRules.signatory.notEnoughTokens(store);
+      expect(rule.validator(null, {}, transferSignatoryFeeStore)).toBe(true);
+    });
+
+    it('should fail when signatory has insufficient balance for fee and deposit', () => {
+      const transferSignatoryFeeStore: TransferSignatoryFeeStore = {
+        fee: '1000000000',
+        isMultisig: true,
+        multisigDeposit: '1000000000',
+        balance: '1000000000',
+      };
+      const store = createStore<TransferSignatoryFeeStore>(transferSignatoryFeeStore);
+
+      const rule = TransferRules.signatory.notEnoughTokens(store);
+      expect(rule.validator(null, {}, transferSignatoryFeeStore)).toBe(false);
+    });
+  });
+
+  describe('Destination Validation', () => {
+    it('should pass when destination is provided', () => {
+      const rule = TransferRules.destination.required;
+      expect(rule.validator('5Hjdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjh')).toBe(true);
+    });
+
+    it('should fail when destination is empty', () => {
+      const rule = TransferRules.destination.required;
+      expect(rule.validator('')).toBe(false);
+    });
+
+    it('should pass when destination address is valid for chain', () => {
+      const chain = createTestChain();
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('5Hjdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjhdsfkjh', {}, chain)).toBe(true);
+    });
+
+    it('should fail when destination address is invalid for chain', () => {
+      const chain = createTestChain();
+      const store = createStore(chain);
+      const rule = TransferRules.destination.incorrectRecipient(store);
+
+      expect(rule.validator('invalid-address', {}, chain)).toBe(false);
+    });
+  });
+
+  describe('Amount Validation', () => {
+    it('should pass when amount is provided', () => {
+      const rule = TransferRules.amount.required;
+      expect(rule.validator('1000000000')).toBe(true);
+    });
+
+    it('should fail when amount is empty', () => {
+      const rule = TransferRules.amount.required;
+      expect(rule.validator('')).toBe(false);
+    });
+
+    it('should pass when amount is non-zero', () => {
+      const rule = TransferRules.amount.notZero;
+      expect(rule.validator('1000000000')).toBe(true);
+    });
+
+    it('should fail when amount is zero', () => {
+      const rule = TransferRules.amount.notZero;
+      expect(rule.validator(ZERO_BALANCE)).toBe(false);
+    });
+
+    it('should pass when account has sufficient balance', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        balance: { balance: '2000000000', native: '2000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.notEnoughBalance(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(true);
+    });
+
+    it('should fail when account has insufficient balance', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        balance: { balance: '1000000000', native: '1000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.notEnoughBalance(store);
+      expect(rule.validator('2000000000', {}, storeState)).toBe(false);
+    });
+
+    it('should pass when account has sufficient balance for fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '0',
+        deliveryFee: '0',
+        isNative: true,
+        isProxy: false,
+        isMultisig: false,
+        isXcm: false,
+        balance: { balance: '3000000000', native: '3000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(true);
+    });
+
+    it('should fail when account has insufficient balance for fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '0',
+        deliveryFee: '0',
+        isNative: true,
+        isProxy: false,
+        isMultisig: false,
+        isXcm: false,
+        balance: { balance: '1000000000', native: '1000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(false);
+    });
+
+    it('should pass when account has sufficient balance for XCM fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '1000000000',
+        deliveryFee: '0',
+        isNative: true,
+        isProxy: false,
+        isMultisig: false,
+        isXcm: true,
+        balance: { balance: '4000000000', native: '4000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(true);
+    });
+
+    it('should fail when account has insufficient balance for XCM fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '1000000000',
+        deliveryFee: '0',
+        isNative: true,
+        isProxy: false,
+        isMultisig: false,
+        isXcm: true,
+        balance: { balance: '1000000000', native: '1000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForXcmFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(false);
+    });
+
+    it('should pass when account has sufficient balance for delivery fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '0',
+        deliveryFee: '1000000000',
+        isNative: true,
+        isProxy: true,
+        isMultisig: true,
+        isXcm: true,
+        balance: { balance: '4000000000', native: '4000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(true);
+    });
+
+    it('should fail when account has insufficient balance for delivery fee', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: createTestAsset(),
+        },
+        fee: '1000000000',
+        xcmFee: '0',
+        deliveryFee: '1000000000',
+        isNative: true,
+        isProxy: true,
+        isMultisig: true,
+        isXcm: true,
+        balance: { balance: '1000000000', native: '1000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store);
+      expect(rule.validator('1000000000', {}, storeState)).toBe(false);
+    });
+  });
+});

--- a/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
+++ b/src/renderer/widgets/Transfer/model/__tests__/validation.test.ts
@@ -370,5 +370,33 @@ describe('Transfer Validation Rules', () => {
       const rule = TransferRules.amount.insufficientBalanceForDeliveryFee(store, defaultConfig);
       expect(rule.validator('1000000000', {}, storeState)).toBe(false);
     });
+
+    it('should pass when amount is valid with format amount and asset precision', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: { ...createTestAsset(), precision: 10 },
+        },
+        balance: { balance: '15000000000', native: '15000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.notEnoughBalance(store, { withFormatAmount: true });
+      expect(rule.validator('1.5', {}, storeState)).toBe(true);
+    });
+
+    it('should fail when amount exceeds balance with format amount and asset precision', () => {
+      const storeState = {
+        network: {
+          chain: createTestChain(),
+          asset: { ...createTestAsset(), precision: 10 },
+        },
+        balance: { balance: '1000000000', native: '1000000000' },
+      };
+      const store = createStore(storeState);
+
+      const rule = TransferRules.amount.notEnoughBalance(store, { withFormatAmount: true });
+      expect(rule.validator('2.5', {}, storeState)).toBe(false);
+    });
   });
 });


### PR DESCRIPTION
```bash
✓ src/renderer/widgets/Transfer/model/__tests__/validation.test.ts (32 tests) 13ms
   ✓ Transfer Validation Rules > Account Validation > should pass when proxy has enough native balance for fee
   ✓ Transfer Validation Rules > Account Validation > should fail when proxy has insufficient native balance for fee
   ✓ Transfer Validation Rules > Account Validation > should pass when not using proxy
   ✓ Transfer Validation Rules > Signatory Validation > should pass when no signatory is required
   ✓ Transfer Validation Rules > Signatory Validation > should pass when signatory is selected for multisig
   ✓ Transfer Validation Rules > Signatory Validation > should fail when no signatory is selected for multisig
   ✓ Transfer Validation Rules > Signatory Validation > should pass when signatory has enough balance for fee and deposit
   ✓ Transfer Validation Rules > Signatory Validation > should fail when signatory has insufficient balance for deposit
   ✓ Transfer Validation Rules > Signatory Validation > should fail when signatory has insufficient balance for fee
   ✓ Transfer Validation Rules > Destination Validation > should pass when destination is provided
   ✓ Transfer Validation Rules > Destination Validation > should fail when destination is empty
   ✓ Transfer Validation Rules > Destination Validation > should pass when destination address is valid for Substrate chain
   ✓ Transfer Validation Rules > Destination Validation > should fail when destination address is invalid for Substrate chain
   ✓ Transfer Validation Rules > Destination Validation > should pass when destination address is valid for ETH chain - no checksum
   ✓ Transfer Validation Rules > Destination Validation > should pass when destination address is valid for ETH chain - checksum
   ✓ Transfer Validation Rules > Destination Validation > should fail when destination address is eth for substrate
   ✓ Transfer Validation Rules > Destination Validation > should fail when destination address is substrate for eth
   ✓ Transfer Validation Rules > Destination Validation > should fail when destination address is invalid
   ✓ Transfer Validation Rules > Amount Validation > should pass when amount is provided
   ✓ Transfer Validation Rules > Amount Validation > should fail when amount is empty
   ✓ Transfer Validation Rules > Amount Validation > should pass when amount is non-zero
   ✓ Transfer Validation Rules > Amount Validation > should fail when amount is zero
   ✓ Transfer Validation Rules > Amount Validation > should pass when account has sufficient balance
   ✓ Transfer Validation Rules > Amount Validation > should fail when account has insufficient balance
   ✓ Transfer Validation Rules > Amount Validation > should pass when account has sufficient balance for fee
   ✓ Transfer Validation Rules > Amount Validation > should fail when account has insufficient balance for fee
   ✓ Transfer Validation Rules > Amount Validation > should pass when account has sufficient balance for XCM fee
   ✓ Transfer Validation Rules > Amount Validation > should fail when account has insufficient balance for XCM fee
   ✓ Transfer Validation Rules > Amount Validation > should pass when account has sufficient balance for delivery fee
   ✓ Transfer Validation Rules > Amount Validation > should fail when account has insufficient balance for delivery fee
   ✓ Transfer Validation Rules > Amount Validation > should pass when amount is valid with format amount and asset precision
   ✓ Transfer Validation Rules > Amount Validation > should fail when amount exceeds balance with format amount and asset precision
```