### PR TITLE
Fix: Use accountId

### DIFF
--- a/src/renderer/entities/wallet/lib/account-utils.ts
+++ b/src/renderer/entities/wallet/lib/account-utils.ts
@@ -199,7 +199,10 @@ function getSignatoryAccounts<T extends VaultBaseAccount>(accountIds: AccountId[
   return accountIds.map((id) => accountsMap[id]);
 }
 
-type DerivationPathLike = { derivationPath: string };
+type DerivationPathLike = {
+  derivationPath: string;
+};
+
 function getDerivationPath(data: DerivationPathLike | DerivationPathLike[]): string {
   if (!Array.isArray(data)) return data.derivationPath;
 
@@ -236,7 +239,7 @@ function isNonBaseVaultAccount(account: AnyAccount, wallet: Wallet): boolean {
 
 function getAccountsIdsForWallet(wallet: Wallet, chain: Chain) {
   const matchedAccounts = walletUtils.getAccountsBy([wallet], (account) => {
-    return accountUtils.isNonBaseVaultAccount(account, wallet) && isChainIdMatch(account, chain.chainId);
+    return isNonBaseVaultAccount(account, wallet) && isChainIdMatch(account, chain.chainId);
   });
 
   return matchedAccounts.map((a) => a.accountId);

--- a/src/renderer/features/governance/aggregates/voting.ts
+++ b/src/renderer/features/governance/aggregates/voting.ts
@@ -28,7 +28,7 @@ const $activeWalletVotes = combine(
 
     for (const accountId of accountIds) {
       if (accountId in voting) {
-        res[accountId] = voting[accountId];
+        result[accountId] = voting[accountId];
       }
     }
 

--- a/src/renderer/features/governance/aggregates/voting.ts
+++ b/src/renderer/features/governance/aggregates/voting.ts
@@ -23,7 +23,7 @@ const $activeWalletVotes = combine(
       return {};
     }
 
-    const addresses = accountUtils.getAddressesForWallet(wallet, chain);
+    const addresses = accountUtils.getAccountsIdsForWallet(wallet, chain);
     const res: VotingMap = {};
 
     for (const address of addresses) {

--- a/src/renderer/features/governance/aggregates/voting.ts
+++ b/src/renderer/features/governance/aggregates/voting.ts
@@ -23,16 +23,16 @@ const $activeWalletVotes = combine(
       return {};
     }
 
-    const addresses = accountUtils.getAccountsIdsForWallet(wallet, chain);
-    const res: VotingMap = {};
+    const accountIds = accountUtils.getAccountsIdsForWallet(wallet, chain);
+    const result: VotingMap = {};
 
-    for (const address of addresses) {
-      if (address in voting) {
-        res[address] = voting[address];
+    for (const accountId of accountIds) {
+      if (accountId in voting) {
+        res[accountId] = voting[accountId];
       }
     }
 
-    return res;
+    return result;
   },
 );
 


### PR DESCRIPTION
- Use `accountId` instead of `address`

closes #3295 