### PR TITLE
Fix: Filter accounts for Vote/Revote

### DIFF
--- a/src/renderer/app/providers/context/MultisigChainContext/MultisigChainContext.tsx
+++ b/src/renderer/app/providers/context/MultisigChainContext/MultisigChainContext.tsx
@@ -49,10 +49,7 @@ export const MultisigChainProvider = ({ children }: PropsWithChildren) => {
   const txs = getLiveAccountMultisigTxs(account?.accountId ? [account.accountId] : []);
   const events = getLiveEventsByKeys(txs);
 
-  useGate(operationsModel.gate.flow, {
-    transactions: txs,
-    events,
-  });
+  useGate(operationsModel.gates.flow, { transactions: txs, events });
 
   useEffect(() => {
     // eslint-disable-next-line no-restricted-syntax

--- a/src/renderer/entities/operations/model/operations-model.ts
+++ b/src/renderer/entities/operations/model/operations-model.ts
@@ -21,7 +21,7 @@ export const operationsModel = {
     changeFilteredTxs,
   },
 
-  gate: {
+  gates: {
     flow,
   },
 };

--- a/src/renderer/features/governance/aggregates/delegation.ts
+++ b/src/renderer/features/governance/aggregates/delegation.ts
@@ -41,7 +41,9 @@ const $activeDelegations = combine(
   ({ activeVotes, chain }) => {
     const activeBalances: DelegationBalanceMap = {};
 
-    for (const [address, delegations] of Object.entries(activeVotes)) {
+    for (const [voterAccountId, delegations] of Object.entries(activeVotes)) {
+      const voterAddress = toAddress(voterAccountId, { prefix: chain?.addressPrefix });
+
       for (const delegation of Object.values(delegations)) {
         if (!votingService.isDelegating(delegation)) continue;
 
@@ -51,7 +53,7 @@ const $activeDelegations = combine(
           activeBalances[target] = {};
         }
 
-        activeBalances[target][address] = {
+        activeBalances[target][voterAddress] = {
           conviction: delegation.conviction,
           balance: delegation.balance,
         };
@@ -70,7 +72,9 @@ const $activeTracks = combine(
   ({ activeVotes, chain }) => {
     const activeTracks: DelegationTracksMap = {};
 
-    for (const [address, delegations] of Object.entries(activeVotes)) {
+    for (const [voterAccountId, delegations] of Object.entries(activeVotes)) {
+      const voterAddress = toAddress(voterAccountId, { prefix: chain?.addressPrefix });
+
       for (const [track, delegation] of Object.entries(delegations)) {
         if (!votingService.isDelegating(delegation)) continue;
 
@@ -80,11 +84,11 @@ const $activeTracks = combine(
           activeTracks[target] = {};
         }
 
-        if (!activeTracks[target][address]) {
-          activeTracks[target][address] = [];
+        if (!activeTracks[target][voterAddress]) {
+          activeTracks[target][voterAddress] = [];
         }
 
-        activeTracks[target][address].push(track);
+        activeTracks[target][voterAddress].push(track);
       }
     }
 

--- a/src/renderer/features/governance/components/VotedBy/VotedBy.tsx
+++ b/src/renderer/features/governance/components/VotedBy/VotedBy.tsx
@@ -1,5 +1,6 @@
 import { type DelegateInfo } from '@/shared/api/governance';
 import { type AccountVote, type Address, type Asset, type Identity } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 
 import { VotedByDelegates } from './VotedByDelegates';
 import { VotedCombined } from './VotedCombined';
@@ -9,7 +10,7 @@ type Props = {
   identity: Record<Address, Identity>;
   delegates: DelegateInfo[];
   castingVotes: {
-    voter: Address;
+    voter: AccountId;
     vote: AccountVote;
   }[];
 };

--- a/src/renderer/features/governance/components/VotedBy/VotedCombined.tsx
+++ b/src/renderer/features/governance/components/VotedBy/VotedCombined.tsx
@@ -4,15 +4,9 @@ import { Trans } from 'react-i18next';
 
 import { type DelegateInfo } from '@/shared/api/governance';
 import { TEST_IDS } from '@/shared/constants';
-import {
-  type AccountVote,
-  type Address,
-  type Asset,
-  type SplitAbstainVote,
-  type StandardVote,
-  type XOR,
-} from '@/shared/core';
+import { type AccountVote, type Asset, type SplitAbstainVote, type StandardVote, type XOR } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, Icon } from '@/shared/ui';
 import { AssetBalance } from '@/shared/ui-entities';
 import { votingService } from '@/entities/governance';
@@ -21,7 +15,7 @@ type Props = {
   asset: Asset;
   delegates: DelegateInfo[];
   castingVotes: {
-    voter: Address;
+    voter: AccountId;
     vote: AccountVote;
   }[];
 };

--- a/src/renderer/features/governance/lib/createTransactionForm.ts
+++ b/src/renderer/features/governance/lib/createTransactionForm.ts
@@ -4,27 +4,21 @@ import { type Store, combine, createEvent, createStore, sample } from 'effector'
 import { type Form, type FormConfig, createForm } from 'effector-forms';
 import { isNil } from 'lodash';
 
-import {
-  type Account,
-  type Address,
-  type Asset,
-  type Balance,
-  type Chain,
-  type Transaction,
-  type Wallet,
-} from '@/shared/core';
+import { type Address, type Asset, type Balance, type Chain, type Transaction, type Wallet } from '@/shared/core';
 import { nullable, toAddress, transferableAmountBN } from '@/shared/lib/utils';
 import { createTxStore } from '@/shared/transactions';
+import { type AnyAccount } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
 import { transactionService } from '@/entities/transaction';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 
 export type BasicFormParams = {
-  account: Account | null;
-  signatory: Account | null;
+  account: AnyAccount | null;
+  signatory: AnyAccount | null;
 };
 
 type Params<FormShape extends NonNullable<unknown>> = {
+  $type: Store<'vote' | 'revote' | null>;
   $voters: Store<Address[]>;
   $activeWallet: Store<Wallet | null>;
   $wallets: Store<Wallet[]>;
@@ -40,9 +34,13 @@ type TransactionFactory<FormShape extends NonNullable<unknown>> = (
   params: Omit<Params<FormShape>, 'createTransactionStore' | 'form'> & { form: Form<FormShape & BasicFormParams> },
 ) => Store<Transaction | null>;
 
-export type AccountOption = { account: Account; balance: Balance | null };
+export type AccountOption = {
+  account: AnyAccount;
+  balance: Balance | null;
+};
 
 export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
+  $type,
   $voters,
   $activeWallet,
   $wallets,
@@ -92,6 +90,7 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
   // Transactions
 
   const $coreTx = createTransactionStore({
+    $type,
     $voters,
     $activeWallet,
     $wallets,
@@ -115,12 +114,19 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
   // Derived
 
   sample({
-    clock: [$chain, $asset, $activeWallet, $balances, $voters],
-    source: { chain: $chain, asset: $asset, wallet: $activeWallet, balances: $balances, voters: $voters },
-    fn: ({ chain, asset, wallet, balances, voters }) => {
-      if (nullable(wallet) || nullable(chain) || nullable(asset)) return [];
+    clock: [$type, $chain, $asset, $activeWallet, $balances, $voters],
+    source: {
+      type: $type,
+      chain: $chain,
+      asset: $asset,
+      wallet: $activeWallet,
+      balances: $balances,
+      voters: $voters,
+    },
+    fn: ({ type, chain, asset, wallet, balances, voters }) => {
+      if (nullable(type) || nullable(wallet) || nullable(chain) || nullable(asset)) return [];
 
-      let walletAccounts: Account[] = [];
+      let walletAccounts: AnyAccount[] = [];
 
       if (walletUtils.isPolkadotVault(wallet)) {
         const shards = wallet.accounts.filter((a) => {
@@ -141,7 +147,13 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
         walletAccounts = wallet.accounts.filter((a) => accountUtils.isChainAndCryptoMatch(a, chain));
       }
 
-      if (voters.length) {
+      if (voters.length > 0 && type === 'vote') {
+        walletAccounts = walletAccounts.filter((account) => {
+          return !voters.includes(toAddress(account.accountId, { prefix: chain.addressPrefix }));
+        });
+      }
+
+      if (voters.length > 0 && type === 'revote') {
         walletAccounts = walletAccounts.filter((account) => {
           return voters.includes(toAddress(account.accountId, { prefix: chain.addressPrefix }));
         });
@@ -150,23 +162,20 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
       return walletAccounts.map<AccountOption>((account) => {
         const balance = balanceUtils.getBalance(balances, account.accountId, chain.chainId, asset.assetId.toString());
 
-        return {
-          account,
-          balance: balance ?? null,
-        };
+        return { account, balance: balance ?? null };
       });
     },
     target: $accounts,
   });
 
   sample({
-    clock: [$chain, $asset, $wallets, $activeWallet, tx.$txWrappers, $balances],
+    clock: [$chain, $asset, $wallets, $activeWallet, $balances, tx.$txWrappers],
     source: {
       chain: $chain,
       asset: $asset,
       wallets: $wallets,
-      txWrappers: tx.$txWrappers,
       balances: $balances,
+      txWrappers: tx.$txWrappers,
     },
     fn: ({ chain, asset, txWrappers, wallets, balances }) => {
       if (!chain || !asset) return [];
@@ -278,11 +287,7 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
     clock: reinitForm,
     source: $signatories,
     filter: (signatories) => signatories.length === 1,
-    fn: (signers) => {
-      const signer = signers.at(0);
-
-      return signer ? signer.account : null;
-    },
+    fn: (signers) => signers.at(0)?.account ?? null,
     target: form.fields.signatory.onChange,
   });
 

--- a/src/renderer/features/governance/lib/createTransactionForm.ts
+++ b/src/renderer/features/governance/lib/createTransactionForm.ts
@@ -2,10 +2,9 @@ import { type ApiPromise } from '@polkadot/api';
 import { BN_ZERO } from '@polkadot/util';
 import { type Store, combine, createEvent, createStore, sample } from 'effector';
 import { type Form, type FormConfig, createForm } from 'effector-forms';
-import { isNil } from 'lodash';
 
 import { type Address, type Asset, type Balance, type Chain, type Transaction, type Wallet } from '@/shared/core';
-import { nullable, toAddress, transferableAmountBN } from '@/shared/lib/utils';
+import { nonNullable, nullable, toAddress, transferableAmountBN } from '@/shared/lib/utils';
 import { createTxStore } from '@/shared/transactions';
 import { type AnyAccount } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
@@ -68,7 +67,7 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
           {
             name: 'emptyAccount',
             errorText: 'governance.vote.errors.noAccountError',
-            validator: (account) => !isNil(account),
+            validator: nonNullable,
           },
         ],
       },
@@ -79,7 +78,7 @@ export const createTransactionForm = <FormShape extends NonNullable<unknown>>({
             name: 'emptySignatory',
             errorText: 'governance.vote.errors.noSignatoryError',
             source: $signatories,
-            validator: (signatory, _, signatories) => signatories.length === 0 || !isNil(signatory),
+            validator: (signatory, _, signatories) => signatories.length === 0 || nonNullable(signatory),
           },
         ],
       },

--- a/src/renderer/pages/Governance/ui/GovernanceReferendumDetails.tsx
+++ b/src/renderer/pages/Governance/ui/GovernanceReferendumDetails.tsx
@@ -33,9 +33,11 @@ export const GovernanceReferendumDetails = () => {
   const selectedReferendum = useMemo(() => {
     if (!selectedReferendumId) return null;
 
-    return (
-      all.find((x) => referendaPallet.helpers.toReferendumId(parseInt(x.referendumId)) === selectedReferendumId) ?? null
-    );
+    const referendum = all.find(({ referendumId }) => {
+      return referendaPallet.helpers.toReferendumId(parseInt(referendumId)) === selectedReferendumId;
+    });
+
+    return referendum ?? null;
   }, [all, selectedReferendumId]);
 
   useEffect(() => {
@@ -98,7 +100,6 @@ export const GovernanceReferendumDetails = () => {
         referendumService.isOngoing(selectedReferendum) && (
           <RevoteModal
             referendum={selectedReferendum}
-            votes={selectedReferendum.voting.votes}
             chain={network.chain}
             asset={network.asset}
             onClose={() => setShowRevoteModal(false)}

--- a/src/renderer/widgets/DelegateDetails/model/delegate-details-model.ts
+++ b/src/renderer/widgets/DelegateDetails/model/delegate-details-model.ts
@@ -58,7 +58,10 @@ const $activeTracks = combine(
 );
 
 const $activeDelegations = combine(
-  { delegations: delegationAggregate.$activeDelegations, delegate: $delegate },
+  {
+    delegations: delegationAggregate.$activeDelegations,
+    delegate: $delegate,
+  },
   ({ delegations, delegate }) => {
     if (!delegate) return {};
 

--- a/src/renderer/widgets/DelegateDetails/ui/YourDelegations.tsx
+++ b/src/renderer/widgets/DelegateDetails/ui/YourDelegations.tsx
@@ -92,10 +92,11 @@ export const YourDelegations = () => {
 
         <ul className="mx-2 mb-4 flex flex-col gap-y-2">
           {activeAccounts.map((address, index) => {
+            const activeDelegation = activeDelegations[address];
+
             const account = wallet?.accounts.find((a) => {
               return toAddress(a.accountId, { prefix: chain.addressPrefix }) === address;
             });
-            const activeDelegation = activeDelegations[address];
 
             if (!account || !activeDelegation || !activeTracks[address]) return null;
 

--- a/src/renderer/widgets/VoteModal/aggregates/voteForm.ts
+++ b/src/renderer/widgets/VoteModal/aggregates/voteForm.ts
@@ -1,6 +1,5 @@
 import { type BN, BN_ZERO } from '@polkadot/util';
 import { combine, createEvent, createStore, sample } from 'effector';
-import { isNil } from 'lodash';
 import { and, empty, not, reset } from 'patronum';
 
 import { type AccountVote, type Address, type Conviction, type OngoingReferendum } from '@/shared/core';
@@ -9,7 +8,7 @@ import { balanceModel } from '@/entities/balance';
 import { locksService, voteTransactionService } from '@/entities/governance';
 import { type WrappedTransactions, transactionBuilder } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
-import { networkSelectorModel } from '@/features/governance';
+import { type AggregatedReferendum, networkSelectorModel } from '@/features/governance';
 import { locksAggregate } from '@/features/governance/aggregates/locks';
 import { type BasicFormParams, createTransactionForm } from '@/features/governance/lib/createTransactionForm';
 import { voteValidateModel } from '@/features/governance/model/vote/voteValidateModel';
@@ -28,9 +27,10 @@ type FormInput = {
   wrappedTransactions: WrappedTransactions;
 };
 
+const $type = createStore<'vote' | 'revote' | null>(null);
 const $voters = createStore<Address[]>([]);
 const $existingVote = createStore<AccountVote | null>(null);
-const $referendum = createStore<OngoingReferendum | null>(null);
+const $referendum = createStore<AggregatedReferendum<OngoingReferendum> | null>(null);
 const $availableBalance = createStore(BN_ZERO);
 const $lockForAccount = createStore(BN_ZERO);
 
@@ -39,12 +39,13 @@ const $canSubmit = createStore(false);
 const formSubmitted = createEvent<FormInput>();
 
 const transactionForm = createTransactionForm<Form>({
+  $type,
   $voters,
   $asset: votingAssetModel.$votingAsset,
   $chain: networkSelectorModel.$governanceChain,
   $api: networkSelectorModel.$governanceChainApi,
 
-  $activeWallet: walletModel.$activeWallet.map((x) => x ?? null),
+  $activeWallet: walletModel.$activeWallet.map((w) => w ?? null),
   $wallets: walletModel.$wallets,
   $balances: balanceModel.$balances,
 
@@ -129,12 +130,15 @@ sample({
 
 sample({
   clock: form.fields.account.onChange,
-  source: { referendum: $referendum, accounts: accounts.$available },
-  filter: ({ referendum }, account) => !isNil(account) && !isNil(referendum),
+  source: {
+    referendum: $referendum,
+    accounts: accounts.$available,
+  },
+  filter: ({ referendum }, account) => nonNullable(account) && nonNullable(referendum),
   fn: ({ referendum, accounts }, account) => {
     if (!account || !referendum) return BN_ZERO;
 
-    const accountBalance = accounts.find((x) => x.account.accountId === account.accountId)?.balance ?? null;
+    const accountBalance = accounts.find((a) => a.account.accountId === account.accountId)?.balance ?? null;
     if (!accountBalance) return BN_ZERO;
 
     return locksService.getAvailableBalance(accountBalance);
@@ -217,6 +221,7 @@ sample({
 export const voteFormAggregate = {
   transactionForm,
 
+  $type,
   $referendum,
   $voters,
   $existingVote,

--- a/src/renderer/widgets/VoteModal/aggregates/voteModal.ts
+++ b/src/renderer/widgets/VoteModal/aggregates/voteModal.ts
@@ -1,13 +1,15 @@
 import { combine, createEvent, createStore, sample } from 'effector';
 import { createGate } from 'effector-react';
+import { spread } from 'patronum';
 
-import { type AccountVote, type Address, type OngoingReferendum } from '@/shared/core';
+import { type OngoingReferendum } from '@/shared/core';
 import { Step, isStep, nonNullable, nullable, toAddress } from '@/shared/lib/utils';
 import { type PathType, Paths } from '@/shared/routes';
 import { votingService } from '@/entities/governance';
 import { walletModel } from '@/entities/wallet';
 import { basketOperations } from '@/aggregates/basket-operations';
 import {
+  type AggregatedReferendum,
   delegationAggregate,
   lockPeriodsModel,
   locksModel,
@@ -22,11 +24,11 @@ import { voteConfirmModel } from '@/features/operations/OperationsConfirm';
 import { voteFormAggregate } from './voteForm';
 
 const flow = createGate<{
-  referendum: OngoingReferendum | null;
-  votes: { voter: Address; vote: AccountVote }[];
+  type: 'vote' | 'revote' | null;
+  referendum: AggregatedReferendum<OngoingReferendum> | null;
 }>({
   defaultState: {
-    votes: [],
+    type: null,
     referendum: null,
   },
 });
@@ -47,8 +49,8 @@ const $hasDelegatedTrack = combine(
 
     const accountAddress = toAddress(account.accountId, { prefix: network.chain.addressPrefix });
 
-    for (const dalegators of Object.values(tracks)) {
-      for (const [address, tracks] of Object.entries(dalegators)) {
+    for (const delegators of Object.values(tracks)) {
+      for (const [address, tracks] of Object.entries(delegators)) {
         if (address === accountAddress && tracks.includes(referendum.track)) {
           return true;
         }
@@ -141,30 +143,45 @@ sample({
 
 sample({
   clock: flow.open,
-  fn: ({ referendum }) => referendum,
-  target: voteFormAggregate.$referendum,
+  source: networkSelectorModel.$network,
+  filter: (network, { referendum }) => {
+    return nonNullable(network) && nonNullable(referendum);
+  },
+  fn: (network, { type, referendum }) => {
+    const voters = referendum!.voting.votes.map((vote) =>
+      toAddress(vote.voter, { prefix: network?.chain.addressPrefix }),
+    );
+
+    return { type, referendum, voters };
+  },
+  target: spread({
+    type: voteFormAggregate.$type,
+    referendum: voteFormAggregate.$referendum,
+    voters: voteFormAggregate.$voters,
+  }),
+});
+
+sample({
+  clock: flow.open,
+  target: reinitForm,
 });
 
 sample({
   clock: form.fields.account.$value,
-  source: { state: flow.state, network: networkSelectorModel.$network },
+  source: {
+    state: flow.state,
+    network: networkSelectorModel.$network,
+  },
   fn: ({ state, network }, account) => {
-    if (nullable(account) || nullable(network) || state.votes.length === 0) return null;
+    if (nullable(account) || nullable(network) || state.referendum?.voting.votes.length === 0) return null;
 
-    const record = state.votes.find(({ voter }) => {
-      return voter === toAddress(account.accountId, { prefix: network.chain.addressPrefix });
-    });
+    const record = state.referendum?.voting.votes.find(({ voter }) => voter === account.accountId);
 
     if (!record) return null;
 
     return record.vote;
   },
   target: voteFormAggregate.$existingVote,
-});
-
-sample({
-  clock: flow.open,
-  target: reinitForm,
 });
 
 sample({
@@ -188,7 +205,13 @@ sample({
 
 sample({
   clock: flow.state,
-  fn: ({ votes }) => votes.map((x) => x.voter),
+  source: networkSelectorModel.$network,
+  filter: (network, { referendum }) => {
+    return nonNullable(network) && nonNullable(referendum);
+  },
+  fn: (network, { referendum }) => {
+    return referendum!.voting.votes.map((vote) => toAddress(vote.voter, { prefix: network?.chain.addressPrefix }));
+  },
   target: voteFormAggregate.$voters,
 });
 
@@ -196,7 +219,9 @@ sample({
 
 sample({
   clock: voteConfirmModel.events.sign,
-  source: { confirms: voteConfirmModel.$confirmMap },
+  source: {
+    confirms: voteConfirmModel.$confirmMap,
+  },
   fn: ({ confirms }): { signingPayloads: SigningPayload[] } => {
     if (!confirms) {
       return { signingPayloads: [] };

--- a/src/renderer/widgets/VoteModal/ui/RevoteModal.tsx
+++ b/src/renderer/widgets/VoteModal/ui/RevoteModal.tsx
@@ -1,6 +1,6 @@
 import { useGate, useUnit } from 'effector-react';
 
-import { type AccountVote, type Address, type Asset, type Chain, type OngoingReferendum } from '@/shared/core';
+import { type Asset, type Chain, type OngoingReferendum } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { useModalClose } from '@/shared/lib/hooks';
 import { Step, isStep } from '@/shared/lib/utils';
@@ -8,6 +8,7 @@ import { BaseModal, Button } from '@/shared/ui';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
 import { OperationResult } from '@/entities/transaction';
+import { type AggregatedReferendum } from '@/features/governance';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { VoteConfirmation } from '@/features/operations/OperationsConfirm';
 import { voteModalAggregate } from '../aggregates/voteModal';
@@ -15,17 +16,17 @@ import { voteModalAggregate } from '../aggregates/voteModal';
 import { VoteForm } from './VoteForm';
 
 type Props = {
-  referendum: OngoingReferendum;
-  votes: { voter: Address; vote: AccountVote }[];
+  referendum: AggregatedReferendum<OngoingReferendum>;
   chain: Chain;
   asset: Asset;
   onClose: VoidFunction;
 };
 
-export const RevoteModal = ({ referendum, votes, asset, chain, onClose }: Props) => {
-  useGate(voteModalAggregate.gates.flow, { referendum, votes });
-
+export const RevoteModal = ({ referendum, asset, chain, onClose }: Props) => {
   const { t } = useI18n();
+
+  useGate(voteModalAggregate.gates.flow, { type: 'revote', referendum });
+
   const step = useUnit(voteModalAggregate.$step);
   const initiatorWallet = useUnit(voteModalAggregate.accounts.$initiatorWallet);
 

--- a/src/renderer/widgets/VoteModal/ui/VoteModal.tsx
+++ b/src/renderer/widgets/VoteModal/ui/VoteModal.tsx
@@ -9,6 +9,7 @@ import { Modal } from '@/shared/ui-kit';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
 import { OperationResult } from '@/entities/transaction';
+import { type AggregatedReferendum } from '@/features/governance';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { VoteConfirmation } from '@/features/operations/OperationsConfirm';
 import { voteModalAggregate } from '../aggregates/voteModal';
@@ -16,16 +17,17 @@ import { voteModalAggregate } from '../aggregates/voteModal';
 import { VoteForm } from './VoteForm';
 
 type Props = {
-  referendum: OngoingReferendum;
+  referendum: AggregatedReferendum<OngoingReferendum>;
   chain: Chain;
   asset: Asset;
   onClose: VoidFunction;
 };
 
 export const VoteModal = ({ referendum, asset, chain, onClose }: Props) => {
-  useGate(voteModalAggregate.gates.flow, { referendum, votes: [] });
-
   const { t } = useI18n();
+
+  useGate(voteModalAggregate.gates.flow, { type: 'vote', referendum });
+
   const step = useUnit(voteModalAggregate.$step);
   const initiatorWallet = useUnit(voteModalAggregate.accounts.$initiatorWallet);
 


### PR DESCRIPTION
- Use `AccountId` instead of `Address`
- Filter available accounts on Vote and Revote forms

closes #3307 