### PR TITLE
feat: suspense for asset icon

### DIFF
--- a/src/renderer/features/assets/AssetsPortfolioView/ui/AssetsPortfolioView.tsx
+++ b/src/renderer/features/assets/AssetsPortfolioView/ui/AssetsPortfolioView.tsx
@@ -61,7 +61,10 @@ export const AssetsPortfolioView = () => {
 
       <ul className="flex min-h-full w-full flex-col items-center gap-y-2">
         {list.map((asset) => (
-          <li key={`${asset.priceId || ''}${asset.symbol}`} className="w-full max-w-[736px]">
+          <li
+            key={`${asset.priceId || ''}-${asset.symbol}-${asset.chains[0]?.chainId}`}
+            className="w-full max-w-[736px]"
+          >
             {asset.chains.length === 1 ? <TokenBalance asset={asset} /> : <TokenBalanceList asset={asset} />}
           </li>
         ))}

--- a/src/renderer/shared/ui-entities/AssetIcon/AssetIcon.tsx
+++ b/src/renderer/shared/ui-entities/AssetIcon/AssetIcon.tsx
@@ -2,7 +2,7 @@ import { memo, useState } from 'react';
 
 import { type Asset } from '@/shared/core';
 import { cnTw } from '@/shared/lib/utils';
-import { useTheme } from '@/shared/ui-kit';
+import { Skeleton, useTheme } from '@/shared/ui-kit';
 
 type Props = {
   asset: Pick<Asset, 'name' | 'icon'>;
@@ -27,9 +27,11 @@ export const AssetIcon = memo(({ asset, style, size = 36 }: Props) => {
         'border border-token-border bg-token-background p-px': computedStyle === 'monochrome',
       })}
     >
+      {!isImgLoaded && <Skeleton circle width={iconSize / 4} height={iconSize / 4} />}
+
       <img
         src={iconSrc}
-        className={cnTw('select-none transition-opacity duration-75', !isImgLoaded && 'opacity-0')}
+        className={cnTw('select-none transition-opacity duration-75', !isImgLoaded && 'hidden')}
         // using width and height attr doesn't work properly for invisible img. It gets reset by tailwind @base styles
         style={{ width: iconSize, height: iconSize }}
         alt={asset.name}


### PR DESCRIPTION
** before ** 
<img width="500" alt="image" src="https://github.com/user-attachments/assets/9ee12396-f931-4fa5-b242-799cafb9306d" />

** after **
<img width="500" alt="image" src="https://github.com/user-attachments/assets/b46d5412-2380-40b1-9494-70fe612e9b49" />


closes #2909 