### PR TITLE
fix: show tasks for watch-only wallets in fellowship profile

### DIFF
--- a/src/renderer/features/fellowship-evidence-salary/components/VotingActions.tsx
+++ b/src/renderer/features/fellowship-evidence-salary/components/VotingActions.tsx
@@ -13,19 +13,20 @@ type Props = {
   evidence: Evidence;
   endBlock: number | null;
   variant: 'large' | 'small';
+  disabled: boolean;
 };
 
-export const VotingActions = memo(({ evidence, endBlock, variant }: Props) => {
+export const VotingActions = memo(({ evidence, endBlock, variant, disabled }: Props) => {
   const { t } = useI18n();
 
   const buttonNodes = (
     <Box direction="row" gap={1}>
       <EvidenceVotingModal evidence={evidence} aye={false}>
-        <FilledIconButton variant="negative" icon="thumbDown" />
+        <FilledIconButton variant="negative" icon="thumbDown" disabled={disabled} />
       </EvidenceVotingModal>
 
       <EvidenceVotingModal evidence={evidence} aye={true}>
-        <FilledIconButton variant="positive" icon="thumbUp" />
+        <FilledIconButton variant="positive" icon="thumbUp" disabled={disabled} />
       </EvidenceVotingModal>
     </Box>
   );
@@ -34,12 +35,12 @@ export const VotingActions = memo(({ evidence, endBlock, variant }: Props) => {
     return (
       <Box direction="row" gap={4} width="100%">
         <EvidenceVotingModal evidence={evidence} aye={false}>
-          <ButtonCard pallet="negative" icon="thumbDown" fullWidth>
+          <ButtonCard pallet="negative" icon="thumbDown" fullWidth disabled={disabled}>
             {t('fellowship.voting.nay')}
           </ButtonCard>
         </EvidenceVotingModal>
         <EvidenceVotingModal evidence={evidence} aye={true}>
-          <ButtonCard pallet="positive" icon="thumbUp" fullWidth>
+          <ButtonCard pallet="positive" icon="thumbUp" fullWidth disabled={disabled}>
             {t('fellowship.voting.aye')}
           </ButtonCard>
         </EvidenceVotingModal>

--- a/src/renderer/features/fellowship-evidence-salary/index.tsx
+++ b/src/renderer/features/fellowship-evidence-salary/index.tsx
@@ -28,6 +28,7 @@ import { SubmitEvidenceConfirmation } from './components/SubmitEvidenceConfirmat
 import { VotingActions } from './components/VotingActions';
 import { fellowshipSalaryFeature } from './model/feature';
 import { memberSalary } from './model/memberSalary';
+import { profile } from './model/profile';
 import { salaryInduct } from './model/salaryInduct';
 import { salaryPayout } from './model/salaryPayout';
 import { salaryRequest } from './model/salaryRequest';
@@ -43,6 +44,7 @@ fellowshipSalaryFeature.inject(requestSalaryTaskActionSlot, () => {
   const { t } = useI18n();
   const account = useUnit(salaryRequest.$account);
   const currentPeriod = useUnit(memberSalary.$currentPeriod);
+  const canVote = useUnit(profile.$canVote);
   const canSaveToBasket = account && basketUtils.isBasketAvailableForAccount(account);
   const currentPeriodExists = currentPeriod && currentPeriod.type !== 'unknown';
 
@@ -50,7 +52,7 @@ fellowshipSalaryFeature.inject(requestSalaryTaskActionSlot, () => {
     return (
       <>
         {currentPeriodExists && <PeriodEndTimer endBlock={currentPeriod.until} shortDateFormat />}
-        <Button size="sm" onClick={() => salaryRequest.saveToBasket()}>
+        <Button size="sm" disabled={!canVote} onClick={() => salaryRequest.saveToBasket()}>
           {t('fellowship.tasks.task.requestSalary.request')}
         </Button>
       </>
@@ -60,7 +62,9 @@ fellowshipSalaryFeature.inject(requestSalaryTaskActionSlot, () => {
       <>
         {currentPeriodExists && <PeriodEndTimer endBlock={currentPeriod.until} shortDateFormat />}
         <SalaryRegisterModal>
-          <Button size="sm">{t('fellowship.tasks.task.requestSalary.request')}</Button>
+          <Button size="sm" disabled={!canVote}>
+            {t('fellowship.tasks.task.requestSalary.request')}
+          </Button>
         </SalaryRegisterModal>
       </>
     );
@@ -70,18 +74,21 @@ fellowshipSalaryFeature.inject(requestSalaryTaskActionSlot, () => {
 fellowshipSalaryFeature.inject(requestSalaryInductTaskActionSlot, () => {
   const { t } = useI18n();
   const account = useUnit(salaryInduct.$account);
+  const canVote = useUnit(profile.$canVote);
   const canSaveToBasket = account && basketUtils.isBasketAvailableForAccount(account);
 
   if (canSaveToBasket) {
     return (
-      <Button size="sm" onClick={() => salaryInduct.saveToBasket()}>
+      <Button size="sm" disabled={!canVote} onClick={() => salaryInduct.saveToBasket()}>
         {t('fellowship.tasks.task.requestSalaryInduct.request')}
       </Button>
     );
   } else {
     return (
       <SalaryInductModal>
-        <Button size="sm">{t('fellowship.tasks.task.requestSalaryInduct.request')}</Button>
+        <Button size="sm" disabled={!canVote}>
+          {t('fellowship.tasks.task.requestSalaryInduct.request')}
+        </Button>
       </SalaryInductModal>
     );
   }
@@ -90,18 +97,21 @@ fellowshipSalaryFeature.inject(requestSalaryInductTaskActionSlot, () => {
 fellowshipSalaryFeature.inject(payoutSalaryTaskActionSlot, () => {
   const { t } = useI18n();
   const account = useUnit(salaryPayout.$account);
+  const canVote = useUnit(profile.$canVote);
   const canSaveToBasket = account && basketUtils.isBasketAvailableForAccount(account);
 
   if (canSaveToBasket) {
     return (
-      <Button size="sm" onClick={() => salaryPayout.saveToBasket()}>
+      <Button size="sm" disabled={!canVote} onClick={() => salaryPayout.saveToBasket()}>
         {t('fellowship.tasks.task.requestPayout.request')}
       </Button>
     );
   } else {
     return (
       <SalaryRegisterModal>
-        <Button size="sm">{t('fellowship.tasks.task.requestPayout.request')}</Button>
+        <Button size="sm" disabled={!canVote}>
+          {t('fellowship.tasks.task.requestPayout.request')}
+        </Button>
       </SalaryRegisterModal>
     );
   }
@@ -109,18 +119,24 @@ fellowshipSalaryFeature.inject(payoutSalaryTaskActionSlot, () => {
 
 fellowshipSalaryFeature.inject(requestPromotionTaskActionSlot, () => {
   const { t } = useI18n();
+  const canVote = useUnit(profile.$canVote);
+
   return (
     <EvidencePostFlowModal wish="Promotion">
-      <Button size="sm">{t('fellowship.tasks.task.promotion.request')}</Button>
+      <Button size="sm" disabled={!canVote}>
+        {t('fellowship.tasks.task.promotion.request')}
+      </Button>
     </EvidencePostFlowModal>
   );
 });
 
 fellowshipSalaryFeature.inject(requestRetentionATaskActionSlot, () => {
   const { t } = useI18n();
+  const canVote = useUnit(profile.$canVote);
+
   return (
     <EvidencePostFlowModal wish="Retention">
-      <Button size="sm" className="w-[102px]">
+      <Button size="sm" className="w-[102px]" disabled={!canVote}>
         {t('fellowship.tasks.task.retention.request')}
       </Button>
     </EvidencePostFlowModal>
@@ -151,9 +167,13 @@ fellowshipSalaryFeature.inject(activityFeedRecordDescriptionSlot, ({ t, record }
 });
 
 fellowshipSalaryFeature.inject(evidenceVotingTaskActionSlot, ({ evidence, endBlock }) => {
-  return <VotingActions evidence={evidence} endBlock={endBlock} variant="small" />;
+  const canVote = useUnit(profile.$canVote);
+
+  return <VotingActions evidence={evidence} endBlock={endBlock} variant="small" disabled={!canVote} />;
 });
 
 fellowshipSalaryFeature.inject(evidenceActionsSlot, ({ evidence }) => {
-  return <VotingActions evidence={evidence} endBlock={null} variant="large" />;
+  const canVote = useUnit(profile.$canVote);
+
+  return <VotingActions evidence={evidence} endBlock={null} variant="large" disabled={!canVote} />;
 });

--- a/src/renderer/features/fellowship-evidence-salary/model/profile.ts
+++ b/src/renderer/features/fellowship-evidence-salary/model/profile.ts
@@ -2,9 +2,9 @@ import { combine, sample } from 'effector';
 import { and, or } from 'patronum';
 
 import { attachToFeatureInput } from '@/shared/feature';
-import { nullable } from '@/shared/lib/utils';
+import { nonNullable, nullable } from '@/shared/lib/utils';
 import { member, track } from '@/domains/collectives';
-import { identity } from '@/domains/network';
+import { accountService, identity } from '@/domains/network';
 
 import { fellowshipSalaryFeature } from './feature';
 
@@ -22,6 +22,8 @@ const $identity = combine($member, $identities, (member, identities) => {
 
   return identities[member.accountId] ?? null;
 });
+
+const $canVote = $account.map(a => nonNullable(a) && accountService.hasPermissionToMakeActions(a));
 
 const $pendingMember = and(or(member.pending, identity.request.pending), $member.map(nullable));
 
@@ -50,5 +52,6 @@ export const profile = {
   $member,
   $account,
   $identity,
+  $canVote,
   $pending: or($pendingMember, fellowshipSalaryFeature.isStarting),
 };

--- a/src/renderer/features/fellowship-tasks/components/Tasks.tsx
+++ b/src/renderer/features/fellowship-tasks/components/Tasks.tsx
@@ -22,7 +22,6 @@ export const Tasks = memo(({ onReferendumSelect }: Props) => {
   const { t } = useI18n();
   const input = useUnit(fellowshipTasksFeature.input);
   const activeTasks = useUnit(tasks.$list);
-  const hasPermission = useUnit(memberProfile.$hasPermission);
   const pending = useUnit(tasks.pending);
   const hasAccount = useUnit(memberProfile.$hasAccount);
 
@@ -41,7 +40,7 @@ export const Tasks = memo(({ onReferendumSelect }: Props) => {
   return (
     <div className="flex h-full flex-col overflow-hidden rounded-xl border border-filter-border">
       <Title count={tasksCount} />
-      {hasAccount && hasPermission && activeTasks.length ? (
+      {hasAccount && activeTasks.length ? (
         <ScrollArea>
           {groups.personal ? (
             <TasksGroup
@@ -70,7 +69,7 @@ export const Tasks = memo(({ onReferendumSelect }: Props) => {
           ) : null}
         </ScrollArea>
       ) : null}
-      {(hasAccount && hasPermission && !activeTasks.length) || (hasAccount && !hasPermission) ? <AllDone /> : null}
+      {hasAccount && !activeTasks.length ? <AllDone /> : null}
       {!hasAccount ? <AccountNotFound /> : null}
       <Basket />
     </div>

--- a/src/renderer/features/fellowship-tasks/model/tasks.ts
+++ b/src/renderer/features/fellowship-tasks/model/tasks.ts
@@ -14,7 +14,6 @@ import {
   trackService,
   votingService,
 } from '@/domains/collectives';
-import { accountService } from '@/domains/network';
 import { basketOperations } from '@/aggregates/basket-operations';
 import { CompletedReferendumVoting } from '../components/tasks/CompletedReferendumVoting';
 import { OngoingReferendumVoting } from '../components/tasks/OngoingReferendumVoting';
@@ -38,15 +37,10 @@ import { referendums } from './referendums';
 
 const $chain = fellowshipTasksFeature.input.map(input => input?.chain ?? null);
 const $member = fellowshipTasksFeature.input.map(input => input?.member ?? null);
-const $account = fellowshipTasksFeature.input.map(store => (store ? store.account : null));
 const $evidencePeriods = fellowship.$store.map(store => store?.evidencePeriods ?? null);
 const $maxRank = fellowship.$store.map(input => input?.maxRank ?? 0);
 const $members = fellowship.$store.map(input => input?.members ?? []);
 const $chainName = $chain.map(chain => chain?.name ?? 'Unknown');
-
-const $hasPermission = $account.map(account => {
-  return nonNullable(account) && accountService.hasPermissionToMakeActions(account);
-});
 
 // basket
 
@@ -339,28 +333,16 @@ const $list = combine(
     referendumTasks: $ongoingReferendumsTasks,
     completedReferendumsTasks: $completedReferendumsTasks,
     evidenceTasks: $evidenceTasks,
-    hasPermission: $hasPermission,
   },
-  ({
-    memberSalaryTasks,
-    memberEvidenceTasks,
-    evidenceTasks,
-    referendumTasks,
-    completedReferendumsTasks,
-    hasPermission,
-  }) => {
-    if (hasPermission) {
-      const list = [
-        ...memberSalaryTasks,
-        ...memberEvidenceTasks,
-        ...evidenceTasks,
-        ...referendumTasks,
-        ...completedReferendumsTasks,
-      ];
-      return list.sort((a, b) => b.weight - a.weight);
-    }
-
-    return [];
+  ({ memberSalaryTasks, memberEvidenceTasks, evidenceTasks, referendumTasks, completedReferendumsTasks }) => {
+    const list = [
+      ...memberSalaryTasks,
+      ...memberEvidenceTasks,
+      ...evidenceTasks,
+      ...referendumTasks,
+      ...completedReferendumsTasks,
+    ];
+    return list.sort((a, b) => b.weight - a.weight);
   },
 );
 


### PR DESCRIPTION
## Description
Show tasks for watch-only wallets on fellowship page. Disable buttons.

## Related Issues
Closes #3570
