### PR TITLE
feat: button to copy contact's address on address book page

### DIFF
--- a/src/renderer/entities/contact/ui/ContactRow.tsx
+++ b/src/renderer/entities/contact/ui/ContactRow.tsx
@@ -1,7 +1,8 @@
 import { type PropsWithChildren } from 'react';
 
 import { type Contact } from '@/shared/core';
-import { Plate } from '@/shared/ui';
+import { copyToClipboard } from '@/shared/lib/utils';
+import { IconButton, Plate } from '@/shared/ui';
 import { Address } from '@/shared/ui-entities';
 
 type Props = {
@@ -11,10 +12,15 @@ type Props = {
 export const ContactRow = ({ contact, children }: PropsWithChildren<Props>) => {
   return (
     <Plate className="flex p-0">
-      <div className="flex flex-1 items-center gap-x-2 p-3">
+      <div className="flex gap-x-2 p-3">
         <Address address={contact.address} showIcon iconSize={20} variant="truncate" title={contact.name} />
+        <IconButton
+          className="shrink-0 self-end text-icon-default"
+          name="copy"
+          onClick={() => copyToClipboard(contact.address)}
+        />
       </div>
-      <div className="flex items-center justify-items-end gap-x-3 p-3">{children}</div>
+      <div className="ml-auto flex items-center gap-x-3 p-3">{children}</div>
     </Plate>
   );
 };


### PR DESCRIPTION
## Description
Added button next to the contact on the address page to copy the address as proposed in figma designs.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/3664

## Screenshots/Recordings
<img width="1335" alt="Screenshot 2025-05-02 at 11 10 16 AM" src="https://github.com/user-attachments/assets/45942ce1-2312-458b-a976-e13a721f5c62" />

