### PR TITLE
fix: show valid address option as signatory

### DIFF
--- a/src/renderer/features/multisig-wallet-pairing/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-pairing/components/components/Signatory.tsx
@@ -148,7 +148,7 @@ export const Signatory = ({
 
   // Contacts
   useEffect(() => {
-    if (isOwnAccount || contacts.length === 0 || !chain) return;
+    if (isOwnAccount || !chain) return;
 
     const addressOptions: ComboboxItem[] = [];
     for (const contact of filteredContacts) {
@@ -172,6 +172,8 @@ export const Signatory = ({
         value: { address: displayedAddress },
       });
     }
+
+    if (addressOptions.length === 0) return;
 
     const contactsOptions: ComboboxGroup[] = [
       {


### PR DESCRIPTION
## Description
Manually typed address into signatory input didn't show as an option if address book contacts list is empty.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/3680

## Changes Made
- Fix early return if contact list is empty

