### PR TITLE
fix: governance search referendums by title

### DIFF
--- a/src/renderer/pages/Governance/aggregates/governancePage.ts
+++ b/src/renderer/pages/Governance/aggregates/governancePage.ts
@@ -19,6 +19,7 @@ const $referendumsFilteredByQuery = combine(
   {
     referendums: $currentReferendums,
     query: filterModel.$debouncedQuery,
+    titles: listAggregate.$titles,
   },
   governancePageUtils.filteredByQuery,
 );

--- a/src/renderer/pages/Governance/lib/__tests__/governancePageUtils.test.ts
+++ b/src/renderer/pages/Governance/lib/__tests__/governancePageUtils.test.ts
@@ -71,7 +71,7 @@ describe('pages/Governance/lib/governancePageUtils', () => {
     { referendums, query: '222', expected: referendums.filter(({ referendumId }) => referendumId === '222') },
     { referendums, query: 'none', expected: [] },
   ])('should return correct referendums if query is "$query"', ({ referendums, query, expected }) => {
-    const result = governancePageUtils.filteredByQuery({ referendums, query });
+    const result = governancePageUtils.filteredByQuery({ referendums, query, titles: {} });
     expect(result).toEqual(expected);
   });
 

--- a/src/renderer/pages/Governance/lib/governancePageUtils.ts
+++ b/src/renderer/pages/Governance/lib/governancePageUtils.ts
@@ -15,11 +15,13 @@ export const governancePageUtils = {
 type FilteredByQueryParams<T> = {
   referendums: T[];
   query: string;
+  titles: Record<string, string>;
 };
 
-function filteredByQuery<T extends AggregatedReferendum>({ referendums, query }: FilteredByQueryParams<T>): T[] {
-  const res = performSearch<AggregatedReferendum>({
+function filteredByQuery<T extends AggregatedReferendum>({ referendums, query, titles }: FilteredByQueryParams<T>): T[] {
+  const res = performSearch<AggregatedReferendum, { title: string}>({
     records: referendums,
+    getMeta: (ref) => ({ title: titles[ref.referendumId], referendumId: ref.referendumId }),
     query,
     weights: {
       title: 1,


### PR DESCRIPTION
## Description
Fix the search in governance to be able to search by referendum title 

## Related Issues
Closes #3690 