### PR TITLE
fix: reserve space for focus

### DIFF
--- a/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/ManageVault.tsx
+++ b/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/ManageVault.tsx
@@ -252,7 +252,7 @@ export const ManageVault = ({ seedInfo, onBack, onClose, onComplete }: Props) =>
           <FootnoteText className="ml-9 pl-2 text-text-tertiary">{t('onboarding.vault.accountTitle')}</FootnoteText>
 
           <ScrollArea>
-            <div className="ml-9 flex flex-col gap-2 divide-y">
+            <div className="ml-9 mr-1 flex flex-col gap-2 divide-y">
               {chainElements.map(([chainId, chainAccounts]) => {
                 if (chainAccounts.length === 0) return;
 


### PR DESCRIPTION
## Description

Scroll container hides everything that overflows it, but we need to show outline of focused elements

closes #3159