### PR TITLE
fix: hide icon with details popup for shards group

### DIFF
--- a/src/renderer/entities/wallet/ui/VaultAccountsList/VaultAccountsList.tsx
+++ b/src/renderer/entities/wallet/ui/VaultAccountsList/VaultAccountsList.tsx
@@ -49,16 +49,18 @@ export const VaultAccountsList = ({ chains, accountsMap, className, onShardClick
                           addressPrefix={chain.addressPrefix}
                           onClick={isSharded ? () => onShardClick?.(account) : undefined}
                         >
-                          <AccountExplorers accountId={accountId} chain={chain}>
-                            <Box gap={0.5}>
-                              <FootnoteText className="text-text-tertiary">
-                                {t('general.explorers.derivationTitle')}
-                              </FootnoteText>
-                              <HelpText className="break-all text-text-secondary">
-                                {accountUtils.getDerivationPath(account)}
-                              </HelpText>
-                            </Box>
-                          </AccountExplorers>
+                          {!isSharded && (
+                            <AccountExplorers accountId={accountId} chain={chain}>
+                              <Box gap={0.5}>
+                                <FootnoteText className="text-text-tertiary">
+                                  {t('general.explorers.derivationTitle')}
+                                </FootnoteText>
+                                <HelpText className="break-all text-text-secondary">
+                                  {accountUtils.getDerivationPath(account)}
+                                </HelpText>
+                              </Box>
+                            </AccountExplorers>
+                          )}
                         </DerivedAccount>
                       </li>
                     );


### PR DESCRIPTION
## Description
There is a an icon button with wrong details information for sharded accounts group in polkadot vault wallet details.
We decided to disable it for shards.

## Related Issues
Closes #2651

## Changes Made
- Removed icon button and popup with wrong details for shards

