### PR TITLE
feat: icon and text click should toggle checkbox instead of accordion

### DIFF
--- a/src/renderer/features/wallets/ShardSelectorModal/ui/SelectableShard.tsx
+++ b/src/renderer/features/wallets/ShardSelectorModal/ui/SelectableShard.tsx
@@ -25,53 +25,55 @@ export const SelectableShard = ({ account, chain, checked, semiChecked, onChange
   return (
     <div
       className={cnTw(
-        'group flex h-11 w-full max-w-full cursor-pointer gap-x-2 rounded-md px-2 py-1.5 transition-colors',
+        'group grid h-11 w-full max-w-full grid-cols-[1fr_auto] items-center gap-x-2 rounded-md px-2 py-1.5',
         'transition-colors duration-100 hover:bg-action-background-hover',
       )}
     >
-      <Checkbox checked={checked} semiChecked={semiChecked} onChange={(checked) => onChange(checked)} />
-
-      <div className="flex w-full grow items-center gap-x-2 truncate">
-        {isChain ? (
+      <div className="overflow-hidden">
+        <Checkbox checked={checked} semiChecked={semiChecked} onChange={(checked) => onChange(checked)}>
+          <div className="flex w-full grow items-center gap-x-2 overflow-hidden">
+            {isChain ? (
+              <>
+                <div className="flex flex-row">
+                  <Identicon address={address} size={20} background={false} canCopy={false} />
+                  <Icon
+                    className="z-10 -ml-2.5 rounded-full border bg-white text-text-secondary"
+                    size={20}
+                    name={KeyIcon[account.keyType]}
+                  />
+                </div>
+                <div className="flex flex-col overflow-hidden">
+                  <FootnoteText
+                    className={cnTw('truncate', checked || semiChecked ? 'text-text-primary' : 'text-text-secondary')}
+                  >
+                    {account.name}
+                  </FootnoteText>
+                  <HelpText className="text-text-tertiary">
+                    <Hash value={address} variant="truncate" />
+                  </HelpText>
+                </div>
+              </>
+            ) : (
+              <>
+                <Identicon address={address} size={20} background={false} canCopy={false} />
+                <FootnoteText
+                  className={cnTw('min-w-0', checked || semiChecked ? 'text-text-primary' : 'text-text-secondary')}
+                >
+                  <Hash value={address} variant="truncate" />
+                </FootnoteText>
+              </>
+            )}
+          </div>
+        </Checkbox>
+      </div>
+      <AccountExplorers accountId={account.accountId} chain={chain}>
+        {(isShard || isChain) && (
           <>
-            <div className="flex">
-              <Identicon address={address} size={20} background={false} canCopy={false} />
-              <Icon
-                className="z-10 -ml-2.5 rounded-full border bg-white text-text-secondary"
-                size={20}
-                name={KeyIcon[account.keyType]}
-              />
-            </div>
-            <div className="flex flex-col overflow-hidden">
-              <FootnoteText
-                className={cnTw('truncate', checked || semiChecked ? 'text-text-primary' : 'text-text-secondary')}
-              >
-                {account.name}
-              </FootnoteText>
-              <HelpText className="text-text-tertiary">
-                <Hash value={address} variant="truncate" />
-              </HelpText>
-            </div>
-          </>
-        ) : (
-          <>
-            <Identicon address={address} size={20} background={false} canCopy={false} />
-            <FootnoteText
-              className={cnTw('min-w-0', checked || semiChecked ? 'text-text-primary' : 'text-text-secondary')}
-            >
-              <Hash value={address} variant="truncate" />
-            </FootnoteText>
+            <FootnoteText className="text-text-tertiary">{t('general.explorers.derivationTitle')}</FootnoteText>
+            <HelpText className="break-all text-text-secondary">{account.derivationPath}</HelpText>
           </>
         )}
-        <AccountExplorers accountId={account.accountId} chain={chain}>
-          {(isShard || isChain) && (
-            <>
-              <FootnoteText className="text-text-tertiary">{t('general.explorers.derivationTitle')}</FootnoteText>
-              <HelpText className="break-all text-text-secondary">{account.derivationPath}</HelpText>
-            </>
-          )}
-        </AccountExplorers>
-      </div>
+      </AccountExplorers>
     </div>
   );
 };

--- a/src/renderer/features/wallets/ShardSelectorModal/ui/ShardedGroup.tsx
+++ b/src/renderer/features/wallets/ShardSelectorModal/ui/ShardedGroup.tsx
@@ -48,17 +48,18 @@ export const ShardedGroup = ({ rootAccountId, accounts, chain }: Props) => {
   return (
     <Accordion initialOpen>
       <Accordion.Trigger>
-        <div onClick={(e) => e.stopPropagation()}>
-          <Checkbox checked={isChecked} semiChecked={isSemiChecked} onChange={toggleSharded} />
+        <div className="w-full" onClick={(e) => e.stopPropagation()}>
+          <Checkbox checked={isChecked} semiChecked={isSemiChecked} onChange={toggleSharded}>
+            <div className="flex h-5 w-7.5 items-center justify-center rounded-2lg bg-input-background-disabled">
+              <CaptionText className="text-text-secondary">{accounts.length}</CaptionText>
+            </div>
+            <FootnoteText
+              className={cnTw('normal-case', isChecked || isSemiChecked ? 'text-text-primary' : 'text-text-secondary')}
+            >
+              {account.name}
+            </FootnoteText>
+          </Checkbox>
         </div>
-        <div className="flex h-5 w-7.5 items-center justify-center rounded-2lg bg-input-background-disabled">
-          <CaptionText className="text-text-secondary">{accounts.length}</CaptionText>
-        </div>
-        <FootnoteText
-          className={cnTw('normal-case', isChecked || isSemiChecked ? 'text-text-primary' : 'text-text-secondary')}
-        >
-          {account.name}
-        </FootnoteText>
       </Accordion.Trigger>
       <Accordion.Content>
         {accounts.map((shard) => (

--- a/src/renderer/features/wallets/ShardSelectorModal/ui/ShardsStructure.tsx
+++ b/src/renderer/features/wallets/ShardSelectorModal/ui/ShardsStructure.tsx
@@ -49,21 +49,24 @@ export const ShardsStructure = () => {
                 <li key={chainId} className="mt-2">
                   <Accordion initialOpen>
                     <Accordion.Trigger>
-                      <div onClick={(e) => e.stopPropagation()}>
+                      <div className="w-full" onClick={(e) => e.stopPropagation()}>
                         <Checkbox
                           checked={isChecked}
                           semiChecked={isSemiChecked}
                           onChange={(checked) => toggleChain(rootAccountId, chainId, checked)}
-                        />
+                        >
+                          <div className="flex items-center gap-2">
+                            <ChainTitle
+                              chain={chains[chainId]}
+                              fontClass={cnTw(isChecked || isSemiChecked ? 'text-text-primary' : 'text-text-secondary')}
+                            />
+                            <HelpText className="text-text-tertiary">
+                              {selectedStructure[rootAccountId][chainId].checked} /{' '}
+                              {selectedStructure[rootAccountId][chainId].total}
+                            </HelpText>
+                          </div>
+                        </Checkbox>
                       </div>
-                      <ChainTitle
-                        chain={chains[chainId]}
-                        fontClass={cnTw(isChecked || isSemiChecked ? 'text-text-primary' : 'text-text-secondary')}
-                      />
-                      <HelpText className="text-text-tertiary">
-                        {selectedStructure[rootAccountId][chainId].checked} /{' '}
-                        {selectedStructure[rootAccountId][chainId].total}
-                      </HelpText>
                     </Accordion.Trigger>
                     <Accordion.Content>
                       <div className="ml-6">


### PR DESCRIPTION
## Description
Updated account selector modal behavior: icon and address now toggle checkbox; only arrow toggles accordion.

## Changes Made
 - fixed styles
 - moved icon and address components to Checkbox children

