### PR TITLE
fix: null in derivation path

### DIFF
--- a/src/renderer/features/wallets/KeyConstructor/model/constructor-model.ts
+++ b/src/renderer/features/wallets/KeyConstructor/model/constructor-model.ts
@@ -241,7 +241,7 @@ sample({
 sample({
   clock: $chain,
   source: $constructorForm.fields.keyType.$value,
-  filter: (_, chain) => nonNullable(chain),
+  filter: (keyType, chain) => nonNullable(keyType) && nonNullable(chain),
   fn: (keyType, chain) => {
     const type = keyType === KeyType.MAIN ? '' : `//${keyType}`;
 


### PR DESCRIPTION
## Description
In pv wallet keys editor, when user adds a new key, form resets to a default state, but derivation path has a null value. 
This PR fixes that bug and correctly resets derivation path to default value (empty string).

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/3756#event-17731798784

## Changes Made

- Fixed a bug with `null` in derivation path
