### PR TITLE
feat: export polkadot vault dynamic derivations via QR code

### DIFF
--- a/src/renderer/entities/transaction/ui/QrCode/QrGenerator/QrDerivationsExportGenerator.tsx
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGenerator/QrDerivationsExportGenerator.tsx
@@ -1,0 +1,47 @@
+import { useUnit } from 'effector-react';
+import { useMemo } from 'react';
+
+import { type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
+import { toAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { networkModel } from '@/entities/network';
+
+import { DEFAULT_FRAME_DELAY } from './common/constants';
+import useGenerator from './common/useGenerator';
+import { createDynamicDerivationExportPayload } from './common/utils';
+
+type Props = {
+  walletName: string;
+  rootAccountId: AccountId;
+  derivations: (VaultChainAccount | VaultShardAccount)[];
+  size?: number;
+  bgColor?: string;
+  skipEncoding?: boolean;
+  delay?: number;
+};
+
+export const QrDerivationsExportGenerator = ({
+  walletName,
+  rootAccountId,
+  derivations,
+  size,
+  skipEncoding = false,
+  bgColor = 'none',
+  delay = DEFAULT_FRAME_DELAY,
+}: Props) => {
+  const chains = useUnit(networkModel.$chains);
+
+  const payload = useMemo(
+    () =>
+      createDynamicDerivationExportPayload(walletName, toAddress(rootAccountId, { prefix: 1 }), derivations, chains),
+    [walletName, rootAccountId, derivations, chains],
+  );
+
+  const image = useGenerator(payload, skipEncoding, delay, bgColor);
+
+  if (!payload || !image) {
+    return null;
+  }
+
+  return <div style={{ width: size, height: size }} dangerouslySetInnerHTML={{ __html: image }} />;
+};

--- a/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/constants.ts
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/constants.ts
@@ -16,4 +16,5 @@ export const enum Command {
   MultipleTransactions = 0x04,
   DynamicDerivationsTransaction = 0x05,
   DynamicDerivationsRequestV1 = 0xdf,
+  DynamicDerivationsExport = 0xde,
 }

--- a/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/utils.ts
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/utils.ts
@@ -1,12 +1,12 @@
 import { hexToU8a, u8aConcat, u8aToU8a } from '@polkadot/util';
-import { decodeAddress } from '@polkadot/util-crypto';
+import { decodeAddress, encodeAddress } from '@polkadot/util-crypto';
 import { str } from 'parity-scale-codec';
 import qrcode from 'qrcode-generator';
 import { type Encoder } from 'raptorq/raptorq';
 
-import { type Address, type ChainId } from '@/shared/core';
+import { type Address, type Chain, type ChainId, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
 import { CryptoType, CryptoTypeString, SigningType } from '@/shared/core';
-import { DYNAMIC_DERIVATIONS_REQUEST } from '../../common/constants';
+import { DYNAMIC_DERIVATIONS_REQUEST, EXPORT_ADDRESS } from '../../common/constants';
 import { type DynamicDerivationRequestInfo } from '../../common/types';
 
 import {
@@ -165,4 +165,32 @@ export const createDynamicDerivationPayload = (publicKey: Address, derivations: 
     new Uint8Array([Command.DynamicDerivationsRequestV1]),
     dynamicDerivationsRequest,
   );
+};
+
+export const createDynamicDerivationExportPayload = (
+  walletName: string,
+  publicKey: Address,
+  derivations: (VaultChainAccount | VaultShardAccount)[],
+  chains: Record<ChainId, Chain>,
+) => {
+  const payload = EXPORT_ADDRESS.encode({
+    ExportAddrs: 'V1',
+    payload: [
+      {
+        name: walletName,
+        multiSigner: {
+          MultiSigner: CryptoTypeString.SR25519,
+          public: decodeAddress(publicKey, false, 1),
+        },
+        derivedKeys: derivations.map((d) => ({
+          address: encodeAddress(d.accountId, chains[d.chainId].addressPrefix),
+          derivationPath: d.derivationPath,
+          genesisHash: hexToU8a(d.chainId),
+          encryption: cryptoTypeToMultisignerIndex(d.cryptoType),
+        })),
+      },
+    ],
+  });
+
+  return u8aConcat(SUBSTRATE_ID, CRYPTO_STUB, new Uint8Array([Command.DynamicDerivationsExport]), payload);
 };

--- a/src/renderer/entities/transaction/ui/index.ts
+++ b/src/renderer/entities/transaction/ui/index.ts
@@ -17,6 +17,7 @@ export { DeliveryFeeWithLabel } from './DeliveryFeeWithLabel/DeliveryFeeWithLabe
 // TODO: requires refactoring clickup task - https://app.clickup.com/t/86933e82e
 export { cryptoTypeToMultisignerIndex } from './QrCode/QrGenerator/common/utils';
 export { QrDerivationsGenerator } from './QrCode/QrGenerator/QrDerivationsGenerator';
+export { QrDerivationsExportGenerator } from './QrCode/QrGenerator/QrDerivationsExportGenerator';
 export { QrTextGenerator } from './QrCode/QrGenerator/QrTextGenerator';
 export { VaultQrReader } from './QrCode/QrReader/VaultQrReader';
 export { QrReaderWrapper } from './QrCode/QrReader/QrReaderWrapper';

--- a/src/renderer/features/wallet-details/lib/utils.ts
+++ b/src/renderer/features/wallet-details/lib/utils.ts
@@ -1,13 +1,5 @@
-import {
-  KeyType,
-  type PolkadotVaultWallet,
-  type VaultChainAccount,
-  type VaultShardAccount,
-  type Wallet,
-} from '@/shared/core';
-import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { KeyType, type PolkadotVaultWallet, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
 import { accountUtils } from '@/entities/wallet';
-import { downloadFiles, exportKeysUtils } from '@/features/wallets/ExportKeys';
 
 import { ForgetStep, ReconnectStep } from './constants';
 import { type VaultMap } from './types';
@@ -23,7 +15,6 @@ export const wcDetailsUtils = {
 export const walletDetailsUtils = {
   isForgetModalOpen,
   getVaultAccountsMap,
-  exportVaultWallet,
   getMainAccounts,
 };
 
@@ -66,18 +57,6 @@ function getVaultAccountsMap(accounts: PolkadotVaultWallet['accounts']): VaultMa
 
     return acc;
   }, {});
-}
-
-function exportVaultWallet(wallet: Wallet, rootAccountId: AccountId, accounts: VaultMap) {
-  const accountsFlat = Object.values(accounts).flat();
-  const exportStructure = exportKeysUtils.getExportStructure(rootAccountId, accountsFlat);
-
-  downloadFiles([
-    {
-      blob: new Blob([exportStructure], { type: 'text/plain' }),
-      fileName: `${wallet.name}.txt`,
-    },
-  ]);
 }
 
 function getMainAccounts(accounts: (VaultChainAccount | VaultShardAccount[])[]): VaultChainAccount[] {

--- a/src/renderer/features/wallet-details/ui/wallets/VaultWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/VaultWalletDetails.tsx
@@ -20,7 +20,7 @@ import { networkModel } from '@/entities/network';
 import { RootAccountLg, VaultAccountsList, WalletCardLg, accountUtils, permissionUtils } from '@/entities/wallet';
 import { proxyAddFeature } from '@/features/proxy-add';
 import { proxyAddPureFeature } from '@/features/proxy-add-pure';
-import { DerivationsAddressModal, ImportKeysModal, KeyConstructor } from '@/features/wallets';
+import { DerivationsAddressModal, ExportKeysModal, ImportKeysModal, KeyConstructor } from '@/features/wallets';
 import { ForgetWalletModal } from '@/features/wallets/ForgetWallet';
 import { RenameWalletModal } from '@/features/wallets/RenameWallet';
 import { walletDetailsUtils } from '../../lib/utils';
@@ -60,6 +60,7 @@ export const VaultWalletDetails = ({ wallet, onClose }: Props) => {
   const [isRenameModalOpen, toggleIsRenameModalOpen] = useToggle();
   const [isConstructorModalOpen, toggleConstructorModal] = useToggle();
   const [isImportModalOpen, toggleImportModal] = useToggle();
+  const [isExportModalOpen, toggleExportModal] = useToggle();
   const [isScanModalOpen, toggleScanModal] = useToggle();
   const [isConfirmForgetOpen, toggleConfirmForget] = useToggle();
 
@@ -129,7 +130,7 @@ export const VaultWalletDetails = ({ wallet, onClose }: Props) => {
     {
       icon: 'export' as IconNames,
       title: t('walletDetails.vault.export'),
-      onClick: () => walletDetailsUtils.exportVaultWallet(wallet, wallet.rootAccountId, accountsMap),
+      onClick: toggleExportModal,
     },
     {
       icon: 'forget' as IconNames,
@@ -257,6 +258,12 @@ export const VaultWalletDetails = ({ wallet, onClose }: Props) => {
         existingKeys={Object.values(accountsMap).flat(2)}
         onConfirm={handleImportedKeys}
         onClose={toggleImportModal}
+      />
+      <ExportKeysModal
+        isOpen={isExportModalOpen}
+        wallet={wallet}
+        accounts={Object.values(accountsMap).flat()}
+        onClose={toggleExportModal}
       />
       <DerivationsAddressModal
         isOpen={isScanModalOpen}

--- a/src/renderer/features/wallets/ExportKeys/index.ts
+++ b/src/renderer/features/wallets/ExportKeys/index.ts
@@ -1,2 +1,3 @@
 export { exportKeysUtils } from './lib/export-keys-utils';
 export { downloadFiles } from './lib/download-multiple-files';
+export { ExportKeysModal } from './ui/ExportKeysModal';

--- a/src/renderer/features/wallets/ExportKeys/lib/export-keys-utils.ts
+++ b/src/renderer/features/wallets/ExportKeys/lib/export-keys-utils.ts
@@ -1,11 +1,9 @@
 import { chainsService } from '@/shared/api/network';
-import { type ChainId, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
+import { type ChainId, type VaultChainAccount, type VaultShardAccount, type Wallet } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accountUtils } from '@/entities/wallet';
 
-export const exportKeysUtils = {
-  getExportStructure,
-};
+import { downloadFiles } from './download-multiple-files';
 
 const IMPORT_FILE_VERSION = 1;
 
@@ -37,3 +35,22 @@ function accountToDerivationExport(account: VaultChainAccount | VaultShardAccoun
 
   return `${derivationPath}: ${account.name} [${account.keyType}]\n`;
 }
+
+function exportVaultWallet(
+  wallet: Wallet,
+  rootAccountId: AccountId,
+  accounts: (VaultChainAccount | VaultShardAccount[])[],
+) {
+  const exportStructure = getExportStructure(rootAccountId, accounts);
+
+  downloadFiles([
+    {
+      blob: new Blob([exportStructure], { type: 'text/plain' }),
+      fileName: `${wallet.name}.txt`,
+    },
+  ]);
+}
+
+export const exportKeysUtils = {
+  exportVaultWallet,
+};

--- a/src/renderer/features/wallets/ExportKeys/ui/ExportKeysModal.tsx
+++ b/src/renderer/features/wallets/ExportKeys/ui/ExportKeysModal.tsx
@@ -1,0 +1,57 @@
+import { useState } from 'react';
+
+import { type PolkadotVaultWallet, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
+import { useI18n } from '@/shared/i18n';
+import { Button, SmallTitleText } from '@/shared/ui';
+import { Box, Modal } from '@/shared/ui-kit';
+import { OperationResult, QrDerivationsExportGenerator } from '@/entities/transaction';
+import { exportKeysUtils } from '../lib/export-keys-utils';
+
+type Props = {
+  isOpen: boolean;
+  wallet: PolkadotVaultWallet;
+  accounts: (VaultChainAccount | VaultShardAccount[])[];
+  onClose: () => void;
+};
+
+export const ExportKeysModal = ({ isOpen, wallet, accounts, onClose }: Props) => {
+  const { t } = useI18n();
+  const [isDownloadModalOpen, setDownloadModalOpen] = useState(false);
+
+  const downloadKeysFile = () => {
+    exportKeysUtils.exportVaultWallet(wallet, wallet.rootAccountId, accounts);
+    setDownloadModalOpen(true);
+  };
+
+  return (
+    <Modal isOpen={isOpen} size="md" height="fit" onToggle={onClose}>
+      <Modal.Title close>{t('dynamicDerivations.exportKeys.modalTitle')}</Modal.Title>
+      <Modal.Content>
+        <Box direction="column" gap={6} horizontalAlign="center">
+          <SmallTitleText>{t('dynamicDerivations.exportKeys.qrCodeTitle')}</SmallTitleText>
+          <QrDerivationsExportGenerator
+            walletName={wallet.name}
+            rootAccountId={wallet.rootAccountId}
+            derivations={accounts.flat()}
+            size={240}
+          />
+          <Button variant="fill" pallet="primary" onClick={downloadKeysFile}>
+            {t('dynamicDerivations.exportKeys.downloadButton')}
+          </Button>
+        </Box>
+      </Modal.Content>
+      <Modal.Footer align="start">
+        <Button variant="text" onClick={onClose}>
+          {t('dynamicDerivations.exportKeys.closeButton')}
+        </Button>
+      </Modal.Footer>
+      <OperationResult
+        isOpen={isDownloadModalOpen}
+        variant="success"
+        title={t('dynamicDerivations.exportKeys.downloadSuccessPopup')}
+        autoCloseTimeout={2000}
+        onClose={() => setDownloadModalOpen(false)}
+      />
+    </Modal>
+  );
+};

--- a/src/renderer/features/wallets/index.ts
+++ b/src/renderer/features/wallets/index.ts
@@ -2,5 +2,6 @@ export { KeyConstructor } from './KeyConstructor';
 export { ShardSelectorModal, ShardSelectorButton } from './ShardSelectorModal';
 export { DerivationsAddressModal } from './DerivationsAddressModal/ui/DerivationsAddressModal';
 export { ImportKeysModal } from './ImportKeys/ui/ImportKeysModal';
+export { ExportKeysModal } from './ExportKeys';
 export { shardsModel } from './ShardSelectorModal/model/shards-model';
 export { shardsUtils } from './ShardSelectorModal/lib/shards-utils';

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -228,6 +228,13 @@
     "chooseOptionLabel": "Choose an option"
   },
   "dynamicDerivations": {
+    "exportKeys": {
+      "closeButton": "Close",
+      "downloadButton": "Download as a txt-file",
+      "downloadSuccessPopup": "Keys exported",
+      "modalTitle": "Export keys",
+      "qrCodeTitle": "Scan the QR code with Polkadot Vault"
+    },
     "importKeys": {
       "backButton": "Back",
       "continueButton": "Continue",


### PR DESCRIPTION
## Description
Polkadot Vault wallet export keys modal. With keyset QR code and download button.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/3758

## Changes Made
- Keyset exports modal
- Moved keyset export as txt file functionality to download button inside new modal
- New functionality to encode dynamic derived keys for export
- QR code for dynamic derived keys export

## Screenshots/Recordings
<img width="1488" alt="Screenshot 2025-05-21 at 2 43 34 PM" src="https://github.com/user-attachments/assets/1b9cbc01-1174-44a9-a04c-c37e2547eab5" />

