### PR TITLE
fix: polkadot vault keys export via QR code

### DIFF
--- a/src/renderer/entities/transaction/ui/QrCode/QrGenerator/QrDerivationsExportGenerator.tsx
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGenerator/QrDerivationsExportGenerator.tsx
@@ -1,5 +1,6 @@
 import { useUnit } from 'effector-react';
-import { useMemo } from 'react';
+import init, { Encoder } from 'raptorq/raptorq';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
 import { toAddress } from '@/shared/lib/utils';
@@ -30,6 +31,7 @@ export const QrDerivationsExportGenerator = ({
   delay = DEFAULT_FRAME_DELAY,
 }: Props) => {
   const chains = useUnit(networkModel.$chains);
+  const [encoder, setEncoder] = useState<Encoder>();
 
   const payload = useMemo(
     () =>
@@ -37,9 +39,22 @@ export const QrDerivationsExportGenerator = ({
     [walletName, rootAccountId, derivations, chains],
   );
 
-  const image = useGenerator(payload, skipEncoding, delay, bgColor);
+  const createEncoder = useCallback(async () => {
+    try {
+      await init();
+      setEncoder(Encoder.with_defaults(payload, 128));
+    } catch (error) {
+      console.error('Failed to create encoder:', error);
+    }
+  }, [payload]);
 
-  if (!payload || !image) {
+  useEffect(() => {
+    createEncoder();
+  }, [createEncoder]);
+
+  const image = useGenerator(payload, skipEncoding, delay, bgColor, encoder);
+
+  if (!image) {
     return null;
   }
 

--- a/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/utils.ts
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGenerator/common/utils.ts
@@ -182,12 +182,14 @@ export const createDynamicDerivationExportPayload = (
           MultiSigner: CryptoTypeString.SR25519,
           public: decodeAddress(publicKey, false, 1),
         },
-        derivedKeys: derivations.map((d) => ({
-          address: encodeAddress(d.accountId, chains[d.chainId].addressPrefix),
-          derivationPath: d.derivationPath,
-          genesisHash: hexToU8a(d.chainId),
-          encryption: cryptoTypeToMultisignerIndex(d.cryptoType),
-        })),
+        derivedKeys: derivations
+          .filter((d) => d.cryptoType !== CryptoType.ETHEREUM)
+          .map((d) => ({
+            address: encodeAddress(d.accountId, chains[d.chainId].addressPrefix),
+            derivationPath: d.derivationPath,
+            genesisHash: hexToU8a(d.chainId),
+            encryption: cryptoTypeToMultisignerIndex(d.cryptoType),
+          })),
       },
     ],
   });


### PR DESCRIPTION
## Description
Fixes the QR code generation crash. Temporarily skip ethereum address export.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/3778
Explains why we skip ethereum addresses https://github.com/novasamatech/parity-signer/issues/2490

## Changes Made
- Polkadot vault recommends to use raptorq encoder for QR codes. So lets use it.
- Skip ethereum addresses in QR code keys export

