### PR TITLE
refactor: give access to profile modal, restrict access to change act…

### DIFF
--- a/src/renderer/features/fellowship-profile/components/ProfileModal.tsx
+++ b/src/renderer/features/fellowship-profile/components/ProfileModal.tsx
@@ -27,11 +27,7 @@ export const ProfileModal = ({ children }: PropsWithChildren) => {
   const identity = useUnit(profile.$identity);
   const salary = useUnit(memberSalary.$memberSalary);
 
-  const disabled =
-    nullable(member) ||
-    nullable(featureInput) ||
-    nullable(account) ||
-    !accountService.hasPermissionToMakeActions(account);
+  const disabled = nullable(member) || nullable(featureInput) || nullable(account);
 
   if (disabled) {
     // eslint-disable-next-line react/jsx-no-useless-fragment
@@ -40,7 +36,8 @@ export const ProfileModal = ({ children }: PropsWithChildren) => {
 
   const address = toAddress(member.accountId, { prefix: featureInput.chain.addressPrefix });
   const active = memberService.isCoreMember(member) && member.isActive;
-  const setActiveDisabled = !memberService.canChangeActiveState(member);
+  const setActiveDisabled =
+    !accountService.hasPermissionToMakeActions(account) || !memberService.canChangeActiveState(member);
 
   return (
     <Modal size="md" height="fit">


### PR DESCRIPTION
## Description

Fix profile modal opening with `Watch Only`

## Related Issues

closes #3791 

## Changes Made

- allow opening profile modal with `Watch Only`
- check permissions to change the active status within the modal

## Screenshots/Recordings

<img width="497" alt="image" src="https://github.com/user-attachments/assets/5b253f32-035c-4e30-872a-0f67f5191897" />

