### PR TITLE
fix: unified button in tasks and referendum details, fixed wording

### DIFF
--- a/src/renderer/features/fellowship-voting/components/VotingButtonWithTooltip.tsx
+++ b/src/renderer/features/fellowship-voting/components/VotingButtonWithTooltip.tsx
@@ -1,12 +1,12 @@
-import { type MouseEventHandler, memo } from 'react';
+import { type MouseEventHandler, type PropsWithChildren, memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { nullable } from '@/shared/lib/utils';
+import { cnTw, nullable } from '@/shared/lib/utils';
 import { type IconNames } from '@/shared/ui/types';
 import { FilledIconButton, Tooltip } from '@/shared/ui-kit';
 import { categorizeImpact } from '../utils';
 
-type Props = {
+type Props = PropsWithChildren<{
   variant: 'positive' | 'negative';
   icon: IconNames;
   isVoted?: boolean;
@@ -16,10 +16,23 @@ type Props = {
   voteImpact?: number;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   onHighlight?: (arg: 'Aye' | 'Nay' | null) => void;
-};
+  fullWidth?: boolean;
+}>;
 
 export const VotingButtonWithTooltip = memo(
-  ({ isVoted, checked, disabled, votes, variant, voteImpact, onClick, onHighlight = () => {}, icon }: Props) => {
+  ({
+    isVoted,
+    checked,
+    disabled,
+    votes,
+    variant,
+    voteImpact,
+    onClick,
+    onHighlight = () => {},
+    icon,
+    children,
+    fullWidth,
+  }: Props) => {
     const { t } = useI18n();
 
     const buttonNode = (
@@ -29,10 +42,13 @@ export const VotingButtonWithTooltip = memo(
         disabled={disabled}
         icon={icon}
         variant={variant}
+        fullWidth={fullWidth}
         onClick={onClick}
         onMouseOver={() => onHighlight(variant === 'positive' ? 'Aye' : 'Nay')}
         onMouseLeave={() => onHighlight(null)}
-      />
+      >
+        {children}
+      </FilledIconButton>
     );
 
     if (checked || isVoted || disabled || nullable(votes) || nullable(voteImpact)) return buttonNode;
@@ -43,7 +59,7 @@ export const VotingButtonWithTooltip = memo(
     return (
       <Tooltip>
         <Tooltip.Trigger>
-          <div>{buttonNode}</div>
+          <div className={cnTw({ 'w-full': fullWidth })}>{buttonNode}</div>
         </Tooltip.Trigger>
         <Tooltip.Content>
           <p>

--- a/src/renderer/features/fellowship-voting/components/VotingButtons.tsx
+++ b/src/renderer/features/fellowship-voting/components/VotingButtons.tsx
@@ -1,17 +1,17 @@
 import { useStoreMap, useUnit } from 'effector-react';
-import { type PropsWithChildren, memo, useState } from 'react';
+import { memo, useState } from 'react';
 
 import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
-import { cnTw, nonNullable, nullable } from '@/shared/lib/utils';
-import { ButtonCard, FootnoteText, type IconNames } from '@/shared/ui';
-import { Box, Tooltip } from '@/shared/ui-kit';
+import { nonNullable, nullable } from '@/shared/lib/utils';
+import { FootnoteText } from '@/shared/ui';
+import { Box } from '@/shared/ui-kit';
 import { type Evidence, type Referendum, referendumService, trackService } from '@/domains/collectives';
 import { tasksService } from '@/features/fellowship-tasks';
 import { fellowshipVotingFeature } from '../model/feature';
 import { votingStatus } from '../model/votingStatus';
-import { categorizeImpact } from '../utils';
 
+import { VotingButtonWithTooltip } from './VotingButtonWithTooltip';
 import { VotingModal } from './VotingModal';
 
 type Props = {
@@ -46,7 +46,6 @@ export const VotingButtons = memo(({ referendum }: Props) => {
 
   const alreadyVotedNay = nonNullable(voting) && voting.decision === 'Nay';
   const alreadyVotedAye = nonNullable(voting) && voting.decision === 'Aye';
-  const isVoted = alreadyVotedNay || alreadyVotedAye;
 
   const memberVoteWeight = trackService.getVoteWeight({
     pallet: 'fellowship',
@@ -67,33 +66,33 @@ export const VotingButtons = memo(({ referendum }: Props) => {
 
       <Box gap={4}>
         <Box direction="row" gap={4}>
-          <ButtonWithTooltip
-            pallet="negative"
+          <VotingButtonWithTooltip
+            variant="negative"
             icon="negative"
             disabled={buttonDiabled}
             votes={memberVoteWeight}
             voteImpact={userVotesImpact}
-            isVoted={isVoted}
-            marked={alreadyVotedNay}
-            onClick={() => setDecision('nay')}
+            isVoted={alreadyVotedNay}
+            checked={alreadyVotedNay}
+            fullWidth
+            onClick={() => !alreadyVotedNay && setDecision('nay')}
           >
-            {alreadyVotedAye ? t('fellowship.voting.revote') : null}
             {t('fellowship.voting.notGood')}
-          </ButtonWithTooltip>
+          </VotingButtonWithTooltip>
 
-          <ButtonWithTooltip
-            pallet="positive"
+          <VotingButtonWithTooltip
+            variant="positive"
             icon="positive"
             disabled={buttonDiabled}
             votes={memberVoteWeight}
             voteImpact={userVotesImpact}
-            isVoted={isVoted}
-            marked={alreadyVotedAye}
-            onClick={() => setDecision('aye')}
+            isVoted={alreadyVotedAye}
+            checked={alreadyVotedAye}
+            fullWidth
+            onClick={() => !alreadyVotedAye && setDecision('aye')}
           >
-            {alreadyVotedNay ? t('fellowship.voting.revote') : null}
             {t('fellowship.voting.good')}
-          </ButtonWithTooltip>
+          </VotingButtonWithTooltip>
         </Box>
 
         {canVote && !hasRequiredRank ? (
@@ -103,65 +102,3 @@ export const VotingButtons = memo(({ referendum }: Props) => {
     </>
   );
 });
-
-type ButtonTooltips = {
-  pallet: 'positive' | 'negative';
-  disabled: boolean;
-  votes: number;
-  voteImpact: number;
-  icon: IconNames;
-  onClick: () => void;
-  isVoted: boolean;
-  marked: boolean;
-};
-
-export const ButtonWithTooltip = ({
-  pallet,
-  disabled,
-  onClick,
-  votes,
-  voteImpact,
-  icon,
-  children,
-  isVoted,
-  marked,
-}: PropsWithChildren<ButtonTooltips>) => {
-  const { t } = useI18n();
-
-  const tooltipText = pallet === 'positive' ? t('voteChart.aye') : t('voteChart.nay');
-  const impact = categorizeImpact(voteImpact);
-
-  return (
-    <Tooltip>
-      <Tooltip.Trigger>
-        <div className="w-full">
-          <ButtonCard
-            pallet={pallet}
-            icon={icon}
-            disabled={disabled}
-            fullWidth
-            className={cnTw(
-              { 'bg-secondary-positive-button-background-active': marked && pallet === 'positive' },
-              { 'bg-secondary-negative-button-background-active': marked && pallet === 'negative' },
-              { 'px-2': isVoted },
-            )}
-            onClick={onClick}
-          >
-            {children}
-          </ButtonCard>
-        </div>
-      </Tooltip.Trigger>
-      <Tooltip.Content>
-        <p>
-          <span>
-            {tooltipText}: {t('fellowship.votingHistory.votes', { count: votes })}
-          </span>
-          <br />
-          <span>
-            {t('fellowship.voting.voteImpact.impact')} {t(`fellowship.voting.voteImpact.${impact}`)}
-          </span>
-        </p>
-      </Tooltip.Content>
-    </Tooltip>
-  );
-};

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -661,7 +661,6 @@
       "good": "Good",
       "nay": "Nay",
       "notGood": "Not Good",
-      "revote": "Revote ",
       "summary": "What do others think?",
       "threshold": "Threshold",
       "title": "Vote on",

--- a/src/renderer/shared/ui-kit/FilledIconButton/FilledIconButton.tsx
+++ b/src/renderer/shared/ui-kit/FilledIconButton/FilledIconButton.tsx
@@ -1,21 +1,22 @@
-import { type MouseEventHandler, memo } from 'react';
+import { type MouseEventHandler, type PropsWithChildren, memo } from 'react';
 
 import { cnTw } from '@/shared/lib/utils';
 import { Icon, type IconNames } from '@/shared/ui';
 
-type Props = {
+type Props = PropsWithChildren<{
   variant: 'positive' | 'negative';
   icon: IconNames;
   checked?: boolean;
   marked?: boolean;
   disabled?: boolean;
+  fullWidth?: boolean;
   onClick?: MouseEventHandler<HTMLButtonElement>;
   onMouseOver?: MouseEventHandler<HTMLButtonElement>;
   onMouseLeave?: MouseEventHandler<HTMLButtonElement>;
-};
+}>;
 
 export const FilledIconButton = memo(
-  ({ variant, disabled, checked, marked, icon, onClick, onMouseOver, onMouseLeave }: Props) => {
+  ({ variant, disabled, checked, marked, icon, onClick, onMouseOver, onMouseLeave, children, fullWidth }: Props) => {
     return (
       <button
         type="button"
@@ -38,6 +39,9 @@ export const FilledIconButton = memo(
             'bg-label-background-green': variant === 'positive' && marked,
             'hover:bg-badge-green-background': variant === 'positive' && !marked,
           },
+          {
+            'w-full': fullWidth,
+          },
         )}
         onClick={onClick}
         onMouseOver={onMouseOver}
@@ -52,6 +56,17 @@ export const FilledIconButton = memo(
             'text-icon-button': marked && !disabled,
           })}
         />
+        {children ? (
+          <span
+            className={cnTw('text-button-large', {
+              'text-icon-negative': variant === 'negative' && !disabled,
+              'text-icon-positive': variant === 'positive' && !disabled,
+              'text-icon-button': marked && !disabled,
+            })}
+          >
+            {children}
+          </span>
+        ) : null}
       </button>
     );
   },


### PR DESCRIPTION
## Related Issues
Closes #3842 

## Changes Made
- Removed "revote" word
- Unified buttons on task and referendum 
- Removed tooltip and click on marked button
-->

## Screenshots/Recordings
<img width="377" alt="image" src="https://github.com/user-attachments/assets/1709a1a1-f30b-45f2-a479-21fc48307917" />
