### PR TITLE
fix: same behaviour for referenda details

### DIFF
--- a/src/renderer/features/fellowship-referendum-details/components/VotingRecord.tsx
+++ b/src/renderer/features/fellowship-referendum-details/components/VotingRecord.tsx
@@ -60,7 +60,9 @@ export const VotingRecord = memo(({ evidence }: Props) => {
             <HelpText>{t('fellowship.members.activity')}</HelpText>
             {nullable(activity) ? (
               <Skeleton height={5} />
-            ) : nonNullable(activity.activity) ? (
+            ) : !nonNullable(activity.activity) ? (
+              <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
+            ) : (
               <Box direction="row" verticalAlign="end">
                 <SmallTitleText>
                   {nonNullable(activityThreshold) ? Math.min(activity?.activity, activityThreshold).toString() : '100'}
@@ -69,8 +71,6 @@ export const VotingRecord = memo(({ evidence }: Props) => {
                   {activityThreshold || '100'}%
                 </CaptionText>
               </Box>
-            ) : (
-              <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
             )}
           </Box>
         </Box>
@@ -87,7 +87,9 @@ export const VotingRecord = memo(({ evidence }: Props) => {
             <HelpText>{t('fellowship.members.agreement')}</HelpText>
             {nullable(activity) ? (
               <Skeleton height={5} />
-            ) : nonNullable(activity.agreement) ? (
+            ) : !nonNullable(activity.agreement) ? (
+              <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
+            ) : (
               <Box direction="row" verticalAlign="end">
                 <SmallTitleText>
                   {nonNullable(agreementThreshold)
@@ -98,8 +100,6 @@ export const VotingRecord = memo(({ evidence }: Props) => {
                   {agreementThreshold || '100'}%
                 </CaptionText>
               </Box>
-            ) : (
-              <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
             )}
           </Box>
         </Box>

--- a/src/renderer/features/fellowship-referendum-details/components/VotingRecord.tsx
+++ b/src/renderer/features/fellowship-referendum-details/components/VotingRecord.tsx
@@ -60,7 +60,7 @@ export const VotingRecord = memo(({ evidence }: Props) => {
             <HelpText>{t('fellowship.members.activity')}</HelpText>
             {nullable(activity) ? (
               <Skeleton height={5} />
-            ) : !nonNullable(activity.activity) ? (
+            ) : nullable(activity.activity) ? (
               <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
             ) : (
               <Box direction="row" verticalAlign="end">
@@ -87,7 +87,7 @@ export const VotingRecord = memo(({ evidence }: Props) => {
             <HelpText>{t('fellowship.members.agreement')}</HelpText>
             {nullable(activity) ? (
               <Skeleton height={5} />
-            ) : !nonNullable(activity.agreement) ? (
+            ) : nullable(activity.agreement) ? (
               <SmallTitleText>{t('fellowship.n/a')}</SmallTitleText>
             ) : (
               <Box direction="row" verticalAlign="end">


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

Loading state shows intp referenda details:
![Screenshot 2025-06-04 at 15 46 22](https://github.com/user-attachments/assets/0f5b0b37-4031-4f84-8477-ab055e8a5b64)

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

<img width="808" alt="Screenshot 2025-06-04 at 20 31 05" src="https://github.com/user-attachments/assets/6a19b95e-4a2a-4d6a-856e-545735ca7351" />


