### PR TITLE
Fix: cas proxy call

### DIFF
--- a/src/renderer/entities/transaction/lib/extrinsicService.ts
+++ b/src/renderer/entities/transaction/lib/extrinsicService.ts
@@ -113,11 +113,11 @@ export const getExtrinsic: Record<
     return api.tx.proxy.killPure(spawner, proxyType, index, height, extIndex);
   },
   // TODO: Check that this method works correctly
-  [TransactionType.PROXY]: ({ real, forceProxyType, transaction }, api) => {
+  [TransactionType.PROXY]: ({ real, forceProxyType, transaction, call }, api) => {
     const tx = transaction as Transaction;
-    const call = getExtrinsic[tx.type](tx.args, api).method;
+    const proxyCall = call ?? getExtrinsic[tx.type](tx.args, api).method;
 
-    return api.tx.proxy.proxy(real, forceProxyType, call);
+    return api.tx.proxy.proxy(real, forceProxyType, proxyCall);
   },
   [TransactionType.CREATE_PURE_PROXY]: ({ proxyType, delay, index }, api) => {
     return api.tx.proxy.createPure(proxyType, delay, index);

--- a/src/renderer/widgets/Staking/BondExtra/default/model/form-model.ts
+++ b/src/renderer/widgets/Staking/BondExtra/default/model/form-model.ts
@@ -232,7 +232,7 @@ const { $fee, $pendingFee, $tx, $multisigTx, $route } = createComplexTxStore({
   transaction: $coreTx,
 });
 
-const $proxiedAccount = $route.map((route) => route.find((account) => accountUtils.isProxiedAccount(account)));
+const $proxiedAccount = $route.map((route) => route.find((account) => accountUtils.isProxiedAccount(account)) ?? null);
 const $isProxy = $proxiedAccount.map((account) => nonNullable(account));
 const $isMultisig = $route.map((route) =>
   nonNullable(route.find((account) => accountUtils.isMultisigAccount(account))),

--- a/src/renderer/widgets/Staking/Withdraw/default/model/form-model.ts
+++ b/src/renderer/widgets/Staking/Withdraw/default/model/form-model.ts
@@ -300,7 +300,7 @@ const $isProxy = $route.map((route) => nonNullable(route.find((account) => accou
 const $isMultisig = $route.map((route) =>
   nonNullable(route.find((account) => accountUtils.isMultisigAccount(account))),
 );
-const $proxyAccount = $route.map((route) => route.find((account) => accountUtils.isProxiedAccount(account)));
+const $proxyAccount = $route.map((route) => route.find((account) => accountUtils.isProxiedAccount(account)) ?? null);
 
 const $proxyWallet = combine(
   {


### PR DESCRIPTION
## Description
With CAS form proxy operation had no network fee and was not sent to sign to a Nova wallet 
## Related Issues
Closes #3915 
## Changes Made
- Update proxy extrinsic so it can accept not only transactions but a call
- Clean up the console from effector errors 
