### PR TITLE
refactor: modals step updates

### DIFF
--- a/src/renderer/features/proxy-add-pure/model/add-pure-proxied-model.ts
+++ b/src/renderer/features/proxy-add-pure/model/add-pure-proxied-model.ts
@@ -1,7 +1,7 @@
 /* eslint-disable import-x/max-dependencies */
 import { type ApiPromise } from '@polkadot/api';
 import { type UnsubscribePromise } from '@polkadot/api/types';
-import { combine, createEffect, createEvent, createStore, sample } from 'effector';
+import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
 import { combineEvents, delay, spread } from 'patronum';
 
 import {
@@ -40,7 +40,7 @@ const flowStarted = createEvent();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $addProxyStore = createStore<AddPureProxiedStore | null>(null).reset(flowFinished);
 
@@ -123,8 +123,6 @@ const getPureProxyFx = createEffect(
     });
   },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/features/proxy-add/model/add-proxy-model.ts
+++ b/src/renderer/features/proxy-add/model/add-proxy-model.ts
@@ -1,4 +1,4 @@
-import { combine, createEvent, createStore, sample } from 'effector';
+import { combine, createEvent, createStore, restore, sample } from 'effector';
 import { spread } from 'patronum';
 
 import { type Transaction } from '@/shared/core';
@@ -23,7 +23,7 @@ const flowFinished = createEvent();
 const flowClosed = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $addProxyStore = createStore<AddProxyStore | null>(null).reset(flowFinished);
 const $wrappedTx = createStore<Transaction | null>(null).reset(flowFinished);
@@ -43,8 +43,6 @@ const $initiatorWallet = combine(
   },
   { skipVoid: false },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/features/proxy-remove-pure/model/remove-pure-proxy-model.ts
+++ b/src/renderer/features/proxy-remove-pure/model/remove-pure-proxy-model.ts
@@ -1,4 +1,4 @@
-import { combine, createEvent, createStore, sample, split } from 'effector';
+import { combine, createEvent, createStore, restore, sample, split } from 'effector';
 import { spread } from 'patronum';
 
 import {
@@ -45,7 +45,7 @@ const flowStarted = createEvent<Input>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $removeProxyStore = createStore<RemoveProxyStore | null>(null).reset(flowFinished);
 
@@ -199,8 +199,6 @@ const $shouldRemovePureProxy = combine(
     return isPureProxy && anyProxies.length === 1;
   },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 split({
   clock: wentBackFromConfirm,

--- a/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
+++ b/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
@@ -46,7 +46,7 @@ const flowStarted = createEvent<Input>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $removeProxyStore = createStore<RemoveProxyStore | null>(null);
 const $wrappedTx = createStore<Transaction | null>(null).reset(flowFinished);
@@ -205,8 +205,6 @@ sample({
     isMultisig: $isMultisig,
   }),
 });
-
-sample({ clock: stepChanged, target: $step });
 
 split({
   clock: wentBackFromConfirm,

--- a/src/renderer/widgets/DelegateModal/default/model/delegate-model.ts
+++ b/src/renderer/widgets/DelegateModal/default/model/delegate-model.ts
@@ -40,8 +40,6 @@ const $redirectAfterSubmitPath = createStore<PathType | null>(null).reset(flowSt
 
 // Steps
 
-sample({ clock: stepChanged, target: $step });
-
 sample({
   clock: flowStarted,
   target: $target,

--- a/src/renderer/widgets/DelegateModal/shards/model/delegate-model.ts
+++ b/src/renderer/widgets/DelegateModal/shards/model/delegate-model.ts
@@ -250,8 +250,6 @@ sample({
 
 // Steps
 
-sample({ clock: stepChanged, target: $step });
-
 sample({
   clock: flowStarted,
   target: $target,

--- a/src/renderer/widgets/EditDelegationModal/default/model/edit-delegation-model.ts
+++ b/src/renderer/widgets/EditDelegationModal/default/model/edit-delegation-model.ts
@@ -69,8 +69,6 @@ sample({
   target: $isUnchanged,
 });
 
-sample({ clock: stepChanged, target: $step });
-
 sample({
   clock: flowStarted,
   target: spread({

--- a/src/renderer/widgets/RevokeDelegationModal/default/model/revoke-delegation-model.ts
+++ b/src/renderer/widgets/RevokeDelegationModal/default/model/revoke-delegation-model.ts
@@ -146,11 +146,6 @@ const { $multisigDeposit } = createMultisigDeposit({
 
 // Steps
 
-sample({
-  clock: stepChanged,
-  target: $step,
-});
-
 const dataSubmitted = sample({
   clock: flowStarted,
   source: {

--- a/src/renderer/widgets/RevokeDelegationModal/shards/model/revoke-delegation-model.ts
+++ b/src/renderer/widgets/RevokeDelegationModal/shards/model/revoke-delegation-model.ts
@@ -253,11 +253,6 @@ sample({
 // Steps
 
 sample({
-  clock: stepChanged,
-  target: $step,
-});
-
-sample({
   clock: [flowStarted, $revokeDelegationData.updates],
   source: {
     balances: balanceModel.$balances,

--- a/src/renderer/widgets/Staking/BondExtra/default/model/bond-extra-model.ts
+++ b/src/renderer/widgets/Staking/BondExtra/default/model/bond-extra-model.ts
@@ -21,7 +21,7 @@ const flowStarted = createEvent<WalletDataShards>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletDataShards = restore<WalletDataShards | null>(flowStarted, null).reset(flowFinished);
 const $walletData = $walletDataShards.map((data) => {
@@ -75,8 +75,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/BondExtra/shards/model/bond-extra-model.ts
+++ b/src/renderer/widgets/Staking/BondExtra/shards/model/bond-extra-model.ts
@@ -32,7 +32,7 @@ const flowStarted = createEvent<WalletData>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<WalletData | null>(flowStarted, null).reset(flowFinished);
 const $bondExtraData = createStore<BondExtraData | null>(null).reset(flowFinished);
@@ -218,8 +218,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/BondNominate/default/model/bond-nominate-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/default/model/bond-nominate-model.ts
@@ -26,7 +26,7 @@ const flowStarted = createEvent<WalletData>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<WalletData | null>(flowStarted, null).reset(flowFinished);
 const $bondNominateData = createStore<BondNominateData | null>(null).reset(flowFinished);
@@ -125,8 +125,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/BondNominate/shards/model/bond-nominate-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/shards/model/bond-nominate-model.ts
@@ -37,7 +37,7 @@ const flowStarted = createEvent<WalletData>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<WalletData | null>(flowStarted, null).reset(flowFinished);
 const $bondNominateData = createStore<BondNominateData | null>(null).reset(flowFinished);
@@ -267,8 +267,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Nominate/shards/model/nominate-model.ts
+++ b/src/renderer/widgets/Staking/Nominate/shards/model/nominate-model.ts
@@ -34,7 +34,7 @@ const flowStarted = createEvent<WalletData>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<WalletData | null>(flowStarted, null).reset(flowFinished);
 const $nominateData = createStore<NominateData | null>(null).reset(flowFinished);
@@ -253,8 +253,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Payee/default/model/payee-model.ts
+++ b/src/renderer/widgets/Staking/Payee/default/model/payee-model.ts
@@ -21,7 +21,7 @@ const flowStarted = createEvent<FormInput>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<FormInput | null>(flowStarted, null).reset(flowFinished);
 
@@ -66,8 +66,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Payee/shards/model/payee-model.ts
+++ b/src/renderer/widgets/Staking/Payee/shards/model/payee-model.ts
@@ -32,7 +32,7 @@ const flowStarted = createEvent<WalletData>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $walletData = restore<WalletData | null>(flowStarted, null).reset(flowFinished);
 const $payeeData = createStore<PayeeData | null>(null).reset(flowFinished);
@@ -212,8 +212,6 @@ sample({
 });
 
 // Steps
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Restake/default/model/restake-model.ts
+++ b/src/renderer/widgets/Staking/Restake/default/model/restake-model.ts
@@ -20,7 +20,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $restakeStore = createStore<RestakeStore | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -38,8 +38,6 @@ const $initiatorWallet = combine(
     return walletUtils.getWalletById(wallets, store.initiator.walletId);
   },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Restake/shards/model/restake-model.ts
+++ b/src/renderer/widgets/Staking/Restake/shards/model/restake-model.ts
@@ -21,7 +21,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $restakeStore = createStore<RestakeStore | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -43,8 +43,6 @@ const $initiatorWallet = combine(
   },
   { skipVoid: false },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Unstake/default/model/unstake-model.ts
+++ b/src/renderer/widgets/Staking/Unstake/default/model/unstake-model.ts
@@ -20,7 +20,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $unstakeStore = createStore<UnstakeStore | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -40,8 +40,6 @@ const $initiatorWallet = combine(
     return walletUtils.getWalletById(wallets, store.initiator.walletId) ?? null;
   },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Unstake/shards/model/unstake-model.ts
+++ b/src/renderer/widgets/Staking/Unstake/shards/model/unstake-model.ts
@@ -20,7 +20,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $unstakeStore = createStore<UnstakeStore | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -42,8 +42,6 @@ const $initiatorWallet = combine(
   },
   { skipVoid: false },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Withdraw/default/model/withdraw-model.ts
+++ b/src/renderer/widgets/Staking/Withdraw/default/model/withdraw-model.ts
@@ -19,7 +19,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $withdrawData = createStore<WithdrawData | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -37,8 +37,6 @@ const $initiatorWallet = combine(
     return walletUtils.getWalletById(wallets, store.initiator.walletId);
   },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Staking/Withdraw/shards/model/withdraw-model.ts
+++ b/src/renderer/widgets/Staking/Withdraw/shards/model/withdraw-model.ts
@@ -20,7 +20,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 
 const $withdrawData = createStore<WithdrawData | null>(null).reset(flowFinished);
 const $networkStore = restore<NetworkStore | null>(flowStarted, null);
@@ -43,8 +43,6 @@ const $initiatorWallet = combine(
   },
   { skipVoid: false },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/Transfer/model/transfer-model.ts
+++ b/src/renderer/widgets/Transfer/model/transfer-model.ts
@@ -20,7 +20,7 @@ const flowStarted = createEvent<NetworkStore>();
 const flowFinished = createEvent();
 const txSaved = createEvent();
 
-const $step = createStore<Step>(Step.NONE);
+const $step = restore(stepChanged, Step.NONE);
 const $redirectAfterSubmitPath = createStore<PathType | null>(null).reset(flowStarted);
 
 const $transferStore = createStore<TransferStore | null>(null);
@@ -55,8 +55,6 @@ const $initiatorWallet = combine(
   },
   { skipVoid: false },
 );
-
-sample({ clock: stepChanged, target: $step });
 
 sample({
   clock: flowStarted,

--- a/src/renderer/widgets/UnlockModal/default/model/unlock.ts
+++ b/src/renderer/widgets/UnlockModal/default/model/unlock.ts
@@ -45,11 +45,6 @@ sample({
 });
 
 sample({
-  clock: stepChanged,
-  target: $step,
-});
-
-sample({
   clock: unlockFormStarted,
   source: unlockModel.$claimSchedule,
   filter: (claims) => nonNullable(claims),

--- a/src/renderer/widgets/UnlockModal/shards/model/unlock.ts
+++ b/src/renderer/widgets/UnlockModal/shards/model/unlock.ts
@@ -52,11 +52,6 @@ sample({
 });
 
 sample({
-  clock: stepChanged,
-  target: $step,
-});
-
-sample({
   clock: unlockFormStarted,
   source: unlockModel.$claimSchedule,
   filter: (claims) => nonNullable(claims),


### PR DESCRIPTION
## Description
Refactor how we update steps between modal's forms.
Remove redundant `samples` that duplicate `restore` functionality.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
