### PR TITLE
fix: cas pending fee

### DIFF
--- a/src/renderer/shared/transactions/createFeeCalculator.ts
+++ b/src/renderer/shared/transactions/createFeeCalculator.ts
@@ -1,7 +1,7 @@
 import { type ApiPromise } from '@polkadot/api';
 import { type SignerOptions } from '@polkadot/api/types/submittable';
 import { BN, BN_ZERO } from '@polkadot/util';
-import { type Store, type UnitValue, combine, createEffect, createStore, sample } from 'effector';
+import { type Store, type UnitValue, combine, createEffect, createStore, restore, sample } from 'effector';
 
 import { type Transaction } from '@/shared/core';
 import { nonNullable, nullable } from '@/shared/lib/utils';
@@ -31,6 +31,8 @@ export const createFeeCalculator = ({ $active = createStore(true), $transaction,
   const fetchFeeFx = createEffect(({ api, transaction, signerOptions }: RequestParams) => {
     return transactionService.getTransactionFee(transaction, api, signerOptions).then((x) => new BN(x));
   });
+
+  const $pending = restore(fetchFeeFx.pending.updates, true);
 
   const logErrorFx = createEffect((res: UnitValue<typeof fetchFeeFx.fail>) => {
     console.error('fee calculation faied', res);
@@ -79,6 +81,6 @@ export const createFeeCalculator = ({ $active = createStore(true), $transaction,
 
   return {
     $: $fee,
-    $pending: fetchFeeFx.pending,
+    $pending,
   };
 };


### PR DESCRIPTION
## Description
Sets `pending` flag to `true` as a default as soon as we call `createFeeCalculator`.


The previous impementation created problems with the form submit.
$canSubmit flag depends on `$pending`
In the old version it was:
```
pending = false
fetchFeeFx called, pending = true
fetchFeeFx stopped, pending = false
```

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/4025

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
