### PR TITLE
fix: governance unlock target account

### DIFF
--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -385,9 +385,10 @@ type UnlockParams = {
   accountId: AccountId;
   actions: ClaimAction[];
   amount: string;
+  target: AccountId;
 };
 
-function buildUnlock({ chain, accountId, actions, amount: value }: UnlockParams): Transaction {
+function buildUnlock({ chain, accountId, actions, amount: value, target }: UnlockParams): Transaction {
   const unlockTxs = actions.map((action) => {
     const transaction = {
       chainId: chain.chainId,
@@ -411,7 +412,7 @@ function buildUnlock({ chain, accountId, actions, amount: value }: UnlockParams)
       type: TransactionType.UNLOCK,
       args: {
         trackId: action.trackId,
-        target: toAddress(accountId, { prefix: chain.addressPrefix }),
+        target: toAddress(target, { prefix: chain.addressPrefix }),
         value,
       },
     };

--- a/src/renderer/widgets/UnlockModal/default/model/unlockForm.ts
+++ b/src/renderer/widgets/UnlockModal/default/model/unlockForm.ts
@@ -165,18 +165,17 @@ const $coreTx = combine(
   {
     chain: networkSelectorModel.$governanceChain,
     initiator: form.fields.initiator.$value,
-    signatory: form.fields.signatory.$value,
     isConnected: $isChainConnected,
     claims: $claims,
   },
-  ({ chain, initiator, signatory, isConnected, claims }) => {
-    if (nullable(chain) || nullable(initiator) || nullable(signatory) || nullable(claims) || !isConnected) return null;
+  ({ chain, initiator, isConnected, claims }) => {
+    if (nullable(chain) || nullable(initiator) || nullable(claims) || !isConnected) return null;
     const claim = claims.find((claim) => claim.accountId === initiator.accountId);
 
     return transactionBuilder.buildUnlock({
       actions: claim?.actions ?? [],
       chain: chain,
-      accountId: signatory.accountId,
+      accountId: initiator.accountId,
       amount: claim?.amount.toString() ?? ZERO_BALANCE,
     });
   },

--- a/src/renderer/widgets/UnlockModal/default/model/unlockForm.ts
+++ b/src/renderer/widgets/UnlockModal/default/model/unlockForm.ts
@@ -165,18 +165,20 @@ const $coreTx = combine(
   {
     chain: networkSelectorModel.$governanceChain,
     initiator: form.fields.initiator.$value,
+    signatory: form.fields.signatory.$value,
     isConnected: $isChainConnected,
     claims: $claims,
   },
-  ({ chain, initiator, isConnected, claims }) => {
-    if (nullable(chain) || nullable(initiator) || nullable(claims) || !isConnected) return null;
+  ({ chain, initiator, signatory, isConnected, claims }) => {
+    if (nullable(chain) || nullable(initiator) || nullable(signatory) || nullable(claims) || !isConnected) return null;
     const claim = claims.find((claim) => claim.accountId === initiator.accountId);
 
     return transactionBuilder.buildUnlock({
       actions: claim?.actions ?? [],
       chain: chain,
-      accountId: initiator.accountId,
+      accountId: signatory.accountId,
       amount: claim?.amount.toString() ?? ZERO_BALANCE,
+      target: initiator.accountId,
     });
   },
 );

--- a/src/renderer/widgets/UnlockModal/shards/model/unlockForm.ts
+++ b/src/renderer/widgets/UnlockModal/shards/model/unlockForm.ts
@@ -312,6 +312,7 @@ const $pureTxs = combine(
         chain: chain,
         accountId: shard.accountId,
         amount: shard.amount || ZERO_BALANCE,
+        target: shard.accountId,
       });
     });
   },


### PR DESCRIPTION
## Description
Fixes the target account in the governance unlock transaction.
Sets the initiator account id instead of the signatory.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/4081

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
