### PR TITLE
fix: restake form continue button does nothing

### DIFF
--- a/src/renderer/widgets/Staking/Restake/default/model/restake-model.ts
+++ b/src/renderer/widgets/Staking/Restake/default/model/restake-model.ts
@@ -70,7 +70,6 @@ const formSubmitted = sample({
     nonNullable(networkStore) &&
     nonNullable(coreTx) &&
     nonNullable(tx) &&
-    nonNullable(multisigTx) &&
     nonNullable(route) &&
     nonNullable(formData.initiator) &&
     nonNullable(formData.signatory)


### PR DESCRIPTION
## Description
Continue action (form submit) was skipped by filterMap. We validated that `multisigTx` is not null. But it is allowed to be null there.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/4080

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
