### PR TITLE
fix: remove children with the wallet

### DIFF
--- a/src/renderer/features/wallets/ForgetWallet/model/forget-wallet-model.ts
+++ b/src/renderer/features/wallets/ForgetWallet/model/forget-wallet-model.ts
@@ -97,7 +97,6 @@ sample({
     const walletIdFromGraph = new Set<number>();
 
     for (const chain of Object.values(chains)) {
-      // Should we avoid WatchOnlyAccount in createAccountGraphs by default?
       const filteredAccounts = accounts.filter((a) => !accountUtils.isWatchOnlyAccount(a));
       const graph = accountService.createAccountGraphs(filteredAccounts, chain);
 

--- a/src/renderer/features/wallets/ForgetWallet/service.ts
+++ b/src/renderer/features/wallets/ForgetWallet/service.ts
@@ -1,4 +1,5 @@
 import { type AccountNode, type AnyAccount, accountService } from '@/domains/network';
+import { accountUtils } from '@/entities/wallet';
 
 export const forgetService = {
   findParentAccounts,
@@ -29,9 +30,11 @@ function findParentAccounts(graph: Map<AnyAccount, AccountNode>, account: AnyAcc
           return false; // Stop traversing this path
         }
 
-        if (node.children.length === 1) {
+        const children = node.children.filter((child) => !accountUtils.isMultisigSignatoryAccount(child.account));
+
+        if (children.length === 1) {
           pathParents.push(node.account);
-        } else if (node.children.length > 1) {
+        } else if (children.length > 1) {
           pathParents = []; // Clear the path
         }
       },


### PR DESCRIPTION
## Description
The remove function worked incorrectly for multisig since the graph returns multisig_signatory accounts as well 
## Related Issues
Closes #4096 