### PR TITLE
docs: Remove leftover TOC anchor

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@
 
 <!-- TOC start -->
 - [Key features](#key-features)
-- [Changelog](#changelog)
 - [Development](#development)
   * [Requirements](#requirements)
   * [Commands](#commands)


### PR DESCRIPTION
## Description
Remove "Changelog" from TOC since its content was deleted in https://github.com/novasamatech/nova-spektr/pull/3497.