### PR TITLE
fix: use local config even if fetch request fails

### DIFF
--- a/src/renderer/domains/network/registry/service/chainRegistry.ts
+++ b/src/renderer/domains/network/registry/service/chainRegistry.ts
@@ -10,7 +10,7 @@ import {
 
 import { chainsService } from '@/shared/api/network';
 import { type Chain, type ChainId } from '@/shared/core';
-import { nullable } from '@/shared/lib/utils';
+import { nonNullable, nullable } from '@/shared/lib/utils';
 import { CONFIG } from '../lib/constants';
 import { type PolkadotApi } from '../lib/types';
 
@@ -143,7 +143,7 @@ let instance: ChainRegistry | undefined;
 export async function getChainRegistry(): Promise<ChainRegistry> {
   if (nullable(instance)) {
     const chains = await chainsService.getChainsData();
-    const sortedChains = chainsService.sortChains(chains);
+    const sortedChains = nonNullable(chains) ? chainsService.sortChains(chains) : [];
     instance = new ChainRegistry(sortedChains, {
       createWcProvider: getWsProvider,
       createClient,

--- a/src/renderer/entities/network/model/network-model.ts
+++ b/src/renderer/entities/network/model/network-model.ts
@@ -35,12 +35,6 @@ const failed = createEvent<ChainId>();
 
 const $chains = createStore<Record<ChainId, Chain>>({});
 
-persist({
-  key: 'chains_map',
-  store: $chains,
-  sync: true,
-});
-
 const $providers = createStore<Record<ChainId, ProviderWithMetadata>>({});
 const $apis = createStore<Record<ChainId, ApiPromise>>({});
 
@@ -53,8 +47,9 @@ const $metadataSubscriptions = createStore<Record<ChainId, VoidFn>>({});
 
 const $populated = createStore(false);
 
-const populateChainsFx = createEffect((): Promise<Record<ChainId, Chain>> => {
-  return chainsService.getChainsData().then(chainsService.getChainsMap);
+const populateChainsFx = createEffect(async (): Promise<Record<ChainId, Chain> | null> => {
+  const chains = await chainsService.getChainsData();
+  return nonNullable(chains) ? chainsService.getChainsMap(chains) : null;
 });
 
 const populateMetadataFx = createEffect((): Promise<ChainMetadata[]> => {
@@ -67,6 +62,11 @@ const populateConnectionsFx = createEffect((): Promise<Connection[]> => {
 
 const getDefaultStatusesFx = createEffect((chains: Record<ChainId, Chain>): Record<ChainId, ConnectionStatus> => {
   return dictionary(Object.values(chains), 'chainId', () => ConnectionStatus.DISCONNECTED);
+});
+
+persist({
+  key: 'chains_map',
+  store: $chains,
 });
 
 type MetadataSubResult = {
@@ -183,6 +183,7 @@ const startNetworksFx = createEffect(() => {
 
 sample({
   clock: populateChainsFx.doneData,
+  filter: (data) => nonNullable(data),
   target: [$chains, getDefaultStatusesFx],
 });
 
@@ -243,12 +244,15 @@ sample({
 const readyToConnect = combineEvents({
   events: [populateConnectionsFx.doneData, populateMetadataFx.doneData, populateChainsFx.doneData],
   reset: startNetworksFx,
-}).map(([connections, metadata, chains]) => {
-  return { connections, metadata, chains };
 });
 
 sample({
   clock: readyToConnect,
+  source: {
+    chains: $chains,
+    connections: $connectionData,
+    metadata: $metadata,
+  },
   fn: ({ connections, metadata, chains }) => {
     return Object.values(chains)
       .filter((chain) => {

--- a/src/renderer/entities/network/model/network-model.ts
+++ b/src/renderer/entities/network/model/network-model.ts
@@ -67,6 +67,7 @@ const getDefaultStatusesFx = createEffect((chains: Record<ChainId, Chain>): Reco
 persist({
   key: 'chains_map',
   store: $chains,
+  sync: true,
 });
 
 type MetadataSubResult = {

--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -28,11 +28,12 @@ export const tokensService = {
   calculateTotalBalance,
 };
 
-async function getTokensData(): Promise<AssetByChains[]> {
+async function getTokensData(): Promise<AssetByChains[] | null> {
   const response = await fetch(TOKENS_CONFIG_URL);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch tokens config: ${response.status} ${response.statusText}`);
+    console.error(`Failed to fetch tokens config: ${response.status} ${response.statusText}`);
+    return null;
   }
 
   return response.json();

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -38,6 +38,7 @@ const populateFx = createEffect((): Promise<AssetByChains[] | null> => {
 persist({
   key: 'assets_with_chains',
   store: $defaultTokens,
+  sync: true,
 });
 
 sample({

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -3,7 +3,7 @@ import { persist } from 'effector-storage/local';
 import { once } from 'patronum';
 
 import { type AssetByChains } from '@/shared/core';
-import { includesMultiple, nullable } from '@/shared/lib/utils';
+import { includesMultiple, nonNullable, nullable } from '@/shared/lib/utils';
 import { type AnyAccount, accountService } from '@/domains/network';
 import { AssetsListView } from '@/entities/asset';
 import { balanceModel } from '@/entities/balance';
@@ -31,15 +31,19 @@ const $defaultTokens = createStore<AssetByChains[] | null>(null);
 
 const $filteredAccounts = createStore<AnyAccount[] | null>(null);
 
-const populateFx = createEffect((): Promise<AssetByChains[]> => {
+const populateFx = createEffect((): Promise<AssetByChains[] | null> => {
   return tokensService.getTokensData();
 });
 
 persist({
   key: 'assets_with_chains',
-  source: populateFx.doneData,
+  store: $defaultTokens,
+});
+
+sample({
+  clock: populateFx.doneData,
+  filter: (data) => nonNullable(data),
   target: $defaultTokens,
-  sync: true,
 });
 
 sample({

--- a/src/renderer/shared/api/network/service/chainsService.ts
+++ b/src/renderer/shared/api/network/service/chainsService.ts
@@ -22,11 +22,12 @@ export const chainsService = {
   sortChainsByBalance,
 };
 
-async function getChainsData(): Promise<Chain[]> {
+async function getChainsData(): Promise<Chain[] | null> {
   const response = await fetch(CHAINS_CONFIG_URL);
 
   if (!response.ok) {
-    throw new Error(`Failed to fetch chains config: ${response.status} ${response.statusText}`);
+    console.error(`Failed to fetch chains config: ${response.status} ${response.statusText}`);
+    return null;
   }
 
   return response.json();

--- a/tests/integrations/dataVerification/dataVerification.base.test.ts
+++ b/tests/integrations/dataVerification/dataVerification.base.test.ts
@@ -23,7 +23,7 @@ describe('Verification function can verify parachains', () => {
 
   beforeAll(async () => {
     const chains = await chainsService.getChainsData();
-    const [_, polkadotChains, kusamaChains, polkadot, kusama] = prepareTestData(chains);
+    const [_, polkadotChains, kusamaChains, polkadot, kusama] = prepareTestData(chains ?? []);
     polkadotParachains = polkadotChains;
     kusamaParachains = kusamaChains;
 


### PR DESCRIPTION
## Description
If request to fetch remote chains/tokens configs fails we should not crash the app and load the available config from the local storage.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/4116

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
