### PR TITLE
fix: asset hub sessions per era

### DIFF
--- a/src/renderer/entities/staking/api/stakingDataService.ts
+++ b/src/renderer/entities/staking/api/stakingDataService.ts
@@ -1,7 +1,7 @@
 import { type ApiPromise } from '@polkadot/api';
 
 import { type Address, type ChainId, type EraIndex, type Unlocking } from '@/shared/core';
-import { ZERO_BALANCE, redeemableAmount } from '@/shared/lib/utils';
+import { ZERO_BALANCE, getExpectedBlockTime, redeemableAmount } from '@/shared/lib/utils';
 import { type IStakingDataService, type StakingMap } from '../lib/types';
 
 export const useStakingData = (): IStakingDataService => {
@@ -161,6 +161,14 @@ export const useStakingData = (): IStakingDataService => {
     return redeemableAmount(unlocking, era) !== ZERO_BALANCE;
   };
 
+  const getEraDurationSeconds = (api: ApiPromise, timelineApi: ApiPromise): number => {
+    const sessionsPerEra = api.consts.staking.sessionsPerEra.toNumber();
+    const sessionDuration = timelineApi.consts.babe.epochDuration.toNumber();
+    const expectedBlockTime = getExpectedBlockTime(api).toNumber();
+
+    return (sessionsPerEra * sessionDuration * expectedBlockTime) / 1000;
+  };
+
   return {
     fetchLedger,
     subscribeStaking,
@@ -169,5 +177,6 @@ export const useStakingData = (): IStakingDataService => {
     getTotalStaked,
     getNextUnstakingEra,
     hasRedeem,
+    getEraDurationSeconds,
   };
 };

--- a/src/renderer/entities/staking/lib/types.ts
+++ b/src/renderer/entities/staking/lib/types.ts
@@ -19,6 +19,7 @@ export interface IStakingDataService {
   getTotalStaked: (api: ApiPromise, era: EraIndex) => Promise<string>;
   getNextUnstakingEra: (unlocking?: Unlocking[], era?: number) => EraIndex | undefined;
   hasRedeem: (unlocking?: Unlocking[], era?: number) => boolean;
+  getEraDurationSeconds: (api: ApiPromise, timelineApi: ApiPromise) => number;
 }
 
 // =====================================================

--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/model/confirm-model.ts
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/model/confirm-model.ts
@@ -1,7 +1,4 @@
-import { type BN } from '@polkadot/util';
-import { combine } from 'effector';
-
-import { type Address, type Asset, type ChainId, type Validator } from '@/shared/core';
+import { type Address, type Asset, type Validator } from '@/shared/core';
 import { type TxConfirmInfo, createTransactionConfirmStore } from '@/shared/transactions';
 import { networkModel } from '@/entities/network';
 import { walletModel } from '@/entities/wallet';
@@ -23,23 +20,10 @@ const confirmStore = createTransactionConfirmStore<BondNominateConfirm>({
   $multisigTransactions: selectedWalletMultisigOperations.$list,
 });
 
-const $eraLength = combine(networkModel.$apis, (apis) => {
-  if (!apis) return {};
-
-  return Object.entries(apis).reduce<Record<ChainId, number>>(
-    (acc, [chainId, api]) => ({
-      ...acc,
-      [chainId as ChainId]: (api.consts.staking.sessionsPerEra as unknown as BN).toNumber(),
-    }),
-    {},
-  );
-});
-
 export const confirmModel = {
   $confirms: confirmStore.$confirms,
   $confirmMap: confirmStore.$confirmMap,
   $isMultisigExists: confirmStore.$isMultisigExists,
-  $eraLength,
   $apis: networkModel.$apis,
 
   init: confirmStore.init,

--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
@@ -5,13 +5,13 @@ import { AdditionalType } from '@/shared/core/types/chain';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
 import { formatAmount, getNativeAsset, toAccountId } from '@/shared/lib/utils';
-import { Button, CaptionText, DetailRow, FootnoteText, Icon } from '@/shared/ui';
+import { Button, CaptionText, DetailRow, Duration, FootnoteText, Icon } from '@/shared/ui';
 import { Account, AssetBalance, TransactionDetails } from '@/shared/ui-entities';
 import { Tooltip } from '@/shared/ui-kit';
 import { identity } from '@/domains/network';
 import { SignButton } from '@/entities/operations';
 import { AssetFiatBalance } from '@/entities/price';
-import { SelectedValidatorsModal, StakingPopover, UnstakingDuration } from '@/entities/staking';
+import { SelectedValidatorsModal, StakingPopover, UnstakingDuration, useStakingData } from '@/entities/staking';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { type Config } from '../../../OperationsValidation';
 import { MultisigExistsAlert } from '../../common/MultisigExistsAlert';
@@ -55,11 +55,8 @@ export const Confirmation = ({
     fn: (value, [chainId]) => value?.[chainId],
   });
 
-  const eraLength = useStoreMap({
-    store: confirmModel.$eraLength,
-    keys: [confirmStore?.meta.chain?.chainId],
-    fn: (value, [chainId]) => value?.[chainId],
-  });
+  const { getEraDurationSeconds } = useStakingData();
+  const eraDurationSeconds = getEraDurationSeconds(api, timelineApi);
 
   const identities = useStoreMap({
     store: identity.$list,
@@ -191,7 +188,7 @@ export const Confirmation = ({
             <StakingPopover.Item>
               {t('staking.confirmation.hintRewards')}
               {' ('}
-              {t('time.hours_other', { count: eraLength || 0 })}
+              <Duration seconds={eraDurationSeconds} />
               {')'}
             </StakingPopover.Item>
             <StakingPopover.Item>

--- a/src/renderer/shared/lib/utils/__tests__/substrate.test.ts
+++ b/src/renderer/shared/lib/utils/__tests__/substrate.test.ts
@@ -15,11 +15,6 @@ describe('shared/lib/onChainUtils/substrate', () => {
     return getExpectedBlockTime(mockApi);
   };
 
-  test('should get expected block time from Subspace', () => {
-    const time = getTime({ consts: { subspace: { expectedBlockTime: blockTime } } });
-    expect(time).toEqual(blockTime);
-  });
-
   test('should get expected block time with Threshold check', () => {
     const time = getTime({ consts: { timestamp: { minimumPeriod: blockTime } } });
     expect(time.toString()).toEqual(blockTime.muln(2).toString());

--- a/src/renderer/shared/lib/utils/substrate.ts
+++ b/src/renderer/shared/lib/utils/substrate.ts
@@ -84,10 +84,8 @@ export async function getParachainId(api: ApiPromise): Promise<number> {
 
 export const getExpectedBlockTime = (api: ApiPromise): BN => {
   const substrateBlockTime = api.consts.babe?.expectedBlockTime || api.consts.aura?.slotDuration;
-  const proofOfWorkBlockTime = api.consts.difficulty?.targetBlockTime;
-  const subspaceBlockTime = api.consts.subspace?.expectedBlockTime;
 
-  const blockTime = substrateBlockTime || proofOfWorkBlockTime || subspaceBlockTime;
+  const blockTime = substrateBlockTime;
   if (blockTime) {
     return bnMin(ONE_DAY, blockTime);
   }


### PR DESCRIPTION
## Description
Fixes annoying `sessionsPerEra` error in the console due to the asset hub migration.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
- Added getEraDurationSeconds method to staking service
- Fixed sessionsPerEra error in Confirmation component
- Fixed how era duration is calculated in Confirmation component

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
