### PR TITLE
fix: add proxy

### DIFF
--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -1,3 +1,4 @@
+import { encodeAddress } from '@polkadot/util-crypto';
 import { camelCase } from 'lodash';
 
 import { type ClaimAction } from '@/shared/api/governance';
@@ -581,7 +582,7 @@ function buildAddProxy({ chain, accountId, delegateAccountId, type }: AddProxyPa
     accountId: accountId,
     type: TransactionType.ADD_PROXY,
     args: {
-      delegate: toAddress(delegateAccountId, { prefix: chain.addressPrefix }),
+      delegate: encodeAddress(delegateAccountId, chain.addressPrefix),
       proxyType: type,
       delay: 0,
     },

--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -1,4 +1,3 @@
-import { encodeAddress } from '@polkadot/util-crypto';
 import { camelCase } from 'lodash';
 
 import { type ClaimAction } from '@/shared/api/governance';
@@ -582,7 +581,7 @@ function buildAddProxy({ chain, accountId, delegateAccountId, type }: AddProxyPa
     accountId: accountId,
     type: TransactionType.ADD_PROXY,
     args: {
-      delegate: encodeAddress(delegateAccountId, chain.addressPrefix),
+      delegate: delegateAccountId,
       proxyType: type,
       delay: 0,
     },

--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -571,7 +571,7 @@ function buildCreatePureProxy({ chain, accountId }: CreateProxyPureParams): Tran
 type AddProxyParams = {
   chain: Chain;
   accountId: AccountId;
-  delegateAccountId: AccountId;
+  delegateAccountId: AccountId | Address;
   type: ProxyType;
 };
 

--- a/src/renderer/features/proxy-add/model/form-model.ts
+++ b/src/renderer/features/proxy-add/model/form-model.ts
@@ -331,7 +331,7 @@ const $fakeTx = combine(
     return transactionBuilder.buildAddProxy({
       chain: chain,
       accountId: TEST_ACCOUNTS[0],
-      delegateAccountId: toAddress(TEST_ACCOUNTS[0], { prefix: chain.addressPrefix }),
+      delegateAccountId: TEST_ACCOUNTS[0],
       type: 'Any',
     });
   },

--- a/src/renderer/features/proxy-add/model/form-model.ts
+++ b/src/renderer/features/proxy-add/model/form-model.ts
@@ -5,14 +5,7 @@ import { createGate } from 'effector-react';
 import { spread } from 'patronum';
 
 import { proxyService } from '@/shared/api/proxy';
-import {
-  type Address,
-  type Chain,
-  type ProxyType,
-  type Transaction,
-  TransactionType,
-  type Wallet,
-} from '@/shared/core';
+import { type Address, type Chain, type ProxyType, type Transaction, type Wallet } from '@/shared/core';
 import { type Form, createForm } from '@/shared/forms';
 import {
   ZERO_BALANCE,
@@ -31,6 +24,7 @@ import { createComplexTxStore, createMultisigDeposit, createSignatoriesStore } f
 import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel, networkUtils } from '@/entities/network';
+import { transactionBuilder } from '@/entities/transaction';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { proxiesUtils } from '@/features/proxies';
 
@@ -355,16 +349,12 @@ const $coreTx = combine(
   ({ form, signatory, isConnected }): Transaction | null => {
     if (!isConnected || !signatory || !form.delegate || !form.proxyType || !form.chain) return null;
 
-    return {
-      chainId: form.chain.chainId,
+    return transactionBuilder.buildAddProxy({
+      chain: form.chain,
       accountId: signatory.accountId,
-      type: TransactionType.ADD_PROXY,
-      args: {
-        delegate: toAddress(form.delegate, { prefix: form.chain.addressPrefix }),
-        proxyType: form.proxyType,
-        delay: 0,
-      },
-    };
+      delegateAccountId: form.delegate,
+      type: form.proxyType,
+    });
   },
 );
 

--- a/src/renderer/features/proxy-add/model/form-model.ts
+++ b/src/renderer/features/proxy-add/model/form-model.ts
@@ -8,6 +8,7 @@ import { proxyService } from '@/shared/api/proxy';
 import { type Address, type Chain, type ProxyType, type Transaction, type Wallet } from '@/shared/core';
 import { type Form, createForm } from '@/shared/forms';
 import {
+  TEST_ACCOUNTS,
   ZERO_BALANCE,
   getNativeAsset,
   getProxyTypes,
@@ -319,26 +320,22 @@ const $api = combine(
   },
 );
 
-// const $fakeTx = combine(
-//   {
-//     chain: form.fields.chain.$value,
-//     isConnected: $isChainConnected,
-//   },
-//   ({ isConnected, chain }): Transaction | null => {
-//     if (!chain.chainId || !isConnected) return null;
+const $fakeTx = combine(
+  {
+    chain: form.fields.chain.$value,
+    isConnected: $isChainConnected,
+  },
+  ({ isConnected, chain }): Transaction | null => {
+    if (!chain || !isConnected) return null;
 
-//     return {
-//       chainId: chain.chainId,
-//       accountId: TEST_ACCOUNTS[0],
-//       type: TransactionType.ADD_PROXY,
-//       args: {
-//         delegate: toAddress(TEST_ACCOUNTS[0], { prefix: chain.addressPrefix }),
-//         proxyType: 'Any',
-//         delay: 0,
-//       },
-//     };
-//   },
-// );
+    return transactionBuilder.buildAddProxy({
+      chain: chain,
+      accountId: TEST_ACCOUNTS[0],
+      delegateAccountId: toAddress(TEST_ACCOUNTS[0], { prefix: chain.addressPrefix }),
+      type: 'Any',
+    });
+  },
+);
 
 const $coreTx = combine(
   {
@@ -365,7 +362,7 @@ const { $fee, $pendingFee, $tx, $route } = createComplexTxStore({
   accounts: accounts.$list,
   chain: form.fields.chain.$value,
   transaction: $coreTx,
-  // TODO fakeTx: $fakeTx,
+  feeTransaction: $fakeTx,
 });
 
 const $isMultisig = $route.map((route) => {

--- a/src/renderer/features/proxy-add/ui/AddProxy.tsx
+++ b/src/renderer/features/proxy-add/ui/AddProxy.tsx
@@ -61,7 +61,7 @@ export const AddProxy = ({ wallet }: Props) => {
   }
 
   return (
-    <Modal size="md" height="full" isOpen={isModalOpen} onToggle={closeModal}>
+    <Modal size="md" height="fit" isOpen={isModalOpen} onToggle={closeModal}>
       <Modal.Title close>{getModalTitle(step, chain)}</Modal.Title>
       <Modal.Content>
         {addProxyUtils.isInitStep(step) && <AddProxyForm onGoBack={closeModal} />}


### PR DESCRIPTION
## Description
Fix AddProxy modal height. Use transaction builder. Use fake tx to calculate fee before all form fields are filled.

## Related Issues
Closes #4208

## Changes Made
- Fixed modal height to fit content
- Transaction fee calculation
- Refactored coreTx by using existing transactionBuilder function
- Refactored buildAddProxy. `toAddress` function is made for use in UI only

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
