### PR TITLE
fix(proxy): show delegates & total deposit

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,6 +55,7 @@
     "pretest:system": "playwright install",
     "knip": "knip",
     "types": "tsc -p tsconfig.json --noEmit",
+    "types:watch": "tsc -p tsconfig.json --noEmit --watch",
     "types:files": "tsc-files --noEmit",
     "fmt:generic": "prettier",
     "fmt:check": "pnpm fmt:generic ./src/**/*.ts ./src/**/*.tsx --check",

--- a/src/renderer/entities/proxy/lib/__tests__/mocks/proxy-mocks.ts
+++ b/src/renderer/entities/proxy/lib/__tests__/mocks/proxy-mocks.ts
@@ -1,10 +1,4 @@
-import {
-  type ProxyAccount,
-  type ProxyDeposits,
-  type VaultBaseAccount,
-  type Wallet,
-  type WcAccount,
-} from '@/shared/core';
+import { type ProxyAccount, type VaultBaseAccount, type Wallet, type WcAccount } from '@/shared/core';
 import { AccountType, CryptoType, SigningType, WalletType } from '@/shared/core';
 import { TEST_ACCOUNTS } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
@@ -81,16 +75,6 @@ const wallets: Wallet[] = [
     ],
   },
 ];
-const deposits: ProxyDeposits[] = [
-  {
-    chainId: '0x001',
-    deposits: { [TEST_ACCOUNTS[0]]: '100' },
-  },
-  {
-    chainId: '0x001',
-    deposits: { [TEST_ACCOUNTS[1]]: '200' },
-  },
-];
 
 const proxyAccounts: ProxyAccount[] = [
   {
@@ -123,6 +107,5 @@ export const proxyMock = {
   oldProxy,
   newProxy,
   wallets,
-  deposits,
   proxyAccounts,
 };

--- a/src/renderer/entities/proxy/lib/__tests__/proxy-utils.test.ts
+++ b/src/renderer/entities/proxy/lib/__tests__/proxy-utils.test.ts
@@ -31,33 +31,6 @@ describe('entities/proxy/lib/proxy-utils', () => {
     expect(result).toEqual('Any for 5CGQ7B...VbXyr9');
   });
 
-  test('should return proxy group', () => {
-    const { wallets, deposits } = proxyMock;
-    const result = proxyUtils.getProxyGroups([wallets[0]], deposits[0]);
-
-    expect(result).toEqual([
-      {
-        walletId: 1,
-        proxiedAccountId: TEST_ACCOUNTS[0],
-        chainId: '0x001',
-        totalDeposit: '100',
-      },
-    ]);
-  });
-
-  test('should return proxy group for Wallet Connect', () => {
-    const { wallets, deposits } = proxyMock;
-    const result = proxyUtils.getProxyGroups([wallets[1]], deposits[1]);
-
-    expect(result).toEqual([
-      {
-        walletId: 2,
-        proxiedAccountId: TEST_ACCOUNTS[1],
-        chainId: '0x001',
-        totalDeposit: '200',
-      },
-    ]);
-  });
 
   test('should sort proxy accounts by type', () => {
     const { proxyAccounts } = proxyMock;

--- a/src/renderer/entities/proxy/lib/proxy-utils.ts
+++ b/src/renderer/entities/proxy/lib/proxy-utils.ts
@@ -3,29 +3,21 @@ import uniqBy from 'lodash/uniqBy';
 
 import {
   type ChainId,
-  type NoID,
   type PartialProxiedAccount,
   type ProxyAccount,
-  type ProxyDeposits,
-  type ProxyGroup,
   type ProxyType,
   ProxyVariant,
-  type Wallet,
 } from '@/shared/core';
 import { splitCamelCaseString, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount } from '@/domains/network';
-import { accountUtils } from '@/entities/wallet';
 
 import { ProxyTypeName } from './constants';
 
 export const proxyUtils = {
   isSameProxy,
-  isSameProxyGroup,
   sortAccountsByProxyType,
   getProxiedName,
-  getProxyGroups,
-  createProxyGroups,
   getProxyTypeName,
   getProxyAccountsOnChain,
 };
@@ -55,14 +47,6 @@ function sortAccountsByProxyType(accounts: ProxyAccount[]): ProxyAccount[] {
   return sortBy(accounts, (account) => typeOrder.indexOf(account.proxyType));
 }
 
-function isSameProxyGroup(oldGroup: NoID<ProxyGroup>, newGroup: NoID<ProxyGroup>): boolean {
-  return (
-    oldGroup.walletId === newGroup.walletId &&
-    oldGroup.proxiedAccountId === newGroup.proxiedAccountId &&
-    oldGroup.chainId === newGroup.chainId
-  );
-}
-
 // TODO: Add i18n for wallet name
 function getProxiedName(
   { accountId, proxyVariant, connections }: PartialProxiedAccount,
@@ -77,65 +61,6 @@ function getProxiedName(
   } else {
     return address;
   }
-}
-
-function getProxyGroups(wallets: Wallet[], deposits: ProxyDeposits): NoID<ProxyGroup>[] {
-  const walletsAccounts = wallets.map(({ accounts }) => accounts);
-
-  return Object.values(walletsAccounts).reduce<NoID<ProxyGroup>[]>((acc, accounts) => {
-    const walletProxyGroups = accounts.reduce<NoID<ProxyGroup>[]>((acc, account) => {
-      const isChainMatch = accountUtils.isChainIdMatch(account, deposits.chainId);
-      const accountDeposit = deposits.deposits[account.accountId];
-
-      if (isChainMatch && accountDeposit) {
-        acc.push({
-          walletId: account.walletId,
-          proxiedAccountId: account.accountId,
-          chainId: deposits.chainId,
-          totalDeposit: accountDeposit,
-        });
-      }
-
-      return acc;
-    }, []);
-
-    acc.push(...walletProxyGroups);
-
-    return acc;
-  }, []);
-}
-
-type CreateProxyGroupResult = {
-  toAdd: NoID<ProxyGroup>[];
-  toUpdate: NoID<ProxyGroup>[];
-  toRemove: ProxyGroup[];
-};
-
-function createProxyGroups(wallets: Wallet[], groups: ProxyGroup[], deposits: ProxyDeposits): CreateProxyGroupResult {
-  const proxyGroups = getProxyGroups(wallets, deposits);
-
-  const { toAdd, toUpdate } = proxyGroups.reduce<Record<'toAdd' | 'toUpdate', NoID<ProxyGroup>[]>>(
-    (acc, g) => {
-      const shouldUpdate = groups.some((p) => isSameProxyGroup(p, g));
-
-      if (shouldUpdate) {
-        acc.toUpdate.push(g);
-      } else {
-        acc.toAdd.push(g);
-      }
-
-      return acc;
-    },
-    { toAdd: [], toUpdate: [] },
-  );
-
-  const toRemove = groups.filter((p) => {
-    if (p.chainId !== deposits.chainId) return false;
-
-    return proxyGroups.every((g) => !proxyUtils.isSameProxyGroup(g, p));
-  });
-
-  return { toAdd, toUpdate, toRemove };
 }
 
 function getProxyTypeName(proxyType: ProxyType | string): string {

--- a/src/renderer/entities/proxy/model/__tests__/proxy-model.test.ts
+++ b/src/renderer/entities/proxy/model/__tests__/proxy-model.test.ts
@@ -1,7 +1,7 @@
 import { allSettled, fork } from 'effector';
 
 import { storageService } from '@/shared/api/storage';
-import { type HexString, type ProxyAccount, type ProxyGroup } from '@/shared/core';
+import { type HexString, type ProxyAccount } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { proxyModel } from '../proxy-model';
 
@@ -23,13 +23,6 @@ const newProxyMock = {
   delay: 0,
 } as ProxyAccount;
 
-const proxyGroupMock = {
-  id: 1,
-  chainId: '0x00' as HexString,
-  proxiedAccountId: '0x01' as AccountId,
-  walletId: 1,
-  totalDeposit: '1,000,000',
-} as ProxyGroup;
 
 describe('entities/proxy/model/proxy-model', () => {
   afterEach(() => {
@@ -60,25 +53,4 @@ describe('entities/proxy/model/proxy-model', () => {
     expect(scope.getState(proxyModel.$proxies)).toEqual({ '0x01': [newProxyMock] });
   });
 
-  test('should add proxy group on proxyGroupsAdded', async () => {
-    jest.spyOn(storageService.proxyGroups, 'createAll').mockResolvedValue([proxyGroupMock]);
-
-    const scope = fork();
-
-    await allSettled(proxyModel.events.proxyGroupsAdded, { scope, params: [proxyGroupMock] });
-
-    expect(scope.getState(proxyModel.$proxyGroups)).toEqual([proxyGroupMock]);
-    expect(scope.getState(proxyModel.$walletsProxyGroups)).toEqual({ 1: [proxyGroupMock] });
-  });
-
-  test('should remove proxy group on proxyGroupsRemoved', async () => {
-    jest.spyOn(storageService.proxyGroups, 'deleteAll').mockResolvedValue([1]);
-
-    const scope = fork();
-
-    await allSettled(proxyModel.events.proxyGroupsRemoved, { scope, params: [proxyGroupMock] });
-
-    expect(scope.getState(proxyModel.$proxyGroups)).toEqual([]);
-    expect(scope.getState(proxyModel.$walletsProxyGroups)).toEqual({});
-  });
 });

--- a/src/renderer/entities/proxy/model/proxy-model.ts
+++ b/src/renderer/entities/proxy/model/proxy-model.ts
@@ -1,26 +1,16 @@
-import { combine, createEffect, createEvent, createStore, sample } from 'effector';
+import { createEffect, createEvent, createStore, sample } from 'effector';
 import groupBy from 'lodash/groupBy';
 
 import { storageService } from '@/shared/api/storage';
-import { type ID, type NoID, type ProxyAccount, type ProxyGroup } from '@/shared/core';
+import { type ID, type NoID, type ProxyAccount } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { proxyUtils } from '../lib/proxy-utils';
 
 type ProxyStore = Record<AccountId, ProxyAccount[]>;
 
 const proxiesAdded = createEvent<NoID<ProxyAccount>[]>();
 const proxiesRemoved = createEvent<ProxyAccount[]>();
 
-const proxyGroupsAdded = createEvent<NoID<ProxyGroup>[]>();
-const proxyGroupsUpdated = createEvent<NoID<ProxyGroup>[]>();
-const proxyGroupsRemoved = createEvent<ProxyGroup[]>();
-
 const $proxies = createStore<ProxyStore>({});
-const $proxyGroups = createStore<ProxyGroup[]>([]);
-
-const $walletsProxyGroups = combine($proxyGroups, (groups) => {
-  return groupBy(groups, 'walletId');
-});
 
 const populateProxiesFx = createEffect((): Promise<ProxyAccount[]> => {
   return storageService.proxies.readAll();
@@ -34,36 +24,14 @@ const removeProxiesFx = createEffect((proxies: ProxyAccount[]): Promise<ID[] | u
   return storageService.proxies.deleteAll(proxies.map((p) => p.id));
 });
 
-const populateProxyGroupsFx = createEffect((): Promise<ProxyGroup[]> => {
-  return storageService.proxyGroups.readAll();
-});
-
-const addProxyGroupsFx = createEffect((groups: NoID<ProxyGroup>[]): Promise<ProxyGroup[] | undefined> => {
-  return storageService.proxyGroups.createAll(groups);
-});
-
-const updateProxyGroupsFx = createEffect((groups: ProxyGroup[]) => {
-  return storageService.proxyGroups.updateAll(groups);
-});
-
-const removeProxyGroupsFx = createEffect((groups: ProxyGroup[]): Promise<ID[] | undefined> => {
-  return storageService.proxyGroups.deleteAll(groups.map((p) => p.id));
-});
-
 const proxyStartFx = createEffect(async () => {
   await populateProxiesFx();
-  await populateProxyGroupsFx();
 });
 
 sample({
   clock: populateProxiesFx.doneData,
   fn: (proxies) => groupBy(proxies, 'proxiedAccountId'),
   target: $proxies,
-});
-
-sample({
-  clock: populateProxyGroupsFx.doneData,
-  target: $proxyGroups,
 });
 
 sample({
@@ -115,82 +83,13 @@ sample({
   target: $proxies,
 });
 
-sample({
-  clock: proxyGroupsAdded,
-  target: addProxyGroupsFx,
-});
-
-sample({
-  clock: addProxyGroupsFx.doneData,
-  source: $proxyGroups,
-  filter: (_, newProxyGroups) => Boolean(newProxyGroups) && newProxyGroups!.length > 0,
-  fn: (groups, newProxyGroups) => {
-    return groups.concat(newProxyGroups!);
-  },
-  target: $proxyGroups,
-});
-
-sample({
-  clock: proxyGroupsUpdated,
-  source: $proxyGroups,
-  filter: (_, proxyGroups) => Boolean(proxyGroups),
-  fn: (groups, proxyGroups) => {
-    return proxyGroups.reduce<ProxyGroup[]>((acc, g) => {
-      const group = groups.find((p) => proxyUtils.isSameProxyGroup(p, g));
-      if (group) {
-        acc.push(group);
-      }
-
-      return acc;
-    }, []);
-  },
-  target: updateProxyGroupsFx,
-});
-
-sample({
-  clock: updateProxyGroupsFx.done,
-  source: $proxyGroups,
-  filter: (_, { params: proxyGroups }) => Boolean(proxyGroups),
-  fn: (groups, { params: proxyGroups }) => {
-    return groups
-      .filter((g) => {
-        return !proxyGroups!.some((p) => proxyUtils.isSameProxyGroup(g, p));
-      })
-      .concat(proxyGroups);
-  },
-  target: $proxyGroups,
-});
-
-sample({
-  clock: proxyGroupsRemoved,
-  target: removeProxyGroupsFx,
-});
-
-sample({
-  clock: removeProxyGroupsFx.doneData,
-  source: $proxyGroups,
-  filter: (_, proxyGroups) => Boolean(proxyGroups),
-  fn: (groups, proxyGroups) => {
-    const proxySet = new Set(proxyGroups);
-
-    return groups.filter((g) => !proxySet.has(g.id));
-  },
-  target: $proxyGroups,
-});
-
 export const proxyModel = {
   $proxies,
-  $proxyGroups,
-  $walletsProxyGroups,
 
   populate: proxyStartFx,
 
   events: {
     proxiesAdded,
     proxiesRemoved,
-
-    proxyGroupsAdded,
-    proxyGroupsUpdated,
-    proxyGroupsRemoved,
   },
 };

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
@@ -232,6 +232,7 @@ sample({
       type: 'chain',
       signingType: SigningType.WATCH_ONLY,
       cryptoType: isEthereumChain ? CryptoType.ETHEREUM : CryptoType.SR25519,
+      deposit: '100',
       connections: [
         {
           proxyAccountId: multisigAccountId!,

--- a/src/renderer/features/proxied-wallet/service.test.ts
+++ b/src/renderer/features/proxied-wallet/service.test.ts
@@ -23,6 +23,7 @@ function createProxy(proxyType: ProxyType): ProxiedAccount {
     proxyVariant: ProxyVariant.NONE,
     name: proxyType,
     walletId: 0,
+    deposit: '100',
   };
 }
 

--- a/src/renderer/features/proxies/lib/worker-utils.test.ts
+++ b/src/renderer/features/proxies/lib/worker-utils.test.ts
@@ -60,6 +60,7 @@ describe('features/proxies/lib/worker-utils', () => {
       name: 'Proxied wallet',
       accountType: AccountType.PROXIED,
       accountId: '0x00' as AccountId,
+      deposit: '100',
       connections: [
         {
           proxyAccountId: '0x01' as AccountId,
@@ -78,6 +79,7 @@ describe('features/proxies/lib/worker-utils', () => {
       name: 'Proxied wallet 2',
       accountType: AccountType.PROXIED,
       accountId: '0x00' as AccountId,
+      deposit: '100',
       connections: [
         {
           proxyAccountId: '0x01' as AccountId,
@@ -102,6 +104,7 @@ describe('features/proxies/lib/worker-utils', () => {
       name: 'Proxied wallet',
       accountType: AccountType.PROXIED,
       accountId: '0x00' as AccountId,
+      deposit: '100',
       connections: [
         {
           proxyAccountId: '0x01' as AccountId,
@@ -120,6 +123,7 @@ describe('features/proxies/lib/worker-utils', () => {
       name: 'Proxied wallet 2',
       accountType: AccountType.PROXIED,
       accountId: '0x00' as AccountId,
+      deposit: '100',
       connections: [
         {
           proxyAccountId: '0x02' as AccountId,

--- a/src/renderer/features/proxies/model/proxies-model.ts
+++ b/src/renderer/features/proxies/model/proxies-model.ts
@@ -312,22 +312,8 @@ sample({
   target: series(walletModel.events.proxiedCreated),
 });
 
-sample({
-  clock: depositsReceived,
-  source: {
-    wallets: walletModel.$wallets,
-    groups: proxyModel.$proxyGroups,
-  },
-  filter: (_, deposits) => Boolean(deposits),
-  fn: ({ wallets, groups }, deposits) => proxyUtils.createProxyGroups(wallets, groups, deposits!),
-  target: spread({
-    toAdd: proxyModel.events.proxyGroupsAdded,
-    toUpdate: proxyModel.events.proxyGroupsUpdated,
-    toRemove: proxyModel.events.proxyGroupsRemoved,
-  }),
-});
-
 export const proxiesModel = {
+  $deposits,
   findAllProxies: findAllProxiesFx,
   createProxiedWallet: createProxiedWalletFx,
   createProxiesWallets: createProxiesWalletsFx,

--- a/src/renderer/features/proxies/model/proxies-model.ts
+++ b/src/renderer/features/proxies/model/proxies-model.ts
@@ -15,7 +15,6 @@ import {
   type ProxiedAccount,
   type ProxiedWallet,
   type ProxyAccount,
-  type ProxyDeposits,
   ProxyVariant,
   SigningType,
   type Wallet,
@@ -23,7 +22,6 @@ import {
 } from '@/shared/core';
 import { series } from '@/shared/effector';
 import { dictionary, withTimeout } from '@/shared/lib/utils';
-import { type AccountId } from '@/shared/polkadotjs-schemas';
 import {
   type AnyAccount,
   type IdentityMap,
@@ -45,10 +43,8 @@ const LOADING_TIMEOUT = 15_000;
 
 const proxiedAccountsRemoved = createEvent<ProxiedAccount[]>();
 const proxiedAccountsUpdated = createEvent<ProxiedAccount[]>();
-const depositsReceived = createEvent<ProxyDeposits>();
 
 const $worker = createStore<WorkerType | null>(null);
-const $deposits = createStore<ProxyDeposits[]>([]);
 
 // Worker management
 
@@ -89,10 +85,6 @@ type GetProxiesResult = {
   proxiedAccountsToAdd: PartialProxiedAccount[];
   proxiedAccountsToRemove: ProxiedAccount[];
   proxiedAccountsToUpdate: PartialProxiedAccount[];
-  deposits: {
-    chainId: ChainId;
-    deposits: Record<AccountId, string>;
-  };
 };
 
 const requestIdentitiesFx = attach({
@@ -268,7 +260,6 @@ spread({
     proxiesToAdd: proxyModel.events.proxiesAdded,
     proxiedAccountsToRemove: proxiedAccountsRemoved,
     proxiedAccountsToUpdate: proxiedAccountsUpdated,
-    deposits: depositsReceived,
   },
 });
 
@@ -282,14 +273,6 @@ sample({
 sample({
   clock: proxiedAccountsUpdated,
   target: accounts.updateAccounts,
-});
-
-sample({
-  clock: depositsReceived,
-  source: $deposits,
-  filter: (_, newDeposits) => newDeposits && Object.keys(newDeposits.deposits).length > 0,
-  fn: (deposits, newDeposits) => deposits.filter((d) => d.chainId === newDeposits.chainId).concat(newDeposits),
-  target: $deposits,
 });
 
 sample({
@@ -313,7 +296,6 @@ sample({
 });
 
 export const proxiesModel = {
-  $deposits,
   findAllProxies: findAllProxiesFx,
   createProxiedWallet: createProxiedWalletFx,
   createProxiesWallets: createProxiesWalletsFx,

--- a/src/renderer/features/proxies/model/proxy-worker.ts
+++ b/src/renderer/features/proxies/model/proxy-worker.ts
@@ -14,7 +14,6 @@ import {
   type ProxiedAccount,
   type ProxiedConnection,
   type ProxyAccount,
-  type ProxyDeposits,
   type ProxyType,
   ProxyVariant,
 } from '@/shared/core';
@@ -74,11 +73,6 @@ async function getProxies({
   const proxiedAccountsToAdd: PartialProxiedAccount[] = [];
   const proxiedAccountsToUpdate: ProxiedAccount[] = [];
 
-  const deposits: ProxyDeposits = {
-    chainId: chain.chainId,
-    deposits: {},
-  };
-
   if (!api || !api.query.proxy) {
     return {
       proxiesToAdd,
@@ -86,7 +80,6 @@ async function getProxies({
       proxiedAccountsToAdd,
       proxiedAccountsToRemove: [],
       proxiedAccountsToUpdate,
-      deposits,
     };
   }
 
@@ -103,6 +96,7 @@ async function getProxies({
           chainId: chain.chainId,
           accountId: account,
           proxyVariant: ProxyVariant.NONE,
+          deposit: value.deposit.toString(),
           connections: value.proxies
             .filter(
               (delegatedAccount) =>
@@ -127,6 +121,7 @@ async function getProxies({
           } else {
             const hasChanged =
               existingProxied.connections.length !== newProxied.connections.length ||
+              existingProxied.deposit !== newProxied.deposit ||
               existingProxied.connections.some((existingConnection, index) => {
                 const newConnection = newProxied.connections.at(index);
                 return (
@@ -141,8 +136,6 @@ async function getProxies({
               proxiedAccountsToUpdate.push({ ...existingProxied, ...newProxied });
             }
           }
-
-          deposits.deposits[account] = value.deposit.toString();
         }
 
         existingProxiedAccounts.push(newProxied);
@@ -191,7 +184,6 @@ async function getProxies({
     proxiedAccountsToAdd,
     proxiedAccountsToRemove,
     proxiedAccountsToUpdate,
-    deposits,
   };
 }
 

--- a/src/renderer/features/proxy-add-pure/model/__tests__/add-pure-proxied-model.test.ts
+++ b/src/renderer/features/proxy-add-pure/model/__tests__/add-pure-proxied-model.test.ts
@@ -22,9 +22,7 @@ describe('widgets/AddPureProxyModal/model/add-pure-proxied-model', () => {
 
   test('should go through the process of pure proxied create', async () => {
     jest.spyOn(storageService.proxies, 'createAll').mockResolvedValue([]);
-    jest.spyOn(storageService.proxyGroups, 'createAll').mockResolvedValue([]);
     jest.spyOn(storageService.proxies, 'updateAll').mockResolvedValue([]);
-    jest.spyOn(storageService.proxyGroups, 'updateAll').mockResolvedValue([]);
 
     jest.spyOn(subscriptionService, 'subscribeEvents').mockImplementation((api, params, callback) => {
       callback({ data: [{ toHex: () => '0x01' }] } as unknown as Event);

--- a/src/renderer/features/proxy-add-pure/model/add-pure-proxied-model.ts
+++ b/src/renderer/features/proxy-add-pure/model/add-pure-proxied-model.ts
@@ -1,22 +1,15 @@
 import { type ApiPromise } from '@polkadot/api';
 import { type UnsubscribePromise } from '@polkadot/api/types';
 import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
-import { combineEvents, delay, spread } from 'patronum';
+import { delay, spread } from 'patronum';
 
-import {
-  type NoID,
-  type PartialProxiedAccount,
-  type ProxyGroup,
-  ProxyVariant,
-  type Timepoint,
-  WalletType,
-} from '@/shared/core';
+import { type PartialProxiedAccount, ProxyVariant, type Timepoint } from '@/shared/core';
 import { nonNullable, nullable, toAddress } from '@/shared/lib/utils';
 import { type AccountId, pjsSchema } from '@/shared/polkadotjs-schemas';
 import { type PathType, Paths } from '@/shared/routes';
 import { subscriptionService } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
-import { proxyModel, proxyUtils } from '@/entities/proxy';
+import { proxyModel } from '@/entities/proxy';
 import { type ExtrinsicResultParams } from '@/entities/transaction';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { type BasketTransactionDraft, basketOperations } from '@/aggregates/basket-operations';
@@ -292,37 +285,6 @@ sample({
     ] as PartialProxiedAccount[];
   },
   target: proxiesModel.createProxiesWallets,
-});
-
-sample({
-  clock: combineEvents({
-    events: [getPureProxyFx.doneData, walletModel.events.walletCreatedDone],
-    reset: formModel.flowStarted,
-  }),
-  source: {
-    chain: formModel.form.fields.chain.$value,
-    proxyGroups: proxyModel.$proxyGroups,
-    proxyDeposit: formModel.$proxyDeposit,
-  },
-  filter: ({ chain }, [_, { wallet }]) => wallet.type === WalletType.PROXIED && nonNullable(chain),
-  fn: ({ chain, proxyGroups, proxyDeposit }, [{ accountId }, { wallet }]) => {
-    const newProxyGroup: NoID<ProxyGroup> = {
-      walletId: wallet.id,
-      chainId: chain!.chainId,
-      proxiedAccountId: accountId,
-      totalDeposit: proxyDeposit,
-    };
-
-    const existingProxyGroup = proxyGroups.find((group) => proxyUtils.isSameProxyGroup(group, newProxyGroup));
-
-    return existingProxyGroup
-      ? { toUpdate: [{ id: existingProxyGroup.id, ...newProxyGroup }] }
-      : { toAdd: [newProxyGroup] };
-  },
-  target: spread({
-    toAdd: proxyModel.events.proxyGroupsAdded,
-    toUpdate: proxyModel.events.proxyGroupsUpdated,
-  }),
 });
 
 sample({

--- a/src/renderer/features/proxy-add/model/__tests__/add-proxy-model.test.ts
+++ b/src/renderer/features/proxy-add/model/__tests__/add-proxy-model.test.ts
@@ -31,9 +31,7 @@ describe('widgets/AddProxyModal/model/add-proxy-model', () => {
 
   test('should go through the process of proxy create', async () => {
     jest.spyOn(storageService.proxies, 'createAll').mockResolvedValue([]);
-    jest.spyOn(storageService.proxyGroups, 'createAll').mockResolvedValue([]);
     jest.spyOn(storageService.proxies, 'updateAll').mockResolvedValue([]);
-    jest.spyOn(storageService.proxyGroups, 'updateAll').mockResolvedValue([]);
 
     const scope = fork({
       values: new Map()

--- a/src/renderer/features/wallet-details/model/wallet-details-model.ts
+++ b/src/renderer/features/wallet-details/model/wallet-details-model.ts
@@ -6,7 +6,6 @@ import { nullable } from '@/shared/lib/utils';
 import { networkModel } from '@/entities/network';
 import { proxyModel, proxyUtils } from '@/entities/proxy';
 import { accountUtils, permissionUtils } from '@/entities/wallet';
-import { proxiesModel } from '@/features/proxies';
 
 const flow = createGate<{ wallet: Wallet | null }>({ defaultState: { wallet: null } });
 
@@ -34,27 +33,18 @@ const $chainsProxies = combine(
   },
 );
 
-const $walletProxyGroups = combine(
-  {
-    wallet: $wallet,
-    deposits: proxiesModel.$deposits,
-  },
-  ({ wallet, deposits }) => {
-    if (nullable(wallet)) return [];
+const $walletProxyGroups = $wallet.map(wallet => {
+  if (nullable(wallet)) return [];
 
-    return wallet.accounts.filter(accountUtils.isProxiedAccount).map(account => {
-      const chainDeposits = deposits.find(d => d.chainId === account.chainId);
-      const deposit = chainDeposits?.deposits[account.accountId] || '0';
-
-      return {
-        chainId: account.chainId,
-        proxiedAccountId: account.accountId,
-        walletId: account.walletId,
-        totalDeposit: deposit,
-      };
-    });
-  },
-);
+  return wallet.accounts.filter(accountUtils.isProxiedAccount).map(account => {
+    return {
+      chainId: account.chainId,
+      proxiedAccountId: account.accountId,
+      walletId: account.walletId,
+      totalDeposit: account.deposit,
+    };
+  });
+});
 
 const $hasProxies = combine($chainsProxies, chainsProxies => {
   return Object.values(chainsProxies).some(accounts => accounts.length > 0);

--- a/src/renderer/features/wallet-details/model/wallet-details-model.ts
+++ b/src/renderer/features/wallet-details/model/wallet-details-model.ts
@@ -1,11 +1,12 @@
 import { combine } from 'effector';
 import { createGate } from 'effector-react';
 
-import { type ChainId, type ProxyAccount, type ProxyGroup, type Wallet } from '@/shared/core';
+import { type ChainId, type ProxyAccount, type Wallet } from '@/shared/core';
 import { nullable } from '@/shared/lib/utils';
 import { networkModel } from '@/entities/network';
 import { proxyModel, proxyUtils } from '@/entities/proxy';
-import { permissionUtils } from '@/entities/wallet';
+import { accountUtils, permissionUtils } from '@/entities/wallet';
+import { proxiesModel } from '@/features/proxies';
 
 const flow = createGate<{ wallet: Wallet | null }>({ defaultState: { wallet: null } });
 
@@ -36,28 +37,22 @@ const $chainsProxies = combine(
 const $walletProxyGroups = combine(
   {
     wallet: $wallet,
-    chainsProxies: $chainsProxies,
-    groups: proxyModel.$walletsProxyGroups,
+    deposits: proxiesModel.$deposits,
   },
-  ({ wallet, groups }): ProxyGroup[] => {
-    if (nullable(wallet) || nullable(groups[wallet.id])) return [];
+  ({ wallet, deposits }) => {
+    if (nullable(wallet)) return [];
 
-    // TODO: Find why it can be doubled sometimes https://github.com/novasamatech/nova-spektr/issues/1655
-    const walletGroups = groups[wallet.id];
-    const filteredGroups = walletGroups.reduceRight(
-      (acc, group) => {
-        const id = `${group.chainId}_${group.proxiedAccountId}_${group.walletId}`;
+    return wallet.accounts.filter(accountUtils.isProxiedAccount).map(account => {
+      const chainDeposits = deposits.find(d => d.chainId === account.chainId);
+      const deposit = chainDeposits?.deposits[account.accountId] || '0';
 
-        if (!acc[id]) {
-          acc[id] = group;
-        }
-
-        return acc;
-      },
-      {} as Record<string, ProxyGroup>,
-    );
-
-    return Object.values(filteredGroups);
+      return {
+        chainId: account.chainId,
+        proxiedAccountId: account.accountId,
+        walletId: account.walletId,
+        totalDeposit: deposit,
+      };
+    });
   },
 );
 

--- a/src/renderer/features/wallets/ForgetWallet/__tests__/mocks.ts
+++ b/src/renderer/features/wallets/ForgetWallet/__tests__/mocks.ts
@@ -70,6 +70,7 @@ export const accounts = {
     proxyVariant: ProxyVariant.PURE,
     blockNumber: 23960326,
     extrinsicIndex: 2,
+    deposit: '100',
     connections: [
       {
         proxyAccountId: '0xf9e94d71f4e3695e07e21b574e1ce2e56b228a020a34824884ed9987e6a4e4ad' as AccountId,

--- a/src/renderer/shared/api/storage/lib/types.ts
+++ b/src/renderer/shared/api/storage/lib/types.ts
@@ -7,7 +7,6 @@ import {
   type Contact,
   type Notification,
   type ProxyAccount,
-  type ProxyGroup,
   type Serializable,
   type Wallet,
 } from '@/shared/core';
@@ -33,7 +32,6 @@ export type TAccount2 = Table<AnyAccountDS, AnyAccountDS['id']>;
 export type TBalance = Table<Serializable<Balance>, Balance['id']>;
 export type TConnection = Table<Connection, Connection['id']>;
 export type TProxy = Table<ProxyAccount, ProxyAccount['id']>;
-export type TProxyGroup = Table<ProxyGroup, ProxyGroup['id']>;
 export type TMultisigOperations = Table<Serializable<MultisigOperation>, MultisigOperation['id']>;
 export type TNotification = Table<Notification, Notification['id']>;
 export type TMetadata = Table<ChainMetadata, ChainMetadata['id']>;

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -12,7 +12,6 @@ import {
   type TMultisigOperations,
   type TNotification,
   type TProxy,
-  type TProxyGroup,
   type TWallet,
 } from '../lib/types';
 import {
@@ -42,7 +41,6 @@ class DexieStorage extends Dexie {
   notifications: TNotification;
   metadata: TMetadata;
   proxies: TProxy;
-  proxyGroups: TProxyGroup;
   basketTransactions: TBasketTransaction;
 
   constructor() {
@@ -76,7 +74,6 @@ class DexieStorage extends Dexie {
 
     this.version(21).stores({
       proxies: '++id',
-      proxyGroups: '++id',
       connections: '++id',
       notifications: '++id',
       metadata: null,
@@ -136,7 +133,6 @@ class DexieStorage extends Dexie {
     this.notifications = this.table('notifications');
     this.metadata = this.table('metadata');
     this.proxies = this.table('proxies');
-    this.proxyGroups = this.table('proxyGroups');
     this.basketTransactions = this.table('basketTransactions');
   }
 }
@@ -146,7 +142,7 @@ const dexie = new DexieStorage();
 export const exportDb = async () => {
   const blob = await exportDB(dexie, {
     prettyJson: true,
-    skipTables: ['metadata', 'balances', 'proxies', 'proxyGroups', 'basketTransactions'],
+    skipTables: ['metadata', 'balances', 'proxies', 'basketTransactions'],
   });
 
   return { blob, fileName: 'spektr-database.json' };
@@ -167,7 +163,6 @@ export const dexieStorage = {
   contacts: dexie.contacts,
   connections: dexie.connections,
   proxies: dexie.proxies,
-  proxyGroups: dexie.proxyGroups,
   notifications: dexie.notifications,
   metadata: dexie.metadata,
   balances: dexie.balances,

--- a/src/renderer/shared/api/storage/service/storageService.ts
+++ b/src/renderer/shared/api/storage/service/storageService.ts
@@ -144,7 +144,6 @@ export const storageService = {
   contacts: new StorageService(dexieStorage.contacts),
   connections: new StorageService(dexieStorage.connections),
   proxies: new StorageService(dexieStorage.proxies),
-  proxyGroups: new StorageService(dexieStorage.proxyGroups),
   notifications: new StorageService(dexieStorage.notifications),
   metadata: new StorageService(dexieStorage.metadata),
   balances: new StorageService(dexieStorage.balances),

--- a/src/renderer/shared/core/index.ts
+++ b/src/renderer/shared/core/index.ts
@@ -61,13 +61,7 @@ export type { Validator } from './types/validator';
 export { RewardsDestination } from './types/stake';
 export type { Stake, Unlocking } from './types/stake';
 
-export type {
-  ProxyAccount,
-  PartialProxyAccount,
-  PartialProxiedAccount,
-  ProxyDeposits,
-  ProxyType,
-} from './types/proxy';
+export type { ProxyAccount, PartialProxyAccount, PartialProxiedAccount, ProxyType } from './types/proxy';
 export { ProxyVariant } from './types/proxy';
 
 export type {

--- a/src/renderer/shared/core/index.ts
+++ b/src/renderer/shared/core/index.ts
@@ -66,7 +66,6 @@ export type {
   PartialProxyAccount,
   PartialProxiedAccount,
   ProxyDeposits,
-  ProxyGroup,
   ProxyType,
 } from './types/proxy';
 export { ProxyVariant } from './types/proxy';

--- a/src/renderer/shared/core/types/account.ts
+++ b/src/renderer/shared/core/types/account.ts
@@ -58,6 +58,7 @@ export interface ProxiedAccount extends ChainAccount {
   accountType: AccountType.PROXIED;
   connections: ProxiedConnection[];
   proxyVariant: ProxyVariant;
+  deposit: string;
   blockNumber?: number;
   extrinsicIndex?: number;
 }

--- a/src/renderer/shared/core/types/proxy.ts
+++ b/src/renderer/shared/core/types/proxy.ts
@@ -33,10 +33,5 @@ export type PartialProxyAccount = Omit<ProxyAccount, 'chainId'>;
 
 export type PartialProxiedAccount = Pick<
   ProxiedAccount,
-  'chainId' | 'connections' | 'accountId' | 'proxyVariant' | 'blockNumber' | 'extrinsicIndex'
+  'chainId' | 'connections' | 'accountId' | 'proxyVariant' | 'blockNumber' | 'extrinsicIndex' | 'deposit'
 >;
-
-export type ProxyDeposits = {
-  chainId: ChainId;
-  deposits: Record<AccountId, string>;
-};

--- a/src/renderer/shared/core/types/proxy.ts
+++ b/src/renderer/shared/core/types/proxy.ts
@@ -3,14 +3,6 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type ProxiedAccount } from './account';
 import { type ChainId, type ID } from './general';
 
-export type ProxyGroup = {
-  id: ID;
-  walletId: ID;
-  proxiedAccountId: AccountId;
-  chainId: ChainId;
-  totalDeposit: string;
-};
-
 export type ProxyAccount = {
   id: ID;
   accountId: AccountId;

--- a/src/renderer/shared/mocks/index.ts
+++ b/src/renderer/shared/mocks/index.ts
@@ -245,6 +245,7 @@ export const createProxiedAccount = (id = createRandomId(), walletId = 0): Proxi
       proxyType: 'Any',
     },
   ],
+  deposit: '100',
   chainId: polkadotChainId,
   cryptoType: CryptoType.SR25519,
   name: `Proxied Account ${id}`,


### PR DESCRIPTION
## Description

Derive the list of delegations from the proxied accounts.
Remove an excessive proxy groups DB field

## Related Issues

closes #4271

## Changes Made

- removed ProxyGroup entity
- deposits are now pulled from the deposits store instead
- proxy connections now derrived from proxied accounts instead

## Screenshots/Recordings

<img width="610" height="752" alt="image" src="https://github.com/user-attachments/assets/ef4a9157-0a82-47ae-bbde-fee5e27be151" />

