### PR TITLE
feat(call-data): support multisigs + proxies

### DIFF
--- a/src/renderer/domains/network/transaction/service.ts
+++ b/src/renderer/domains/network/transaction/service.ts
@@ -44,7 +44,7 @@ function isDecodedTransaction(transaction: AnyTransaction): transaction is AnyDe
   return transaction.type === 'decoded';
 }
 
-async function wrapTransaction(transaction: EncodedTransaction, route: AnyAccount[], api: ApiPromise) {
+async function wrapTransaction(transaction: AnyTransaction, route: AnyAccount[], api: ApiPromise) {
   let wrapped: AnyTransaction = transaction;
 
   for (const [index, account] of Array.from(route).entries()) {

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -252,10 +252,7 @@ const $signatories = createSignatoriesStore({
   initiator: form.fields.initiator.$value,
 });
 
-const $showSignatories = combine({
-  signatories: $signatories,
-  initiator: form.fields.initiator.$value,
-}).map(({ signatories, initiator }) => signatories.length > 1 || signatories.at(0)?.accountId !== initiator?.accountId);
+const $showSignatories = $signatories.map((signatories) => signatories.length > 1);
 
 // flow setup
 

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -240,11 +240,6 @@ const $availableChains = combine(
   },
 );
 
-sample({
-  clock: walletModel.$availableAccounts,
-  target: balanceSubModel.fetchAccounts,
-});
-
 const $signatories = createSignatoriesStore({
   chain: form.fields.chain.$value,
   accounts: walletModel.$availableAccounts,
@@ -252,6 +247,11 @@ const $signatories = createSignatoriesStore({
 });
 
 const $showSignatories = $signatories.map((signatories) => signatories.length > 1);
+
+sample({
+  clock: $signatories,
+  target: balanceSubModel.fetchAccounts,
+});
 
 // flow setup
 

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -9,7 +9,15 @@ import { createQueuedEffect } from '@/shared/effector';
 import { type Form, createForm } from '@/shared/forms';
 import { getNativeAsset, nonNullable, nonNullableMap, nullable, withdrawableAmountBN } from '@/shared/lib/utils';
 import { createFeeCalculator, createSignatoriesStore } from '@/shared/transactions';
-import { type AnyAccount, type EncodedTransaction, accountService, transactionService } from '@/domains/network';
+import { createRouteStore } from '@/shared/transactions/createRouteStore';
+import { createWrappedTxStore } from '@/shared/transactions/createWrappedTxStore';
+import {
+  type AnyAccount,
+  type AnyTransaction,
+  type EncodedTransaction,
+  accountService,
+  transactionService,
+} from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { walletModel } from '@/entities/wallet';
@@ -64,7 +72,7 @@ const form: Form<FormData> = createForm<FormData>({
       }),
     },
     callData: {
-      defaultValue: '',
+      defaultValue: `0x05030090e4c8ab9ba4ed26165638d3e96dc6853c0b4570dd825b5269eb45b66d647106050000e40b5402`,
       validator: () => (callData) => {
         if (!callData) return { message: 'callData.errors.required' };
         if (!callData.startsWith('0x')) {
@@ -91,7 +99,6 @@ const $api = combine(form.fields.chain.$value, networkModel.$apis, (chain, apis)
 
 const $throttledCallData = restore(throttle(form.fields.callData.$value, 500), '').reset(flow.close);
 
-// build transaction
 const $transaction = $throttledCallData.map((callData): EncodedTransaction | null => {
   if (callData.length === 0) return null;
   return {
@@ -100,20 +107,34 @@ const $transaction = $throttledCallData.map((callData): EncodedTransaction | nul
   };
 });
 
+const $route = createRouteStore({
+  chain: form.fields.chain.$value,
+  initiator: form.fields.initiator.$value,
+  signatory: form.fields.signatory.$value,
+  accounts: walletModel.$availableAccounts,
+});
+
+const { $tx: $wrappedTx } = createWrappedTxStore({
+  api: $api,
+  transaction: $transaction,
+  route: $route,
+});
+
 const $extrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
+// make 2 - one wrapped for submit, and one unwrapped for display
 const $args = combine($extrinsic, form.fields.chain.$value, (extrinsic, chain) => {
   return extrinsic && chain ? callDataExecuteService.formatExtrinsic(extrinsic, chain) : null;
 });
 
 const createExtrinsicFx = createQueuedEffect(
-  ({ transaction, api }: { transaction: EncodedTransaction | null; api: ApiPromise | null }) => {
+  ({ transaction, api }: { transaction: AnyTransaction | null; api: ApiPromise | null }) => {
     if (nullable(transaction) || nullable(api)) return null;
-    return transactionService.createSubmittableExtrinsicFromCallData(transaction.callData, api);
+    return transactionService.createSubmittableExtrinsic(transaction, api);
   },
 );
 
 sample({
-  source: { transaction: $transaction, api: $api },
+  source: { transaction: $wrappedTx, api: $api },
   target: createExtrinsicFx,
 });
 
@@ -285,7 +306,7 @@ const $canSubmit = combine(
 const showConfirmation = sample({
   clock: form.submit.doneData,
   source: {
-    transaction: $transaction,
+    transaction: $wrappedTx,
     args: $args,
     fee: $fee,
     api: $api,
@@ -317,7 +338,7 @@ const sign = sample({
   clock: confirmModel.startSigning,
   source: {
     form: form.$values,
-    transaction: $transaction,
+    transaction: $wrappedTx,
     api: $api,
   },
   fn({ form, transaction, api }) {
@@ -332,7 +353,6 @@ const sign = sample({
 
     return {
       transaction,
-      // initiator: form.initiator,
       signatory: form.signatory,
       chain: form.chain,
       api,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -113,25 +113,53 @@ const { $tx: $wrappedTx } = createWrappedTxStore({
 });
 
 const $wrappedExtrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
-const $hasExtrinsic = $wrappedExtrinsic.map((value) => nonNullable(value));
 
 const $wrappedArgs = combine($wrappedExtrinsic, form.fields.chain.$value, (extrinsic, chain) => {
   return extrinsic && chain ? callDataExecuteService.formatExtrinsic(extrinsic, chain) : null;
 });
 
+const $extrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
+
 const $args = combine(
   {
-    api: $api,
-    transaction: $transaction,
+    extrinsic: $extrinsic,
     chain: form.fields.chain.$value,
   },
-  ({ api, transaction, chain }) => {
-    if (!api || !transaction || !chain) return null;
+  ({ extrinsic, chain }) => {
+    if (!extrinsic || !chain) return null;
 
-    const extrinsic = transactionService.createSubmittableExtrinsic(transaction, api);
     return callDataExecuteService.formatExtrinsic(extrinsic, chain);
   },
 );
+
+const createWrappedExtrinsicFx = createQueuedEffect(
+  ({ transaction, api }: { transaction: AnyTransaction | null; api: ApiPromise | null }) => {
+    if (nullable(transaction) || nullable(api)) return null;
+    return transactionService.createSubmittableExtrinsic(transaction, api);
+  },
+);
+
+sample({
+  source: { transaction: $wrappedTx, api: $api },
+  target: createWrappedExtrinsicFx,
+});
+
+sample({
+  clock: createWrappedExtrinsicFx.doneData,
+  target: $wrappedExtrinsic,
+});
+
+sample({
+  clock: createWrappedExtrinsicFx.fail,
+  fn: () => null,
+  target: $wrappedExtrinsic,
+});
+
+sample({
+  clock: createWrappedExtrinsicFx.fail,
+  fn: () => [{ message: 'callData.errors.invalidCallData' }],
+  target: form.fields.callData.setErrors,
+});
 
 const createExtrinsicFx = createQueuedEffect(
   ({ transaction, api }: { transaction: AnyTransaction | null; api: ApiPromise | null }) => {
@@ -141,25 +169,19 @@ const createExtrinsicFx = createQueuedEffect(
 );
 
 sample({
-  source: { transaction: $wrappedTx, api: $api },
+  source: { transaction: $transaction, api: $api },
   target: createExtrinsicFx,
 });
 
 sample({
   clock: createExtrinsicFx.doneData,
-  target: $wrappedExtrinsic,
+  target: $extrinsic,
 });
 
 sample({
   clock: createExtrinsicFx.fail,
   fn: () => null,
-  target: $wrappedExtrinsic,
-});
-
-sample({
-  clock: createExtrinsicFx.fail,
-  fn: () => [{ message: 'callData.errors.invalidCallData' }],
-  target: form.fields.callData.setErrors,
+  target: $extrinsic,
 });
 
 const { $: $fee, $pending: $pendingFee } = createFeeCalculator({
@@ -383,7 +405,7 @@ export const formModel = {
   $canSubmit,
   $step,
   $api,
-  $hasExtrinsic,
+  $extrinsic,
   $args,
   $fee,
   $pendingFee,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -8,7 +8,7 @@ import { type CallData, type Chain } from '@/shared/core';
 import { createQueuedEffect } from '@/shared/effector';
 import { type Form, createForm } from '@/shared/forms';
 import { getNativeAsset, nonNullable, nonNullableMap, nullable, withdrawableAmountBN } from '@/shared/lib/utils';
-import { createFeeCalculator } from '@/shared/transactions';
+import { createFeeCalculator, createSignatoriesStore } from '@/shared/transactions';
 import { type AnyAccount, type EncodedTransaction, accountService, transactionService } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
@@ -26,6 +26,7 @@ import { callDataExecuteFeature } from './feature';
 
 type FormData = {
   chain: Chain | null;
+  initiator: AnyAccount | null;
   signatory: AnyAccount | null;
   callData: string;
 };
@@ -39,6 +40,9 @@ const form: Form<FormData> = createForm<FormData>({
       validator: () => (chain) => {
         if (!chain) return { message: 'callData.errors.chainRequired' };
       },
+    },
+    initiator: {
+      defaultValue: null,
     },
     signatory: {
       defaultValue: null,
@@ -71,6 +75,14 @@ const form: Form<FormData> = createForm<FormData>({
   },
 });
 
+// Clear signatory errors when initiator has permissions
+sample({
+  clock: form.fields.initiator.$value,
+  source: form.fields.initiator.$value,
+  filter: (initiator) => Boolean(initiator && accountService.hasPermissionToMakeActions(initiator)),
+  target: form.fields.signatory.resetError,
+});
+
 // extrinsic
 
 const $api = combine(form.fields.chain.$value, networkModel.$apis, (chain, apis) =>
@@ -79,6 +91,7 @@ const $api = combine(form.fields.chain.$value, networkModel.$apis, (chain, apis)
 
 const $throttledCallData = restore(throttle(form.fields.callData.$value, 500), '').reset(flow.close);
 
+// build transaction
 const $transaction = $throttledCallData.map((callData): EncodedTransaction | null => {
   if (callData.length === 0) return null;
   return {
@@ -133,7 +146,8 @@ const $signatoryBalance = combine(
     balances: balanceModel.$balances,
   },
   ({ signatory, chain, balances }) => {
-    if (nullable(signatory) || nullable(chain)) return null;
+    if (nullable(chain)) return null;
+    if (nullable(signatory)) return null;
 
     return (
       balanceUtils.getBalance(balances, signatory.accountId, chain.chainId, getNativeAsset(chain.assets).assetId) ??
@@ -173,27 +187,36 @@ sample({
 
 // form options
 
-const $availableSignatories = walletModel.$availableAccounts.map((accounts) => {
-  return accounts.filter(accountService.hasPermissionToMakeActions);
-});
+const $allAccounts = walletModel.$availableAccounts;
 
 const $availableChains = combine(
   {
     chains: networkModel.$chains.map((chains) => Object.values(chains)),
-    selectedSignatory: form.fields.signatory.$value,
+    initiator: form.fields.initiator.$value,
   },
-  ({ chains, selectedSignatory }) => {
-    if (nullable(selectedSignatory)) return [];
+  ({ chains, initiator }) => {
+    if (nullable(initiator)) return [];
     return chains.filter((chain) => {
-      return accountService.isAccountAvailableOnChain(selectedSignatory, chain);
+      return accountService.isAccountAvailableOnChain(initiator, chain);
     });
   },
 );
 
 sample({
-  clock: $availableSignatories,
+  clock: $allAccounts,
   target: balanceSubModel.fetchAccounts,
 });
+
+const $signatories = createSignatoriesStore({
+  chain: form.fields.chain.$value,
+  accounts: $allAccounts,
+  initiator: form.fields.initiator.$value,
+});
+
+const $showSignatories = combine({
+  signatories: $signatories,
+  initiator: form.fields.initiator.$value,
+}).map(({ signatories, initiator }) => signatories.length > 1 || signatories.at(0)?.accountId !== initiator?.accountId);
 
 // flow setup
 
@@ -206,40 +229,41 @@ sample({
   target: form.fields.chain.change,
 });
 
-// Preselect signatory based on selected wallet
+// Preselect initiator based on selected wallet
 sample({
-  clock: [walletSelect.$selectedWallet, $availableSignatories, flow.open],
+  clock: [flow.open],
   source: {
     selectedWallet: walletSelect.$selectedWallet,
-    availableSignatories: $availableSignatories,
-    currentSignatory: form.fields.signatory.$value,
+    allAccounts: $allAccounts,
+    initiator: form.fields.initiator.$value,
   },
-  fn: ({ selectedWallet, availableSignatories, currentSignatory }) => {
-    if (nonNullable(currentSignatory) || nullable(selectedWallet)) return currentSignatory;
+  fn: ({ selectedWallet, allAccounts, initiator }) => {
+    if (nonNullable(initiator) || nullable(selectedWallet)) return initiator;
 
-    const matchingSignatory = availableSignatories.find((signatory) =>
-      selectedWallet.accounts.some((account) => account.accountId === signatory.accountId),
+    const matchingAccount = allAccounts.find((account) =>
+      selectedWallet.accounts.some((walletAccount) => walletAccount.accountId === account.accountId),
     );
 
-    return (matchingSignatory || availableSignatories.at(0)) ?? null;
+    return (matchingAccount || allAccounts.at(0)) ?? null;
   },
+  target: form.fields.initiator.change,
+});
+
+// Preselect signatory when initiator changes
+sample({
+  clock: [$signatories],
+  source: {
+    selectedSignatory: form.fields.signatory.$value,
+  },
+  filter: ({ selectedSignatory }, signatories) =>
+    !selectedSignatory || !signatories.some((s) => s.accountId === selectedSignatory.accountId),
+  fn: (_, signatories) => signatories.at(0) ?? null,
   target: form.fields.signatory.change,
 });
 
 sample({
   clock: form.fields.chain.change,
   target: form.fields.callData.resetError,
-});
-
-sample({
-  clock: form.fields.chain.change,
-  source: form.fields.signatory.$value,
-  fn: (signatory, chain) => {
-    if (nullable(signatory) || nullable(chain)) return null;
-
-    return signatory;
-  },
-  target: form.fields.signatory.change,
 });
 
 sample({
@@ -273,9 +297,9 @@ const showConfirmation = sample({
       api: source.api,
       chain: form.chain,
       transaction: source.transaction,
-      initiator: form.signatory,
-      signatory: form.signatory,
-      route: [form.signatory],
+      initiator: form.initiator,
+      signatory: form.signatory || form.initiator,
+      route: [form.signatory || form.initiator],
       args: source.args,
       fee: source.fee,
     } satisfies ConfirmInput;
@@ -288,6 +312,7 @@ sample({
   target: confirmModel.init,
 });
 
+// pass signatory from form
 const sign = sample({
   clock: confirmModel.startSigning,
   source: {
@@ -296,9 +321,18 @@ const sign = sample({
     api: $api,
   },
   fn({ form, transaction, api }) {
-    if (nullable(api) || nullable(transaction) || nullable(form.signatory) || nullable(form.chain)) return null;
+    if (
+      nullable(api) ||
+      nullable(transaction) ||
+      nullable(form.initiator) ||
+      nullable(form.signatory) ||
+      nullable(form.chain)
+    )
+      return null;
+
     return {
       transaction,
+      // initiator: form.initiator,
       signatory: form.signatory,
       chain: form.chain,
       api,
@@ -331,8 +365,10 @@ export const formModel = {
   $fee,
   $pendingFee,
 
-  $availableSignatories,
-  $availableChains,
+  $allAccounts: $allAccounts,
+  $availableChains: $availableChains,
+  $signatories: $signatories,
+  $showSignatories: $showSignatories,
 
   stepChanged,
 };

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -180,12 +180,12 @@ const $availableSignatories = walletModel.$availableAccounts.map((accounts) => {
 const $availableChains = combine(
   {
     chains: networkModel.$chains.map((chains) => Object.values(chains)),
-    signatories: $availableSignatories,
+    selectedSignatory: form.fields.signatory.$value,
   },
-  ({ chains, signatories }) => {
-    if (signatories.length === 0) return [];
+  ({ chains, selectedSignatory }) => {
+    if (nullable(selectedSignatory)) return [];
     return chains.filter((chain) => {
-      return signatories.some((a) => accountService.isAccountAvailableOnChain(a, chain));
+      return accountService.isAccountAvailableOnChain(selectedSignatory, chain);
     });
   },
 );
@@ -197,11 +197,12 @@ sample({
 
 // flow setup
 
-// Auto-select first available chain when chains become available
 sample({
-  clock: [$availableChains, flow.open],
-  source: $availableChains,
-  fn: (chains) => chains.at(0) ?? null,
+  clock: [$availableChains],
+  source: { availableChains: $availableChains, selectedChain: form.fields.chain.$value },
+  filter: ({ availableChains, selectedChain }) =>
+    !selectedChain || !availableChains.some((chain) => chain.chainId === selectedChain.chainId),
+  fn: ({ availableChains }) => availableChains.at(0) ?? null,
   target: form.fields.chain.change,
 });
 

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -221,10 +221,6 @@ sample({
   target: stepChanged,
 });
 
-// form options
-
-const $allAccounts = walletModel.$availableAccounts;
-
 const $availableChains = combine(
   {
     chains: networkModel.$chains.map((chains) => Object.values(chains)),
@@ -239,13 +235,13 @@ const $availableChains = combine(
 );
 
 sample({
-  clock: $allAccounts,
+  clock: walletModel.$availableAccounts,
   target: balanceSubModel.fetchAccounts,
 });
 
 const $signatories = createSignatoriesStore({
   chain: form.fields.chain.$value,
-  accounts: $allAccounts,
+  accounts: walletModel.$availableAccounts,
   initiator: form.fields.initiator.$value,
 });
 
@@ -270,7 +266,7 @@ sample({
   clock: [flow.open],
   source: {
     selectedWallet: walletSelect.$selectedWallet,
-    allAccounts: $allAccounts,
+    allAccounts: walletModel.$availableAccounts,
     initiator: form.fields.initiator.$value,
   },
   fn: ({ selectedWallet, allAccounts, initiator }) => {
@@ -400,7 +396,6 @@ export const formModel = {
   $fee,
   $pendingFee,
 
-  $allAccounts: $allAccounts,
   $availableChains: $availableChains,
   $signatories: $signatories,
   $showSignatories: $showSignatories,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -189,8 +189,7 @@ const $signatoryBalance = combine(
     balances: balanceModel.$balances,
   },
   ({ signatory, chain, balances }) => {
-    if (nullable(chain)) return null;
-    if (nullable(signatory)) return null;
+    if (nullable(signatory) || nullable(chain)) return null;
 
     return (
       balanceUtils.getBalance(balances, signatory.accountId, chain.chainId, getNativeAsset(chain.assets).assetId) ??

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -72,7 +72,7 @@ const form: Form<FormData> = createForm<FormData>({
       }),
     },
     callData: {
-      defaultValue: `0x05030090e4c8ab9ba4ed26165638d3e96dc6853c0b4570dd825b5269eb45b66d647106050000e40b5402`,
+      defaultValue: '',
       validator: () => (callData) => {
         if (!callData) return { message: 'callData.errors.required' };
         if (!callData.startsWith('0x')) {
@@ -120,11 +120,26 @@ const { $tx: $wrappedTx } = createWrappedTxStore({
   route: $route,
 });
 
-const $extrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
-// make 2 - one wrapped for submit, and one unwrapped for display
-const $args = combine($extrinsic, form.fields.chain.$value, (extrinsic, chain) => {
+const $wrappedExtrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
+const $hasExtrinsic = $wrappedExtrinsic.map((value) => nonNullable(value));
+
+const $wrappedArgs = combine($wrappedExtrinsic, form.fields.chain.$value, (extrinsic, chain) => {
   return extrinsic && chain ? callDataExecuteService.formatExtrinsic(extrinsic, chain) : null;
 });
+
+const $args = combine(
+  {
+    api: $api,
+    transaction: $transaction,
+    chain: form.fields.chain.$value,
+  },
+  ({ api, transaction, chain }) => {
+    if (!api || !transaction || !chain) return null;
+
+    const extrinsic = transactionService.createSubmittableExtrinsic(transaction, api);
+    return callDataExecuteService.formatExtrinsic(extrinsic, chain);
+  },
+);
 
 const createExtrinsicFx = createQueuedEffect(
   ({ transaction, api }: { transaction: AnyTransaction | null; api: ApiPromise | null }) => {
@@ -140,13 +155,13 @@ sample({
 
 sample({
   clock: createExtrinsicFx.doneData,
-  target: $extrinsic,
+  target: $wrappedExtrinsic,
 });
 
 sample({
   clock: createExtrinsicFx.fail,
   fn: () => null,
-  target: $extrinsic,
+  target: $wrappedExtrinsic,
 });
 
 sample({
@@ -157,7 +172,7 @@ sample({
 
 const { $: $fee, $pending: $pendingFee } = createFeeCalculator({
   active: callDataExecuteFeature.isRunning,
-  extrinsic: $extrinsic,
+  extrinsic: $wrappedExtrinsic,
 });
 
 const $signatoryBalance = combine(
@@ -295,7 +310,7 @@ sample({
 const $canSubmit = combine(
   {
     isValid: form.$isValid,
-    extrinsic: $extrinsic,
+    extrinsic: $wrappedExtrinsic,
     fee: $fee,
   },
   ({ isValid, extrinsic, fee }) => isValid && nonNullable(extrinsic) && !fee.isZero(),
@@ -307,7 +322,7 @@ const showConfirmation = sample({
   clock: form.submit.doneData,
   source: {
     transaction: $wrappedTx,
-    args: $args,
+    args: $wrappedArgs,
     fee: $fee,
     api: $api,
   },
@@ -380,7 +395,7 @@ export const formModel = {
   $canSubmit,
   $step,
   $api,
-  $extrinsic,
+  $hasExtrinsic,
   $args,
   $fee,
   $pendingFee,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -182,29 +182,23 @@ const $availableChains = combine(
     signatories: $availableSignatories,
   },
   ({ chains, signatories }) => {
-    if (signatories.length === 0) return chains;
+    if (signatories.length === 0) return [];
     return chains.filter((chain) => {
       return signatories.some((a) => accountService.isAccountAvailableOnChain(a, chain));
     });
   },
 );
 
-const $signatories = combine(form.fields.chain.$value, $availableSignatories, (chain, signatories) => {
-  if (nullable(chain)) return [];
-  return signatories.filter((a) => accountService.isAccountAvailableOnChain(a, chain));
-});
-
-// additional data loading
-
 sample({
-  clock: $signatories,
+  clock: $availableSignatories,
   target: balanceSubModel.fetchAccounts,
 });
 
 // flow setup
 
+// Auto-select first available chain when chains become available
 sample({
-  clock: flow.open,
+  clock: [$availableChains, flow.open],
   source: $availableChains,
   fn: (chains) => chains.at(0) ?? null,
   target: form.fields.chain.change,
@@ -318,7 +312,7 @@ export const formModel = {
   $fee,
   $pendingFee,
 
-  $signatories,
+  $availableSignatories,
   $availableChains,
 
   stepChanged,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -83,14 +83,6 @@ const form: Form<FormData> = createForm<FormData>({
   },
 });
 
-// Clear signatory errors when initiator has permissions
-sample({
-  clock: form.fields.initiator.$value,
-  source: form.fields.initiator.$value,
-  filter: (initiator) => Boolean(initiator && accountService.hasPermissionToMakeActions(initiator)),
-  target: form.fields.signatory.resetError,
-});
-
 // extrinsic
 
 const $api = combine(form.fields.chain.$value, networkModel.$apis, (chain, apis) =>
@@ -253,17 +245,17 @@ const $showSignatories = combine({
 // flow setup
 
 sample({
-  clock: [$availableChains],
-  source: { availableChains: $availableChains, selectedChain: form.fields.chain.$value },
-  filter: ({ availableChains, selectedChain }) =>
+  clock: $availableChains,
+  source: { selectedChain: form.fields.chain.$value },
+  filter: ({ selectedChain }, availableChains) =>
     !selectedChain || !availableChains.some((chain) => chain.chainId === selectedChain.chainId),
-  fn: ({ availableChains }) => availableChains.at(0) ?? null,
+  fn: (_, availableChains) => availableChains.at(0) ?? null,
   target: form.fields.chain.change,
 });
 
 // Preselect initiator based on selected wallet
 sample({
-  clock: [flow.open],
+  clock: flow.open,
   source: {
     selectedWallet: walletSelect.$selectedWallet,
     allAccounts: walletModel.$availableAccounts,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -13,6 +13,7 @@ import { type AnyAccount, type EncodedTransaction, accountService, transactionSe
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { walletModel } from '@/entities/wallet';
+import { walletSelect } from '@/aggregates/wallet-select';
 // TODO move balances subscription to balance model
 import { balanceSubModel } from '@/features/assets-balances';
 import { type TransactionSigningPayload, signModel } from '@/features/operations/OperationSign';
@@ -204,6 +205,28 @@ sample({
   target: form.fields.chain.change,
 });
 
+// Preselect signatory based on selected wallet
+sample({
+  clock: [walletSelect.$selectedWallet, $availableSignatories, flow.open],
+  source: {
+    selectedWallet: walletSelect.$selectedWallet,
+    availableSignatories: $availableSignatories,
+    currentSignatory: form.fields.signatory.$value,
+  },
+  fn: ({ selectedWallet, availableSignatories, currentSignatory }) => {
+    if (nonNullable(currentSignatory) || nullable(selectedWallet)) return currentSignatory;
+
+    const matchingSignatory = availableSignatories.find((signatory) =>
+      selectedWallet.accounts.some((account) => account.accountId === signatory.accountId),
+    );
+
+    console.log({ matchingSignatory });
+
+    return matchingSignatory || null;
+  },
+  target: form.fields.signatory.change,
+});
+
 sample({
   clock: form.fields.chain.change,
   target: form.fields.callData.resetError,
@@ -214,11 +237,8 @@ sample({
   source: form.fields.signatory.$value,
   fn: (signatory, chain) => {
     if (nullable(signatory) || nullable(chain)) return null;
-    // don't touch selected signatory if it exists on the new chain
-    if (accountService.isAccountAvailableOnChain(signatory, chain)) {
-      return signatory;
-    }
-    return null;
+
+    return signatory;
   },
   target: form.fields.signatory.change,
 });

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -221,9 +221,7 @@ sample({
       selectedWallet.accounts.some((account) => account.accountId === signatory.accountId),
     );
 
-    console.log({ matchingSignatory });
-
-    return matchingSignatory || null;
+    return (matchingSignatory || availableSignatories.at(0)) ?? null;
   },
   target: form.fields.signatory.change,
 });

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -99,6 +99,13 @@ const $transaction = $throttledCallData.map((callData): EncodedTransaction | nul
   };
 });
 
+const $extrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
+const $args = combine($extrinsic, form.fields.chain.$value, (extrinsic, chain) => {
+  if (!extrinsic || !chain) return null;
+
+  return callDataExecuteService.formatExtrinsic(extrinsic, chain);
+});
+
 const $route = createRouteStore({
   chain: form.fields.chain.$value,
   initiator: form.fields.initiator.$value,
@@ -117,20 +124,6 @@ const $wrappedExtrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(nu
 const $wrappedArgs = combine($wrappedExtrinsic, form.fields.chain.$value, (extrinsic, chain) => {
   return extrinsic && chain ? callDataExecuteService.formatExtrinsic(extrinsic, chain) : null;
 });
-
-const $extrinsic = createStore<SubmittableExtrinsic<'promise'> | null>(null);
-
-const $args = combine(
-  {
-    extrinsic: $extrinsic,
-    chain: form.fields.chain.$value,
-  },
-  ({ extrinsic, chain }) => {
-    if (!extrinsic || !chain) return null;
-
-    return callDataExecuteService.formatExtrinsic(extrinsic, chain);
-  },
-);
 
 const createWrappedExtrinsicFx = createQueuedEffect(
   ({ transaction, api }: { transaction: AnyTransaction | null; api: ApiPromise | null }) => {

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -126,20 +126,9 @@ const InitiatorSelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    // Group accounts by wallet
-    const walletGroups = new Map<number, typeof allAccounts>();
-
-    for (const account of allAccounts) {
-      const walletId = account.walletId;
-      if (!walletGroups.has(walletId)) {
-        walletGroups.set(walletId, []);
-      }
-      walletGroups.get(walletId)!.push(account);
-    }
-
-    for (const [walletId, walletAccounts] of walletGroups) {
-      const wallet = wallets.find((w) => w.id === walletId);
-      if (!wallet) continue;
+    for (const wallet of wallets) {
+      const walletAccounts = accountService.filterAccountsByWallet(allAccounts, wallet.id);
+      if (walletAccounts.length === 0) continue;
 
       const walletTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -18,6 +18,7 @@ import { JsonArgs } from './JsonArgs';
 export const CallDataForm = () => {
   const { t } = useI18n();
   const { submit } = useForm(formModel.form);
+  const showSignatories = useUnit(formModel.$showSignatories);
 
   const submitForm = (event: FormEvent) => {
     event.preventDefault();
@@ -29,7 +30,8 @@ export const CallDataForm = () => {
   return (
     <>
       <form id="transfer-form" className="flex flex-col gap-y-4 px-5 pb-4" onSubmit={submitForm}>
-        <SignatorySelect />
+        <InitiatorSelect />
+        {showSignatories && <SignatorySelect />}
         <NetworkSelect />
         <CallDataInput />
       </form>
@@ -99,11 +101,138 @@ const NetworkSelect = memo(() => {
   );
 });
 
+const InitiatorSelect = memo(() => {
+  const { t } = useI18n();
+
+  const wallets = useUnit(walletModel.$wallets);
+  const allAccounts = useUnit(formModel.$allAccounts);
+  const balances = useUnit(balanceModel.$balances);
+  const chain = useUnit(formModel.form.fields.chain.$value);
+  const {
+    fields: { initiator: initiator },
+  } = useForm(formModel.form);
+
+  const asset = chain ? getNativeAsset(chain.assets) : null;
+
+  const onChange = (id: string) => {
+    const v = allAccounts.find((c) => c.id === id);
+    if (nonNullable(v)) {
+      initiator.onChange(v);
+    }
+  };
+
+  const options = useMemo(() => {
+    const options: ReactNode[] = [];
+    if (nullable(chain) || nullable(asset)) return options;
+
+    // Group accounts by wallet
+    const walletGroups = new Map<number, typeof allAccounts>();
+
+    for (const account of allAccounts) {
+      const walletId = account.walletId;
+      if (!walletGroups.has(walletId)) {
+        walletGroups.set(walletId, []);
+      }
+      walletGroups.get(walletId)!.push(account);
+    }
+
+    for (const [walletId, walletAccounts] of walletGroups) {
+      const wallet = wallets.find((w) => w.id === walletId);
+      if (!wallet) continue;
+
+      const walletTitle = (
+        <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
+          <WalletIcon type={wallet.type} />
+          <FootnoteText className="text-text-secondary">{wallet.name}</FootnoteText>
+        </Box>
+      );
+
+      options.push(
+        <Select.Group key={wallet.id} title={walletTitle}>
+          {walletAccounts.map((a) => {
+            const balance = balanceUtils.getBalance(balances, a.accountId, chain.chainId, asset.assetId);
+
+            return (
+              <Select.Item key={a.id} value={a.id} depth={1}>
+                <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
+                  <Address
+                    showIcon
+                    canCopy={false}
+                    variant="truncate"
+                    title={a.name !== wallet.name ? a.name : void 0}
+                    address={toAddress(a.accountId, { prefix: chain?.addressPrefix })}
+                  />
+                  <AssetBalance
+                    className="text-footnote text-text-secondary"
+                    value={transferableAmountBN(balance)}
+                    asset={asset}
+                  />
+                </Box>
+              </Select.Item>
+            );
+          })}
+        </Select.Group>,
+      );
+    }
+
+    return options;
+  }, [wallets, balances, chain, asset, allAccounts]);
+
+  const wallet = useMemo(() => {
+    if (initiator.value) {
+      return wallets.find((w) => w.id === initiator.value?.walletId) ?? null;
+    }
+
+    return null;
+  }, [wallets, initiator.value]);
+
+  const balance = useMemo(() => {
+    if (initiator.value && chain && asset) {
+      const balance = balanceUtils.getBalance(balances, initiator.value.accountId, chain.chainId, asset.assetId);
+      return transferableAmountBN(balance);
+    }
+
+    return BN_ZERO;
+  }, [wallets, initiator.value, chain, asset]);
+
+  return (
+    <Field text={t('callData.fields.initiator.label')}>
+      <Select
+        placeholder={t('callData.fields.initiator.placeholder')}
+        value={initiator.value?.id ?? null}
+        valueNode={
+          nonNullable(initiator.value) && nonNullable(wallet) ? (
+            <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
+              <Address
+                showIcon
+                canCopy={false}
+                variant="truncate"
+                title={wallet.name}
+                address={toAddress(initiator.value.accountId, { prefix: chain?.addressPrefix })}
+              />
+              {nonNullable(asset) && (
+                <AssetBalance className="text-footnote text-text-secondary" value={balance} asset={asset} />
+              )}
+            </Box>
+          ) : null
+        }
+        height="md"
+        onChange={onChange}
+      >
+        {options}
+      </Select>
+      <InputHint variant="error" active={initiator.hasError}>
+        {t(initiator.errorMessage)}
+      </InputHint>
+    </Field>
+  );
+});
+
 const SignatorySelect = memo(() => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
-  const signatories = useUnit(formModel.$availableSignatories);
+  const signatories = useUnit(formModel.$signatories);
   const balances = useUnit(balanceModel.$balances);
   const chain = useUnit(formModel.form.fields.chain.$value);
   const {
@@ -123,7 +252,7 @@ const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    // Group signatories by wallet - signatories are already filtered by selected wallet
+    // Group signatories by wallet
     const walletGroups = new Map<number, typeof signatories>();
 
     for (const signatory of signatories) {

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -359,7 +359,7 @@ const ActionsSection = () => {
   const { t } = useI18n();
 
   const canSubmit = useUnit(formModel.$canSubmit);
-  const extrinsic = useUnit(formModel.$extrinsic);
+  const hasExtrinsic = useUnit(formModel.$hasExtrinsic);
   const fee = useUnit(formModel.$fee);
   const pendingFee = useUnit(formModel.$pendingFee);
   const chain = useUnit(formModel.form.fields.chain.$value);
@@ -367,7 +367,7 @@ const ActionsSection = () => {
 
   return (
     <Modal.Footer>
-      {nonNullable(asset) && nonNullable(extrinsic) && (
+      {nonNullable(asset) && hasExtrinsic && (
         <Box direction="row" gap={2} verticalAlign="center">
           <FootnoteText className="text-text-tertiary">{t('operation.networkFee')}</FootnoteText>
           <Fee className="text-footnote" fee={fee} isLoading={pendingFee} asset={asset} hideFiat />

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -8,7 +8,6 @@ import { getNativeAsset, nonNullable, nullable, toAddress, transferableAmountBN 
 import { Button, FootnoteText, Icon, InputHint, Separator, SmallTitleText } from '@/shared/ui';
 import { Address, AssetBalance, ChainSelect } from '@/shared/ui-entities';
 import { Box, Field, Input, Modal, ScrollArea, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { Fee } from '@/entities/transaction';
 import { WalletIcon, walletModel } from '@/entities/wallet';
@@ -30,8 +29,8 @@ export const CallDataForm = () => {
   return (
     <>
       <form id="transfer-form" className="flex flex-col gap-y-4 px-5 pb-4" onSubmit={submitForm}>
-        <NetworkSelect />
         <SignatorySelect />
+        <NetworkSelect />
         <CallDataInput />
       </form>
 
@@ -104,7 +103,7 @@ const SignatorySelect = memo(() => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
-  const signatories = useUnit(formModel.$signatories);
+  const signatories = useUnit(formModel.$availableSignatories);
   const balances = useUnit(balanceModel.$balances);
   const chain = useUnit(formModel.form.fields.chain.$value);
   const {
@@ -124,9 +123,20 @@ const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    for (const wallet of wallets) {
-      const walletAccounts = accountService.filterAccountsByWallet(signatories, wallet.id);
-      if (walletAccounts.length === 0) continue;
+    // Group signatories by wallet - signatories are already filtered by selected wallet
+    const walletGroups = new Map<number, typeof signatories>();
+
+    for (const signatory of signatories) {
+      const walletId = signatory.walletId;
+      if (!walletGroups.has(walletId)) {
+        walletGroups.set(walletId, []);
+      }
+      walletGroups.get(walletId)!.push(signatory);
+    }
+
+    for (const [walletId, walletAccounts] of walletGroups) {
+      const wallet = wallets.find((w) => w.id === walletId);
+      if (!wallet) continue;
 
       const walletTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -349,7 +349,7 @@ const ActionsSection = () => {
   const { t } = useI18n();
 
   const canSubmit = useUnit(formModel.$canSubmit);
-  const hasExtrinsic = useUnit(formModel.$hasExtrinsic);
+  const extrinsic = useUnit(formModel.$extrinsic);
   const fee = useUnit(formModel.$fee);
   const pendingFee = useUnit(formModel.$pendingFee);
   const chain = useUnit(formModel.form.fields.chain.$value);
@@ -357,7 +357,7 @@ const ActionsSection = () => {
 
   return (
     <Modal.Footer>
-      {nonNullable(asset) && hasExtrinsic && (
+      {nonNullable(asset) && nonNullable(extrinsic) && (
         <Box direction="row" gap={2} verticalAlign="center">
           <FootnoteText className="text-text-tertiary">{t('operation.networkFee')}</FootnoteText>
           <Fee className="text-footnote" fee={fee} isLoading={pendingFee} asset={asset} hideFiat />

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -8,6 +8,7 @@ import { getNativeAsset, nonNullable, nullable, toAddress, transferableAmountBN 
 import { Button, FootnoteText, Icon, InputHint, Separator, SmallTitleText } from '@/shared/ui';
 import { Address, AssetBalance, ChainSelect } from '@/shared/ui-entities';
 import { Box, Field, Input, Modal, ScrollArea, Select } from '@/shared/ui-kit';
+import { accountService } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { Fee } from '@/entities/transaction';
 import { WalletIcon, walletModel } from '@/entities/wallet';
@@ -252,20 +253,9 @@ const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    // Group signatories by wallet
-    const walletGroups = new Map<number, typeof signatories>();
-
-    for (const signatory of signatories) {
-      const walletId = signatory.walletId;
-      if (!walletGroups.has(walletId)) {
-        walletGroups.set(walletId, []);
-      }
-      walletGroups.get(walletId)!.push(signatory);
-    }
-
-    for (const [walletId, walletAccounts] of walletGroups) {
-      const wallet = wallets.find((w) => w.id === walletId);
-      if (!wallet) continue;
+    for (const wallet of wallets) {
+      const walletAccounts = accountService.filterAccountsByWallet(signatories, wallet.id);
+      if (walletAccounts.length === 0) continue;
 
       const walletTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -106,7 +106,7 @@ const InitiatorSelect = memo(() => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
-  const allAccounts = useUnit(formModel.$allAccounts);
+  const allAccounts = useUnit(walletModel.$availableAccounts);
   const balances = useUnit(balanceModel.$balances);
   const chain = useUnit(formModel.form.fields.chain.$value);
   const {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -165,12 +165,16 @@
       "signatoryRequired": "Signatory is required"
     },
     "fields": {
+      "initiator": {
+        "label": "Submit from",
+        "placeholder": "Select account..."
+      },
       "network": {
         "label": "Network",
         "placeholder": "Select network..."
       },
       "signatory": {
-        "label": "Signing from",
+        "label": "Signing with",
         "placeholder": "Select signatory..."
       }
     },

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -178,7 +178,7 @@
     "noDecodedTxDescription": "Operation details will appear here after call data parsed",
     "noDecodedTxTitle": "No data available",
     "placeholder": "Paste the call data here",
-    "title": "Import from call data"
+    "title": "Submit call data"
   },
   "createMultisigAccount": {
     "accountsTab": "Accounts",
@@ -1220,7 +1220,7 @@
     "addressBookLabel": "Address Book",
     "balancesLabel": "Portfolio",
     "basketLabel": "Basket",
-    "callDataLabel": "Import from call data",
+    "callDataLabel": "Submit call data",
     "fellowship": "Fellowship",
     "governance": "Governance",
     "historyLabel": "History",

--- a/src/renderer/shared/transactions/createComplexTxStore.ts
+++ b/src/renderer/shared/transactions/createComplexTxStore.ts
@@ -3,10 +3,11 @@ import { type Store, combine, createEffect, createStore, sample } from 'effector
 
 import { type Chain, type Transaction } from '@/shared/core';
 import { assert, nonNullable, nonNullableMap, nullable } from '@/shared/lib/utils';
-import { type AnyAccount, accountService, transactionService } from '@/domains/network';
+import { type AnyAccount, transactionService } from '@/domains/network';
 import { getExtrinsic } from '@/entities/transaction';
 
 import { createFeeCalculator } from './createFeeCalculator';
+import { createRouteStore } from './createRouteStore';
 
 type Params<T extends Transaction> = {
   active?: Store<boolean>;
@@ -29,12 +30,7 @@ export const createComplexTxStore = <T extends Transaction>({
   initiator,
   signatory,
 }: Params<T>) => {
-  const $route = combine({ accounts, initiator, signatory, chain }, (params) => {
-    if (nonNullableMap(params)) {
-      return accountService.findRoute(params.initiator, params.signatory, params.accounts, params.chain);
-    }
-    return [];
-  });
+  const $route = createRouteStore({ accounts, initiator, signatory, chain });
 
   const $tx = createStore<Transaction | null>(null);
   const $feeTx = createStore<Transaction | null>(null);
@@ -45,7 +41,7 @@ export const createComplexTxStore = <T extends Transaction>({
     route: AnyAccount[];
   };
 
-  const wrapTransactionHandler = async ({ transaction, route, api }: WrapParams) => {
+  const wrapLegacyTransactionHandler = async ({ transaction, route, api }: WrapParams) => {
     const tx = await transactionService.wrapLegacyTransaction(transaction, route, api);
     const signatory = route.at(-1);
 
@@ -58,8 +54,8 @@ export const createComplexTxStore = <T extends Transaction>({
     return tx;
   };
 
-  const wrapTransactionFx = createEffect(wrapTransactionHandler);
-  const wrapFeeTransactionFx = createEffect(wrapTransactionHandler);
+  const wrapTransactionFx = createEffect(wrapLegacyTransactionHandler);
+  const wrapFeeTransactionFx = createEffect(wrapLegacyTransactionHandler);
 
   const wrapTransaction = sample({
     clock: [transaction, api, $route],

--- a/src/renderer/shared/transactions/createRouteStore.ts
+++ b/src/renderer/shared/transactions/createRouteStore.ts
@@ -1,0 +1,21 @@
+import { type Store, combine } from 'effector';
+
+import { type Chain } from '@/shared/core';
+import { nonNullableMap } from '@/shared/lib/utils';
+import { type AnyAccount, accountService } from '@/domains/network';
+
+type Params = {
+  chain: Store<Chain | null>;
+  accounts: Store<AnyAccount[]>;
+  initiator: Store<AnyAccount | null>;
+  signatory: Store<AnyAccount | null>;
+};
+
+export function createRouteStore({ accounts, initiator, signatory, chain }: Params) {
+  return combine({ accounts, initiator, signatory, chain }, (params) => {
+    if (nonNullableMap(params)) {
+      return accountService.findRoute(params.initiator, params.signatory, params.accounts, params.chain);
+    }
+    return [];
+  });
+}

--- a/src/renderer/shared/transactions/createWrappedTxStore.ts
+++ b/src/renderer/shared/transactions/createWrappedTxStore.ts
@@ -1,7 +1,7 @@
 import { type ApiPromise } from '@polkadot/api';
 import { type Store, createEffect, createStore, sample } from 'effector';
 
-import { assert, nonNullableMap, nullable } from '@/shared/lib/utils';
+import { nonNullableMap, nullable } from '@/shared/lib/utils';
 import { type AnyAccount, type AnyTransaction, transactionService } from '@/domains/network';
 
 type Params = {
@@ -20,12 +20,7 @@ export const createWrappedTxStore = ({ api, transaction, route }: Params) => {
   };
 
   const wrapTransactionHandler = async ({ transaction, route, api }: WrapParams) => {
-    const tx = await transactionService.wrapTransaction(transaction, route, api);
-    const signatory = route.at(-1);
-
-    assert(signatory, 'Signatory is required');
-
-    return tx;
+    return transactionService.wrapTransaction(transaction, route, api);
   };
 
   const wrapTransactionFx = createEffect(wrapTransactionHandler);

--- a/src/renderer/shared/transactions/createWrappedTxStore.ts
+++ b/src/renderer/shared/transactions/createWrappedTxStore.ts
@@ -1,0 +1,59 @@
+import { type ApiPromise } from '@polkadot/api';
+import { type Store, createEffect, createStore, sample } from 'effector';
+
+import { assert, nonNullableMap, nullable } from '@/shared/lib/utils';
+import { type AnyAccount, type AnyTransaction, transactionService } from '@/domains/network';
+
+type Params = {
+  api: Store<ApiPromise | null>;
+  transaction: Store<AnyTransaction | null>;
+  route: Store<AnyAccount[]>;
+};
+
+export const createWrappedTxStore = ({ api, transaction, route }: Params) => {
+  const $tx = createStore<AnyTransaction | null>(null);
+
+  type WrapParams = {
+    api: ApiPromise;
+    transaction: AnyTransaction;
+    route: AnyAccount[];
+  };
+
+  const wrapTransactionHandler = async ({ transaction, route, api }: WrapParams) => {
+    const tx = await transactionService.wrapTransaction(transaction, route, api);
+    const signatory = route.at(-1);
+
+    assert(signatory, 'Signatory is required');
+
+    return tx;
+  };
+
+  const wrapTransactionFx = createEffect(wrapTransactionHandler);
+
+  const wrapTransaction = sample({
+    clock: [transaction, api, route],
+    source: { transaction, api, route: route },
+  }).filter({ fn: nonNullableMap });
+
+  sample({
+    clock: wrapTransaction,
+    target: wrapTransactionFx,
+  });
+
+  sample({
+    clock: transaction,
+    filter: (t) => nullable(t),
+    fn: () => null,
+    target: $tx,
+  });
+
+  sample({
+    clock: wrapTransactionFx.doneData,
+    target: $tx,
+  });
+
+  return {
+    $tx,
+    $pending: wrapTransactionFx.pending,
+  };
+};


### PR DESCRIPTION
## Description

Support call data for proxies and multisigs

## Related Issues

closes #4301
closes #4322

## Changes Made

- reorder selectors, wallet (with preselected) => network (filtered by wallet)
-  signing from field if applicable
- rename entry button
- multisig and proxy wallets in wallet picker
- unwrapped tx json on first step, wrapped tx json on confirmation

## Screenshots/Recordings

<img width="504" height="690" alt="image" src="https://github.com/user-attachments/assets/9ba50214-8d5c-4cfa-a7bc-0526680de578" />

<img width="492" height="684" alt="image" src="https://github.com/user-attachments/assets/8d60c651-62a2-4257-8a56-91d41e82a33e" />

<img width="808" height="494" alt="image" src="https://github.com/user-attachments/assets/98c1ec1f-0dd2-4959-9c68-2a5d88e72f7d" />

