### PR TITLE
fix: single vault signer as signatory

### DIFF
--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
@@ -97,7 +97,8 @@ export const Signatory = ({
     const filteredWallets = walletUtils.getWalletsFilteredAccounts(wallets, {
       walletFn: walletUtils.isValidSignatory,
       accountFn: account => {
-        const isCorrectAccount = !accountUtils.isVaultBaseAccount(account);
+        const isCorrectAccount = !accountUtils.isWatchOnlyAccount(account);
+
         const isChainMatch = accountService.isAccountAvailableOnChain(account, chain);
         const address = toAddress(account.accountId, { prefix: chain.addressPrefix });
 

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
@@ -94,7 +94,7 @@ export const Signatory = ({
     const filteredWallets = walletUtils.getWalletsFilteredAccounts(wallets, {
       walletFn: walletUtils.isValidSignatory,
       accountFn: account => {
-        const isCorrectAccount = !accountUtils.isVaultBaseAccount(account);
+        const isCorrectAccount = !accountUtils.isWatchOnlyAccount(account);
 
         if (isOwnAccount) return isCorrectAccount;
 


### PR DESCRIPTION
## Description
Polkadot single parity signer has a 'base' account type, but can sign a transaction 

Closes #4343 