### PR TITLE
chore: group by type

### DIFF
--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -246,7 +246,11 @@ const $signatories = createSignatoriesStore({
   initiator: form.fields.initiator.$value,
 });
 
-const $showSignatories = $signatories.map((signatories) => signatories.length > 1);
+const $showSignatories = combine(
+  $signatories,
+  form.fields.initiator.$value,
+  (signatories, initiator) => signatories.length > 1 || signatories.at(0)?.accountId !== initiator?.accountId,
+);
 
 sample({
   clock: $signatories,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -314,7 +314,11 @@ sample({
     const walletAccounts = accountService.filterAccountsByWallet(allAccounts, initiator.walletId);
     const matchingAccount = walletAccounts.find((account) => accountService.isAccountAvailableOnChain(account, chain));
 
-    return matchingAccount ?? allAccounts?.at(0) ?? null;
+    if (matchingAccount) {
+      return matchingAccount;
+    }
+
+    return allAccounts.filter((a) => accountService.isAccountAvailableOnChain(a, chain))?.at(0) ?? null;
   },
   target: form.fields.initiator.change,
 });

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -227,9 +227,11 @@ sample({
   target: stepChanged,
 });
 
+const $allChains = networkModel.$chains.map((chains) => Object.values(chains));
+
 const $availableChains = combine(
   {
-    chains: networkModel.$chains.map((chains) => Object.values(chains)),
+    chains: $allChains,
     initiator: form.fields.initiator.$value,
   },
   ({ chains, initiator }) => {
@@ -259,16 +261,7 @@ sample({
 
 // flow setup
 
-sample({
-  clock: $availableChains,
-  source: { selectedChain: form.fields.chain.$value },
-  filter: ({ selectedChain }, availableChains) =>
-    !selectedChain || !availableChains.some((chain) => chain.chainId === selectedChain.chainId),
-  fn: (_, availableChains) => availableChains.at(0) ?? null,
-  target: form.fields.chain.change,
-});
-
-// Preselect initiator based on selected wallet
+// Preselect initiator on form open
 sample({
   clock: flow.open,
   source: {
@@ -284,6 +277,42 @@ sample({
     );
 
     return (matchingAccount || allAccounts.at(0)) ?? null;
+  },
+  target: form.fields.initiator.change,
+});
+
+sample({
+  clock: form.fields.initiator.change,
+  source: {
+    allChains: $allChains,
+    selectedChain: form.fields.chain.$value,
+    isOpen: flow.status,
+  },
+  filter: ({ isOpen, selectedChain }) => isOpen && nullable(selectedChain),
+  fn: ({ allChains }, initiator) => {
+    if (nullable(initiator)) return null;
+    return allChains.find((chain) => accountService.isAccountAvailableOnChain(initiator, chain)) ?? null;
+  },
+  target: form.fields.chain.change,
+});
+
+sample({
+  clock: form.fields.chain.change,
+  source: {
+    initiator: form.fields.initiator.$value,
+    allAccounts: walletModel.$availableAccounts,
+  },
+  filter: ({ initiator }, chain) => {
+    if (nullable(initiator) || nullable(chain)) return false;
+    return !accountService.isAccountAvailableOnChain(initiator, chain);
+  },
+  fn: ({ initiator, allAccounts }, chain) => {
+    if (nullable(initiator) || nullable(chain)) return null;
+
+    const walletAccounts = accountService.filterAccountsByWallet(allAccounts, initiator.walletId);
+    const matchingAccount = walletAccounts.find((account) => accountService.isAccountAvailableOnChain(account, chain));
+
+    return matchingAccount ?? null;
   },
   target: form.fields.initiator.change,
 });
@@ -403,6 +432,7 @@ export const formModel = {
   $fee,
   $pendingFee,
 
+  $allChains: $allChains,
   $availableChains: $availableChains,
   $signatories: $signatories,
   $showSignatories: $showSignatories,

--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -282,14 +282,16 @@ sample({
 });
 
 sample({
-  clock: form.fields.initiator.change,
+  clock: flow.open,
   source: {
     allChains: $allChains,
     selectedChain: form.fields.chain.$value,
-    isOpen: flow.status,
+    initiator: form.fields.initiator.$value,
   },
-  filter: ({ isOpen, selectedChain }) => isOpen && nullable(selectedChain),
-  fn: ({ allChains }, initiator) => {
+  filter: ({ initiator, selectedChain }) =>
+    nullable(selectedChain) ||
+    (nonNullable(initiator) && accountService.isAccountAvailableOnChain(initiator, selectedChain)),
+  fn: ({ allChains, initiator }) => {
     if (nullable(initiator)) return null;
     return allChains.find((chain) => accountService.isAccountAvailableOnChain(initiator, chain)) ?? null;
   },
@@ -312,7 +314,7 @@ sample({
     const walletAccounts = accountService.filterAccountsByWallet(allAccounts, initiator.walletId);
     const matchingAccount = walletAccounts.find((account) => accountService.isAccountAvailableOnChain(account, chain));
 
-    return matchingAccount ?? null;
+    return matchingAccount ?? allAccounts?.at(0) ?? null;
   },
   target: form.fields.initiator.change,
 });

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -169,7 +169,9 @@ const InitiatorSelect = memo(() => {
       const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
           <WalletIcon type={walletGroup.walletType} />
-          <FootnoteText className="text-text-secondary">{t(walletTypesTitles[walletGroup.walletType])}</FootnoteText>
+          <FootnoteText className="text-text-secondary uppercase">
+            {t(walletTypesTitles[walletGroup.walletType])}
+          </FootnoteText>
         </Box>
       );
 
@@ -321,7 +323,9 @@ const SignatorySelect = memo(() => {
       const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
           <WalletIcon type={walletGroup.walletType} />
-          <FootnoteText className="text-text-secondary">{walletTypesTitles[walletGroup.walletType]}</FootnoteText>
+          <FootnoteText className="text-text-secondary uppercase">
+            {walletTypesTitles[walletGroup.walletType]}
+          </FootnoteText>
         </Box>
       );
 

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -138,7 +138,6 @@ const InitiatorSelect = memo(() => {
       const matchingAccount = walletAccounts.find((account) =>
         accountService.isAccountAvailableOnChain(account, chain),
       );
-      // If no matching account, use the first account from the wallet
       const accountToUse = matchingAccount ?? walletAccounts[0] ?? null;
       initiator.onChange(accountToUse);
     }
@@ -148,7 +147,6 @@ const InitiatorSelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    // Group wallets by type (show all wallets, even without accounts on selected chain)
     const walletsByType = wallets.reduce(
       (groups, wallet) => {
         if (!groups[wallet.type]) {
@@ -160,7 +158,6 @@ const InitiatorSelect = memo(() => {
       {} as Record<string, { walletType: WalletType; wallets: Wallet[] }>,
     );
 
-    // Render each wallet type group
     for (const walletGroup of Object.values(walletsByType)) {
       const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
@@ -278,7 +275,6 @@ const SignatorySelect = memo(() => {
     const wallet = wallets.find((w) => w.id === Number(walletId));
     if (nonNullable(wallet) && nonNullable(chain)) {
       const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
-      // Find first signatory account that matches the selected network
       const matchingSignatory = walletSignatories.find((account) =>
         accountService.isAccountAvailableOnChain(account, chain),
       );
@@ -292,7 +288,6 @@ const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    // Group wallets by type
     const walletsByType = wallets.reduce(
       (groups, wallet) => {
         const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
@@ -310,7 +305,6 @@ const SignatorySelect = memo(() => {
       {} as Record<string, { walletType: WalletType; wallets: Wallet[] }>,
     );
 
-    // Render each wallet type group
     for (const walletGroup of Object.values(walletsByType)) {
       const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -47,9 +47,9 @@ export const CallDataForm = () => {
   return (
     <>
       <form id="transfer-form" className="flex flex-col gap-y-4 px-5 pb-4" onSubmit={submitForm}>
+        <NetworkSelect />
         <InitiatorSelect />
         {showSignatories && <SignatorySelect />}
-        <NetworkSelect />
         <CallDataInput />
       </form>
 
@@ -98,7 +98,7 @@ const CallDataInput = () => {
 const NetworkSelect = memo(() => {
   const { t } = useI18n();
 
-  const availableChains = useUnit(formModel.$availableChains);
+  const allChains = useUnit(formModel.$allChains);
   const {
     fields: { chain },
   } = useForm(formModel.form);
@@ -108,7 +108,7 @@ const NetworkSelect = memo(() => {
       <ChainSelect
         placeholder={t('callData.fields.network.placeholder')}
         value={chain.value}
-        options={availableChains}
+        options={allChains}
         onChange={chain.onChange}
       />
       <InputHint variant="error" active={chain.hasError}>
@@ -149,6 +149,13 @@ const InitiatorSelect = memo(() => {
 
     const walletsByType = wallets.reduce(
       (groups, wallet) => {
+        const walletAccounts = accountService.filterAccountsByWallet(allAccounts, wallet.id);
+        const hasMatchingAccounts = walletAccounts.some((account) =>
+          accountService.isAccountAvailableOnChain(account, chain),
+        );
+
+        if (!hasMatchingAccounts) return groups;
+
         if (!groups[wallet.type]) {
           groups[wallet.type] = { walletType: wallet.type, wallets: [] };
         }
@@ -173,11 +180,14 @@ const InitiatorSelect = memo(() => {
             accountService.isAccountAvailableOnChain(account, chain),
           );
 
-          const accountToShow = firstMatchingAccount ?? walletAccounts.at(0);
+          if (!firstMatchingAccount) return null;
 
-          if (!accountToShow) return null;
-
-          const balance = balanceUtils.getBalance(balances, accountToShow.accountId, chain.chainId, asset.assetId);
+          const balance = balanceUtils.getBalance(
+            balances,
+            firstMatchingAccount.accountId,
+            chain.chainId,
+            asset.assetId,
+          );
 
           return (
             <Select.Item key={wallet.id} value={wallet.id.toString()} depth={1}>
@@ -187,7 +197,7 @@ const InitiatorSelect = memo(() => {
                   canCopy={false}
                   variant="truncate"
                   title={wallet.name}
-                  address={toAddress(accountToShow.accountId, { prefix: chain?.addressPrefix })}
+                  address={toAddress(firstMatchingAccount.accountId, { prefix: chain?.addressPrefix })}
                 />
                 <AssetBalance
                   className="text-footnote text-text-secondary"
@@ -198,13 +208,15 @@ const InitiatorSelect = memo(() => {
             </Select.Item>
           );
         })
-        .filter(Boolean);
+        .filter(nonNullable);
 
-      options.push(
-        <Select.Group key={walletGroup.walletType} title={walletTypeTitle}>
-          {walletItems}
-        </Select.Group>,
-      );
+      if (walletItems.length > 0) {
+        options.push(
+          <Select.Group key={walletGroup.walletType} title={walletTypeTitle}>
+            {walletItems}
+          </Select.Group>,
+        );
+      }
     }
 
     return options;

--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -1,7 +1,9 @@
 import { BN_ZERO } from '@polkadot/util';
 import { useUnit } from 'effector-react';
+import { t } from 'i18next';
 import { type FormEvent, type ReactNode, memo, useMemo } from 'react';
 
+import { type Wallet, WalletType } from '@/shared/core';
 import { useForm } from '@/shared/forms';
 import { useI18n } from '@/shared/i18n';
 import { getNativeAsset, nonNullable, nullable, toAddress, transferableAmountBN } from '@/shared/lib/utils';
@@ -15,6 +17,20 @@ import { WalletIcon, walletModel } from '@/entities/wallet';
 import { formModel } from '../model/form';
 
 import { JsonArgs } from './JsonArgs';
+
+const walletTypesTitles: Record<WalletType, string> = {
+  [WalletType.POLKADOT_EXTENSION]: t('wallets.polkadotExtensionLabel'),
+  [WalletType.WATCH_ONLY]: t('wallets.watchOnlyLabel'),
+  [WalletType.POLKADOT_VAULT]: t('wallets.paritySignerLabel'),
+  [WalletType.MULTISIG]: t('wallets.multisigLabel'),
+  [WalletType.FLEXIBLE_MULTISIG]: t('wallets.flexibleMultisigLabel'),
+  [WalletType.WALLET_CONNECT]: t('wallets.walletConnectLabel'),
+  [WalletType.NOVA_WALLET]: t('wallets.novaWalletLabel'),
+  [WalletType.PROXIED]: t('wallets.proxiedLabel'),
+  [WalletType.TALISMAN_EXTENSION]: t('wallets.talismanExtensionLabel'),
+  [WalletType.SUBWALLET_EXTENSION]: t('wallets.subWalletExtensionLabel'),
+  [WalletType.SINGLE_PARITY_SIGNER]: t('wallets.paritySignerLabel'),
+};
 
 export const CallDataForm = () => {
   const { t } = useI18n();
@@ -110,15 +126,21 @@ const InitiatorSelect = memo(() => {
   const balances = useUnit(balanceModel.$balances);
   const chain = useUnit(formModel.form.fields.chain.$value);
   const {
-    fields: { initiator: initiator },
+    fields: { initiator },
   } = useForm(formModel.form);
 
   const asset = chain ? getNativeAsset(chain.assets) : null;
 
-  const onChange = (id: string) => {
-    const v = allAccounts.find((c) => c.id === id);
-    if (nonNullable(v)) {
-      initiator.onChange(v);
+  const onChange = (walletId: string) => {
+    const wallet = wallets.find((w) => w.id === Number(walletId));
+    if (nonNullable(wallet) && nonNullable(chain)) {
+      const walletAccounts = accountService.filterAccountsByWallet(allAccounts, wallet.id);
+      const matchingAccount = walletAccounts.find((account) =>
+        accountService.isAccountAvailableOnChain(account, chain),
+      );
+      // If no matching account, use the first account from the wallet
+      const accountToUse = matchingAccount ?? walletAccounts[0] ?? null;
+      initiator.onChange(accountToUse);
     }
   };
 
@@ -126,41 +148,64 @@ const InitiatorSelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    for (const wallet of wallets) {
-      const walletAccounts = accountService.filterAccountsByWallet(allAccounts, wallet.id);
-      if (walletAccounts.length === 0) continue;
+    // Group wallets by type (show all wallets, even without accounts on selected chain)
+    const walletsByType = wallets.reduce(
+      (groups, wallet) => {
+        if (!groups[wallet.type]) {
+          groups[wallet.type] = { walletType: wallet.type, wallets: [] };
+        }
+        groups[wallet.type].wallets.push(wallet);
+        return groups;
+      },
+      {} as Record<string, { walletType: WalletType; wallets: Wallet[] }>,
+    );
 
-      const walletTitle = (
+    // Render each wallet type group
+    for (const walletGroup of Object.values(walletsByType)) {
+      const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
-          <WalletIcon type={wallet.type} />
-          <FootnoteText className="text-text-secondary">{wallet.name}</FootnoteText>
+          <WalletIcon type={walletGroup.walletType} />
+          <FootnoteText className="text-text-secondary">{t(walletTypesTitles[walletGroup.walletType])}</FootnoteText>
         </Box>
       );
 
-      options.push(
-        <Select.Group key={wallet.id} title={walletTitle}>
-          {walletAccounts.map((a) => {
-            const balance = balanceUtils.getBalance(balances, a.accountId, chain.chainId, asset.assetId);
+      const walletItems = walletGroup.wallets
+        .map((wallet) => {
+          const walletAccounts = accountService.filterAccountsByWallet(allAccounts, wallet.id);
+          const firstMatchingAccount = walletAccounts.find((account) =>
+            accountService.isAccountAvailableOnChain(account, chain),
+          );
 
-            return (
-              <Select.Item key={a.id} value={a.id} depth={1}>
-                <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
-                  <Address
-                    showIcon
-                    canCopy={false}
-                    variant="truncate"
-                    title={a.name !== wallet.name ? a.name : void 0}
-                    address={toAddress(a.accountId, { prefix: chain?.addressPrefix })}
-                  />
-                  <AssetBalance
-                    className="text-footnote text-text-secondary"
-                    value={transferableAmountBN(balance)}
-                    asset={asset}
-                  />
-                </Box>
-              </Select.Item>
-            );
-          })}
+          const accountToShow = firstMatchingAccount ?? walletAccounts.at(0);
+
+          if (!accountToShow) return null;
+
+          const balance = balanceUtils.getBalance(balances, accountToShow.accountId, chain.chainId, asset.assetId);
+
+          return (
+            <Select.Item key={wallet.id} value={wallet.id.toString()} depth={1}>
+              <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
+                <Address
+                  showIcon
+                  canCopy={false}
+                  variant="truncate"
+                  title={wallet.name}
+                  address={toAddress(accountToShow.accountId, { prefix: chain?.addressPrefix })}
+                />
+                <AssetBalance
+                  className="text-footnote text-text-secondary"
+                  value={transferableAmountBN(balance)}
+                  asset={asset}
+                />
+              </Box>
+            </Select.Item>
+          );
+        })
+        .filter(Boolean);
+
+      options.push(
+        <Select.Group key={walletGroup.walletType} title={walletTypeTitle}>
+          {walletItems}
         </Select.Group>,
       );
     }
@@ -168,11 +213,10 @@ const InitiatorSelect = memo(() => {
     return options;
   }, [wallets, balances, chain, asset, allAccounts]);
 
-  const wallet = useMemo(() => {
+  const selectedWallet = useMemo(() => {
     if (initiator.value) {
       return wallets.find((w) => w.id === initiator.value?.walletId) ?? null;
     }
-
     return null;
   }, [wallets, initiator.value]);
 
@@ -181,23 +225,22 @@ const InitiatorSelect = memo(() => {
       const balance = balanceUtils.getBalance(balances, initiator.value.accountId, chain.chainId, asset.assetId);
       return transferableAmountBN(balance);
     }
-
     return BN_ZERO;
-  }, [wallets, initiator.value, chain, asset]);
+  }, [initiator.value, chain, asset, balances]);
 
   return (
     <Field text={t('callData.fields.initiator.label')}>
       <Select
         placeholder={t('callData.fields.initiator.placeholder')}
-        value={initiator.value?.id ?? null}
+        value={selectedWallet?.id.toString() ?? null}
         valueNode={
-          nonNullable(initiator.value) && nonNullable(wallet) ? (
+          nonNullable(initiator.value) && nonNullable(selectedWallet) ? (
             <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
               <Address
                 showIcon
                 canCopy={false}
                 variant="truncate"
-                title={wallet.name}
+                title={selectedWallet.name}
                 address={toAddress(initiator.value.accountId, { prefix: chain?.addressPrefix })}
               />
               {nonNullable(asset) && (
@@ -231,10 +274,17 @@ const SignatorySelect = memo(() => {
 
   const asset = chain ? getNativeAsset(chain.assets) : null;
 
-  const onChange = (id: string) => {
-    const v = signatories.find((c) => c.id === id);
-    if (nonNullable(v)) {
-      signatory.onChange(v);
+  const onChange = (walletId: string) => {
+    const wallet = wallets.find((w) => w.id === Number(walletId));
+    if (nonNullable(wallet) && nonNullable(chain)) {
+      const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
+      // Find first signatory account that matches the selected network
+      const matchingSignatory = walletSignatories.find((account) =>
+        accountService.isAccountAvailableOnChain(account, chain),
+      );
+      if (matchingSignatory) {
+        signatory.onChange(matchingSignatory);
+      }
     }
   };
 
@@ -242,53 +292,86 @@ const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    for (const wallet of wallets) {
-      const walletAccounts = accountService.filterAccountsByWallet(signatories, wallet.id);
-      if (walletAccounts.length === 0) continue;
+    // Group wallets by type
+    const walletsByType = wallets.reduce(
+      (groups, wallet) => {
+        const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
+        const hasMatchingSignatories = walletSignatories.some((account) =>
+          accountService.isAccountAvailableOnChain(account, chain),
+        );
+        if (!hasMatchingSignatories) return groups;
 
-      const walletTitle = (
+        if (!groups[wallet.type]) {
+          groups[wallet.type] = { walletType: wallet.type, wallets: [] };
+        }
+        groups[wallet.type].wallets.push(wallet);
+        return groups;
+      },
+      {} as Record<string, { walletType: WalletType; wallets: Wallet[] }>,
+    );
+
+    // Render each wallet type group
+    for (const walletGroup of Object.values(walletsByType)) {
+      const walletTypeTitle = (
         <Box direction="row" gap={2} padding={[1, 0]} verticalAlign="center">
-          <WalletIcon type={wallet.type} />
-          <FootnoteText className="text-text-secondary">{wallet.name}</FootnoteText>
+          <WalletIcon type={walletGroup.walletType} />
+          <FootnoteText className="text-text-secondary">{walletTypesTitles[walletGroup.walletType]}</FootnoteText>
         </Box>
       );
 
-      options.push(
-        <Select.Group key={wallet.id} title={walletTitle}>
-          {walletAccounts.map((a) => {
-            const balance = balanceUtils.getBalance(balances, a.accountId, chain.chainId, asset.assetId);
+      const walletItems = walletGroup.wallets
+        .map((wallet) => {
+          const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
+          const firstMatchingSignatory = walletSignatories.find((account) =>
+            accountService.isAccountAvailableOnChain(account, chain),
+          );
 
-            return (
-              <Select.Item key={a.id} value={a.id} depth={1}>
-                <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
-                  <Address
-                    showIcon
-                    canCopy={false}
-                    variant="truncate"
-                    title={a.name !== wallet.name ? a.name : void 0}
-                    address={toAddress(a.accountId, { prefix: chain?.addressPrefix })}
-                  />
-                  <AssetBalance
-                    className="text-footnote text-text-secondary"
-                    value={transferableAmountBN(balance)}
-                    asset={asset}
-                  />
-                </Box>
-              </Select.Item>
-            );
-          })}
-        </Select.Group>,
-      );
+          if (!firstMatchingSignatory) return null;
+
+          const balance = balanceUtils.getBalance(
+            balances,
+            firstMatchingSignatory.accountId,
+            chain.chainId,
+            asset.assetId,
+          );
+
+          return (
+            <Select.Item key={wallet.id} value={wallet.id.toString()} depth={1}>
+              <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
+                <Address
+                  showIcon
+                  canCopy={false}
+                  variant="truncate"
+                  title={wallet.name}
+                  address={toAddress(firstMatchingSignatory.accountId, { prefix: chain?.addressPrefix })}
+                />
+                <AssetBalance
+                  className="text-footnote text-text-secondary"
+                  value={transferableAmountBN(balance)}
+                  asset={asset}
+                />
+              </Box>
+            </Select.Item>
+          );
+        })
+        .filter(Boolean);
+
+      if (walletItems.length > 0) {
+        options.push(
+          <Select.Group key={walletGroup.walletType} title={walletTypeTitle}>
+            {walletItems}
+          </Select.Group>,
+        );
+      }
     }
 
     return options;
   }, [wallets, balances, chain, asset, signatories]);
 
-  const signatoryWallet = useMemo(() => {
+  const selectedSignatoryWallet = useMemo(() => {
     if (signatory.value) {
       return wallets.find((w) => w.id === signatory.value?.walletId) ?? null;
     }
-
     return null;
   }, [wallets, signatory.value]);
 
@@ -297,23 +380,22 @@ const SignatorySelect = memo(() => {
       const balance = balanceUtils.getBalance(balances, signatory.value.accountId, chain.chainId, asset.assetId);
       return transferableAmountBN(balance);
     }
-
     return BN_ZERO;
-  }, [wallets, signatory.value, chain, asset]);
+  }, [signatory.value, chain, asset, balances]);
 
   return (
     <Field text={t('callData.fields.signatory.label')}>
       <Select
         placeholder={t('callData.fields.signatory.placeholder')}
-        value={signatory.value?.id ?? null}
+        value={selectedSignatoryWallet?.id.toString() ?? null}
         valueNode={
-          nonNullable(signatory.value) && nonNullable(signatoryWallet) ? (
+          nonNullable(signatory.value) && nonNullable(selectedSignatoryWallet) ? (
             <Box direction="row" verticalAlign="center" horizontalAlign="space-between" gap={2}>
               <Address
                 showIcon
                 canCopy={false}
                 variant="truncate"
-                title={signatoryWallet.name}
+                title={selectedSignatoryWallet.name}
                 address={toAddress(signatory.value.accountId, { prefix: chain?.addressPrefix })}
               />
               {nonNullable(asset) && (


### PR DESCRIPTION
## Description

Group accounts by wallet & wallet type

## Related Issues

closes #4374

## Changes Made

- display 1 acc per wallet (chain acc or 1st acc)
- group by wallet type
- show signatory for proxy/multisig
- filter networks by account but don't filter accounts by network

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
