### PR TITLE
fix: change scrollable area on governance page

### DIFF
--- a/src/renderer/pages/Governance/ui/Governance.tsx
+++ b/src/renderer/pages/Governance/ui/Governance.tsx
@@ -90,7 +90,7 @@ export const Governance = () => {
       </Header>
 
       <Box direction="column" height="100%">
-        <Box horizontalAlign="center" padding={[6, 0, 5, 0]} shrink={0}>
+        <Box horizontalAlign="center" padding={[6, 0, 2, 0]} shrink={0}>
           <Box width="736px" gap={5}>
             <div className="flex gap-x-3">
               <Plate className="h-[90px] w-[240px] px-4 pt-3 pb-4.5">

--- a/src/renderer/pages/Governance/ui/Governance.tsx
+++ b/src/renderer/pages/Governance/ui/Governance.tsx
@@ -11,6 +11,7 @@ import { networkModel, networkUtils } from '@/entities/network';
 import { accountUtils } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
 import {
+  Filters,
   Locks,
   NetworkSelector,
   Search,
@@ -88,9 +89,9 @@ export const Governance = () => {
         <Box width="230px">{isApiConnected && <Search />}</Box>
       </Header>
 
-      <ScrollArea>
-        <Box horizontalAlign="center" height="100%" padding={[6, 0]}>
-          <Box width="736px" height="100%" gap={5}>
+      <Box direction="column" height="100%">
+        <Box horizontalAlign="center" padding={[6, 0, 5, 0]} shrink={0}>
+          <Box width="736px" gap={5}>
             <div className="flex gap-x-3">
               <Plate className="h-[90px] w-[240px] px-4 pt-3 pb-4.5">
                 <NetworkSelector />
@@ -108,11 +109,17 @@ export const Governance = () => {
                 </>
               )}
             </div>
-
-            <Outlet />
+            {isApiConnected && <Filters />}
           </Box>
         </Box>
-      </ScrollArea>
+        <ScrollArea>
+          <Box horizontalAlign="center" height="100%">
+            <Box width="736px" height="100%">
+              <Outlet />
+            </Box>
+          </Box>
+        </ScrollArea>
+      </Box>
 
       <CurrentDelegationModal />
       <DelegationModal />

--- a/src/renderer/pages/Governance/ui/GovernanceReferendumList.tsx
+++ b/src/renderer/pages/Governance/ui/GovernanceReferendumList.tsx
@@ -6,7 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Paths } from '@/shared/routes';
 import { AsyncItem, Box } from '@/shared/ui-kit';
 import { InactiveNetwork } from '@/entities/network';
-import { CompletedReferendums, Filters, OngoingReferendums, networkSelectorModel } from '@/features/governance';
+import { CompletedReferendums, OngoingReferendums, networkSelectorModel } from '@/features/governance';
 import { navigationModel } from '@/features/navigation';
 import { governancePageAggregate } from '../aggregates/governancePage';
 
@@ -40,8 +40,6 @@ export const GovernanceReferendumList = () => {
 
   return (
     <Box gap={4} grow={1}>
-      {isApiConnected && <Filters />}
-
       {isEmptyState && <EmptyGovernance />}
 
       {isNetworkDisabled && <InactiveNetwork active className="grow" />}


### PR DESCRIPTION
## Description
Resolves [#3163](https://github.com/novasamatech/nova-spektr/issues/3163)


The governance page controls (network selector, locks, delegation) and track/vote filters were scrolling with the content, making them inaccessible when users scrolled down through long referendum lists.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
Restructured the governance page layout to keep essential controls and filters always visible at the top while allowing only the referendum content to scroll.

## Screenshots/Recordings
Before the fix:
<img width="1512" height="857" alt="Screenshot 2025-09-01 at 12 31 25" src="https://github.com/user-attachments/assets/010c486d-912c-41ef-b6b0-9c247d78e792" />
After:
<img width="1512" height="856" alt="Screenshot 2025-09-02 at 05 41 31" src="https://github.com/user-attachments/assets/9b14e1ae-2c40-4085-8614-44989f096cfc" />

