### PR TITLE
fix: handle decimal values without leading zeros in formatAmount util

### DIFF
--- a/src/renderer/shared/lib/utils/__tests__/balance.test.ts
+++ b/src/renderer/shared/lib/utils/__tests__/balance.test.ts
@@ -2,7 +2,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 
 import { type AssetBalance, type AssetId, type Balance, type BalanceId, LockTypes } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { formatBalance, stakeableAmountBN, transferableAmountBN, withdrawableAmount } from '../balance';
+import { formatAmount, formatBalance, stakeableAmountBN, transferableAmountBN, withdrawableAmount } from '../balance';
 
 const createBalance = (params: {
   free?: string | number;
@@ -25,6 +25,36 @@ const createBalance = (params: {
 };
 
 describe('shared/lib/onChainUtils/balance', () => {
+  describe('formatAmount', () => {
+    test('should handle regular decimal values', () => {
+      const result1 = formatAmount('1.5', 12);
+      const result2 = formatAmount('123.456', 6);
+
+      expect(result1).toEqual('1500000000000');
+      expect(result2).toEqual('123456000');
+    });
+
+    test('should handle whole numbers', () => {
+      const result1 = formatAmount('1', 12);
+      const result2 = formatAmount('123', 6);
+
+      expect(result1).toEqual('1000000000000');
+      expect(result2).toEqual('123000000');
+    });
+
+    test('should handle decimal values without leading zero', () => {
+      const result1 = formatAmount('.1', 12);
+      const result2 = formatAmount('0.1', 12);
+      const result3 = formatAmount('.5', 10);
+      const result4 = formatAmount('.123456', 6);
+
+      expect(result1).toEqual('100000000000');
+      expect(result2).toEqual('100000000000');
+      expect(result3).toEqual('5000000000');
+      expect(result4).toEqual('123456');
+    });
+  });
+
   describe('formatBalance', () => {
     test('should calculate amount without without float part', () => {
       const { value, suffix, decimalPlaces } = formatBalance('50000000000000', 12);

--- a/src/renderer/shared/lib/utils/balance.ts
+++ b/src/renderer/shared/lib/utils/balance.ts
@@ -23,11 +23,11 @@ export const enum Decimal {
 export const formatAmount = (amount: string, precision: number): string => {
   if (!amount) return ZERO_BALANCE;
 
-  const isDecimalValue = amount.match(/^(\d+)\.(\d+)$/);
+  const isDecimalValue = amount.match(/^(\d*)\.(\d+)$/);
   const bnPrecision = new BN(precision);
   if (isDecimalValue) {
-    const div = new BN(amount.replace(/\.\d*$/, ''));
-    const modString = amount.replace(/^\d+\./, '').slice(0, precision);
+    const div = new BN(amount.replace(/\.\d*$/, '') || '0');
+    const modString = amount.replace(/^\d*\./, '').slice(0, precision);
     const mod = new BN(modString);
 
     return div


### PR DESCRIPTION
Resolves [#3951](https://github.com/novasamatech/nova-spektr/issues/3951)

## Description
Fixes a bug in the transaction confirmation modal where decimal numbers without leading zeros (eg .1 ) were incorrectly displayed as whole numbers on the transaction confirmation screen. The issue occurred because the formatAmount function's regex pattern only matched decimal values with at least one digit before the decimal point, causing values like .1 to fall through to fallback logic that stripped the decimal point.
## Related Issues


## Changes Made

1. Updated regex pattern in formatAmount function from `/^(\d+)\.(\d+)$/` to `/^(\d*)\.(\d+)$/` to allow optional digits before decimal point
2. Added fallback `|| '0' `when extracting integer part to handle empty string case for values like .1
3. Added tests to formatAmount

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
