### PR TITLE
feat(ui-kit): add enableHover to Popover

### DIFF
--- a/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/VaultInfoPopover.tsx
+++ b/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/VaultInfoPopover.tsx
@@ -6,7 +6,7 @@ export const VaultInfoPopover = () => {
   const { t } = useI18n();
 
   return (
-    <Popover>
+    <Popover enableHover>
       <Popover.Trigger>
         <div>
           <Icon name="questionOutline" size={16} />

--- a/src/renderer/shared/ui-kit/Popover/Popover.stories.tsx
+++ b/src/renderer/shared/ui-kit/Popover/Popover.stories.tsx
@@ -57,3 +57,23 @@ export const Controlled: Story = {
     },
   ],
 };
+
+export const Hover: Story = {
+  args: {
+    enableHover: true,
+  },
+  render: args => {
+    return (
+      <Box padding={20}>
+        <Popover {...args}>
+          <Popover.Trigger>
+            <Button>Hover over me</Button>
+          </Popover.Trigger>
+          <Popover.Content>
+            <Box padding={4}>Some content</Box>
+          </Popover.Content>
+        </Popover>
+      </Box>
+    );
+  },
+};

--- a/src/renderer/shared/ui-kit/Popover/Popover.tsx
+++ b/src/renderer/shared/ui-kit/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import * as RadixPopover from '@radix-ui/react-popover';
-import { type PropsWithChildren, createContext, useContext, useMemo } from 'react';
+import { type PropsWithChildren, createContext, useContext, useMemo, useState } from 'react';
 
 import { type XOR } from '@/shared/core';
 import { useTheme } from '../Theme/useTheme';
@@ -11,6 +11,8 @@ type ContextProps = {
   align?: 'start' | 'center' | 'end';
   alignOffset?: number;
   testId?: string;
+  enableHover?: boolean;
+  setHoverOpen?: (open: boolean) => void;
 };
 
 const Context = createContext<ContextProps>({});
@@ -24,6 +26,7 @@ type RootProps = PropsWithChildren<
   ControlledPopoverProps &
     ContextProps & {
       dialog?: boolean;
+      enableHover?: boolean;
     }
 >;
 
@@ -36,16 +39,31 @@ const Root = ({
   align = 'center',
   alignOffset = 0,
   testId = 'Popover',
+  enableHover,
   children,
 }: RootProps) => {
+  const [hoverOpen, setHoverOpen] = useState(false);
+
   const ctx = useMemo(
-    () => ({ side, sideOffset, align, alignOffset, testId }),
-    [side, sideOffset, align, alignOffset, testId],
+    () => ({
+      side,
+      sideOffset,
+      align,
+      alignOffset,
+      testId,
+      enableHover,
+      setHoverOpen: enableHover ? setHoverOpen : undefined,
+    }),
+    [side, sideOffset, align, alignOffset, testId, enableHover, setHoverOpen],
   );
 
   return (
     <Context.Provider value={ctx}>
-      <RadixPopover.Root modal={!dialog} open={open} onOpenChange={onToggle}>
+      <RadixPopover.Root
+        modal={enableHover ? false : !dialog}
+        open={enableHover ? hoverOpen : open}
+        onOpenChange={enableHover ? undefined : onToggle}
+      >
         {children}
       </RadixPopover.Root>
     </Context.Provider>
@@ -53,7 +71,17 @@ const Root = ({
 };
 
 const Trigger = ({ children }: PropsWithChildren) => {
-  return <RadixPopover.Trigger asChild>{children}</RadixPopover.Trigger>;
+  const { enableHover, setHoverOpen } = useContext(Context);
+
+  return (
+    <RadixPopover.Trigger
+      asChild
+      onMouseEnter={enableHover && setHoverOpen ? () => setHoverOpen(true) : undefined}
+      onMouseLeave={enableHover && setHoverOpen ? () => setHoverOpen(false) : undefined}
+    >
+      {children}
+    </RadixPopover.Trigger>
+  );
 };
 
 const Anchor = ({ children }: PropsWithChildren) => {
@@ -62,7 +90,7 @@ const Anchor = ({ children }: PropsWithChildren) => {
 
 const Content = ({ children }: PropsWithChildren) => {
   const { portalContainer } = useTheme();
-  const { align, alignOffset, side, sideOffset, testId } = useContext(Context);
+  const { align, alignOffset, side, sideOffset, testId, enableHover, setHoverOpen } = useContext(Context);
 
   return (
     <RadixPopover.Portal container={portalContainer}>
@@ -76,6 +104,8 @@ const Content = ({ children }: PropsWithChildren) => {
         sideOffset={sideOffset && gridSpaceConverter(sideOffset)}
         data-testid={testId}
         onClick={e => e.stopPropagation()}
+        onMouseEnter={enableHover && setHoverOpen ? () => setHoverOpen(true) : undefined}
+        onMouseLeave={enableHover && setHoverOpen ? () => setHoverOpen(false) : undefined}
       >
         <div className="pointer-events-auto z-50 h-fit max-h-(--radix-popper-available-height) min-h-0 origin-(--radix-popper-transform-origin) overflow-hidden rounded-md border border-token-container-border bg-block-background-default text-body shadow-shadow-2 duration-100 animate-in fade-in zoom-in-95">
           {children}


### PR DESCRIPTION
Resolves #3160 

## Description
Added `enableHover` prop to Popover component to support hover-triggered popovers. Updated vault info popover to show on hover instead of click for better UX.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

1. Added enableHover prop to Popover component
2. Updated VaultInfoPopover to use hover behavior
3. Added hover story to Storybook

## Screenshots/Recordings
<img width="1512" height="856" alt="Screenshot 2025-09-02 at 09 50 42" src="https://github.com/user-attachments/assets/db3945bd-39fc-466d-b72b-0210648aa591" />
