### PR TITLE
feat(governance): add loading state to referendum vote chart

### DIFF
--- a/src/renderer/features/governance/aggregates/list.ts
+++ b/src/renderer/features/governance/aggregates/list.ts
@@ -164,4 +164,5 @@ export const listAggregate = {
   $titles: $chainTitles,
   $isLoading: referendumModel.$isLoading,
   $isTitlesLoading,
+  $isApprovalThresholdsLoading: approveThresholdModel.$getApproveThresholdsPending,
 };

--- a/src/renderer/features/governance/components/ReferendumList/OngoingReferendums.tsx
+++ b/src/renderer/features/governance/components/ReferendumList/OngoingReferendums.tsx
@@ -18,6 +18,7 @@ type Props = {
   referendums: AggregatedReferendum[];
   isLoading: boolean;
   isTitlesLoading: boolean;
+  isApprovalThresholdsLoading: boolean;
   mixLoadingWithData: boolean;
   onSelect: (value: AggregatedReferendum) => void;
 };
@@ -31,7 +32,17 @@ const createPlaceholders = (size: number) => {
 };
 
 export const OngoingReferendums = memo(
-  ({ api, chain, asset, referendums, isLoading, isTitlesLoading, mixLoadingWithData, onSelect }: Props) => {
+  ({
+    api,
+    chain,
+    asset,
+    referendums,
+    isLoading,
+    isTitlesLoading,
+    isApprovalThresholdsLoading,
+    mixLoadingWithData,
+    onSelect,
+  }: Props) => {
     const { t } = useI18n();
 
     const placeholdersCount = isLoading ? Math.min(referendums.length || 4, 20) : Math.max(1, 4 - referendums.length);
@@ -65,6 +76,7 @@ export const OngoingReferendums = memo(
                       asset={asset}
                       referendum={referendum}
                       isTitlesLoading={isTitlesLoading}
+                      isApprovalThresholdsLoading={isApprovalThresholdsLoading}
                       onSelect={onSelect}
                     />
                   </AsyncItem>

--- a/src/renderer/features/governance/components/ReferendumList/ReferendumItem.tsx
+++ b/src/renderer/features/governance/components/ReferendumList/ReferendumItem.tsx
@@ -28,84 +28,90 @@ type Props = {
   asset: Asset;
   referendum: AggregatedReferendum;
   isTitlesLoading: boolean;
+  isApprovalThresholdsLoading?: boolean;
   onSelect: (value: AggregatedReferendum) => void;
 };
 
-export const ReferendumItem = memo(({ api, chain, asset, referendum, isTitlesLoading, onSelect }: Props) => {
-  const { t } = useI18n();
+export const ReferendumItem = memo(
+  ({ api, chain, asset, referendum, isTitlesLoading, isApprovalThresholdsLoading, onSelect }: Props) => {
+    const { t } = useI18n();
 
-  const { referendumId, approvalThreshold } = referendum;
+    const { referendumId, approvalThreshold } = referendum;
 
-  const title = useStoreMap({
-    store: listAggregate.$titles,
-    keys: [referendum.referendumId],
-    fn: (titles, [id]) => titles[id] ?? null,
-  });
+    const title = useStoreMap({
+      store: listAggregate.$titles,
+      keys: [referendum.referendumId],
+      fn: (titles, [id]) => titles[id] ?? null,
+    });
 
-  const identity = useStoreMap({
-    store: proposerIdentityAggregate.$proposers,
-    keys: [referendum.votedByDelegates],
-    fn: (proposers, [delegates]) => listService.getMappedIdentity(proposers, delegates),
-  });
+    const identity = useStoreMap({
+      store: proposerIdentityAggregate.$proposers,
+      keys: [referendum.votedByDelegates],
+      fn: (proposers, [delegates]) => listService.getMappedIdentity(proposers, delegates),
+    });
 
-  const voteFractions =
-    referendumService.isOngoing(referendum) && approvalThreshold
-      ? votingService.getVoteFractions(referendum.tally, approvalThreshold.value)
-      : null;
+    const voteFractions =
+      referendumService.isOngoing(referendum) && approvalThreshold
+        ? votingService.getVoteFractions(referendum.tally, approvalThreshold.value)
+        : null;
 
-  const titleNode =
-    title ||
-    (isTitlesLoading ? (
-      <Skeleton height="1em" width="28ch" />
-    ) : (
-      t('governance.referendums.referendumTitle', { index: referendumId })
-    ));
+    const titleNode =
+      title ||
+      (isTitlesLoading ? (
+        <Skeleton height="1em" width="28ch" />
+      ) : (
+        t('governance.referendums.referendumTitle', { index: referendumId })
+      ));
 
-  const referendumPath = generatePath(Paths.GOVERNANCE_REFERENDUM, {
-    chainId: networkUtils.chainNameToUrl(chain.name),
-    referendumId,
-  });
-  const referendumLink = getAppUrl(referendumPath);
+    const referendumPath = generatePath(Paths.GOVERNANCE_REFERENDUM, {
+      chainId: networkUtils.chainNameToUrl(chain.name),
+      referendumId,
+    });
+    const referendumLink = getAppUrl(referendumPath);
 
-  return (
-    <ListItem onClick={() => onSelect(referendum)}>
-      <div className="flex w-full items-center gap-x-2">
-        <VotingStatusBadge referendum={referendum} />
+    return (
+      <ListItem onClick={() => onSelect(referendum)}>
+        <div className="flex w-full items-center gap-x-2">
+          <VotingStatusBadge referendum={referendum} />
 
-        <ReferendumEndTimer status={referendum.status} endBlock={referendum.end} api={api} />
+          <ReferendumEndTimer status={referendum.status} endBlock={referendum.end} api={api} />
 
-        <div className="ml-auto flex text-text-secondary">
-          {referendumId && (
-            <FootnoteText className="text-inherit" testId={TEST_IDS.GOVERNANCE.PROPOSAL_ID}>
-              #{referendumId}
-            </FootnoteText>
-          )}
-          {referendumService.isOngoing(referendum) && <TrackInfo trackId={referendum.track} />}
-          <Copy value={referendumLink.href} notification={t('governance.referendums.linkCopied')}>
-            <IconButton className="ml-2 shrink-0 p-0 text-icon-default" name="export" />
-          </Copy>
+          <div className="ml-auto flex text-text-secondary">
+            {referendumId && (
+              <FootnoteText className="text-inherit" testId={TEST_IDS.GOVERNANCE.PROPOSAL_ID}>
+                #{referendumId}
+              </FootnoteText>
+            )}
+            {referendumService.isOngoing(referendum) && <TrackInfo trackId={referendum.track} />}
+            <Copy value={referendumLink.href} notification={t('governance.referendums.linkCopied')}>
+              <IconButton className="ml-2 shrink-0 p-0 text-icon-default" name="export" />
+            </Copy>
+          </div>
         </div>
-      </div>
 
-      <div className="flex w-full items-start gap-x-6">
-        <HeadlineText className="pointer-events-auto flex-1">{titleNode}</HeadlineText>
-        <div className="shrink-0 basis-[200px]">
-          {voteFractions ? (
-            <ReferendumVoteChart aye={voteFractions.aye} nay={voteFractions.nay} pass={voteFractions.pass} />
-          ) : null}
+        <div className="flex w-full items-start gap-x-6">
+          <HeadlineText className="pointer-events-auto flex-1">{titleNode}</HeadlineText>
+          <div className="shrink-0 basis-[200px]">
+            {voteFractions && (
+              <ReferendumVoteChart aye={voteFractions.aye} nay={voteFractions.nay} pass={voteFractions.pass} />
+            )}
+            {!voteFractions && referendumService.isOngoing(referendum) && isApprovalThresholdsLoading && (
+              <Skeleton height={4} />
+            )}
+          </div>
         </div>
-      </div>
 
-      <Box width="max-content">
-        <VotedBy
-          direction="row"
-          chain={chain}
-          asset={asset}
-          identity={identity}
-          delegates={referendum.votedByDelegates}
-          castingVotes={referendum.voting.votes}
-        />
-      </Box>
-    </ListItem>
-  );
-});
+        <Box width="max-content">
+          <VotedBy
+            direction="row"
+            chain={chain}
+            asset={asset}
+            identity={identity}
+            delegates={referendum.votedByDelegates}
+            castingVotes={referendum.voting.votes}
+          />
+        </Box>
+      </ListItem>
+    );
+  },
+);

--- a/src/renderer/pages/Governance/aggregates/governancePage.ts
+++ b/src/renderer/pages/Governance/aggregates/governancePage.ts
@@ -107,6 +107,7 @@ export const governancePageAggregate = {
   $isSearching: filterModel.$query.map((x) => x.length > 0),
   $isLoading: listAggregate.$isLoading,
   $isTitlesLoading: listAggregate.$isTitlesLoading,
+  $isApprovalThresholdsLoading: listAggregate.$isApprovalThresholdsLoading,
 
   gates: {
     flow,

--- a/src/renderer/pages/Governance/ui/GovernanceReferendumList.tsx
+++ b/src/renderer/pages/Governance/ui/GovernanceReferendumList.tsx
@@ -20,6 +20,7 @@ export const GovernanceReferendumList = () => {
 
   const isLoading = useUnit(governancePageAggregate.$isLoading);
   const isTitlesLoading = useUnit(governancePageAggregate.$isTitlesLoading);
+  const isApprovalThresholdsLoading = useUnit(governancePageAggregate.$isApprovalThresholdsLoading);
   const isSearching = useUnit(governancePageAggregate.$isSearching);
   const displayedReferendums = useUnit(governancePageAggregate.$displayedReferendums);
   const ongoing = useUnit(governancePageAggregate.$ongoing);
@@ -53,6 +54,7 @@ export const GovernanceReferendumList = () => {
             referendums={ongoing}
             isLoading={isLoading}
             isTitlesLoading={isTitlesLoading}
+            isApprovalThresholdsLoading={isApprovalThresholdsLoading}
             mixLoadingWithData={isLoadingState}
             onSelect={({ referendumId }) => navigate(referendumId)}
           />


### PR DESCRIPTION
Resolves [#4517](https://github.com/novasamatech/nova-spektr/issues/4517)

## Description
Added skeleton loading indicators for referendum vote charts. Previously, referendum items displayed with empty vote chart areas while approval thresholds loaded, then suddenly showed charts when data arrived.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
Added skeleton loading indicators for referendum vote charts

## Screenshots/Recordings
<img width="1512" height="857" alt="Screenshot 2025-09-04 at 04 19 15" src="https://github.com/user-attachments/assets/656be81b-6b6f-4d9c-962b-2d5674185f40" />
