### PR TITLE
fix: add fiat values to governance lock and delegation blocks

### DIFF
--- a/src/renderer/features/governance/components/Delegations/TotalDelegation.tsx
+++ b/src/renderer/features/governance/components/Delegations/TotalDelegation.tsx
@@ -7,6 +7,7 @@ import { useConfirmContext } from '@/shared/providers';
 import { FootnoteText, Icon, Plate, SmallTitleText } from '@/shared/ui';
 import { AssetBalance } from '@/shared/ui-entities';
 import { Skeleton } from '@/shared/ui-kit';
+import { AssetFiatBalance } from '@/entities/price';
 import { walletUtils } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
 import { EmptyAccountMessage } from '@/features/emptyList';
@@ -30,6 +31,8 @@ export const TotalDelegation = ({ onClick }: Props) => {
   const activeWallet = useUnit(walletSelect.$selectedWallet);
 
   const [showWalletDetails, setShowWalletDetails] = useState(false);
+
+  const delegatedVotingPowerString = delegatedVotingPower.toString();
 
   const handleClick = () => {
     if (hasAccount && canDelegate) {
@@ -81,7 +84,10 @@ export const TotalDelegation = ({ onClick }: Props) => {
             )}
 
             {!isLoading && nonNullable(network) && !delegatedVotingPower.isZero() && (
-              <AssetBalance className="text-small-title" value={delegatedVotingPower} asset={network.asset} />
+              <div className="flex flex-col gap-y-0.5">
+                <AssetBalance className="text-small-title" value={delegatedVotingPowerString} asset={network.asset} />
+                <AssetFiatBalance amount={delegatedVotingPowerString} asset={network.asset} />
+              </div>
             )}
           </div>
 

--- a/src/renderer/features/governance/components/Locks/Locks.tsx
+++ b/src/renderer/features/governance/components/Locks/Locks.tsx
@@ -4,6 +4,7 @@ import { useI18n } from '@/shared/i18n';
 import { FootnoteText, Icon, Plate } from '@/shared/ui';
 import { AssetBalance } from '@/shared/ui-entities';
 import { Skeleton } from '@/shared/ui-kit';
+import { AssetFiatBalance } from '@/entities/price';
 import { locksModel } from '../../model/locks';
 import { networkSelectorModel } from '../../model/networkSelector';
 import { unlockModel } from '../../model/unlock/unlock';
@@ -21,6 +22,8 @@ export const Locks = ({ onClick }: Props) => {
   const isUnlockable = useUnit(unlockModel.$isUnlockable);
   const isUnlockLoading = useUnit(unlockModel.$isLoading);
 
+  const totalLockString = totalLock.toString();
+
   return (
     <button disabled={isLoading || totalLock.isZero()} onClick={onClick}>
       <Plate className="flex h-[90px] w-[240px] items-center justify-between px-4 pt-3 pb-4.5">
@@ -35,7 +38,10 @@ export const Locks = ({ onClick }: Props) => {
           </div>
           {isLoading && <Skeleton width={30} height={4.5} />}
           {!isLoading && network && (
-            <AssetBalance className="text-small-title" value={totalLock.toString()} asset={network.asset} />
+            <div className="flex flex-col gap-y-0.5">
+              <AssetBalance className="text-small-title" value={totalLockString} asset={network.asset} />
+              <AssetFiatBalance amount={totalLockString} asset={network.asset} />
+            </div>
           )}
         </div>
         <Icon name="arrowRight" />


### PR DESCRIPTION
## Description
Add fiat currency values to Governance page Lock and Delegated voting power blocks.

## Related Issues
Closes #3162

## Changes Made
Updated Locks.tsx to show fiat value alongside locked DOT amount
Updated TotalDelegation.tsx to show fiat value alongside delegated voting power

## Screenshots/Recordings
Before:
<img width="797" height="173" alt="Снимок экрана 2025-09-04 в 18 09 04" src="https://github.com/user-attachments/assets/21b23828-2413-4b4b-b659-94295cfacaa4" />

After:
<img width="827" height="175" alt="Снимок экрана 2025-09-04 в 18 10 54" src="https://github.com/user-attachments/assets/9f4eb618-d194-48d1-a31e-a8bee0683652" />

