### PR TITLE
fix: close modals before redirecting to operations in flexible multisig edit flow

### DIFF
--- a/src/renderer/features/flexible-change-signatories/model/change-signatories-model.ts
+++ b/src/renderer/features/flexible-change-signatories/model/change-signatories-model.ts
@@ -338,6 +338,12 @@ sample({
 
 sample({
   clock: viewOperation,
+  fn: () => ({ wallet: null }),
+  target: flow.close,
+});
+
+sample({
+  clock: viewOperation,
   fn: () => Paths.OPERATIONS,
   target: navigationModel.events.navigateTo,
 });
@@ -361,12 +367,9 @@ export const changeSignatoriesModel = {
   $canSubmit,
   $route,
   $errors,
-
   $fee,
   $isLoading,
-
   stepChanged,
   viewOperation,
-
   flow,
 };

--- a/src/renderer/features/flexible-change-signatories/ui/ChangeSignatories.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/ChangeSignatories.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { type ComponentProps, type PropsWithChildren, useEffect, useState } from 'react';
+import { type ComponentProps, type PropsWithChildren, useState } from 'react';
 
 import { type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -55,20 +55,13 @@ export const ChangeSignatories = ({ wallet, onClose, children }: Props) => {
     onClose?.();
   };
 
-  useEffect(() => {
-    if (step === Step.NONE) {
-      setIsModalOpen(false);
-    }
-  }, [step]);
-
   const onToggle = (isOpen: boolean) => {
     if (isOpen) {
       setIsModalOpen(true);
       changeSignatoriesModel.flow.open({ wallet });
-      return;
+    } else {
+      closeModal();
     }
-
-    closeModal();
   };
 
   const onSubmit = () => {
@@ -77,7 +70,13 @@ export const ChangeSignatories = ({ wallet, onClose, children }: Props) => {
   };
 
   if (isStep(step, Step.SUBMIT)) {
-    return <OperationSubmitWithAction isOpen={isModalOpen} onClose={closeModal} onSubmit={onSubmit} />;
+    return (
+      <OperationSubmitWithAction
+        isOpen={isModalOpen}
+        onClose={() => changeSignatoriesModel.stepChanged(Step.CONFIRM)}
+        onSubmit={onSubmit}
+      />
+    );
   }
 
   return (

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -4,7 +4,7 @@ import { type ReactNode, useMemo, useState } from 'react';
 import { type FlexibleMultisigWallet, type MultisigWallet, WalletType } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { useToggle } from '@/shared/lib/hooks';
+import { useModalClose, useToggle } from '@/shared/lib/hooks';
 import { assert, isEthereumAccountId, nonNullable, toAddress } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, HeadlineText, Icon, IconButton, Separator } from '@/shared/ui';
 import { AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
@@ -41,6 +41,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const accountList = useUnit(accounts.$list);
   const proxiesCount = useUnit(walletDetailsModel.$proxiesCount);
 
+  const [isModalOpen, closeModal] = useModalClose(true, onClose);
   const [isRenameInputOpen, toggleIsRenameInputOpen] = useToggle();
   const [tab, setTab] = useState('1');
 
@@ -68,7 +69,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const actions: WalletAction[] = [
     {
       component: (
-        <ChangeSignatories wallet={wallet}>
+        <ChangeSignatories wallet={wallet} onClose={closeModal}>
           <Action title={t('walletDetails.multisig.changeSignatories')} icon="changeSignatories" />
         </ChangeSignatories>
       ),
@@ -182,7 +183,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   }
 
   return (
-    <Modal size="mdlg" height="full" isOpen onToggle={open => !open && onClose()}>
+    <Modal size="mdlg" height="full" isOpen={isModalOpen} onToggle={closeModal}>
       <Modal.Title close>{t('walletDetails.common.title')}</Modal.Title>
       <Modal.HeaderContent>
         <div className="mb-6 flex flex-col gap-y-2.5 px-5">


### PR DESCRIPTION
Resolves #4534 

## Description
Fixed the modal management flow in the flexible multisig edit signatories feature. Previously, when users completed the flexible multisig edit flow (edit → change signatories → submit → sign → success → view operation), the modals would stay open after redirecting to the operations page. 

Additionally, transaction errors would incorrectly close all modals, preventing users from retrying failed operations.

This PR implements proper modal lifecycle management by distinguishing between success and error scenarios, on success, all modals close before navigation, on error, modals remain open to allow users to retry the operation.


## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- Close modals before redirect on successful operations
- Keep modals open on transaction errors for retry

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
