### PR TITLE
feat: update sorting for tokens on portfolio, add utility tokens priority

### DIFF
--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -1,6 +1,6 @@
 import { BN_ZERO } from '@polkadot/util';
 import { default as BigNumber } from 'bignumber.js';
-import { concat, orderBy, sortBy } from 'lodash';
+import { concat } from 'lodash';
 
 import { isKusama, isNameStartsWithNumber, isPolkadot } from '@/shared/api/network/lib/utils';
 import { sumValues } from '@/shared/api/network/service/chainsService';
@@ -158,6 +158,19 @@ function hideZeroBalances(hideZeroBalance: boolean, activeTokensWithBalance: Ass
   return result;
 }
 
+/**
+ * Sorts tokens by balance with the following priority hierarchy:
+ *
+ * 1. Tokens with fiat balance (highest fiat value first)
+ * 2. Relay chains (Polkadot/Kusama) with balance
+ * 3. Relay chains without balance
+ * 4. Parachains with balance
+ * 5. Parachains without balance
+ * 6. Number-named chains with balance
+ * 7. Number-named chains without balance
+ * 8. Test networks with balance
+ * 9. Test networks without balance
+ */
 function sortTokensByBalance(
   tokens: AssetByChains[],
   assetsPrices: PriceObject | null,
@@ -179,7 +192,7 @@ function sortTokensByBalance(
     const hasBalance = !tokenTotal.isZero();
     let collection: AssetByChainsWithBalance[] = [];
 
-    token.chains.sort((a, b) => chainBalanceSorter(a, b, assetsPrices, token, currency));
+    token.chains.sort((a, b) => compareChainsByFiatAndBalance(a, b, assetsPrices, token, currency));
 
     if ((isPolkadot(token.name) || isKusama(token.name)) && !token.isTestToken) {
       collection = hasBalance ? relaychains.withBalance : relaychains.noBalance;
@@ -206,15 +219,15 @@ function sortTokensByBalance(
   }
 
   return concat<AssetByChainsWithBalance>(
-    orderBy(relaychains.withBalance, 'name', ['desc']),
-    orderBy(relaychains.noBalance, 'name', ['desc']),
     tokensWithFiatBalance.sort((a, b) => (new BigNumber(b.fiatBalance).lt(new BigNumber(a.fiatBalance)) ? -1 : 1)),
-    parachains.withBalance.sort((a, b) => (b.tokenBalance!.lt(a.tokenBalance!) ? -1 : 1)),
-    sortBy(parachains.noBalance, 'symbol'),
-    sortBy(numberchains.withBalance, 'symbol'),
-    sortBy(numberchains.noBalance, 'symbol'),
-    sortBy(testnets.withBalance, 'symbol'),
-    sortBy(testnets.noBalance, 'symbol'),
+    relaychains.withBalance.sort(compareTokensByUtilityAndBalance),
+    relaychains.noBalance.sort(compareTokensByUtilityAndBalance),
+    parachains.withBalance.sort(compareTokensByUtilityAndBalance),
+    parachains.noBalance.sort(compareTokensByUtilityAndBalance),
+    numberchains.withBalance.sort(compareTokensByUtilityAndBalance),
+    numberchains.noBalance.sort(compareTokensByUtilityAndBalance),
+    testnets.withBalance.sort(compareTokensByUtilityAndBalance),
+    testnets.noBalance.sort(compareTokensByUtilityAndBalance),
   );
 }
 
@@ -222,7 +235,48 @@ const isPolkadotOrKusama = (name: string): boolean => {
   return isPolkadot(name) || isKusama(name);
 };
 
-function chainBalanceSorter(
+const isUtilityToken = (token: AssetByChains): boolean => {
+  return token.chains.some((chain) => chain.assetId === 0);
+};
+
+/**
+ * Sorts tokens within the same category using priority rules:
+ *
+ * 1. Relay chains (Polkadot/Kusama) come first
+ * 2. Utility tokens (assetId === 0) come before other tokens
+ * 3. Tokens with higher balance come before tokens with lower balance
+ * 4. Alphabetical order by symbol as final tiebreaker
+ */
+function compareTokensByUtilityAndBalance(first: AssetByChainsWithBalance, second: AssetByChainsWithBalance) {
+  const isFirstPolkadotOrKusama = isPolkadotOrKusama(first.name);
+  const isSecondPolkadotOrKusama = isPolkadotOrKusama(second.name);
+
+  if (isFirstPolkadotOrKusama && !isSecondPolkadotOrKusama) return -1;
+  if (!isFirstPolkadotOrKusama && isSecondPolkadotOrKusama) return 1;
+
+  const isFirstUtility = isUtilityToken(first);
+  const isSecondUtility = isUtilityToken(second);
+
+  if (isFirstUtility && !isSecondUtility) return -1;
+  if (!isFirstUtility && isSecondUtility) return 1;
+
+  if (first.tokenBalance && second.tokenBalance) {
+    if (first.tokenBalance.gt(second.tokenBalance)) return -1;
+    if (first.tokenBalance.lt(second.tokenBalance)) return 1;
+  }
+
+  return first.symbol.localeCompare(second.symbol);
+}
+
+/**
+ * Sorts chains within a token by the following criteria:
+ *
+ * 1. Relay chains (Polkadot/Kusama) appear first
+ * 2. Chains with higher fiat balance come before chains with lower fiat balance
+ * 3. Chains with higher token balance come before chains with lower token balance
+ * 4. Alphabetical order as final tiebreaker
+ */
+function compareChainsByFiatAndBalance(
   first: AssetChain,
   second: AssetChain,
   assetsPrices: PriceObject | null,


### PR DESCRIPTION
Resolves [#4476](https://github.com/novasamatech/nova-spektr/issues/4476)

## Description
Enhance token sorting with utility token prioritization.

General sorting logic:

1. Tokens with fiat balance (highest fiat value first)
2. Relay chains (Polkadot/Kusama) with balance
3. Relay chains without balance
4. Parachains with balance
5. Parachains without balance
6. Number-named chains with balance
7. Number-named chains without balance
8. Test networks with balance
9. Test networks without balance

(NEW) Within-Category Sorting (applied to every category except for _1. Tokens with fiat balance_):

1. Relay chains (Polkadot/Kusama) come first
2. Utility tokens (assetId === 0) prioritized over other tokens
3. Higher balance amounts ranked before lower amounts
4. Alphabetical order by symbol as final tiebreaker


## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
- Added compareTokensByUtilityAndBalance
- Added sorting functions descriptions

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
