### PR TITLE
fix: division by zero error in referendum threshold calculation

### DIFF
--- a/src/renderer/entities/governance/lib/opengovThresholdService.ts
+++ b/src/renderer/entities/governance/lib/opengovThresholdService.ts
@@ -1,4 +1,4 @@
-import { type BN, BN_BILLION, bnMax, bnMin } from '@polkadot/util';
+import { type BN, BN_BILLION, BN_ZERO, bnMax, bnMin } from '@polkadot/util';
 
 import { type AyesParams, type SupportParams } from '@/shared/api/governance';
 import { type BlockHeight, type VotingCurve, type VotingThreshold } from '@/shared/core';
@@ -27,7 +27,8 @@ function supportThreshold({
 
 function ayesFractionThreshold({ approvalCurve, tally, blockDifference, decisionPeriod }: AyesParams): VotingThreshold {
   const threshold = getThreshold(approvalCurve, blockDifference, decisionPeriod);
-  const ayeFraction = BN_BILLION.mul(tally.ayes).div(tally.ayes.add(tally.nays));
+  const total = tally.ayes.add(tally.nays);
+  const ayeFraction = total.isZero() ? BN_ZERO : BN_BILLION.mul(tally.ayes).div(total);
 
   return {
     value: threshold,


### PR DESCRIPTION
Resolves [#4503](https://github.com/novasamatech/nova-spektr/issues/4503)

## Description
The `ayesFractionThreshold` function was calculating the fraction of "Aye" votes by dividing `tally.ayes` by the total votes (`tally.ayes + tally.nays`). When referendums had no votes yet (both values were zero), this caused a division by zero error that crashed the threshold calculation batch, preventing some referendum charts from appearing in the UI.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
- Added a zero-check before division

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
Charts now display gray instead of crashing when no votes exist

<img width="795" height="367" alt="Screenshot 2025-09-08 at 10 29 17" src="https://github.com/user-attachments/assets/2aad4b6b-700f-4151-b122-0a6bb23bf57b" />

