### PR TITLE
fix: reorder dot\ksm sorting

### DIFF
--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -194,15 +194,15 @@ function sortTokensByBalance(
 
     token.chains.sort((a, b) => compareChainsByFiatAndBalance(a, b, assetsPrices, token, currency));
 
-    if ((isPolkadot(token.name) || isKusama(token.name)) && !token.isTestToken) {
-      collection = hasBalance ? relaychains.withBalance : relaychains.noBalance;
-      collection.push(token);
+    if (fiatBalance.gt(0) && !token.isTestToken) {
+      tokensWithFiatBalance.push({ ...token, fiatBalance: fiatBalance.toString() });
 
       continue;
     }
 
-    if (fiatBalance.gt(0) && !token.isTestToken) {
-      tokensWithFiatBalance.push({ ...token, fiatBalance: fiatBalance.toString() });
+    if ((isPolkadot(token.name) || isKusama(token.name)) && !token.isTestToken) {
+      collection = hasBalance ? relaychains.withBalance : relaychains.noBalance;
+      collection.push(token);
 
       continue;
     }


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

1. Wrong order of checks: The code was checking if a token is DOT/KSM before checking if it has fiat balance
2. Early categorization: DOT/KSM tokens were immediately categorized into the relaychains group (middle priority) and the loop continued with continue
3. Missed fiat balance check: The fiat balance check happened after DOT/KSM tokens were already categorized, so they never made it to the tokensWithFiatBalance group (highest priority)


## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->
closes #4476

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

Fiat balance check first: Now the code checks if (fiatBalance.gt(0) && !token.isTestToken) before checking if it's DOT/KSM

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

Before:
<img width="788" height="1230" alt="Screenshot 2025-09-09 at 13 49 35" src="https://github.com/user-attachments/assets/90bcb553-3263-493d-85d1-7cc0b3de993e" />

After:
<img width="797" height="1191" alt="Screenshot 2025-09-09 at 13 49 48" src="https://github.com/user-attachments/assets/045accef-f43f-4b5d-8f1f-939ddcfedd7a" />

