### PR TITLE
fix: hydrate multisig operations

### DIFF
--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -34,7 +34,7 @@ const removeTransactionsFx = createEffect((operations: MultisigOperation[]) => {
 });
 
 const syncOperationsFx = createQueuedEffect(async (operations: MultisigOperation[]) => {
-  await storageService.multisigOperations.updateAll(operations.map(serializeOperation));
+  await storageService.multisigOperations.insertAll(operations.map(serializeOperation));
 });
 
 type UpdateCallDataParams = {

--- a/src/renderer/entities/transaction/hooks/useTransactionAsset.ts
+++ b/src/renderer/entities/transaction/hooks/useTransactionAsset.ts
@@ -17,10 +17,24 @@ export const useTransactionAsset = (operation: MultisigOperation) => {
   });
 
   if (operation.transaction && chain) {
-    if (operation.transaction.args.assetId && api) {
-      return getAssetByTypeExtras(api, chain.assets, operation.transaction.args.assetId);
+    if (operation.transaction.args.assetId) {
+      const targetAssetId = operation.transaction.args.assetId;
+
+      const foundAsset = chain.assets.find((asset) => {
+        return asset.typeExtras && 'assetId' in asset.typeExtras && asset.typeExtras.assetId === targetAssetId;
+      });
+
+      if (foundAsset) {
+        return foundAsset;
+      }
+
+      if (api) {
+        return getAssetByTypeExtras(api, chain.assets, targetAssetId);
+      }
+
+      return null;
     } else {
-      return getAssetById(operation.transaction.args.asset, chain?.assets) ?? null;
+      return getAssetById(operation.transaction.args.asset, chain.assets) ?? null;
     }
   }
 


### PR DESCRIPTION
Resolves [#4551](https://github.com/novasamatech/nova-spektr/issues/4551)

## Description
Fixed hydration issues with multisig operations where operations weren't being properly persisted, and optimized asset loading to avoid unnecessary API calls when asset data is already available locally.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

1. Fixed multisig operations storage by changing from updateAll() to insertAll() to handle both new and existing records during hydration
2. Optimized asset resolution in useTransactionAsset hook by checking local chain data before making API calls

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
