### PR TITLE
feat: filter flex mustisig accounts by chain, show proxy balance instead of msig balance for flex msigs

### DIFF
--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -20,6 +20,7 @@ import {
 } from '@/shared/ui-entities';
 import { balanceUtils } from '@/entities/balance';
 import { networkUtils } from '@/entities/network';
+import { accountUtils } from '@/entities/wallet';
 import { type AnyTransaction } from '../transaction/types';
 
 import {
@@ -109,6 +110,19 @@ function isAccountAvailableOnChain(account: AnyAccount, chain: Chain) {
 
 function filterAccountsOnChain(accounts: AnyAccount[], chain: Chain) {
   return accounts.filter(account => isAccountAvailableOnChain(account, chain));
+}
+
+function filterAccountsAvailableForChain(accounts: AnyAccount[], chain: Chain): AnyAccount[] {
+  return accounts.filter(account => {
+    if (!isAccountAvailableOnChain(account, chain)) return false;
+    if (accountUtils.isFlexibleProxiedAccount(account)) {
+      return account.chainId === chain.chainId;
+    }
+    if (accountUtils.isFlexibleMultisigAccount(account)) {
+      return account.chainId === chain.chainId;
+    }
+    return true;
+  });
 }
 
 function filterAccountsByWallet(accounts: AnyAccount[], walletId: number) {
@@ -414,6 +428,7 @@ export const accountService = {
   hasPermissionToMakeActions,
 
   filterAccountsOnChain,
+  filterAccountsAvailableForChain,
   filterAccountsByWallet,
 
   // graph

--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -20,7 +20,6 @@ import {
 } from '@/shared/ui-entities';
 import { balanceUtils } from '@/entities/balance';
 import { networkUtils } from '@/entities/network';
-import { accountUtils } from '@/entities/wallet';
 import { type AnyTransaction } from '../transaction/types';
 
 import {
@@ -110,19 +109,6 @@ function isAccountAvailableOnChain(account: AnyAccount, chain: Chain) {
 
 function filterAccountsOnChain(accounts: AnyAccount[], chain: Chain) {
   return accounts.filter(account => isAccountAvailableOnChain(account, chain));
-}
-
-function filterAccountsAvailableForChain(accounts: AnyAccount[], chain: Chain): AnyAccount[] {
-  return accounts.filter(account => {
-    if (!isAccountAvailableOnChain(account, chain)) return false;
-    if (accountUtils.isFlexibleProxiedAccount(account)) {
-      return account.chainId === chain.chainId;
-    }
-    if (accountUtils.isFlexibleMultisigAccount(account)) {
-      return account.chainId === chain.chainId;
-    }
-    return true;
-  });
 }
 
 function filterAccountsByWallet(accounts: AnyAccount[], walletId: number) {
@@ -428,7 +414,6 @@ export const accountService = {
   hasPermissionToMakeActions,
 
   filterAccountsOnChain,
-  filterAccountsAvailableForChain,
   filterAccountsByWallet,
 
   // graph

--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -24,7 +24,6 @@ import {
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount, accountService } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
-import { accountUtils } from '@/entities/wallet';
 
 import { type AssetByChainsWithBalance, type AssetByChainsWithFiatBalance, type AssetChain } from './types';
 
@@ -73,13 +72,11 @@ function sumTokenBalances(a: PortfolioTokenBalance, b: PortfolioTokenBalance): P
 }
 
 function getSelectedAccountIds(accounts: AnyAccount[], chain: Chain): AccountId[] {
-  const availableAccounts = accountService.filterAccountsAvailableForChain(accounts, chain);
-
-  return availableAccounts.reduce<AccountId[]>((acc, account) => {
-    if (accountUtils.isFlexibleMultisigAccount(account)) {
-      return acc;
+  return accounts.reduce<AccountId[]>((acc, account) => {
+    if (accountService.isAccountAvailableOnChain(account, chain)) {
+      acc.push(account.accountId);
     }
-    acc.push(account.accountId);
+
     return acc;
   }, []);
 }

--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -24,6 +24,7 @@ import {
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount, accountService } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
+import { accountUtils } from '@/entities/wallet';
 
 import { type AssetByChainsWithBalance, type AssetByChainsWithFiatBalance, type AssetChain } from './types';
 
@@ -73,10 +74,13 @@ function sumTokenBalances(a: PortfolioTokenBalance, b: PortfolioTokenBalance): P
 
 function getSelectedAccountIds(accounts: AnyAccount[], chain: Chain): AccountId[] {
   return accounts.reduce<AccountId[]>((acc, account) => {
-    if (accountService.isAccountAvailableOnChain(account, chain)) {
-      acc.push(account.accountId);
+    if (!accountService.isAccountAvailableOnChain(account, chain)) {
+      return acc;
     }
-
+    if (accountUtils.isFlexibleMultisigAccount(account)) {
+      return acc;
+    }
+    acc.push(account.accountId);
     return acc;
   }, []);
 }

--- a/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/lib/tokensService.ts
@@ -24,6 +24,7 @@ import {
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount, accountService } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
+import { accountUtils } from '@/entities/wallet';
 
 import { type AssetByChainsWithBalance, type AssetByChainsWithFiatBalance, type AssetChain } from './types';
 
@@ -72,11 +73,13 @@ function sumTokenBalances(a: PortfolioTokenBalance, b: PortfolioTokenBalance): P
 }
 
 function getSelectedAccountIds(accounts: AnyAccount[], chain: Chain): AccountId[] {
-  return accounts.reduce<AccountId[]>((acc, account) => {
-    if (accountService.isAccountAvailableOnChain(account, chain)) {
-      acc.push(account.accountId);
-    }
+  const availableAccounts = accountService.filterAccountsAvailableForChain(accounts, chain);
 
+  return availableAccounts.reduce<AccountId[]>((acc, account) => {
+    if (accountUtils.isFlexibleMultisigAccount(account)) {
+      return acc;
+    }
+    acc.push(account.accountId);
     return acc;
   }, []);
 }

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -101,7 +101,7 @@ const $tokens = combine(
         const chain = chains[tokenChain.chainId];
         if (!chain) return false;
 
-        const availableAccounts = accountService.filterAccountsAvailableForChain(accounts, chain);
+        const availableAccounts = accountService.filterAccountsOnChain(accounts, chain);
 
         return availableAccounts.length > 0;
       });
@@ -138,7 +138,7 @@ const $activeTokens = combine(
         if (nullable(chain)) return false;
         if (networkUtils.isDisabledConnection(connection)) return false;
 
-        const availableAccounts = accountService.filterAccountsAvailableForChain(filteredAccounts, chain);
+        const availableAccounts = accountService.filterAccountsOnChain(filteredAccounts, chain);
 
         return availableAccounts.length > 0;
       });

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -100,7 +100,10 @@ const $tokens = combine(
       const filteredChains = token.chains.filter((tokenChain) => {
         const chain = chains[tokenChain.chainId];
         if (!chain) return false;
-        return accountService.filterAccountsOnChain(accounts, chain).length > 0;
+
+        const availableAccounts = accountService.filterAccountsAvailableForChain(accounts, chain);
+
+        return availableAccounts.length > 0;
       });
 
       if (filteredChains.length === 0) continue;
@@ -135,7 +138,9 @@ const $activeTokens = combine(
         if (nullable(chain)) return false;
         if (networkUtils.isDisabledConnection(connection)) return false;
 
-        return accountService.filterAccountsOnChain(filteredAccounts, chain).length > 0;
+        const availableAccounts = accountService.filterAccountsAvailableForChain(filteredAccounts, chain);
+
+        return availableAccounts.length > 0;
       });
 
       if (filteredChains.length === 0) continue;

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -101,9 +101,7 @@ const $tokens = combine(
         const chain = chains[tokenChain.chainId];
         if (!chain) return false;
 
-        const availableAccounts = accountService.filterAccountsOnChain(accounts, chain);
-
-        return availableAccounts.length > 0;
+        return accountService.filterAccountsOnChain(accounts, chain).length > 0;
       });
 
       if (filteredChains.length === 0) continue;
@@ -138,9 +136,7 @@ const $activeTokens = combine(
         if (nullable(chain)) return false;
         if (networkUtils.isDisabledConnection(connection)) return false;
 
-        const availableAccounts = accountService.filterAccountsOnChain(filteredAccounts, chain);
-
-        return availableAccounts.length > 0;
+        return accountService.filterAccountsOnChain(filteredAccounts, chain).length > 0;
       });
 
       if (filteredChains.length === 0) continue;

--- a/src/renderer/features/multisig-wallet/index.tsx
+++ b/src/renderer/features/multisig-wallet/index.tsx
@@ -44,7 +44,11 @@ accountSDK(multisigWalletFeature, {
     }
 
     if (accountUtils.isFlexibleMultisigAccount(account)) {
-      return networkUtils.isMultisigSupported(chain.options) && networkUtils.isPureProxySupported(chain.options);
+      return (
+        accountService.isChainMatch(account, chain) &&
+        networkUtils.isMultisigSupported(chain.options) &&
+        networkUtils.isPureProxySupported(chain.options)
+      );
     }
 
     if (accountUtils.isFlexibleProxiedAccount(account)) {


### PR DESCRIPTION
Resolves [#4522](https://github.com/novasamatech/nova-spektr/issues/4522)

## Description
Fixes the token-centric portfolio view for flexible multisig accounts by ensuring tokens are only displayed on the chain where the flex multisig actually exists. Additionally, addresses the balance display issue where the portfolio view was showing the multisig balance instead of proxy balance for flexible multisig accounts.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- Created accountService.filterAccountsAvailableForChain() for flexible account chain filtering
- Fix token-centric view: Apply chain-specific filtering to ensure flex multisig tokens only appear on their actual chain
- Correct balance display: Ensure proxy balance is shown instead of multisig balance for flexible multisig accounts

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="1509" height="636" alt="Screenshot 2025-09-11 at 13 48 00" src="https://github.com/user-attachments/assets/9a26a014-d9af-40b7-ac8c-7e88e141234d" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
