### PR TITLE
fix: added word wrap for wallet names in remove confirm modal

### DIFF
--- a/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
+++ b/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
@@ -196,7 +196,9 @@ const ForgetWallet = ({ wallet, onClose, onForget, children, isModalOpen, setIsM
       confirmText={t('walletDetails.common.forgetButton')}
       type="warning"
       title={t('walletDetails.common.removeWalletTitle')}
-      description={t('walletDetails.common.removeWalletDesc', { walletName: wallet.name })}
+      description={
+        <span className="break-all">{t('walletDetails.common.removeWalletDesc', { walletName: wallet.name })}</span>
+      }
       onCancel={onClose}
       onConfirm={forgetWallet}
     >


### PR DESCRIPTION
## Description
Remove wallet confirm modal - long name doesn't fit in the modal

## Related Issues
Closes #4571

## Changes Made
Added word break for wallet names

## Screenshots/Recordings
Before:
<img width="312" height="185" alt="Снимок экрана 2025-09-12 в 14 39 19" src="https://github.com/user-attachments/assets/ddcc1e22-a1b6-4509-9ad3-0b1d1757db19" />

After:
<img width="311" height="201" alt="Снимок экрана 2025-09-12 в 14 42 51" src="https://github.com/user-attachments/assets/f01de769-01e5-4be3-8ae0-ae041f093b51" />
