### PR TITLE
fix: sort multisigs, flexible come first

### DIFF
--- a/src/renderer/features/multisig-wallet/model/wallets.ts
+++ b/src/renderer/features/multisig-wallet/model/wallets.ts
@@ -1,6 +1,11 @@
+import { orderBy } from 'lodash';
+
 import { walletModel, walletUtils } from '@/entities/wallet';
 
-export const $multisigs = walletModel.$wallets.map(list => list.filter(walletUtils.isMultisig));
+export const $multisigs = walletModel.$wallets.map(list => {
+  const multisigs = list.filter(walletUtils.isMultisig);
+  return orderBy(multisigs, [walletUtils.isFlexibleMultisig], ['desc']);
+});
 
 export const walletsModel = {
   $multisigs,


### PR DESCRIPTION
Resolves #4567

## Description
Sorts multisigs, puts flexible multisigs first

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="346" height="842" alt="Screenshot 2025-09-12 at 06 55 21" src="https://github.com/user-attachments/assets/56eec1a0-2a12-4963-8c50-f2400b086a5d" />

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines


DB used for testing: 
[spektr-database (8).json](https://github.com/user-attachments/files/22298428/spektr-database.8.json)

