### PR TITLE
feat(sync): sync only indexed accounts

### DIFF
--- a/src/renderer/domains/network/account-sync/resource.ts
+++ b/src/renderer/domains/network/account-sync/resource.ts
@@ -25,7 +25,7 @@ const chainIdSchema = z.string().transform((id, ctx) => {
 
 // proxieds
 
-const PROXIED_ACCOUNTS_QUERY = gql`
+const PROXY_ACCOUNT_QUERY = gql`
   query Proxieds($accounts: [String!]) {
     proxieds(filter: { proxyAccountId: { in: $accounts }, delay: { equalTo: 0 } }) {
       nodes {
@@ -59,7 +59,7 @@ export const proxyAccountsProvider: AccountProvider<SyncedProxyAccount> = {
     // subquery request
     const client = new GraphQLClient(INDEXER_URL);
     const response = await client.request<{ proxieds: { nodes: unknown[] } }, { accounts: AccountId[] }>(
-      PROXIED_ACCOUNTS_QUERY,
+      PROXY_ACCOUNT_QUERY,
       { accounts },
     );
     const parsed = response.proxieds.nodes.map(x => proxySchema.parse(x));

--- a/src/renderer/domains/network/account-sync/resource.ts
+++ b/src/renderer/domains/network/account-sync/resource.ts
@@ -2,7 +2,7 @@ import { GraphQLClient, gql } from 'graphql-request';
 import { uniq } from 'lodash';
 import { z } from 'zod';
 
-import { CryptoType, ProxyVariant } from '@/shared/core';
+import { type ChainId, CryptoType, ProxyVariant } from '@/shared/core';
 import { entries, groupBy, isEthereumAccountId, isHex, nullable } from '@/shared/lib/utils';
 import { proxyPallet } from '@/shared/pallet/proxy';
 import { type AccountId, pjsSchema } from '@/shared/polkadotjs-schemas';
@@ -23,9 +23,9 @@ const chainIdSchema = z.string().transform((id, ctx) => {
   }
 });
 
-// proxy
+// proxieds
 
-const PROXY_ACCOUNT_QUERY = gql`
+const PROXIED_ACCOUNTS_QUERY = gql`
   query Proxieds($accounts: [String!]) {
     proxieds(filter: { proxyAccountId: { in: $accounts }, delay: { equalTo: 0 } }) {
       nodes {
@@ -59,7 +59,7 @@ export const proxyAccountsProvider: AccountProvider<SyncedProxyAccount> = {
     // subquery request
     const client = new GraphQLClient(INDEXER_URL);
     const response = await client.request<{ proxieds: { nodes: unknown[] } }, { accounts: AccountId[] }>(
-      PROXY_ACCOUNT_QUERY,
+      PROXIED_ACCOUNTS_QUERY,
       { accounts },
     );
     const parsed = response.proxieds.nodes.map(x => proxySchema.parse(x));
@@ -127,7 +127,7 @@ export const proxyAccountsProvider: AccountProvider<SyncedProxyAccount> = {
 
 // multisig
 
-const MULTISIG_ACCOUNT_QUERY = gql`
+const MULTISIG_ACCOUNTS_QUERY = gql`
   query Multisigs($accounts: [String!]) {
     accounts(filter: { accountId: { in: $accounts } }) {
       nodes {
@@ -178,7 +178,7 @@ export const multisigAccountsProvider: AccountProvider<SyncedMultisigAccount> = 
     // subquery request
     const client = new GraphQLClient(INDEXER_URL);
     const response = await client.request<{ accounts: { nodes: unknown[] } }, { accounts: AccountId[] }>(
-      MULTISIG_ACCOUNT_QUERY,
+      MULTISIG_ACCOUNTS_QUERY,
       { accounts },
     );
 
@@ -211,5 +211,43 @@ export const multisigAccountsProvider: AccountProvider<SyncedMultisigAccount> = 
     }
 
     return result;
+  },
+};
+
+// chains metadata
+
+const METADATAS_QUERY = gql`
+  query Metadatas {
+    _metadatas {
+      nodes {
+        chain
+        lastProcessedHeight
+        genesisHash
+      }
+    }
+  }
+`;
+
+const metadataSchema = z.object({
+  chain: z.string(),
+  lastProcessedHeight: z.number(),
+  genesisHash: z.string<ChainId>(),
+});
+
+export const indexedBlocksProvider = {
+  async fn(): Promise<Map<ChainId, number>> {
+    const client = new GraphQLClient(INDEXER_URL);
+    const response = await client.request<{
+      _metadatas: { nodes: { chain: string; genesisHash: ChainId; lastProcessedHeight: number }[] };
+    }>(METADATAS_QUERY);
+
+    const parsedData = response._metadatas.nodes.map(x => metadataSchema.parse(x));
+    const metadataMap = new Map<ChainId, number>();
+
+    for (const meta of parsedData) {
+      metadataMap.set(meta.genesisHash, meta.lastProcessedHeight);
+    }
+
+    return metadataMap;
   },
 };

--- a/src/renderer/domains/network/account-sync/service.ts
+++ b/src/renderer/domains/network/account-sync/service.ts
@@ -7,6 +7,7 @@ import { type AnyAccount } from '../account/types';
 import {
   type AccountProvider,
   type AccountProviderChain,
+  type IndexedBlocksProvider,
   type SyncedAccount,
   type SyncedMultisigAccount,
   type SyncedProxyAccount,
@@ -18,18 +19,21 @@ type InferProviderAccount<Provider extends AccountProvider<any>> =
 type Params<Providers extends AccountProvider<any>[]> = {
   accounts: AnyAccount[];
   chains: Record<ChainId, AccountProviderChain>;
-  providers: Providers;
+  accountsProviders: Providers;
+  indexedBlocksProvider: IndexedBlocksProvider;
 };
 
 type SyncResult<Providers extends AccountProvider<any>[]> = {
   accounts: InferProviderAccount<Providers[number]>[];
   chains: ChainId[];
+  indexedBlocks: Map<ChainId, number>;
 };
 
 async function syncAccounts<const Providers extends AccountProvider<any>[]>({
   accounts,
   chains,
-  providers,
+  accountsProviders,
+  indexedBlocksProvider,
 }: Params<Providers>): Promise<SyncResult<Providers>> {
   const possingAccounts = accounts.filter(accountService.hasPermissionToMakeActions);
   let foundAccounts: InferProviderAccount<Providers[number]>[] = [];
@@ -39,6 +43,7 @@ async function syncAccounts<const Providers extends AccountProvider<any>[]>({
     return {
       accounts: foundAccounts,
       chains: inputChains,
+      indexedBlocks: new Map<ChainId, number>(),
     };
   }
 
@@ -52,8 +57,8 @@ async function syncAccounts<const Providers extends AccountProvider<any>[]>({
   const foundAccountIds = new Set(initialAccountIds);
 
   const process = async (accounts: AccountId[]) => {
-    const requests = providers.map(provider => pool.call(() => provider.fn(accounts, chains)));
-    const searchResults = await Promise.all(requests).then(r => r.flat());
+    const accountsRequests = accountsProviders.map(provider => pool.call(() => provider.fn(accounts, chains)));
+    const searchResults = await Promise.all(accountsRequests).then(r => r.flat());
 
     const resultsIds = searchResults.map(a => a.accountId);
     const nextSearchCandidates = resultsIds.filter(a => !foundAccountIds.has(a));
@@ -66,11 +71,12 @@ async function syncAccounts<const Providers extends AccountProvider<any>[]>({
     }
   };
 
-  await process(Array.from(foundAccountIds));
+  const [indexedBlocks] = await Promise.all([await indexedBlocksProvider.fn(), process(Array.from(foundAccountIds))]);
 
   return {
     accounts: foundAccounts,
     chains: inputChains,
+    indexedBlocks,
   };
 }
 

--- a/src/renderer/domains/network/account-sync/store.ts
+++ b/src/renderer/domains/network/account-sync/store.ts
@@ -5,7 +5,7 @@ import { entries, nullable } from '@/shared/lib/utils';
 import { networkModel } from '@/entities/network';
 import { accounts } from '../account/store';
 
-import { multisigAccountsProvider, proxyAccountsProvider } from './resource';
+import { indexedBlocksProvider, multisigAccountsProvider, proxyAccountsProvider } from './resource';
 import { accountSyncService } from './service';
 import { type AccountProviderChain } from './types';
 
@@ -15,7 +15,7 @@ export const syncAccountsFx = attach({
     chains: networkModel.$chains,
     apis: networkModel.$apis,
   },
-  effect: ({ chains, apis, accounts }) => {
+  effect: async ({ chains, apis, accounts }) => {
     const chainsToSync: Record<ChainId, AccountProviderChain> = {};
 
     for (const [chainId, chain] of entries(chains)) {
@@ -30,7 +30,8 @@ export const syncAccountsFx = attach({
     return accountSyncService.syncAccounts({
       accounts,
       chains: chainsToSync,
-      providers: [proxyAccountsProvider, multisigAccountsProvider],
+      accountsProviders: [proxyAccountsProvider, multisigAccountsProvider],
+      indexedBlocksProvider,
     });
   },
 });

--- a/src/renderer/domains/network/account-sync/types.ts
+++ b/src/renderer/domains/network/account-sync/types.ts
@@ -5,6 +5,10 @@ import { type Chain, type ChainId, type ProxyVariant } from '@/shared/core';
 import { type KitchensinkRuntimeProxyType } from '@/shared/pallet/proxy';
 import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
 
+export type IndexedBlocksProvider = {
+  fn(): Promise<Map<ChainId, number>>;
+};
+
 export interface SyncedAccount {
   accountId: AccountId;
 }

--- a/src/renderer/features/account-sync/model/sync.ts
+++ b/src/renderer/features/account-sync/model/sync.ts
@@ -397,7 +397,7 @@ sample({
       if (matchingProxies.length === 0) continue;
 
       const existingFlexibleMultisig = flexibleMultisigAccounts.find(
-        (account) => account.accountId === syncedMultisig.accountId,
+        (account) => account.multisigAccountId === syncedMultisig.accountId,
       );
 
       if (existingFlexibleMultisig) {

--- a/src/renderer/features/account-sync/model/sync.ts
+++ b/src/renderer/features/account-sync/model/sync.ts
@@ -104,7 +104,20 @@ sample({
     const updateAccounts: ProxiedAccount[] = [];
 
     const deleteWallets = new Set<Wallet>();
-    const deleteAccounts = new Set(proxiedAccounts.filter((account) => syncedChains.has(account.chainId)));
+    const deleteAccounts = new Set(
+      proxiedAccounts.filter((account) => {
+        if (!syncedChains.has(account.chainId)) {
+          return false;
+        }
+
+        if (!account.blockNumber) {
+          return true;
+        } else {
+          const lastIndexedBlock = syncResult.indexedBlocks.get(account.chainId);
+          return lastIndexedBlock && lastIndexedBlock >= account.blockNumber;
+        }
+      }),
+    );
 
     const proxiedGroups = groupBy(syncedProxyAccounts, (a) => a.accountId);
 
@@ -283,7 +296,18 @@ sample({
     const createWallets: WalletCreateParams<MultisigAccount, MultisigWallet>[] = [];
 
     const deleteWallets = new Set<Wallet>();
-    const deleteAccounts = new Set(syncedChains.size > 0 ? multisigAccounts : []);
+    const deleteAccounts = new Set(
+      syncedChains.size > 0
+        ? multisigAccounts.filter((account) => {
+            if (!account.remarkChainId || !account.blockNumber) {
+              return true;
+            } else {
+              const lastIndexedBlock = syncResult.indexedBlocks.get(account.remarkChainId);
+              return lastIndexedBlock && lastIndexedBlock >= account.blockNumber;
+            }
+          })
+        : [],
+    );
 
     for (const syncedAccount of syncedMultisigAccounts) {
       const existingMultisigAccount = multisigAccounts.find((a) => a.accountId === syncedAccount.accountId);
@@ -355,7 +379,20 @@ sample({
     >[] = [];
 
     const deleteWallets = new Set<Wallet>();
-    const deleteAccounts = new Set(flexibleMultisigAccounts.filter((account) => syncedChains.has(account.chainId)));
+    const deleteAccounts = new Set(
+      flexibleMultisigAccounts.filter((account) => {
+        if (!syncedChains.has(account.chainId)) {
+          return false;
+        }
+
+        if (!account.blockNumber) {
+          return true;
+        } else {
+          const lastIndexedBlock = syncResult.indexedBlocks.get(account.chainId);
+          return lastIndexedBlock && lastIndexedBlock >= account.blockNumber;
+        }
+      }),
+    );
 
     for (const syncedMultisig of syncedMultisigAccounts) {
       const matchingProxies = syncedProxyAccounts.filter(

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
@@ -32,7 +32,7 @@ import { transactionBuilder } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
 import { signModel } from '@/features/operations/OperationSign';
-import { submitModel, submitUtils } from '@/features/operations/OperationSubmit';
+import { type ExtrinsicResult, submitModel, submitUtils } from '@/features/operations/OperationSubmit';
 
 import { flexibleMultisigFeature } from './feature';
 import { flexibleMultisigModel } from './flexible-multisig-create';
@@ -199,6 +199,11 @@ const $flexibleMultisigCreated = createStore<boolean>(false)
   .reset(flexibleMultisigModel.flow.close)
   .on(flexibleMultisigCreated, () => true);
 
+const successResultSaved = createEvent<{ result: ExtrinsicResult; params: ExtrinsicResultParams }>();
+const $successResult = createStore<{ result: ExtrinsicResult; params: ExtrinsicResultParams } | null>(null)
+  .reset(flexibleMultisigModel.flow.close)
+  .on(successResultSaved, (_, payload) => payload);
+
 sample({
   clock: submitModel.output.formSubmitted,
   source: {
@@ -206,6 +211,17 @@ sample({
     accounts: accounts.$list,
   },
   filter: ({ tx }, results) => nonNullable(tx) && results.some(({ result }) => submitUtils.isSuccessResult(result)),
+  fn: (_, results) => {
+    const successResult = results.find(({ result }) => submitUtils.isSuccessResult(result));
+    assert(successResult, 'Successful result for flexible multisig creation was not found');
+
+    return { result: successResult.result, params: successResult.params as ExtrinsicResultParams };
+  },
+  target: successResultSaved,
+});
+
+sample({
+  clock: successResultSaved,
   target: flexibleMultisigCreated,
 });
 
@@ -225,15 +241,19 @@ sample({
     flexibleMultisigCreated: $flexibleMultisigCreated,
     multisigAccountId: formModel.$multisigAccountId,
     proxyAddress: $proxyAddress,
+    successResult: $successResult,
   },
-  filter: ({ flexibleMultisigCreated, chain, multisigAccountId, proxyAddress }) => {
-    return nonNullable(chain) && flexibleMultisigCreated && nonNullable(multisigAccountId) && nonNullable(proxyAddress);
+  filter: ({ flexibleMultisigCreated, chain, multisigAccountId, proxyAddress, successResult }) => {
+    return (
+      nonNullable(chain) &&
+      flexibleMultisigCreated &&
+      nonNullable(multisigAccountId) &&
+      nonNullable(proxyAddress) &&
+      nonNullable(successResult)
+    );
   },
-  fn: ({ signatories, chain, name, threshold, multisigAccountId, proxyAddress }, results) => {
-    const successResult = results.find(({ result }) => submitUtils.isSuccessResult(result));
-    assert(successResult, 'Successful result for flexible multisig creation was not found');
-
-    const timepoint = (successResult.params as ExtrinsicResultParams).timepoint;
+  fn: ({ signatories, chain, name, threshold, multisigAccountId, proxyAddress, successResult }) => {
+    const timepoint = successResult!.params.timepoint;
     const sortedSignatories = sortBy(
       signatories.map(a => ({ address: a.address, accountId: toAccountId(a.address), walletId: a.walletId })),
       'accountId',
@@ -295,11 +315,15 @@ sample({
     chain: formModel.$chain,
     multisigAccountId: formModel.$multisigAccountId,
     proxyAddress: $proxyAddress,
+    successResult: $successResult,
   },
-  filter: ({ chain, multisigAccountId, proxyAddress }) => {
-    return nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(proxyAddress);
+  filter: ({ chain, multisigAccountId, proxyAddress, successResult }) => {
+    return (
+      nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(proxyAddress) && nonNullable(successResult)
+    );
   },
-  fn: ({ chain, name, multisigAccountId, proxyAddress }) => {
+  fn: ({ chain, name, multisigAccountId, proxyAddress, successResult }) => {
+    const timepoint = successResult!.params.timepoint;
     const isEthereumChain = networkUtils.isEthereumBased(chain!.options);
 
     const proxiedAccount: Omit<NoID<ProxiedAccount>, 'walletId'> = {
@@ -319,7 +343,7 @@ sample({
       ],
       proxyVariant: ProxyVariant.PURE,
       deposit: '100',
-      blockNumber: undefined, // Block number not available for consequence account creation
+      blockNumber: timepoint.height,
       extrinsicIndex: undefined,
     };
 
@@ -344,11 +368,13 @@ sample({
     signatories: signatoryModel.$signatories,
     chain: formModel.$chain,
     multisigAccountId: formModel.$multisigAccountId,
+    successResult: $successResult,
   },
-  filter: ({ chain, multisigAccountId }) => {
-    return nonNullable(chain) && nonNullable(multisigAccountId);
+  filter: ({ chain, multisigAccountId, successResult }) => {
+    return nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(successResult);
   },
-  fn: ({ signatories, chain, name, threshold, multisigAccountId }) => {
+  fn: ({ signatories, chain, name, threshold, multisigAccountId, successResult }) => {
+    const timepoint = successResult!.params.timepoint;
     const sortedSignatories = sortBy(
       signatories.map(a => ({ address: a.address, accountId: toAccountId(a.address), walletId: a.walletId })),
       'accountId',
@@ -365,8 +391,8 @@ sample({
       signingType: SigningType.MULTISIG,
       accountType: AccountType.MULTISIG,
       type: 'universal',
-      blockNumber: undefined, // Block number not available for consequence account creation
-      remarkChainId: chain?.chainId, // Chain ID not available for consequence account creation
+      blockNumber: timepoint.height,
+      remarkChainId: chain?.chainId,
     };
 
     const wallet: Omit<NoID<MultisigWallet>, 'accounts'> = {

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
@@ -251,7 +251,7 @@ sample({
       nonNullable(successResult)
     );
   },
-  fn: ({ api, signatories, chain, name, threshold, multisigAccountId, proxiedAddress }) => {
+  fn: ({ api, signatories, chain, name, threshold, multisigAccountId, proxiedAddress, successResult }) => {
     const timepoint = successResult!.params.timepoint;
     const sortedSignatories = sortBy(
       signatories.map(a => ({ address: a.address, accountId: toAccountId(a.address), walletId: a.walletId })),
@@ -310,7 +310,11 @@ sample({
   },
   filter: ({ api, chain, multisigAccountId, proxiedAddress, successResult }) => {
     return (
-      nonNullable(api) && nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(proxiedAddress) && nonNullable(successResult)
+      nonNullable(api) &&
+      nonNullable(chain) &&
+      nonNullable(multisigAccountId) &&
+      nonNullable(proxiedAddress) &&
+      nonNullable(successResult)
     );
   },
   fn: ({ api, chain, name, multisigAccountId, proxiedAddress, successResult }) => {

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
@@ -251,6 +251,7 @@ sample({
       accountType: AccountType.FLEX_MULTISIG,
       type: 'chain',
       chainId: chain!.chainId,
+      blockNumber: timepoint.height,
     };
 
     const pureAccount: Omit<NoID<FlexibleProxiedAccount>, 'walletId'> = {
@@ -318,6 +319,8 @@ sample({
       ],
       proxyVariant: ProxyVariant.PURE,
       deposit: '100',
+      blockNumber: undefined, // Block number not available for consequence account creation
+      extrinsicIndex: undefined,
     };
 
     const wallet: Omit<NoID<ProxiedWallet>, 'accounts'> = {
@@ -362,6 +365,8 @@ sample({
       signingType: SigningType.MULTISIG,
       accountType: AccountType.MULTISIG,
       type: 'universal',
+      blockNumber: undefined, // Block number not available for consequence account creation
+      remarkChainId: chain?.chainId, // Chain ID not available for consequence account creation
     };
 
     const wallet: Omit<NoID<MultisigWallet>, 'accounts'> = {

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
@@ -373,7 +373,6 @@ sample({
     const accountIds = sortedSignatories.map(s => s.accountId);
     const accountId = accountUtils.getMultisigAccountId(accountIds, threshold, cryptoType);
 
-    // Extract blockNumber from successful transaction result
     const successResult = results.find(({ result }) => submitUtils.isSuccessResult(result));
     const blockNumber = successResult ? (successResult.params as ExtrinsicResultParams)?.timepoint?.height : undefined;
 

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
@@ -27,7 +27,7 @@ import { type AnyAccount, type ChainAccount, accountService, accountSync, accoun
 import { balanceModel } from '@/entities/balance';
 import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { transactionBuilder } from '@/entities/transaction';
+import { type ExtrinsicResultParams, transactionBuilder } from '@/entities/transaction';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
 import { signModel } from '@/features/operations/OperationSign/model/sign-model';
@@ -358,7 +358,7 @@ sample({
 
     return nonNullable(chain) && isSubmitStep && isSuccessResult;
   },
-  fn: ({ signatories, chain, name, threshold }) => {
+  fn: ({ signatories, chain, name, threshold }, results) => {
     const sortedSignatories = sortBy(
       Array.from(signatories.values()).map(a => ({
         address: a.address,
@@ -373,6 +373,10 @@ sample({
     const accountIds = sortedSignatories.map(s => s.accountId);
     const accountId = accountUtils.getMultisigAccountId(accountIds, threshold, cryptoType);
 
+    // Extract blockNumber from successful transaction result
+    const successResult = results.find(({ result }) => submitUtils.isSuccessResult(result));
+    const blockNumber = successResult ? (successResult.params as ExtrinsicResultParams)?.timepoint?.height : undefined;
+
     const account: Omit<NoID<MultisigAccount>, 'walletId'> = {
       signatories: sortedSignatories,
       name: name.trim(),
@@ -382,6 +386,8 @@ sample({
       signingType: SigningType.MULTISIG,
       accountType: AccountType.MULTISIG,
       type: 'universal',
+      blockNumber,
+      remarkChainId: chain!.chainId, // Save chain where remark transaction was submitted
     };
 
     return {

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
@@ -387,7 +387,7 @@ sample({
       accountType: AccountType.MULTISIG,
       type: 'universal',
       blockNumber,
-      remarkChainId: chain!.chainId, // Save chain where remark transaction was submitted
+      remarkChainId: chain!.chainId,
     };
 
     return {

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -46,6 +46,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const [tab, setTab] = useState('1');
 
   const walletAccounts = accountService.filterAccountsByWallet(accountList, wallet.id);
+
   const multisigAccount = walletAccounts.find(accountUtils.isFlexibleMultisigAccount);
   const proxiedAccount = walletAccounts.find(accountUtils.isFlexibleProxiedAccount);
 

--- a/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
@@ -45,7 +45,6 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const [tab, setTab] = useState('1');
 
   const walletAccounts = accountService.filterAccountsByWallet(accountList, wallet.id);
-
   const multisigAccount = walletAccounts.find(accountUtils.isMultisigAccount);
   assert(multisigAccount, 'Multisig account not found.');
 

--- a/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
@@ -45,6 +45,7 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const [tab, setTab] = useState('1');
 
   const walletAccounts = accountService.filterAccountsByWallet(accountList, wallet.id);
+
   const multisigAccount = walletAccounts.find(accountUtils.isMultisigAccount);
   assert(multisigAccount, 'Multisig account not found.');
 

--- a/src/renderer/shared/core/types/account.ts
+++ b/src/renderer/shared/core/types/account.ts
@@ -3,7 +3,7 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 // eslint-disable-next-line boundaries/element-types
 import { type AnyAccount, type ChainAccount, type UniversalAccount } from '@/domains/network';
 
-import { type NoID } from './general';
+import { type ChainId, type NoID } from './general';
 import { type ProxyType, type ProxyVariant } from './proxy';
 import { type Signatory } from './signatory';
 
@@ -34,12 +34,20 @@ export interface MultisigAccount extends UniversalAccount {
   accountType: AccountType.MULTISIG;
   signatories: Signatory[];
   threshold: number;
+
+  // Block number when this account was first created, used for sync comparison with indexer metadata
+  blockNumber?: number;
+  // Chain ID where the creation remark transaction was submitted and fees were paid
+  remarkChainId?: ChainId;
 }
 
 export interface FlexibleMultisigAccount extends ChainAccount {
   accountType: AccountType.FLEX_MULTISIG;
   signatories: Signatory[];
   threshold: number;
+
+  // Block number when this account was first created, used for sync comparison with indexer metadata
+  blockNumber?: number;
 }
 
 export interface MultisigSignatoryAccount extends UniversalAccount {

--- a/src/renderer/shared/core/types/account.ts
+++ b/src/renderer/shared/core/types/account.ts
@@ -35,10 +35,9 @@ export interface MultisigAccount extends UniversalAccount {
   signatories: Signatory[];
   threshold: number;
 
-  // Block number when this account was first created, used for sync comparison with indexer metadata
-  blockNumber?: number;
-  // Chain ID where the creation remark transaction was submitted and fees were paid
-  remarkChainId?: ChainId;
+  // Temp fields for freshly created user accounts , used for sync comparison with indexer metadata
+  blockNumber?: number; // Block number when this account was created
+  remarkChainId?: ChainId; // Chain ID where the remark was submitted
 }
 
 export interface FlexibleMultisigAccount extends ChainAccount {
@@ -46,8 +45,8 @@ export interface FlexibleMultisigAccount extends ChainAccount {
   signatories: Signatory[];
   threshold: number;
 
-  // Block number when this account was first created, used for sync comparison with indexer metadata
-  blockNumber?: number;
+  // Temp fields for freshly created user accounts , used for sync comparison with indexer metadata
+  blockNumber?: number; // Block number when this account was created
 }
 
 export interface MultisigSignatoryAccount extends UniversalAccount {


### PR DESCRIPTION
## Description

Compare the block number that account was created on against the last indexed block of the respective chain to not remove freshly created accounts from DB

## Related Issues

closes #4482
closes #4533

## Changes Made

- Request chain metadata to figure out the last indexed block for each chain
- Save blockNumber and chain for all new created accounts
- Do not remove account if the last indexed blockNumber is < blockNumber saved in account

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
