### PR TITLE
fix: wallet details link to actual multisig

### DIFF
--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -7,7 +7,7 @@ import { useI18n } from '@/shared/i18n';
 import { useModalClose, useToggle } from '@/shared/lib/hooks';
 import { assert, isEthereumAccountId, nonNullable, toAddress } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, HeadlineText, Icon, IconButton, Separator } from '@/shared/ui';
-import { AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
+import { Account, AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
 import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { networkModel, networkUtils } from '@/entities/network';
@@ -224,7 +224,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
               <div className="flex items-center gap-1 text-footnote">
                 <FootnoteText>{t('walletDetails.common.proxyVia')}</FootnoteText>
                 <WalletIcon type={WalletType.MULTISIG} size={16} />
-                <FootnoteText className="shrink-0">{t('walletDetails.multisig.multisigWallet')}</FootnoteText>
+                <Account accountId={multisigAccount.accountId} chain={chain} hideIcon variant="short" />
                 <FootnoteText className="shrink-0">{t('walletDetails.multisig.on')}</FootnoteText>
                 <ChainIcon chain={chain} size={16} />
                 <FootnoteText className="truncate">{chain.name}</FootnoteText>


### PR DESCRIPTION
## Description
Flexible multisig. There is no link to actual multisig in flexible details

## Related Issues
Closes #4579

## Changes Made
Added link to actual multisig in flexible details

## Screenshots/Recordings
Before: 
<img width="658" height="790" alt="111" src="https://github.com/user-attachments/assets/b5e2a416-3bd8-4cef-8446-9201467ce491" />

After:
<img width="585" height="729" alt="Снимок экрана 2025-09-12 в 17 30 14" src="https://github.com/user-attachments/assets/0909fffa-78e2-4614-9659-5cb4c33476c2" />

