### PR TITLE
feat(operations): view json

### DIFF
--- a/src/renderer/features/multisig-operations/components/OperationFullInfo.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationFullInfo.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { memo } from 'react';
+import { memo, useMemo } from 'react';
 
 import { type CallData, type FlexibleMultisigAccount, type MultisigAccount } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
@@ -7,9 +7,11 @@ import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
 import { validateCallData } from '@/shared/lib/utils';
 import { Button, Icon, InfoLink, SmallTitleText } from '@/shared/ui';
+import { Box, Json, Modal } from '@/shared/ui-kit';
 import { type MultisigOperation, accounts, multisigOperation } from '@/domains/network';
-import { useNetworkData } from '@/entities/network';
+import { networkModel, useNetworkData } from '@/entities/network';
 import { operationDetailsUtils } from '@/entities/operations';
+import { decodeCallData } from '@/entities/transaction';
 import { accountUtils } from '@/entities/wallet';
 
 import { OperationAdvancedDetails } from './OperationAdvancedDetails';
@@ -36,12 +38,18 @@ export const OperationFullInfo = memo(({ operation, account }: Props) => {
   const { api, chain, connection, extendedChain } = useNetworkData(operation.chainId);
   const allAccounts = useUnit(accounts.$list);
   const [isCallDataModalOpen, toggleCallDataModal] = useToggle();
+  const chains = useUnit(networkModel.$chains);
 
   const explorerLink = operationDetailsUtils.getMultisigExtrinsicLink(
     operation.callHash,
     operation.indexCreated,
     operation.blockCreated,
     chain?.explorers,
+  );
+
+  const jsonArgs = useMemo(
+    () => operation.callData && decodeCallData(api, account.accountId, operation.callData, chains),
+    [api, account.accountId, operation.callData, chains],
   );
 
   const hasAccount = allAccounts.some(a => {
@@ -67,12 +75,29 @@ export const OperationFullInfo = memo(({ operation, account }: Props) => {
           <SmallTitleText className="mr-auto">{t('operation.detailsTitle')}</SmallTitleText>
 
           {(!operation.callData || explorerLink) && (
-            <div className="flex items-center">
+            <div className="flex items-center gap-2">
               {!operation.callData && (
                 <Button pallet="primary" variant="text" size="sm" onClick={toggleCallDataModal}>
                   {t('operation.addCallDataButton')}
                 </Button>
               )}
+
+              {jsonArgs && (
+                <Modal size="lg" height="fit">
+                  <Modal.Trigger>
+                    <Button className="p-0" size="sm" variant="text">
+                      {t('operation.viewJSON.button')}
+                    </Button>
+                  </Modal.Trigger>
+                  <Modal.Title close>{t('operation.viewJSON.label')}</Modal.Title>
+                  <Modal.Content>
+                    <Box padding={5}>
+                      <Json value={jsonArgs} name="operation" />
+                    </Box>
+                  </Modal.Content>
+                </Modal>
+              )}
+
               {explorerLink && (
                 <InfoLink url={explorerLink} className="ml-0.5 flex items-center gap-x-0.5 text-footnote">
                   <span>{t('operation.explorerLink')}</span>

--- a/src/renderer/features/multisig-operations/components/OperationFullInfo.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationFullInfo.tsx
@@ -75,7 +75,7 @@ export const OperationFullInfo = memo(({ operation, account }: Props) => {
           <SmallTitleText className="mr-auto">{t('operation.detailsTitle')}</SmallTitleText>
 
           {(!operation.callData || explorerLink) && (
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-4">
               {!operation.callData && (
                 <Button pallet="primary" variant="text" size="sm" onClick={toggleCallDataModal}>
                   {t('operation.addCallDataButton')}

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1534,6 +1534,10 @@
     "submitErrorButton": "Close",
     "successMessage": "Operation Approved",
     "successRejectMessage": "Operation Rejected",
+    "viewJSON": {
+      "button": "View JSON",
+      "label": "Operation details"
+    },
     "walletConnect": {
       "defaultWalletName": "WalletConnect",
       "expiredDescription": "The operation isn’t valid anymore",


### PR DESCRIPTION
## Description

Add a button + modal to show JSON arguments of an operation

## Related Issues

closes #4496

## Changes Made

- decode of call data
- modal w/ represent

## Screenshots/Recordings

<img width="763" height="367" alt="image" src="https://github.com/user-attachments/assets/33ac1b53-8f96-40ae-98cd-3f6ae3943eaa" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
