### PR TITLE
fix: handle extrinsic `isFuture` status

### DIFF
--- a/src/renderer/domains/network/transaction/service.ts
+++ b/src/renderer/domains/network/transaction/service.ts
@@ -358,6 +358,13 @@ async function submitExtrinsic(
             });
           }
 
+          if (status.isFuture) {
+            resolve({
+              executed: false,
+              error: 'Invalid transaction: queued for future (nonce too high)',
+            });
+          }
+
           if (status.isInBlock) {
             for (const { event, phase } of events) {
               if (!phase.isApplyExtrinsic || !phase.asApplyExtrinsic.eq(txIndex)) continue;

--- a/src/renderer/features/operations/OperationSubmit/model/submit-model.ts
+++ b/src/renderer/features/operations/OperationSubmit/model/submit-model.ts
@@ -64,7 +64,7 @@ const $results = createStore<Result[]>([]).reset(init);
 
 // effects
 
-const submitExtrinsicFx = createEffect(async (payloads: SubmitInput) => {
+const submitExtrinsicFx = createEffect((payloads: SubmitInput) => {
   const boundExtrinsicSucceeded = scopeBind(extrinsicSucceeded, { safe: true });
   const boundExtrinsicFailed = scopeBind(extrinsicFailed, { safe: true });
 


### PR DESCRIPTION
## Description
In the case of multiple transactions, if the first one is failed, next transaction is not executed since nonce it too high, and will be put a transaction pool future queue.
Previously OperationSubmit dialog was showing pending state forever.
This PR handles isFuture transaction status and marks an extrinsic as failed in effector store. That allows to show a failed status in the OperationSubmit dialog.

## Related Issues
Closes #4366

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="552" height="472" alt="Screenshot 2025-09-15 at 6 08 49 PM" src="https://github.com/user-attachments/assets/8d569c89-03fa-42f0-9f32-7556094b0368" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
