### PR TITLE
fix: handle signatory change more gracefully, fix trash icon positioning

### DIFF
--- a/src/renderer/features/flexible-change-signatories/ui/components/Signatory.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/components/Signatory.tsx
@@ -221,7 +221,7 @@ export const Signatory = ({
       </Box>
       {!isOwnAccount && onDelete && (
         <IconButton
-          className="mt-9 self-start justify-self-center"
+          className="mb-1 self-end justify-self-start"
           name="delete"
           size={16}
           onClick={() => onDelete(signatoryIndex)}

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
@@ -195,9 +195,12 @@ export const Signatory = ({
     const selectedOption = options.flatMap(group => group.items).find(option => option.value.address === value);
     const newSignatory = selectedOption?.value;
 
+    const shouldClearName = value !== signatoryAddress && !selectedOption;
+    const newName = shouldClearName ? '' : signatoryName;
+
     signatoryModel.events.changeSignatory({
       index: signatoryIndex,
-      name: signatoryName,
+      name: newName,
       address: value,
       walletId: newSignatory?.walletId?.toString(), // will be undefined for contact
     });
@@ -273,7 +276,7 @@ export const Signatory = ({
       </Field>
       {!isOwnAccount && onDelete && (
         <IconButton
-          className="mt-9 self-start justify-self-center"
+          className="mb-1 self-end justify-self-center"
           name="delete"
           size={16}
           onClick={() => onDelete(signatoryIndex)}

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
@@ -191,9 +191,12 @@ export const Signatory = ({
     const selectedOption = options.flatMap(group => group.items).find(option => option.value.address === value);
     const newSignatory = selectedOption?.value;
 
+    const shouldClearName = value !== signatoryAddress && !selectedOption;
+    const newName = shouldClearName ? '' : signatoryName;
+
     signatoryModel.events.changeSignatory({
       index: signatoryIndex,
-      name: signatoryName,
+      name: newName,
       address: value,
       walletId: newSignatory?.walletId?.toString(), // will be undefined for contact
     });
@@ -278,7 +281,7 @@ export const Signatory = ({
       </Field>
       {!isOwnAccount && onDelete && (
         <IconButton
-          className="mt-9 self-start justify-self-center"
+          className="mb-1 self-end justify-self-center"
           name="delete"
           size={16}
           onClick={() => onDelete(signatoryIndex)}


### PR DESCRIPTION
Resolves #4546 

## Description
This PR fixes two UI issues in the multisig wallet creation form:
- Trashcan Button Misalignment: The delete button for removing signatories was visually misaligned with the input fields in the signatory row.
- Signatory Name Input Reset Bug: When users selected a signatory from the dropdown, the name field auto-populated and became disabled. However, if they then pasted a different address into the address field, the old name remained visible and disabled.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- Fixed trashcan button alignment: Corrected CSS positioning to properly align delete buttons with input fields
- Fixed signatory name input reset: Enhanced form state management to clear and re-enable the name field when address is manually changed after dropdown selection

## Screenshots/Recordings
<img width="905" height="481" alt="Screenshot 2025-09-16 at 18 41 00" src="https://github.com/user-attachments/assets/da7b538b-36e4-4a9a-b234-be3653df8554" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
