### PR TITLE
fix: remove walletConnect & nova wallet

### DIFF
--- a/src/renderer/features/wallet-details/index.tsx
+++ b/src/renderer/features/wallet-details/index.tsx
@@ -1,3 +1,4 @@
+import { useGate } from 'effector-react';
 import { useState } from 'react';
 
 import { type XOR } from '@/shared/core/types/utility';
@@ -22,6 +23,7 @@ import { walletActionsSlot as watchOnlyActionsSlot } from '@/features/watch-only
 
 export { walletDetailsUtils } from './lib/utils';
 
+import { walletConnectForget } from './model/walletConnectForgot';
 import { WalletDetails } from './ui/components';
 
 export { overviewSlot as simpleOverviewSlot } from './ui/wallets/SimpleWalletDetails';
@@ -80,6 +82,7 @@ const DropdownItem = (props: DropdownItemProps) => {
 };
 
 walletDetailsFeature.inject(walletActionSlot, ({ wallet }) => {
+  useGate(walletConnectForget.flow, { accounts: wallet.accounts });
   const [isWalletDetailsOpen, setIsWalletDetailsOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
@@ -119,9 +122,16 @@ walletDetailsFeature.inject(walletActionSlot, ({ wallet }) => {
       title = t('walletDetails.common.hideButton');
     }
 
+    let onForget;
+    if (walletUtils.isWalletConnectGroup(wallet)) {
+      onForget = () => {
+        walletConnectForget.forget(wallet);
+      };
+    }
+
     items.push({
       component: (
-        <ForgetWalletConfirm wallet={wallet} onClose={createModalCloseHandler()}>
+        <ForgetWalletConfirm wallet={wallet} onClose={createModalCloseHandler()} onForget={onForget}>
           <Dropdown.Item>
             <div className="flex items-center gap-2">
               <Icon name={icon} size={20} className="text-icon-accent" />

--- a/src/renderer/features/wallet-details/index.tsx
+++ b/src/renderer/features/wallet-details/index.tsx
@@ -122,6 +122,8 @@ walletDetailsFeature.inject(walletActionSlot, ({ wallet }) => {
       title = t('walletDetails.common.hideButton');
     }
 
+    // TODO refactor
+    // abstract feature wallet details shouldn't know about wallet connect
     let onForget;
     if (walletUtils.isWalletConnectGroup(wallet)) {
       onForget = () => {

--- a/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
+++ b/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
@@ -67,7 +67,7 @@ const HideWallet = ({ onClose, onForget, children, isModalOpen, setIsModalOpen }
   const forgetWallet = () => {
     forgetWalletModel.remove();
     !isHideWalletDoNotShowAgain && forgetWalletModel.changeHideWalletDoNotShowAgain(isHideWalletDoNotShowAgainLocal);
-    onForget && onForget();
+    onForget?.();
     onClose?.();
 
     let description = t('settings.hiddenWallets.youCanRestore');
@@ -147,7 +147,7 @@ const ForgetWallet = ({ wallet, onClose, onForget, children, isModalOpen, setIsM
     forgetWalletModel.remove();
     !isConnectedAccountsDoNotShowAgain &&
       forgetWalletModel.changeConnectedAccountsDoNotShowAgain(isConnectedAccountsDoNotShowAgainLocal);
-    onForget && onForget();
+    onForget?.();
     onClose?.();
 
     notification.modal({


### PR DESCRIPTION
## Description
Wallet forget worked from wallet details modal, but didn't work if user removed a wallet from the dropdown list of actions.
This PR fixes dropdown remove action. Sends disconnect event to wallet connect & nova wallet on wallet removal from Spektr.


## Related Issues
Closes #4572

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
