### PR TITLE
Display account name in flexible multisig wallet details

### DIFF
--- a/src/renderer/features/wallet-details/lib/utils.ts
+++ b/src/renderer/features/wallet-details/lib/utils.ts
@@ -1,4 +1,14 @@
-import { KeyType, type PolkadotVaultWallet, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
+import {
+  type Contact,
+  KeyType,
+  type PolkadotVaultWallet,
+  type Signatory,
+  type VaultChainAccount,
+  type VaultShardAccount,
+  type Wallet,
+} from '@/shared/core';
+import { toAddress, toShortAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accountUtils } from '@/entities/wallet';
 
 import { ForgetStep, ReconnectStep } from './constants';
@@ -16,6 +26,7 @@ export const walletDetailsUtils = {
   isForgetModalOpen,
   getVaultAccountsMap,
   getMainAccounts,
+  getSignatoryName,
 };
 
 function isNotStarted(step: ReconnectStep, connected: boolean): boolean {
@@ -63,4 +74,29 @@ function getMainAccounts(accounts: (VaultChainAccount | VaultShardAccount[])[]):
   return accounts.filter(account => {
     return !accountUtils.isAccountWithShards(account) && account.keyType === KeyType.MAIN;
   }) as VaultChainAccount[];
+}
+
+function getSignatoryName(
+  signatoryId: AccountId,
+  txSignatories: Signatory[],
+  contacts: Contact[],
+  wallets: Wallet[],
+  addressPrefix?: number,
+): string {
+  const finderFn = <T extends { accountId: AccountId }>(collection: T[]): T | undefined => {
+    return collection.find(c => c.accountId === signatoryId);
+  };
+
+  // signatory data source priority: transaction -> contacts -> wallets -> address
+  const fromTx = finderFn(txSignatories)?.name;
+  if (fromTx) return fromTx;
+
+  const fromContact = finderFn(contacts)?.name;
+  if (fromContact) return fromContact;
+
+  const accounts = wallets.map(wallet => wallet.accounts).flat();
+  const fromAccount = finderFn(accounts)?.name;
+  if (fromAccount) return fromAccount;
+
+  return toShortAddress(toAddress(signatoryId, { prefix: addressPrefix }), 5);
 }

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -12,12 +12,12 @@ import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
 import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { operationDetailsUtils } from '@/entities/operations';
 import { ContactItem, WalletCardMd, accountUtils, permissionUtils, walletModel } from '@/entities/wallet';
 import { ChangeSignatories } from '@/features/flexible-change-signatories';
 import { AddPureProxied } from '@/features/proxied-add-pure';
 import { AddProxy } from '@/features/proxy-add';
 import { RenameWallet } from '@/features/wallets/RenameWallet';
+import { walletDetailsUtils } from '../../lib/utils';
 import { multisigWalletDetailsModel } from '../../model/multisig-wallet-details';
 import { walletDetailsModel } from '../../model/wallet-details-model';
 import { WalletFiatBalance } from '../components';
@@ -56,7 +56,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
 
   const chain = chains[multisigAccount.chainId];
 
-  const multisigAccountName = operationDetailsUtils.getSignatoryName(
+  const multisigAccountName = walletDetailsUtils.getSignatoryName(
     multisigAccount.multisigAccountId,
     multisigAccount.signatories,
     contacts,

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -10,8 +10,10 @@ import { BodyText, FootnoteText, HeadlineText, Icon, IconButton, Separator } fro
 import { Account, AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
 import { type AnyAccount, accountService, accounts } from '@/domains/network';
+import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { ContactItem, WalletCardMd, accountUtils, permissionUtils } from '@/entities/wallet';
+import { operationDetailsUtils } from '@/entities/operations';
+import { ContactItem, WalletCardMd, accountUtils, permissionUtils, walletModel } from '@/entities/wallet';
 import { ChangeSignatories } from '@/features/flexible-change-signatories';
 import { AddPureProxied } from '@/features/proxied-add-pure';
 import { AddProxy } from '@/features/proxy-add';
@@ -40,6 +42,8 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const signatories = useUnit(multisigWalletDetailsModel.$signatories);
   const accountList = useUnit(accounts.$list);
   const proxiesCount = useUnit(walletDetailsModel.$proxiesCount);
+  const contacts = useUnit(contactModel.$contacts);
+  const walletsList = useUnit(walletModel.$wallets);
 
   const [isModalOpen, closeModal] = useModalClose(true, onClose);
   const [isRenameInputOpen, toggleIsRenameInputOpen] = useToggle();
@@ -51,6 +55,14 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   assert(multisigAccount, 'Multisig account not found.');
 
   const chain = chains[multisigAccount.chainId];
+
+  const multisigAccountName = operationDetailsUtils.getSignatoryName(
+    multisigAccount.multisigAccountId,
+    multisigAccount.signatories,
+    contacts,
+    walletsList,
+    chain.addressPrefix,
+  );
 
   const canCreateProxy = useMemo(() => {
     const anyProxy = permissionUtils.canCreateAnyProxy(wallet);
@@ -228,7 +240,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
                   hideIcon
                   hideAddress
                   variant="short"
-                  title={multisigAccount.name}
+                  title={multisigAccountName}
                 />
                 <FootnoteText className="shrink-0">{t('walletDetails.multisig.on')}</FootnoteText>
                 <ChainIcon chain={chain} size={16} />

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -222,7 +222,14 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
               <div className="flex items-center gap-1 text-footnote">
                 <FootnoteText>{t('walletDetails.common.proxyVia')}</FootnoteText>
                 <WalletIcon type={WalletType.MULTISIG} size={16} />
-                <Account accountId={multisigAccount.multisigAccountId} chain={chain} hideIcon variant="short" />
+                <Account
+                  accountId={multisigAccount.multisigAccountId}
+                  chain={chain}
+                  hideIcon
+                  hideAddress
+                  variant="short"
+                  title={multisigAccount.name}
+                />
                 <FootnoteText className="shrink-0">{t('walletDetails.multisig.on')}</FootnoteText>
                 <ChainIcon chain={chain} size={16} />
                 <FootnoteText className="truncate">{chain.name}</FootnoteText>


### PR DESCRIPTION
## Description
In the wallet details modal of a flex multisig, the reference to its underlying regular multisig is always displayed using its address, even when a custom name for that multisig exists in the local database.

## Related Issues
Closes #4638

## Changes Made
Display account name in flexible multisig wallet details

## Screenshots/Recordings
<img width="588" height="564" alt="Снимок экрана 2025-09-17 в 14 05 14" src="https://github.com/user-attachments/assets/1d84ee9e-cdc5-4395-9c5e-d4a52e4b2372" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
