### PR TITLE
Fix: display account names in signatories tab of wallet details

### DIFF
--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -6,6 +6,7 @@ import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { useModalClose, useToggle } from '@/shared/lib/hooks';
 import { assert, isEthereumAccountId, nonNullable, toAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { BodyText, FootnoteText, HeadlineText, Icon, IconButton, Separator } from '@/shared/ui';
 import { Account, AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
@@ -55,15 +56,13 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
 
   assert(multisigAccount, 'Multisig account not found.');
 
+  const getSignatoryName = (accountId: AccountId) => {
+    return walletDetailsUtils.getSignatoryName(accountId, multisigAccount.signatories, contacts, walletsList);
+  };
+
   const chain = chains[multisigAccount.chainId];
 
-  const multisigAccountName = walletDetailsUtils.getSignatoryName(
-    multisigAccount.multisigAccountId,
-    multisigAccount.signatories,
-    contacts,
-    walletsList,
-    chain.addressPrefix,
-  );
+  const multisigAccountName = getSignatoryName(multisigAccount.multisigAccountId);
 
   const canCreateProxy = useMemo(() => {
     const anyProxy = permissionUtils.canCreateAnyProxy(wallet);
@@ -166,7 +165,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
             ))}
             {signatories.people.map(accountId => (
               <li key={accountId} className="-mx-2">
-                <ContactItem address={accountId} addressPrefix={chain.addressPrefix}>
+                <ContactItem address={accountId} addressPrefix={chain.addressPrefix} name={getSignatoryName(accountId)}>
                   <AccountExplorers accountId={accountId} chain={chain} />
                 </ContactItem>
               </li>

--- a/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
@@ -5,18 +5,21 @@ import { type FlexibleMultisigWallet, type MultisigWallet } from '@/shared/core'
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
-import { assert, isEthereumAccountId, toAddress } from '@/shared/lib/utils';
+import { assert, isEthereumAccountId, toAccountId, toAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HeadlineText, IconButton, Separator } from '@/shared/ui';
 import { Address, ChainAccountsList, RootExplorers, WalletAccountIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
 import { accountService, accounts } from '@/domains/network';
 import { type AnyAccount } from '@/domains/network';
+import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { ContactItem, WalletCardMd, accountUtils, permissionUtils } from '@/entities/wallet';
+import { ContactItem, WalletCardMd, accountUtils, permissionUtils, walletModel } from '@/entities/wallet';
 import { AddPureProxied } from '@/features/proxied-add-pure';
 import { AddProxy } from '@/features/proxy-add';
 import { ForgetWalletConfirm } from '@/features/wallets/ForgetWallet';
 import { RenameWallet } from '@/features/wallets/RenameWallet';
+import { walletDetailsUtils } from '../../lib/utils';
 import { multisigWalletDetailsModel } from '../../model/multisig-wallet-details';
 import { walletDetailsModel } from '../../model/wallet-details-model';
 import { WalletFiatBalance } from '../components';
@@ -38,6 +41,9 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const chains = useUnit(networkModel.$chains);
   const hasProxies = useUnit(multisigWalletDetailsModel.$hasProxies);
   const signatories = useUnit(multisigWalletDetailsModel.$signatories);
+  const contacts = useUnit(contactModel.$contacts);
+  const walletsList = useUnit(walletModel.$wallets);
+
   const accountList = useUnit(accounts.$list);
   const proxiesCount = useUnit(walletDetailsModel.$proxiesCount);
 
@@ -48,8 +54,11 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const multisigAccount = walletAccounts.find(accountUtils.isMultisigAccount);
   assert(multisigAccount, 'Multisig account not found.');
 
-  // Check for deprecated multichain multisig accounts
+  const getSignatoryName = (accountId: AccountId) => {
+    return walletDetailsUtils.getSignatoryName(accountId, multisigAccount.signatories, contacts, walletsList);
+  };
 
+  // Check for deprecated multichain multisig accounts
   const multisigChains = useMemo(() => {
     return Object.values(chains).filter(chain => {
       const isMultisigSupported = networkUtils.isMultisigSupported(chain.options);
@@ -186,7 +195,7 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
                 <ul className="flex flex-col gap-y-2 text-footnote text-text-secondary">
                   {signatories.people.map(accountId => (
                     <li key={accountId} className="px-3">
-                      <ContactItem address={accountId}>
+                      <ContactItem address={accountId} name={getSignatoryName(toAccountId(accountId))}>
                         <RootExplorers accountId={accountId} />
                       </ContactItem>
                     </li>


### PR DESCRIPTION
## Description
Multisig wallet details. Signatories tab shows addresses instead of custom names

## Related Issues
Closes #4707

## Changes Made
Added account names display in signatories tab of wallet details

## Screenshots/Recordings
<img width="590" height="728" alt="Снимок экрана 2025-09-19 в 19 34 49" src="https://github.com/user-attachments/assets/426e8b8e-9961-4ab6-bf91-3e5dd320dd62" />
<img width="578" height="695" alt="Снимок экрана 2025-09-19 в 19 34 57" src="https://github.com/user-attachments/assets/0f18378d-f820-498a-a50c-d868210192e7" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
