### PR TITLE
fix: fx race condition; take result of last started fx

### DIFF
--- a/src/renderer/shared/effector/createStoreFromEffect.ts
+++ b/src/renderer/shared/effector/createStoreFromEffect.ts
@@ -21,7 +21,7 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
 
   const fx = takeLast({
     key: () => 'createStoreFromEffect',
-    fn: async (args: Args): Promise<Awaited<Value>> => await params.fn(args),
+    fn: (args: Args) => params.fn(args),
   });
 
   sample({

--- a/src/renderer/shared/effector/createStoreFromEffect.ts
+++ b/src/renderer/shared/effector/createStoreFromEffect.ts
@@ -20,7 +20,7 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
   const fx = createEffect<{ args: Args; id: number }, Value>(({ args }) => params.fn(args));
 
   const incrementFxId = createEvent();
-  const $lastFxId = createStore(0).on(incrementFxId, id => id + 1);
+  const $lastFxId = createStore(0).on(incrementFxId, id => (id + 1) % Number.MAX_SAFE_INTEGER);
 
   sample({
     clock: $source,

--- a/src/renderer/shared/effector/createStoreFromEffect.ts
+++ b/src/renderer/shared/effector/createStoreFromEffect.ts
@@ -1,4 +1,4 @@
-import { type Store, combine, createEffect, createStore, sample } from 'effector';
+import { type Store, combine, createEffect, createEvent, createStore, sample } from 'effector';
 import { readonly } from 'patronum';
 
 import { nonNullableMap, nullableMap } from '@/shared/lib/utils';
@@ -17,12 +17,21 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
   const $source = combine(params.params, x => x);
   const $ = createStore<Value>(params.defaultValue);
 
-  const fx = createEffect<Args, Value>(params.fn);
+  const fx = createEffect<{ args: Args; id: number }, Value>(({ args }) => params.fn(args));
+
+  const incrementFxId = createEvent();
+  const $lastFxId = createStore(0).on(incrementFxId, id => id + 1);
 
   sample({
     clock: $source,
     filter: nonNullableMap,
-    fn: x => x as Args,
+    target: incrementFxId,
+  });
+
+  sample({
+    clock: incrementFxId,
+    source: { source: $source, id: $lastFxId },
+    fn: ({ source, id }) => ({ args: source as Args, id }),
     target: fx,
   });
 
@@ -34,11 +43,10 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
   });
 
   sample({
-    clock: fx.doneData,
-    source: $source,
-    // source should be still valid
-    filter: nonNullableMap,
-    fn: (_, res) => res,
+    clock: fx.done,
+    source: { source: $source, lastFxId: $lastFxId },
+    filter: ({ source, lastFxId }, data) => nonNullableMap(source) && data.params.id === lastFxId,
+    fn: (_, data) => data.result,
     target: $,
   });
 

--- a/src/renderer/shared/effector/createStoreFromEffect.ts
+++ b/src/renderer/shared/effector/createStoreFromEffect.ts
@@ -1,7 +1,9 @@
-import { type Store, combine, createEffect, createEvent, createStore, sample } from 'effector';
+import { type Store, combine, createStore, sample } from 'effector';
 import { readonly } from 'patronum';
 
 import { nonNullableMap, nullableMap } from '@/shared/lib/utils';
+
+import { takeLast } from './takeLast';
 
 type Stores<Args> = {
   [K in keyof Args]: Store<Args[K] | null>;
@@ -17,21 +19,15 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
   const $source = combine(params.params, x => x);
   const $ = createStore<Value>(params.defaultValue);
 
-  const fx = createEffect<{ args: Args; id: number }, Value>(({ args }) => params.fn(args));
-
-  const incrementFxId = createEvent();
-  const $lastFxId = createStore(0).on(incrementFxId, id => (id + 1) % Number.MAX_SAFE_INTEGER);
+  const fx = takeLast({
+    key: () => 'createStoreFromEffect',
+    fn: async (args: Args): Promise<Awaited<Value>> => await params.fn(args),
+  });
 
   sample({
     clock: $source,
     filter: nonNullableMap,
-    target: incrementFxId,
-  });
-
-  sample({
-    clock: incrementFxId,
-    source: { source: $source, id: $lastFxId },
-    fn: ({ source, id }) => ({ args: source as Args, id }),
+    fn: source => source as Args,
     target: fx,
   });
 
@@ -43,10 +39,11 @@ export const createStoreFromEffect = <Args, Value>(params: Params<Args, Value>) 
   });
 
   sample({
-    clock: fx.done,
-    source: { source: $source, lastFxId: $lastFxId },
-    filter: ({ source, lastFxId }, data) => nonNullableMap(source) && data.params.id === lastFxId,
-    fn: (_, data) => data.result,
+    clock: fx.doneData,
+    source: $source,
+    // source should be still valid
+    filter: nonNullableMap,
+    fn: (_, res: Value) => res,
     target: $,
   });
 

--- a/src/renderer/shared/effector/takeLast.ts
+++ b/src/renderer/shared/effector/takeLast.ts
@@ -1,7 +1,7 @@
 import { createEffect } from 'effector';
 
 type Params<P, R> = {
-  fn(params: P, abort: AbortSignal): Awaited<R> | Promise<Awaited<R>>;
+  fn(params: P, abort: AbortSignal): R | Promise<R>;
   key(params: P): string;
 };
 


### PR DESCRIPTION
## Description
Fixes a race condition within a tx validator.
Longer running effect were overwriting the effect's result that was triggered last.

## Related Issues
Closes #4713

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
Before:
<img width="821" height="758" alt="Screenshot 2025-09-22 at 11 04 55 AM" src="https://github.com/user-attachments/assets/c141687d-6091-4c9b-b7ea-c8ac71194ddc" />

After:
<img width="841" height="767" alt="Screenshot 2025-09-22 at 3 16 16 PM" src="https://github.com/user-attachments/assets/4926780c-f07c-4c3f-916e-e8da24abb696" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
