### PR TITLE
fix: remove redundant gate

### DIFF
--- a/src/renderer/features/wallet-details/ui/components/ProxiesList.tsx
+++ b/src/renderer/features/wallet-details/ui/components/ProxiesList.tsx
@@ -1,4 +1,4 @@
-import { useGate, useStoreMap, useUnit } from 'effector-react';
+import { useStoreMap, useUnit } from 'effector-react';
 
 import { type ProxyAccount, type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -29,8 +29,6 @@ type Props = {
 };
 
 export const ProxiesList = ({ className, wallet, hasProxies, canCreateProxy = true }: Props) => {
-  useGate(walletProxiesModel.flow, { wallet });
-
   const { t } = useI18n();
 
   const chains = useUnit(networkModel.$chains);


### PR DESCRIPTION
## Description
When switching to the "delegated to" tab in wallet details, the proxies list would show empty initially before displaying the loaded data. This happened because the ProxiesList component was triggering duplicate data loading.

The ProxiesList component was calling `useGate(walletProxiesModel.flow, { wallet })` which triggered a wallet change event, causing the wallet proxies data to be reset and reloaded.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
Removed `useGate(walletProxiesModel.flow, { wallet })` from ProxiesList component
## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
