### PR TITLE
fix: evm transactions for vault 7.0

### DIFF
--- a/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
@@ -54,6 +54,7 @@ export const ScanSingleframeQr = ({
 
   const isPV = account.signingType === SigningType.POLKADOT_VAULT;
   const isMetadataProofsSupported = chain.additional?.supportsGenericLedgerApp ?? false;
+  const isEthereumAccount = accountUtils.isEthereumBased(account);
 
   useEffect(() => {
     if (txPayload && qrPayload && tab === prevTab.current) return;
@@ -105,7 +106,7 @@ export const ScanSingleframeQr = ({
         const { payload } = transactionService.createPayloadWithMetadata(extrinsic, api, metadata);
 
         let signPayload: Uint8Array;
-        if (isPV) {
+        if (isPV && !isEthereumAccount) {
           assert(derivationPath, 'Derivation path not found');
           signPayload = createDynamicDerivationsSignPayload(
             rootAccountId,


### PR DESCRIPTION
## Description
Fixes QR code generation for Ethereum accounts for Polkadot Vault 7.0.
PV 7.0 supports only commands 0x06 and 0x00 for transaction with ethereum accounts.
User should switch to Legacy tab to sign the transaction if he has a version lower than 7.1

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
Scanning error:
![telegram-cloud-photo-size-2-5379818031892527446-y](https://github.com/user-attachments/assets/739aa43b-f264-4fa8-bfae-da65f937fc01)

Working QR:
<img width="486" height="636" alt="Screenshot 2025-09-25 at 3 30 34 PM" src="https://github.com/user-attachments/assets/90ed50b3-a5d1-4f14-85e4-a14a5345c929" />

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
