### PR TITLE
Display flex multisig on Staking page, fix markup BondNominate

### DIFF
--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -126,11 +126,15 @@ function buildBondNominate({
   };
 }
 
+type Staked = 'Staked';
+type Payout = { destination: Address };
+type RewardDestination = Staked | Payout;
+
 type BondParams = {
   chain: Chain;
   asset: Asset;
   accountId: AccountId;
-  destination: string;
+  destination: RewardDestination;
   amount: string;
 };
 function buildBond({ chain, asset, accountId, destination, amount }: BondParams): Transaction {
@@ -141,7 +145,7 @@ function buildBond({ chain, asset, accountId, destination, amount }: BondParams)
     args: {
       value: formatAmount(amount, asset.precision),
       controller: accountId,
-      payee: destination === '' ? 'Staked' : { Account: destination },
+      payee: destination === 'Staked' ? destination : { Account: destination.destination },
     },
   };
 }

--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -130,7 +130,7 @@ type BondParams = {
   chain: Chain;
   asset: Asset;
   accountId: AccountId;
-  destination: Address;
+  destination: string;
   amount: string;
 };
 function buildBond({ chain, asset, accountId, destination, amount }: BondParams): Transaction {

--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -145,7 +145,7 @@ function buildBond({ chain, asset, accountId, destination, amount }: BondParams)
     args: {
       value: formatAmount(amount, asset.precision),
       controller: accountId,
-      payee: destination === 'Staked' ? destination : { Account: destination.destination },
+      payee: destination === 'Staked' ? 'Staked' : { Account: destination.destination },
     },
   };
 }

--- a/src/renderer/pages/Staking/ui/Staking.tsx
+++ b/src/renderer/pages/Staking/ui/Staking.tsx
@@ -288,10 +288,6 @@ export const Staking = () => {
         // @ts-expect-error TODO fix
         acc.push(shardsGroup);
       } else {
-        if (accountUtils.isFlexibleMultisigAccount(account)) {
-          return acc;
-        }
-
         acc.push(getInfo(account));
       }
 

--- a/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
@@ -206,22 +206,27 @@ const $coreTx = combine(
     signatory: form.fields.signatory.$value,
     amount: form.fields.amount.$value,
     destination: form.fields.destination.$value,
+    destinationType: $destinationType,
     validators: $validators,
     networkStore: $networkStore,
   },
-  ({ chain, signatory, amount, destination, validators, networkStore }) => {
-    if (nullable(chain) || nullable(signatory) || nullable(networkStore) || nullable(destination)) {
+  ({ chain, signatory, amount, destination, destinationType, validators, networkStore }) => {
+    if (nullable(chain) || nullable(signatory) || nullable(networkStore)) {
       return null;
     }
 
-    if (!validateAddress(destination)) return null;
+    if (destinationType !== RewardsDestination.RESTAKE) {
+      if (nullable(destination) || !validateAddress(destination)) {
+        return null;
+      }
+    }
 
     return transactionBuilder.buildBondNominate({
       chain: chain,
       asset: networkStore.asset,
       accountId: signatory.accountId,
       amount: amount,
-      destination: destination,
+      destination: toAddress(destination!),
       nominators: validators.map(({ accountId }) => accountId),
     });
   },

--- a/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
@@ -226,7 +226,7 @@ const $coreTx = combine(
       asset: networkStore.asset,
       accountId: signatory.accountId,
       amount: amount,
-      destination: destinationType !== RewardsDestination.RESTAKE ? '' : toAddress(destination!),
+      destination: destinationType === RewardsDestination.RESTAKE ? 'Staked' : { destination: toAddress(destination!) },
       nominators: validators.map(({ accountId }) => accountId),
     });
   },

--- a/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/default/model/form-model.ts
@@ -226,7 +226,7 @@ const $coreTx = combine(
       asset: networkStore.asset,
       accountId: signatory.accountId,
       amount: amount,
-      destination: toAddress(destination!),
+      destination: destinationType !== RewardsDestination.RESTAKE ? '' : toAddress(destination!),
       nominators: validators.map(({ accountId }) => accountId),
     });
   },

--- a/src/renderer/widgets/Staking/BondNominate/default/ui/BondNominate.tsx
+++ b/src/renderer/widgets/Staking/BondNominate/default/ui/BondNominate.tsx
@@ -51,7 +51,7 @@ export const BondNominate = () => {
   return (
     <Modal
       isOpen={isModalOpen}
-      size="fit"
+      size={step === Step.VALIDATORS ? 'fit' : 'md'}
       onToggle={(open) => {
         if (!open) {
           closeModal();

--- a/src/renderer/widgets/Staking/BondNominate/default/ui/BondNominate.tsx
+++ b/src/renderer/widgets/Staking/BondNominate/default/ui/BondNominate.tsx
@@ -51,7 +51,7 @@ export const BondNominate = () => {
   return (
     <Modal
       isOpen={isModalOpen}
-      size="md"
+      size="fit"
       onToggle={(open) => {
         if (!open) {
           closeModal();

--- a/src/renderer/widgets/Staking/BondNominate/shards/model/bond-nominate-model.ts
+++ b/src/renderer/widgets/Staking/BondNominate/shards/model/bond-nominate-model.ts
@@ -6,11 +6,12 @@ import { spread } from 'patronum';
 import {
   type MultisigTxWrapper,
   type ProxyTxWrapper,
+  RewardsDestination,
   type Transaction,
   type TxWrapper,
   WrapperKind,
 } from '@/shared/core';
-import { TEST_ADDRESS, getNativeAsset, getRelaychainAsset, nonNullable } from '@/shared/lib/utils';
+import { TEST_ADDRESS, getNativeAsset, getRelaychainAsset, nonNullable, toAddress } from '@/shared/lib/utils';
 import { type PathType, Paths } from '@/shared/routes';
 import { type AnyAccount } from '@/domains/network';
 import { networkModel } from '@/entities/network';
@@ -193,16 +194,20 @@ sample({
 
 sample({
   clock: $bondNominateData.updates,
-  source: $walletData,
-  filter: (walletData, bondData) => Boolean(walletData) && Boolean(bondData),
-  fn: (walletData, bondData) => {
+  source: {
+    walletData: $walletData,
+    destinationType: formModel.$destinationType,
+  },
+  filter: ({ walletData }, bondData) => Boolean(walletData) && Boolean(bondData),
+  fn: ({ walletData, destinationType }, bondData) => {
     return bondData!.shards.map((shard) => {
       return transactionBuilder.buildBondNominate({
         chain: walletData!.chain,
         asset: getNativeAsset(walletData!.chain.assets)!,
         accountId: shard.accountId,
         amount: bondData!.amount,
-        destination: bondData!.destination,
+        destination:
+          destinationType === RewardsDestination.RESTAKE ? 'Staked' : { destination: toAddress(bondData!.destination) },
         nominators: bondData!.validators.map(({ accountId }) => accountId),
       });
     });


### PR DESCRIPTION
## Description
Broken state for Staking page on Flexible multisig
Incorrect markup on BondNominate modal

## Related Issues
Closes #4746

## Changes Made
Flexible multisig accounts now appear on Staking page
Fixed BondNominate modal layout

## Screenshots/Recordings
<img width="1724" height="612" alt="Снимок экрана 2025-09-25 в 13 36 22" src="https://github.com/user-attachments/assets/cb158e37-8d2e-47c1-8237-b8fff90be2d2" />
<img width="809" height="703" alt="Снимок экрана 2025-09-25 в 13 37 19" src="https://github.com/user-attachments/assets/bc0ea63e-a6af-4c6d-9b86-c4fcf4aa4941" />
<img width="487" height="767" alt="Снимок экрана 2025-09-25 в 13 37 32" src="https://github.com/user-attachments/assets/3095333d-3174-4772-b847-d75b4d30bab5" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
