### PR TITLE
Clean up usage of assetId

### DIFF
--- a/src/renderer/entities/operations/lib/operationDetailsUtils.ts
+++ b/src/renderer/entities/operations/lib/operationDetailsUtils.ts
@@ -1,6 +1,5 @@
 import { type ApiPromise } from '@polkadot/api';
 import { BN } from '@polkadot/util';
-import { isString } from 'lodash';
 
 import {
   type Address,
@@ -16,7 +15,7 @@ import {
   TransactionType,
   type Wallet,
 } from '@/shared/core';
-import { toAccountId, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { OnChainAssetId, toAccountId, toAddress, toShortAddress } from '@/shared/lib/utils';
 import { convictionVotingPallet } from '@/shared/pallet/convictionVoting';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type MultisigEvent, type MultisigOperation } from '@/domains/network';
@@ -77,9 +76,8 @@ export const getSignatoryName = (
   return toShortAddress(toAddress(signatoryId, { prefix: addressPrefix }), 5);
 };
 
-export const getAssetId = (operation: MultisigOperation) => {
-  const asset = operation.transaction?.args.assetId;
-  return isString(asset) ? asset : null;
+export const getAssetId = (operation: MultisigOperation): OnChainAssetId => {
+  return operation.transaction?.args.asset;
 };
 
 export const getDestination = (

--- a/src/renderer/entities/staking/ui/ValidatorsModal/ValidatorsModal.tsx
+++ b/src/renderer/entities/staking/ui/ValidatorsModal/ValidatorsModal.tsx
@@ -14,7 +14,7 @@ type Props = {
   selectedValidators: Validator[];
   notSelectedValidators: Validator[];
   identities: Record<AccountId, AccountIdentity>;
-  asset?: Asset;
+  asset: Asset;
   chain?: Chain;
   onClose: () => void;
 };

--- a/src/renderer/entities/transaction/hooks/useTransactionAsset.ts
+++ b/src/renderer/entities/transaction/hooks/useTransactionAsset.ts
@@ -1,41 +1,19 @@
 import { useStoreMap } from 'effector-react';
 
-import { getAssetById, getAssetByTypeExtras } from '@/shared/lib/utils';
+import { type Asset } from '@/shared/core';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { type MultisigOperation } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 
-export const useTransactionAsset = (operation: MultisigOperation) => {
+export const useTransactionAsset = (operation: MultisigOperation): Asset | null => {
   const chain = useStoreMap({
     store: networkModel.$chains,
     keys: [operation.chainId],
     fn: (chains, [id]) => chains[id] ?? null,
   });
-  const api = useStoreMap({
-    store: networkModel.$apis,
-    keys: [operation.chainId],
-    fn: (apis, [id]) => apis[id] ?? null,
-  });
 
   if (operation.transaction && chain) {
-    if (operation.transaction.args.assetId) {
-      const targetAssetId = operation.transaction.args.assetId;
-
-      const foundAsset = chain.assets.find((asset) => {
-        return asset.typeExtras && 'assetId' in asset.typeExtras && asset.typeExtras.assetId === targetAssetId;
-      });
-
-      if (foundAsset) {
-        return foundAsset;
-      }
-
-      if (api) {
-        return getAssetByTypeExtras(api, chain.assets, targetAssetId);
-      }
-
-      return null;
-    } else {
-      return getAssetById(operation.transaction.args.asset, chain.assets) ?? null;
-    }
+    return getAssetByOnChainId(operation.transaction.args.asset, chain.assets);
   }
 
   return null;

--- a/src/renderer/entities/transaction/lib/callDataDecoder.ts
+++ b/src/renderer/entities/transaction/lib/callDataDecoder.ts
@@ -200,7 +200,7 @@ const getCallDataParser: Record<
   },
   [TransactionType.ASSET_TRANSFER]: (decoded): Record<string, any> => {
     return {
-      assetId: decoded.args[0].toString(),
+      asset: decoded.args[0].toString(),
       dest: decoded.args[1].toString(),
       value: decoded.args[2].toString(),
     };
@@ -208,7 +208,7 @@ const getCallDataParser: Record<
   [TransactionType.ORML_TRANSFER]: (decoded): Record<string, any> => {
     return {
       dest: decoded.args[0].toString(),
-      assetId: decoded.args[1].toString(),
+      asset: decoded.args[1].toString(),
       value: decoded.args[2].toString(),
     };
   },

--- a/src/renderer/entities/transaction/lib/transactionBuilder.ts
+++ b/src/renderer/entities/transaction/lib/transactionBuilder.ts
@@ -15,7 +15,7 @@ import {
   type Transaction,
   TransactionType,
 } from '@/shared/core';
-import { formatAmount, getAssetId } from '@/shared/lib/utils';
+import { formatAmount, getOnChainAssetId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type MultisigOperation } from '@/domains/network';
 import { type RevoteTransaction, type TransactionVote, type VoteTransaction } from '@/entities/governance';
@@ -100,7 +100,7 @@ function buildTransfer({
       palletName,
       dest: destination,
       value: formatAmount(amount, asset.precision),
-      ...(Boolean(asset.type) && { asset: getAssetId(asset) }),
+      ...(Boolean(asset.type) && { asset: getOnChainAssetId(asset) }),
       ...xcmData?.args,
     },
   };

--- a/src/renderer/features/governance-operation-details/components/GovernanceOperationTitle.tsx
+++ b/src/renderer/features/governance-operation-details/components/GovernanceOperationTitle.tsx
@@ -1,7 +1,7 @@
 import { useUnit } from 'effector-react';
 
 import { useI18n } from '@/shared/i18n';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { AssetBalance, AssetIcon } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
@@ -21,7 +21,7 @@ export const GovernanceOperationTitle = ({ operation, title }: Props) => {
 
   const transaction = operation.transaction;
 
-  const asset = transaction && getAssetById(transaction.args.asset, chains[operation.chainId]?.assets);
+  const asset = transaction && getAssetByOnChainId(transaction.args.asset, chains[operation.chainId]?.assets);
   const amount = transaction && getTransactionAmount(transaction);
 
   return (

--- a/src/renderer/features/governance/model/unlock/unlock-validate-model.ts
+++ b/src/renderer/features/governance/model/unlock/unlock-validate-model.ts
@@ -4,7 +4,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { governanceService } from '@/entities/governance';
 import { networkModel } from '@/entities/network';
@@ -79,7 +79,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/governance/model/vote/voteValidateModel.ts
+++ b/src/renderer/features/governance/model/vote/voteValidateModel.ts
@@ -5,7 +5,7 @@ import { attach, createEffect } from 'effector';
 import { t } from 'i18next';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { governanceService, referendumService } from '@/entities/governance';
 import { networkModel } from '@/entities/network';
@@ -83,7 +83,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
@@ -6,7 +6,7 @@ import { useEffect } from 'react';
 import { type Asset, type Chain } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { getAssetById, getAssetByTypeExtras, getNativeAsset } from '@/shared/lib/utils';
+import { getAssetByOnChainId, getNativeAsset } from '@/shared/lib/utils';
 import { Button, DetailRow, Icon } from '@/shared/ui';
 import {
   type TransactionValidationBalanceError,
@@ -70,11 +70,7 @@ export const Confirmation = ({
   const transaction = operation.transaction;
   let asset: Asset | null = null;
   if (transaction) {
-    if (transaction.args.assetId) {
-      asset = getAssetByTypeExtras(api, chain.assets, transaction.args.assetId) ?? getNativeAsset(chain.assets);
-    } else {
-      asset = getAssetById(transaction.args.asset, chain.assets) ?? getNativeAsset(chain.assets);
-    }
+    asset = getAssetByOnChainId(transaction.args.asset, chain.assets) ?? getNativeAsset(chain.assets);
   }
 
   const xcmApi = useStoreMap({

--- a/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
@@ -12,7 +12,7 @@ import {
 import { TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
-import { getAssetByTypeExtras, getNativeAsset, nullable } from '@/shared/lib/utils';
+import { getAssetByOnChainId, getNativeAsset, nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { Modal } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
@@ -76,7 +76,7 @@ export const RejectTxModal = memo(({ api, operation, chain, children }: Props) =
   if (chain) {
     const assetId = operationDetailsUtils.getAssetId(operation);
     if (assetId && api) {
-      asset = getAssetByTypeExtras(api, chain.assets, assetId);
+      asset = getAssetByOnChainId(assetId, chain.assets);
     }
   }
 

--- a/src/renderer/features/operations/OperationsValidation/model/add-proxy-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/add-proxy-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -66,7 +66,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/add-pure-proxied-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/add-pure-proxied-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -55,7 +55,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/bond-extra-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/bond-extra-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, stakeableAmount, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, stakeableAmount, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -68,7 +68,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/bond-nominate-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/bond-nominate-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, stakeableAmount, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, stakeableAmount, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -69,7 +69,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/delegate-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/delegate-validate-model.ts
@@ -3,7 +3,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { type Store, attach, createEffect, sample } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, getNativeAsset, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, getNativeAsset, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -111,7 +111,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/nominate-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/nominate-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, stakeableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, stakeableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { NominateRules } from '../lib/nominate-rules';
@@ -51,7 +51,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/payee-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/payee-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, stakeableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, stakeableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { PayeeRules } from '../lib/payee-rules';
@@ -51,7 +51,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/remove-proxy-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/remove-proxy-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -55,7 +55,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/remove-pure-proxied-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/remove-pure-proxied-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -56,7 +56,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/remove-vote-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/remove-vote-validate-model.ts
@@ -5,7 +5,7 @@ import { attach, createEffect } from 'effector';
 import { t } from 'i18next';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { convictionVotingPallet } from '@/shared/pallet/convictionVoting';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
@@ -81,7 +81,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/restake-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/restake-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -57,7 +57,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/revoke-delegation-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/revoke-delegation-validate-model.ts
@@ -3,7 +3,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -110,7 +110,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/transfer-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/transfer-validate-model.ts
@@ -3,7 +3,7 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -164,7 +164,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/operations/OperationsValidation/model/unstake-validate-model.ts
+++ b/src/renderer/features/operations/OperationsValidation/model/unstake-validate-model.ts
@@ -3,7 +3,7 @@ import { type SignerOptions } from '@polkadot/api/submittable/types';
 import { type Store, attach, createEffect } from 'effector';
 
 import { type Asset, type Balance, type BalanceMap, type Chain, type ID, type Transaction } from '@/shared/core';
-import { getAssetById, stakedAmount, transferableAmount } from '@/shared/lib/utils';
+import { getAssetByOnChainId, stakedAmount, transferableAmount } from '@/shared/lib/utils';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { transactionService } from '@/entities/transaction';
@@ -66,7 +66,7 @@ const validateFx = attach({
   mapParams({ id, transaction, feeMap }: ValidationStartedParams, { chains, balances, apis }) {
     const chain = chains[transaction.chainId];
     const api = apis[transaction.chainId];
-    const asset = getAssetById(transaction.args.asset, chain.assets) || chain.assets[0];
+    const asset = getAssetByOnChainId(transaction.args.asset, chain.assets) || chain.assets[0];
 
     return {
       id,

--- a/src/renderer/features/proxy-operation-details/components/ProxyOperationTitle.tsx
+++ b/src/renderer/features/proxy-operation-details/components/ProxyOperationTitle.tsx
@@ -1,7 +1,7 @@
 import { useUnit } from 'effector-react';
 
 import { useI18n } from '@/shared/i18n';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { AssetBalance, AssetIcon } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
@@ -21,7 +21,7 @@ export const ProxyOperationTitle = ({ operation, title }: Props) => {
 
   const transaction = operation.transaction;
 
-  const asset = transaction && getAssetById(transaction.args.asset, chains[operation.chainId]?.assets);
+  const asset = transaction && getAssetByOnChainId(transaction.args.asset, chains[operation.chainId]?.assets);
   const amount = transaction && getTransactionAmount(transaction);
 
   return (

--- a/src/renderer/features/staking-operation-details/components/StakingOperationTitle.tsx
+++ b/src/renderer/features/staking-operation-details/components/StakingOperationTitle.tsx
@@ -1,7 +1,7 @@
 import { useUnit } from 'effector-react';
 
 import { useI18n } from '@/shared/i18n';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { AssetBalance, AssetIcon } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
@@ -21,7 +21,7 @@ export const StakingOperationTitle = ({ operation, title }: Props) => {
 
   const transaction = operation.transaction;
 
-  const asset = transaction && getAssetById(transaction.args.asset, chains[operation.chainId]?.assets);
+  const asset = transaction && getAssetByOnChainId(transaction.args.asset, chains[operation.chainId]?.assets);
   const amount = transaction && getTransactionAmount(transaction);
 
   return (

--- a/src/renderer/features/staking-operation-details/components/ValidatorsOperationDetails.tsx
+++ b/src/renderer/features/staking-operation-details/components/ValidatorsOperationDetails.tsx
@@ -4,7 +4,7 @@ import { useEffect } from 'react';
 import { type Address, type Transaction, TransactionType, type Validator } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
-import { cnTw, getAssetById, keys, toAccountId } from '@/shared/lib/utils';
+import { cnTw, getAssetByOnChainId, keys, toAccountId } from '@/shared/lib/utils';
 import { DetailRow, FootnoteText, Icon } from '@/shared/ui';
 import { type MultisigOperation, identity } from '@/domains/network';
 import { networkModel } from '@/entities/network';
@@ -57,7 +57,7 @@ export const ValidatorsOperationDetails = ({ operation }: Props) => {
     allValidators.filter((v) => (transaction?.args.targets || startStakingValidators).includes(v.accountId)) || [];
   const selectedValidatorsAddress = selectedValidators.map((validator) => validator.accountId);
   const notSelectedValidators = allValidators.filter((v) => !selectedValidatorsAddress.includes(v.accountId));
-  const validatorsAsset = transaction && getAssetById(transaction.args.asset, chains[operation.chainId]?.assets);
+  const validatorsAsset = transaction && getAssetByOnChainId(transaction.args.asset, chains[operation.chainId]?.assets);
 
   if (Boolean(selectedValidators?.length) && defaultAsset) {
     result.push(
@@ -80,7 +80,7 @@ export const ValidatorsOperationDetails = ({ operation }: Props) => {
 
         <ValidatorsModal
           isOpen={isValidatorsOpen}
-          asset={validatorsAsset}
+          asset={validatorsAsset!}
           identities={identities}
           selectedValidators={selectedValidators}
           notSelectedValidators={notSelectedValidators}

--- a/src/renderer/features/transfer-basket/components/ConfirmTitle.tsx
+++ b/src/renderer/features/transfer-basket/components/ConfirmTitle.tsx
@@ -1,7 +1,7 @@
 import { useUnit } from 'effector-react';
 
 import { useI18n } from '@/shared/i18n';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { OperationTitle } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
 import { isTransferTransaction, isXcmTransaction } from '@/entities/transaction';
@@ -16,7 +16,7 @@ export const ConfirmTitle = ({ transaction }: Props) => {
   const chains = useUnit(networkModel.$chains);
   const tx = basketOperationsService.getCoreTx(transaction);
   const chain = chains[tx.chainId];
-  const asset = getAssetById(tx.args.assetId, chain.assets);
+  const asset = getAssetByOnChainId(tx.args.assetId, chain.assets);
 
   if (isTransferTransaction(tx)) {
     return (

--- a/src/renderer/features/transfer-basket/components/OperationTitle.tsx
+++ b/src/renderer/features/transfer-basket/components/OperationTitle.tsx
@@ -2,7 +2,7 @@ import { useUnit } from 'effector-react';
 
 import { type Transaction } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { getAssetById } from '@/shared/lib/utils';
+import { getAssetByOnChainId } from '@/shared/lib/utils';
 import { AssetBalance, AssetIcon } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
 import { ChainTitle, XcmChains } from '@/entities/chain';
@@ -16,7 +16,7 @@ type Props = {
 export const OperationTitle = ({ coreTx }: Props) => {
   const { t } = useI18n();
   const chains = useUnit(networkModel.$chains);
-  const asset = getAssetById(coreTx.args.asset, chains[coreTx.chainId]?.assets);
+  const asset = getAssetByOnChainId(coreTx.args.asset, chains[coreTx.chainId]?.assets);
   const amount = getTransactionAmount(coreTx);
 
   return (

--- a/src/renderer/features/transfer-basket/model/confirm.ts
+++ b/src/renderer/features/transfer-basket/model/confirm.ts
@@ -4,7 +4,7 @@ import { createEffect, sample } from 'effector';
 import { createGate } from 'effector-react';
 
 import { type Chain, type ChainId } from '@/shared/core';
-import { getAssetById, nonNullable, nullable } from '@/shared/lib/utils';
+import { getAssetByOnChainId, nonNullable, nullable } from '@/shared/lib/utils';
 import { type AnyAccount } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { isTransferTransaction, isXcmTransaction } from '@/entities/transaction';
@@ -25,7 +25,7 @@ const prepareDataFx = createEffect(async ({ transaction, accounts, chains, apis 
   const { chain, account, fee } = await basketOperationsService.getTransactionData(transaction, apis, chains, accounts);
 
   const destinationChain = chains[transaction.coreTx.args.destinationChain] || chain;
-  const asset = getAssetById(transaction.coreTx.args.asset, chain.assets);
+  const asset = getAssetByOnChainId(transaction.coreTx.args.asset, chain.assets);
 
   if (nullable(account) || nullable(asset)) return null;
 

--- a/src/renderer/pages/Staking/ui/Staking.tsx
+++ b/src/renderer/pages/Staking/ui/Staking.tsx
@@ -440,7 +440,7 @@ export const Staking = () => {
       </div>
 
       <ValidatorsModal
-        asset={relaychainAsset}
+        asset={relaychainAsset!}
         selectedValidators={selectedValidators}
         notSelectedValidators={notSelectedValidators}
         identities={identities}

--- a/src/renderer/shared/api/balances/service/balanceService.ts
+++ b/src/renderer/shared/api/balances/service/balanceService.ts
@@ -20,7 +20,7 @@ import {
   type OrmlExtras,
 } from '@/shared/core';
 import {
-  getAssetId,
+  getOnChainAssetId,
   getRepeatedIndex,
   getRoundedValue,
   groupBy,
@@ -202,7 +202,7 @@ function subscribeStatemineAssetsChange(
   }
 
   const assetsTuples = assets.reduce<[string | Codec, AccountId][]>((acc, asset) => {
-    const assetId = getAssetId(asset);
+    const assetId = getOnChainAssetId(asset);
     // @ts-expect-error type argument in createType has incorrect types
     const location = api.createType(type, assetId);
 
@@ -502,7 +502,7 @@ async function fetchStatemineAssets(
   }
 
   const assetsTuples = assets.reduce<[string | Codec, AccountId][]>((acc, asset) => {
-    const assetId = getAssetId(asset);
+    const assetId = getOnChainAssetId(asset);
     // @ts-expect-error type argument in createType has incorrect types
     const location = api.createType(type, assetId);
 
@@ -659,7 +659,7 @@ async function getExistentialDeposit(api: ApiPromise, asset: Asset): Promise<BN>
         pallet = 'assets';
       }
 
-      const assetId = getAssetId(asset);
+      const assetId = getOnChainAssetId(asset);
 
       return await api.query[pallet].asset(assetId).then((balance) => {
         if ((balance as Option<PalletAssetsAssetDetails>).isNone) {

--- a/src/renderer/shared/api/xcm/service/xcmService.ts
+++ b/src/renderer/shared/api/xcm/service/xcmService.ts
@@ -4,7 +4,13 @@ import { BN, BN_TEN, BN_ZERO } from '@polkadot/util';
 import { camelCase, get } from 'lodash';
 
 import { type Chain, type ChainId, type HexString } from '@/shared/core';
-import { getAssetId, getTypeName, getTypeVersion, toLocalChainId } from '@/shared/lib/utils';
+import {
+  type OnChainAssetId,
+  getOnChainAssetId,
+  getTypeName,
+  getTypeVersion,
+  toLocalChainId, assert,
+} from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type XTokenPalletTransferArgs, type XcmPalletTransferArgs } from '@/entities/transaction';
 import { localStorageService } from '../../local-storage';
@@ -299,7 +305,7 @@ function parseXTokensExtrinsic(args: Omit<XTokenPalletTransferArgs, 'destWeight'
 }
 
 type DecodedPayload = {
-  assetId?: number | string;
+  assetId: OnChainAssetId;
   destinationChain?: HexString;
   value: string;
   dest: string;
@@ -326,7 +332,7 @@ function decodeXcm(
 
   const configOriginChain = config.chains.find((c) => `0x${c.chainId}` === chainId);
 
-  let assetId: number | string | undefined;
+  let assetId: OnChainAssetId | undefined;
   if (!data.isRelayToken && configOriginChain) {
     const filteredAssetLocations = configOriginChain.assets.reduce<[number, AssetLocation][]>((acc, asset) => {
       acc.push([asset.assetId, config.assetsLocation[asset.assetLocation]]);
@@ -351,12 +357,14 @@ function decodeXcm(
     if (assetKeyVal) {
       const assetFromChain = chains[chainId]?.assets.find((asset) => asset.assetId === assetKeyVal[0]);
       if (assetFromChain) {
-        assetId = getAssetId(assetFromChain);
+        assetId = getOnChainAssetId(assetFromChain);
       }
     } else {
       console.log(`XCM config cannot handle - ${data}`);
     }
   }
+
+  assert(assetId, 'Asset id not detected');
 
   return {
     assetId,

--- a/src/renderer/shared/lib/utils/assets.ts
+++ b/src/renderer/shared/lib/utils/assets.ts
@@ -1,36 +1,48 @@
-import { type ApiPromise } from '@polkadot/api';
-
-import { type Asset, AssetType, type OrmlExtras, StakingType, type StatemineExtras } from '@/shared/core/types/asset';
+import {
+  type Asset,
+  type AssetId,
+  AssetType,
+  type OrmlExtras,
+  StakingType,
+  type StatemineExtras,
+} from '@/shared/core/types/asset';
 import { assert } from '@/shared/lib/utils';
 
-export const getNativeAsset = (assets: Asset[]): Asset => {
-  const nativeAsset = assets.find((asset) => asset.type === AssetType.NATIVE);
-  if (!nativeAsset) {
-    // some networks use orml assets as native (cringe)
-    const firstAsset = assets.at(0);
-    assert(firstAsset, 'Native asset is not found');
-    return firstAsset;
-  }
+/**
+ * Asset id as seen by the chain. Useful when we want to transact specifying
+ * this asset. Note that this can have different type depending on the type of
+ * the corresponding asset
+ */
+export type OnChainAssetId = string | number | 'Native';
 
+export const getNativeAsset = (assets: Asset[]): Asset => {
+  const nativeId = getNativeAssetId();
+  const nativeAsset = assets.find((asset) => asset.assetId == nativeId);
+  assert(nativeAsset, 'Native asset is not found');
   return nativeAsset;
 };
 
-/**
- * Get ID of the asset by type
- *
- * @param asset Network asset
- *
- * @returns {String}
- */
-export const getAssetId = (asset: Asset): string => {
-  if (asset.type === AssetType.STATEMINE) {
-    return (asset.typeExtras as StatemineExtras).assetId;
-  }
-  if (asset.type === AssetType.ORML) {
-    return (asset.typeExtras as OrmlExtras).currencyIdScale;
-  }
+export const getNativeAssetId = (): AssetId => {
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+  return 0 as AssetId;
+};
 
-  return asset.assetId.toString();
+export const isNativeAsset = (asset: Asset): boolean => {
+  return getNativeAssetId() === asset.assetId;
+};
+
+export const getOnChainAssetId = (asset: Asset): OnChainAssetId => {
+  const type = asset.type;
+  switch (type) {
+    case AssetType.NATIVE:
+      return 'Native';
+    case AssetType.ORML:
+      return (asset.typeExtras as OrmlExtras).currencyIdScale;
+    case AssetType.STATEMINE:
+      return (asset.typeExtras as StatemineExtras).assetId;
+    default:
+      throw type satisfies never;
+  }
 };
 
 /**
@@ -41,30 +53,15 @@ export const getAssetId = (asset: Asset): string => {
  *
  * @returns {Asset | undefined}
  */
-export const getAssetById = (id: string, assets?: Asset[]): Asset | undefined => {
-  if (!assets || assets.length === 0) return undefined;
+export const getAssetByOnChainId = (id: OnChainAssetId, assets: Asset[]): Asset | null => {
+  if (!assets || assets.length === 0) return null;
 
-  return assets.find((asset) => getAssetId(asset) === id);
-};
-
-/**
- * Get asset by type extras
- */
-export const getAssetByTypeExtras = (api: ApiPromise, assets: Asset[], assetId: string): Asset | null => {
-  return (
-    assets.find((asset) => {
-      if (!asset.typeExtras) return;
-
-      if ('assetId' in asset.typeExtras) {
-        return asset.typeExtras.assetId === assetId;
-      }
-
-      const id = api.createType(asset.typeExtras.currencyIdType, asset.typeExtras.currencyIdScale).toJSON();
-      const currencyId = api.createType(asset.typeExtras.currencyIdType, assetId).toJSON();
-
-      return id === currencyId;
-    }) ?? null
-  );
+  const res = assets.find((asset) => getOnChainAssetId(asset) === id);
+  if (res) {
+    return res;
+  } else {
+    return null;
+  }
 };
 
 /**

--- a/src/renderer/widgets/Transfer/default/model/form-model.ts
+++ b/src/renderer/widgets/Transfer/default/model/form-model.ts
@@ -10,8 +10,8 @@ import {
   TEST_EVM_ADDRESS,
   assert,
   formatAmount,
-  getAssetId,
   getNativeAsset,
+  isNativeAsset,
   nonNullable,
   nullable,
   toAccountId,
@@ -382,7 +382,7 @@ sample({
 
 sample({
   clock: formInitiated,
-  fn: ({ chain, asset }) => getAssetId(getNativeAsset(chain.assets)!) === getAssetId(asset),
+  fn: ({ asset }) => isNativeAsset(asset),
   target: $isNative,
 });
 


### PR DESCRIPTION
* Introduce clean separation between on-chain and local ids by introducing`OnChainAsset` and using `AssetId` more
* Unify asset transaction args by removing `assetId` from call data decoder. We always use `asset` now
* Introduce `getOnChainAssetId` which is a replacement for `getAssetId` which was mixing local and on-chain ids
* Remove `getAssetByTypeExtras`

NOTE: I have not tested this PR so someone should go through it