### PR TITLE
fix: revoke authority flow bugs

### DIFF
--- a/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
+++ b/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
@@ -1,6 +1,6 @@
 import { type ApiPromise } from '@polkadot/api';
 import { BN, BN_ZERO } from '@polkadot/util';
-import { combine, createEffect, createEvent, createStore, restore, sample, split } from 'effector';
+import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
 import { createGate } from 'effector-react';
 import { and, not, spread } from 'patronum';
 
@@ -37,8 +37,6 @@ import { removeProxyUtils } from '../lib/remove-proxy-utils';
 import { type RemoveProxyStore, Step } from '../lib/types';
 
 const stepChanged = createEvent<Step>();
-const wentBackFromConfirm = createEvent();
-const stepChangedToInit = stepChanged.prepend(() => Step.INIT);
 
 type Input = {
   proxied: ProxiedAccount;
@@ -244,18 +242,6 @@ sample({
     return proxies.map((el) => el.delegate);
   },
   target: $activeProxiesForAccount,
-});
-
-split({
-  clock: wentBackFromConfirm,
-  source: $isMultisig,
-  match: {
-    multisigWallet: (isMultisig) => isMultisig,
-  },
-  cases: {
-    multisigWallet: stepChangedToInit,
-    __: flowFinished,
-  },
 });
 
 sample({
@@ -547,7 +533,6 @@ export const removeProxyModel = {
   $step,
   $wallet,
   stepChanged,
-  wentBackFromConfirm,
   txSaved,
   $errors,
 };

--- a/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
+++ b/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
@@ -248,9 +248,12 @@ sample({
 
 split({
   clock: wentBackFromConfirm,
-  source: $isMultisig,
+  source: combine({
+    isMultisig: $isMultisig,
+    signatories: $signatories,
+  }),
   match: {
-    multisigWallet: (isMultisig) => isMultisig,
+    multisigWallet: ({ isMultisig, signatories }) => isMultisig && signatories.length !== 1,
   },
   cases: {
     multisigWallet: stepChangedToInit,

--- a/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
+++ b/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
@@ -1,6 +1,6 @@
 import { type ApiPromise } from '@polkadot/api';
 import { BN, BN_ZERO } from '@polkadot/util';
-import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
+import { combine, createEffect, createEvent, createStore, restore, sample, split } from 'effector';
 import { createGate } from 'effector-react';
 import { and, not, spread } from 'patronum';
 
@@ -37,6 +37,8 @@ import { removeProxyUtils } from '../lib/remove-proxy-utils';
 import { type RemoveProxyStore, Step } from '../lib/types';
 
 const stepChanged = createEvent<Step>();
+const wentBackFromConfirm = createEvent();
+const stepChangedToInit = stepChanged.prepend(() => Step.INIT);
 
 type Input = {
   proxied: ProxiedAccount;
@@ -242,6 +244,18 @@ sample({
     return proxies.map((el) => el.delegate);
   },
   target: $activeProxiesForAccount,
+});
+
+split({
+  clock: wentBackFromConfirm,
+  source: $isMultisig,
+  match: {
+    multisigWallet: (isMultisig) => isMultisig,
+  },
+  cases: {
+    multisigWallet: stepChangedToInit,
+    __: flowFinished,
+  },
 });
 
 sample({
@@ -533,6 +547,7 @@ export const removeProxyModel = {
   $step,
   $wallet,
   stepChanged,
+  wentBackFromConfirm,
   txSaved,
   $errors,
 };

--- a/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
@@ -96,7 +96,7 @@ export const RemoveProxy = ({ wallet }: Props) => {
                 </Button>
               )
             }
-            onGoBack={removeProxyModel.wentBackFromConfirm}
+            onGoBack={closeModal}
           />
         )}
         {removeProxyUtils.isSignStep(step) && (

--- a/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
@@ -96,7 +96,7 @@ export const RemoveProxy = ({ wallet }: Props) => {
                 </Button>
               )
             }
-            onGoBack={closeModal}
+            onGoBack={removeProxyModel.wentBackFromConfirm}
           />
         )}
         {removeProxyUtils.isSignStep(step) && (

--- a/src/renderer/features/proxy-remove/ui/RemoveProxyForm.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxyForm.tsx
@@ -4,7 +4,7 @@ import { type FormEvent, useMemo } from 'react';
 import { useForm } from '@/shared/forms';
 import { useI18n } from '@/shared/i18n';
 import { getNativeAsset, withdrawableAmount } from '@/shared/lib/utils';
-import { Alert, Button } from '@/shared/ui';
+import { Button } from '@/shared/ui';
 import { SignatorySelect, TransactionValidationError } from '@/shared/ui-entities';
 import { accounts } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
@@ -33,7 +33,6 @@ export const RemoveProxyForm = ({ onGoBack }: Props) => {
       </form>
       <div className="flex flex-col gap-y-6 pt-6 pb-4">
         <FeeSection />
-        <FeeError />
       </div>
       <ActionSection onGoBack={onGoBack} />
     </div>
@@ -107,20 +106,6 @@ const FeeSection = () => {
 
       <FeeWithLabel asset={getNativeAsset(chain.assets)} fee={fee} />
     </div>
-  );
-};
-
-const FeeError = () => {
-  const { t } = useI18n();
-
-  const {
-    fields: { signatory },
-  } = useForm(removeProxyModel.form);
-
-  return (
-    <Alert title={t('proxy.addProxy.balanceAlertTitle')} active={signatory.hasError} variant="error">
-      <Alert.Item withDot={false}>{t(signatory.errorMessage)}</Alert.Item>
-    </Alert>
   );
 };
 

--- a/src/renderer/features/wallet-details/ui/components/ProxiesList.tsx
+++ b/src/renderer/features/wallet-details/ui/components/ProxiesList.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
-import { accounts } from '@/domains/network';
+import { accountService, accounts } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { proxyRemoveFeature } from '@/features/proxy-remove';
 import { type Proxy, walletProxiesModel } from '../../model/wallet-proxies-model';
@@ -35,7 +35,12 @@ export const ProxiesList = ({ className, wallet, hasProxies, canCreateProxy = tr
   const isLoading = useUnit(walletProxiesModel.$isLoading);
 
   const handleDeleteProxy = (proxyAccount: Proxy) => {
-    const proxiedAccount = allAccounts.find(account => account.accountId === proxyAccount.proxiedAccountId);
+    const chain = chains[proxyAccount.chainId];
+    if (!chain) return;
+    const proxiedAccount = allAccounts.find(
+      account =>
+        account.accountId === proxyAccount.proxiedAccountId && accountService.isAccountAvailableOnChain(account, chain),
+    );
 
     if (proxiedAccount) {
       removeProxyModel.flowStarted({


### PR DESCRIPTION
Resolves [#4789](https://github.com/novasamatech/nova-spektr/issues/4789)

## Description
Fixes three issues in the proxy revocation flow:
- Wrong validation error for the nova wallet
- Outdated token balance validation
- Back button not working in the confirmation modal

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- Fixed account validation: Added `accountService.isAccountAvailableOnChain()` in ProxiesList.tsx to validate accounts on the target chain
- Removed redundant fee error: Removed FeeError in RemoveProxyForm.tsx; TransactionValidationError already handles this
- Fixed back button: Replaced `wentBackFromConfirm` with `closeModal` in RemoveProxy.tsx to close the modal

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
