### PR TITLE
fix: tx signer payload finalized block

### DIFF
--- a/src/renderer/entities/transaction/lib/transactionService.ts
+++ b/src/renderer/entities/transaction/lib/transactionService.ts
@@ -251,14 +251,14 @@ async function createPayloadWithProof(
   if (nonceIncrement) {
     metadata = upgradeNonce(metadata, nonceIncrement);
   }
-  const { signerPayloadBase } = metadata;
+  const { signerPayloadBase, mortalLength } = metadata;
 
   if (api.registry.signedExtensions?.includes('ChargeAssetTxPayment')) {
     signerPayloadBase.assetId = undefined;
   }
 
   // Set era explicitly for security reason - immortal transactions can be used in replay attacks.
-  const era = createEra(api, signerPayloadBase.blockNumber);
+  const era = createEra(api, signerPayloadBase.blockNumber, mortalLength);
 
   const metadataHex = api.runtimeMetadata.toHex();
 
@@ -304,18 +304,18 @@ async function createPayloadWithProof(
   };
 }
 
-function createEra(api: ApiPromise, blockNumber: HexString) {
-  const mortalLength = 64;
+function createEra(api: ApiPromise, blockNumber: HexString, mortalLength: number) {
   return api.registry.createTypeUnsafe<ExtrinsicEra>('ExtrinsicEra', [{ current: blockNumber, period: mortalLength }]);
 }
 
-function createPayloadWithMetadata(extrinsic: Extrinsic, api: ApiPromise, { signerPayloadBase }: TxMetadata) {
+function createPayloadWithMetadata(extrinsic: Extrinsic, api: ApiPromise, metadata: TxMetadata) {
+  const { signerPayloadBase, mortalLength } = metadata;
   if (api.registry.signedExtensions?.includes('ChargeAssetTxPayment')) {
     signerPayloadBase.assetId = undefined;
   }
 
   // Set era explicitly for security reason - immortal transactions can be used in replay attacks.
-  const era = createEra(api, signerPayloadBase.blockNumber);
+  const era = createEra(api, signerPayloadBase.blockNumber, mortalLength);
 
   const signingPayload = new GenericSignerPayload(api.registry, {
     ...signerPayloadBase,

--- a/src/renderer/shared/lib/utils/substrate.ts
+++ b/src/renderer/shared/lib/utils/substrate.ts
@@ -13,6 +13,7 @@ import {
   type ProxyType,
   XcmPallets,
 } from '@/shared/core';
+import { assert } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 
 import { toAddress } from './address';
@@ -20,6 +21,7 @@ import { DEFAULT_TIME, ONE_DAY, THRESHOLD } from './constants';
 
 export type TxMetadata = {
   signerPayloadBase: Omit<SignerPayloadJSON, 'method' | 'version' | 'era'>;
+  mortalLength: number;
 };
 
 const SUPPORTED_VERSIONS = ['V2', 'V3', 'V4'];
@@ -30,7 +32,8 @@ const UNUSED_LABEL = 'unused';
  */
 export const createTxMetadata = async (accountId: AccountId, api: ApiPromise): Promise<TxMetadata> => {
   const chainId = api.genesisHash.toHex();
-  const [header, nonce] = await Promise.all([api.rpc.chain.getHeader(), api.rpc.system.accountNextIndex(accountId)]);
+  const { header, nonce, mortalLength } = await api.derive.tx.signingInfo(accountId);
+  assert(header);
 
   const signerPayloadBase: Omit<SignerPayloadJSON, 'method' | 'version' | 'era'> = {
     address: toAddress(accountId, { prefix: api.consts.system.ss58Prefix.toNumber() }),
@@ -44,7 +47,7 @@ export const createTxMetadata = async (accountId: AccountId, api: ApiPromise): P
     signedExtensions: api.registry.signedExtensions,
   };
 
-  return { signerPayloadBase };
+  return { signerPayloadBase, mortalLength };
 };
 
 export const getCallHash = (callData: HexString) => blake2AsHex(hexToU8a(callData));


### PR DESCRIPTION
## Description
We used to include best block hash and number in the signer payload. 
Use finalized block for the transaction instead.
Use `mortalLength` value from `signingInfo` pjs function instead of hardcoded value.

## Related Issues
Closes #4603

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
