### PR TITLE
feat: polkadot vault migration remove duplicates

### DIFF
--- a/src/renderer/shared/api/storage/migration/__tests__/migration-12.test.ts
+++ b/src/renderer/shared/api/storage/migration/__tests__/migration-12.test.ts
@@ -1,0 +1,129 @@
+import { type Transaction } from 'dexie';
+import { beforeEach } from 'vitest';
+
+import { migrateDuplicateVaultDerivations } from '@/shared/api/storage/migration';
+import { TEST_ACCOUNTS } from '@/shared/lib/utils';
+import {
+  createProxiedAccount,
+  createVaultBaseAccount,
+  createVaultChainAccount,
+  createWcAccount,
+  polkadotAssetHubChainId,
+  polkadotBifrostChainId,
+  polkadotChainId,
+} from '@/shared/mocks';
+// eslint-disable-next-line boundaries/element-types
+import { type AnyAccount } from '@/domains/network';
+
+describe('Migration 12 - Remove duplicate accounts from PolkadotVault wallet', () => {
+  const db = {
+    accounts2: [] as AnyAccount[],
+  };
+
+  const transactionMock = {
+    table: vi.fn().mockImplementation((tableName: 'accounts2') => {
+      return {
+        toArray: vi.fn(() => db[tableName]),
+
+        bulkDelete: vi.fn().mockImplementation((ids: (number | string)[]) => {
+          (db[tableName] as AnyAccount[]) = db[tableName].filter((record) => !ids.includes(record.id));
+        }),
+      };
+    }),
+  } as unknown as Transaction;
+
+  beforeEach(() => {
+    db.accounts2 = [];
+  });
+
+  it('should remove duplicate derivations with one wallet', async () => {
+    const walletId = 1;
+
+    let chainId = polkadotChainId;
+    const uniqAccounts = [
+      createVaultChainAccount('1', { walletId, derivationPath: '/test1', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('2', { walletId, derivationPath: '/test2', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('3', { walletId, derivationPath: '/test3', accountId: TEST_ACCOUNTS[0], chainId }),
+    ];
+
+    chainId = polkadotAssetHubChainId;
+    const duplicateDerivations = [
+      createVaultChainAccount('4', { walletId, derivationPath: '/test1', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('5', { walletId, derivationPath: '/test2', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('6', { walletId, derivationPath: '/test3', accountId: TEST_ACCOUNTS[0], chainId }),
+    ];
+
+    chainId = polkadotBifrostChainId;
+    const duplicateDerivations2 = [
+      createVaultChainAccount('7', { walletId, derivationPath: '/test1', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('8', { walletId, derivationPath: '/test2', accountId: TEST_ACCOUNTS[0], chainId }),
+      createVaultChainAccount('9', { walletId, derivationPath: '/test3', accountId: TEST_ACCOUNTS[0], chainId }),
+    ];
+
+    db.accounts2 = [...uniqAccounts, ...duplicateDerivations, ...duplicateDerivations2];
+
+    await migrateDuplicateVaultDerivations(transactionMock);
+
+    expect(db.accounts2).toEqual(uniqAccounts);
+  });
+
+  it('should remove duplicate derivations with multiple wallets', async () => {
+    const uniqAccounts = [
+      createVaultChainAccount('1', {
+        walletId: 1,
+        derivationPath: '/test1',
+        accountId: TEST_ACCOUNTS[1],
+        chainId: polkadotChainId,
+      }),
+      createVaultChainAccount('1', {
+        walletId: 2,
+        derivationPath: '/test2',
+        accountId: TEST_ACCOUNTS[2],
+        chainId: polkadotChainId,
+      }),
+    ];
+
+    const duplicateDerivations = [
+      createVaultChainAccount('2', {
+        walletId: 1,
+        derivationPath: '/test1',
+        accountId: TEST_ACCOUNTS[1],
+        chainId: polkadotAssetHubChainId,
+      }),
+      createVaultChainAccount('2', {
+        walletId: 2,
+        derivationPath: '/test2',
+        accountId: TEST_ACCOUNTS[2],
+        chainId: polkadotAssetHubChainId,
+      }),
+    ];
+
+    db.accounts2 = [...uniqAccounts, ...duplicateDerivations];
+
+    await migrateDuplicateVaultDerivations(transactionMock);
+
+    expect(db.accounts2).toEqual(uniqAccounts);
+  });
+
+  it('should skip accounts without derivations', async () => {
+    const uniqAccounts = [
+      createVaultChainAccount('1', { walletId: 1, derivationPath: '/test1', accountId: TEST_ACCOUNTS[0] }),
+      createWcAccount('2', 2),
+      createProxiedAccount('3', 3),
+      createVaultBaseAccount('4', { walletId: 4, accountId: TEST_ACCOUNTS[0] }),
+    ];
+
+    db.accounts2 = [...uniqAccounts];
+
+    await migrateDuplicateVaultDerivations(transactionMock);
+
+    expect(db.accounts2).toEqual(uniqAccounts);
+  });
+
+  it('should handle empty accounts array', async () => {
+    db.accounts2 = [];
+    await migrateDuplicateVaultDerivations(transactionMock);
+
+    expect(db.accounts2).toEqual([]);
+  });
+});

--- a/src/renderer/shared/api/storage/migration/index.ts
+++ b/src/renderer/shared/api/storage/migration/index.ts
@@ -8,3 +8,5 @@ export { migrateCASBasket } from './migration-7';
 export { migrateEVMAccountsCryptoType } from './migration-8';
 export { removeDeprecatedProxiedAccounts } from './migration-9';
 export { migrateRevoteToVote } from './migration-10';
+export { migrateBasketTransactionAfterAddressRemoval } from './migration-11';
+export { migrateDuplicateVaultDerivations } from './migration-12';

--- a/src/renderer/shared/api/storage/migration/migration-12.ts
+++ b/src/renderer/shared/api/storage/migration/migration-12.ts
@@ -16,7 +16,7 @@ export async function migrateDuplicateVaultDerivations(t: Transaction): Promise<
   for (const account of accounts) {
     if (nullable(account.derivationPath)) continue;
 
-    const uniqKey = account.accountId + account.derivationPath;
+    const uniqKey = account.walletId + account.accountId + account.derivationPath;
     const existing = seen.get(uniqKey);
 
     if (existing) {

--- a/src/renderer/shared/api/storage/migration/migration-12.ts
+++ b/src/renderer/shared/api/storage/migration/migration-12.ts
@@ -1,0 +1,35 @@
+import { type Transaction } from 'dexie';
+
+import { type VaultChainAccount } from '@/shared/core';
+import { RelayChains, nullable } from '@/shared/lib/utils';
+
+const RELAY_CHAINS = [RelayChains.POLKADOT, RelayChains.KUSAMA, RelayChains.WESTEND, RelayChains.ROCOCO];
+
+/**
+ * Migration to remove duplicate polkadot vault derivations
+ */
+export async function migrateDuplicateVaultDerivations(t: Transaction): Promise<void> {
+  const accounts = await t.table<VaultChainAccount>('accounts2').toArray();
+  const seen = new Map<string, VaultChainAccount>();
+  const accountIdsToRemove: string[] = [];
+
+  for (const account of accounts) {
+    if (nullable(account.derivationPath)) continue;
+
+    const uniqKey = account.accountId + account.derivationPath;
+    const existing = seen.get(uniqKey);
+
+    if (existing) {
+      if (RELAY_CHAINS.includes(account.chainId)) {
+        accountIdsToRemove.push(existing.id);
+        seen.set(uniqKey, account);
+      } else {
+        accountIdsToRemove.push(account.id);
+      }
+    } else {
+      seen.set(uniqKey, account);
+    }
+  }
+
+  await t.table('accounts2').bulkDelete(accountIdsToRemove);
+}

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -16,7 +16,9 @@ import {
 } from '../lib/types';
 import {
   migrateAccounts,
+  migrateBasketTransactionAfterAddressRemoval,
   migrateCASBasket,
+  migrateDuplicateVaultDerivations,
   migrateEVMAccountsCryptoType,
   migrateEvents,
   migrateMultishardAccounts,
@@ -26,7 +28,6 @@ import {
   migrateWallets,
   removeDeprecatedProxiedAccounts,
 } from '../migration';
-import { migrateBasketTransactionAfterAddressRemoval } from '../migration/migration-11';
 
 class DexieStorage extends Dexie {
   connections: TConnection;
@@ -133,6 +134,8 @@ class DexieStorage extends Dexie {
     this.version(37)
       .upgrade(migrateBasketTransactionAfterAddressRemoval)
       .upgrade((t) => t.table('multisigOperations').clear());
+
+    this.version(38).upgrade(migrateDuplicateVaultDerivations);
 
     this.connections = this.table('connections');
     this.balances = this.table('balances');

--- a/src/renderer/shared/mocks/index.ts
+++ b/src/renderer/shared/mocks/index.ts
@@ -30,6 +30,9 @@ const testKeyring = createTestKeyring();
 
 export const polkadotChainId: ChainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
 export const kusamaChainId: ChainId = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
+export const polkadotAssetHubChainId: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f';
+export const kusamaAssetHubChainId: ChainId = '0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a';
+export const polkadotBifrostChainId: ChainId = '0x262e1b2ad728475fd6fe88e62d34c200abe6fd693931ddad144059b1eb884e5b';
 
 export const dotAsset: Asset = {
   assetId: 0 as AssetId,


### PR DESCRIPTION
## Description
Remove duplicate accounts with same `derivationPath` and public key.
Prefer relay chain accounts when removing duplicates.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/4832

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
