### PR TITLE
Fix/fee_loading_state

### DIFF
--- a/src/renderer/shared/transactions/createFeeCalculator.ts
+++ b/src/renderer/shared/transactions/createFeeCalculator.ts
@@ -1,9 +1,9 @@
 import { type SubmittableExtrinsic } from '@polkadot/api/types/submittable';
 import { BN, BN_ZERO } from '@polkadot/util';
-import { type Store, type UnitValue, createEffect, createStore, sample } from 'effector';
+import { type Store, type UnitValue, combine, createEffect, createStore, sample } from 'effector';
 
 import { takeLast } from '@/shared/effector';
-import { nonNullable, nullable } from '@/shared/lib/utils';
+import { nullable } from '@/shared/lib/utils';
 import { transactionService } from '@/domains/network';
 
 type Params = {
@@ -17,6 +17,7 @@ type FeeCalculationRequest = {
 
 export const createFeeCalculator = ({ active = createStore(true), extrinsic }: Params) => {
   const $fee = createStore(BN_ZERO);
+  const $isInitialized = createStore(false);
 
   const fetchFeeFx = takeLast({
     fn: async ({ extrinsic }: FeeCalculationRequest): Promise<BN> => {
@@ -37,8 +38,8 @@ export const createFeeCalculator = ({ active = createStore(true), extrinsic }: P
   sample({
     clock: extrinsic,
     filter: nullable,
-    fn: () => BN_ZERO,
-    target: $fee,
+    fn: () => false,
+    target: $isInitialized,
   });
 
   const feeRequested = sample({
@@ -62,11 +63,9 @@ export const createFeeCalculator = ({ active = createStore(true), extrinsic }: P
   });
 
   sample({
-    clock: fetchFeeFx.fail,
-    source: extrinsic,
-    filter: nonNullable,
-    fn: (_) => BN_ZERO,
-    target: $fee,
+    clock: fetchFeeFx.doneData,
+    fn: () => true,
+    target: $isInitialized,
   });
 
   sample({
@@ -74,8 +73,10 @@ export const createFeeCalculator = ({ active = createStore(true), extrinsic }: P
     target: logErrorFx,
   });
 
+  const $pendingFee = combine(fetchFeeFx.pending, $isInitialized, (pending, initialized) => pending || !initialized);
+
   return {
     $: $fee,
-    $pending: fetchFeeFx.pending,
+    $pending: $pendingFee,
   };
 };


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

**Problem**
When opening transfer modals or recalculating fees, the UI briefly displayed "0" instead of showing a loading indicator. This caused test failures and poor user experience, as users couldn't distinguish between an actual zero fee and a fee that was still being calculated.

**The issue occurred when:**

Opening a transfer modal (before initial fee calculation)
Changing transaction parameters (during recalculation)
Fee calculation failures

**Root Cause**
In createFeeCalculator.ts, the fee store was being reset to BN_ZERO in two scenarios:
When the extrinsic became null (during transaction recalculation)
When fee calculation failed
However, $pendingFee (which was simply fetchFeeFx.pending) would be false in these cases because the effect wasn't running. This created a state where fee = 0 and isLoading = false, causing the UI to render "0" instead of a loading state.


## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

Modified createFeeCalculator.ts to properly track the initialization state:
Added $isInitialized flag - Tracks whether a fee has been successfully calculated at least once
Removed fee resets - Fee now preserves its previous value instead of resetting to zero
Enhanced $pendingFee logic - Now combines fetchFeeFx.pending with $isInitialized:
Reset initialization on extrinsic change - When extrinsic becomes null, $isInitialized is reset to false, ensuring the loader shows during recalculation

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
