### PR TITLE
Feat/filtering old evidences

### DIFF
--- a/graphql.config.yml
+++ b/graphql.config.yml
@@ -22,6 +22,6 @@ projects:
       - src/renderer/entities/staking/**
 
   SubQuery Collectives:
-    schema: https://subquery-collectives-polkadot-stg.novasama-tech.org
+    schema: https://subquery-collectives-polkadot-prod.novasama-tech.org
     include:
       - src/renderer/domains/collectives/**

--- a/src/renderer/domains/collectives/evidence/service.ts
+++ b/src/renderer/domains/collectives/evidence/service.ts
@@ -109,8 +109,3 @@ export const evidenceService = {
   createEvidenceTransaction,
   isEvidenceTransaction,
 };
-
-console.log(
-  'pedik 228',
-  evidenceService.getEvidenceIpfsUrl('0x03bab3cc7ce76f74ef4ad753801db84ff63eb7643d1812aedff371851a6e6947'),
-);

--- a/src/renderer/domains/collectives/evidence/service.ts
+++ b/src/renderer/domains/collectives/evidence/service.ts
@@ -109,3 +109,8 @@ export const evidenceService = {
   createEvidenceTransaction,
   isEvidenceTransaction,
 };
+
+console.log(
+  'pedik 228',
+  evidenceService.getEvidenceIpfsUrl('0x03bab3cc7ce76f74ef4ad753801db84ff63eb7643d1812aedff371851a6e6947'),
+);

--- a/src/renderer/domains/collectives/init.ts
+++ b/src/renderer/domains/collectives/init.ts
@@ -15,6 +15,7 @@ export const $collectiveStore = combine(
   {
     members: member.$list,
     referendums: referendum.$list,
+    referendumsWithEvidence: referendum.$referendumsWithEvidence,
     referendumMeta: referendumMeta.$list,
     tracks: track.$list,
     maxRank: track.$maxRank,

--- a/src/renderer/domains/collectives/referendum/resource.ts
+++ b/src/renderer/domains/collectives/referendum/resource.ts
@@ -1,8 +1,11 @@
+import { gql } from '@apollo/client';
 import { type ApiPromise } from '@polkadot/api';
 import { Compact } from '@polkadot/types';
 import { u8aToHex } from '@polkadot/util';
+import { GraphQLClient } from 'graphql-request';
+import { z } from 'zod';
 
-import { type ChainId, type HexString } from '@/shared/core';
+import { type Chain, type ChainId, ExternalType, type HexString } from '@/shared/core';
 import { createPagesHandler } from '@/shared/effector';
 import { nullable } from '@/shared/lib/utils';
 import {
@@ -17,7 +20,7 @@ import { type BlockHeight, pjsSchema } from '@/shared/polkadotjs-schemas';
 import { createRemoteResource, createSubscriptionResource } from '@/shared/resource';
 import { type CollectivePalletsType } from '../_lib/types';
 
-import { type Proposal, type Referendum } from './types';
+import { type Proposal, type Referendum, type ReferendumWithEvidence } from './types';
 
 async function parseProposal(proposal: FrameSupportPreimagesBounded, api: ApiPromise): Promise<Proposal | null> {
   let proposalHex: HexString | null = null;
@@ -281,5 +284,85 @@ export const fetchResource = createRemoteResource<ReferendumRequestParams, Refer
   async fn({ api, chainId, palletType, referendums }) {
     const response = await referendaPallet.storage.referendumInfoFor(palletType, api, referendums);
     return mapReferendums(response, api, palletType, chainId);
+  },
+});
+
+/**
+ * Use this query to map referendums with evidences. If possible use chain
+ * state.
+ */
+const GET_REFERENDUMS_QUERY = gql`
+  query Referendums {
+    referendums {
+      nodes {
+        index
+        evidence {
+          nodes {
+            hash
+          }
+        }
+        completed
+      }
+    }
+  }
+`;
+
+const referendumsGqlSchema = z.object({
+  referendums: z.object({
+    nodes: z.array(
+      z.object({
+        index: z.custom<ReferendumId>(),
+        evidence: z.object({
+          nodes: z.array(
+            z.object({
+              hash: z.custom<HexString>(),
+            }),
+          ),
+        }),
+        completed: z.boolean(),
+      }),
+    ),
+  }),
+});
+
+export type ReferendumsWithEvidence = z.infer<typeof referendumsGqlSchema>['referendums'];
+
+const requestReferendumsFromSubQuery = async (url: string) => {
+  const client = new GraphQLClient(url);
+  const result = await client.request(GET_REFERENDUMS_QUERY);
+
+  try {
+    const parsed = referendumsGqlSchema.parse(result);
+    return parsed.referendums.nodes;
+  } catch (error) {
+    console.error(error);
+    return [];
+  }
+};
+
+type RequestRefendumsParams = {
+  chain: Chain;
+  palletType: CollectivePalletsType;
+};
+
+export const referendumsWithEvidenceResource = createRemoteResource<RequestRefendumsParams, ReferendumWithEvidence[]>({
+  pool: ({ chain, palletType }) => `${palletType}:${chain.chainId}`,
+  cache: {
+    key: ({ chain, palletType }) => `${palletType}:${chain.chainId}`,
+    ttl: 60 * 1000,
+  },
+  async fn({ chain, palletType }) {
+    const externalApi = chain.externalApi?.[ExternalType.COLLECTIVES]?.at(0);
+    const sourceUrl = externalApi?.url;
+    if (!sourceUrl) return [];
+    const result = await requestReferendumsFromSubQuery(sourceUrl);
+
+    return result.map(item => ({
+      pallet: palletType,
+      chainId: chain.chainId,
+      index: item.index,
+      completed: item.completed,
+      evidence: item.evidence.nodes.map(e => ({ hash: e.hash })),
+    }));
   },
 });

--- a/src/renderer/domains/collectives/referendum/store.ts
+++ b/src/renderer/domains/collectives/referendum/store.ts
@@ -5,8 +5,8 @@ import { deriveFromResources } from '@/shared/resource';
 import { mergeNested } from '../_lib/helpers';
 import { type CollectivesStruct } from '../_lib/types';
 
-import { fetchResource, subscriptionResource } from './resource';
-import { type Referendum } from './types';
+import { fetchResource, referendumsWithEvidenceResource, subscriptionResource } from './resource';
+import { type Referendum, type ReferendumWithEvidence } from './types';
 
 const $list = createStore<CollectivesStruct<Referendum[]>>({});
 
@@ -18,10 +18,23 @@ deriveFromResources({
   },
 });
 
+const $referendumsWithEvidence = createStore<CollectivesStruct<ReferendumWithEvidence[]>>({});
+
+deriveFromResources({
+  store: $referendumsWithEvidence,
+  resources: [referendumsWithEvidenceResource],
+  map(state, referendums) {
+    return mergeNested(state, referendums, r => r.index);
+  },
+});
+
 export const referendum = {
   $list: readonly($list),
+  $referendumsWithEvidence: readonly($referendumsWithEvidence),
   request: fetchResource.request,
   subscribe: subscriptionResource.subscribe,
   unsubscribe: subscriptionResource.unsubscribe,
   fulfilled: subscriptionResource.fulfilled,
+
+  requestReferendumsWithEvidence: referendumsWithEvidenceResource.request,
 };

--- a/src/renderer/domains/collectives/referendum/store.ts
+++ b/src/renderer/domains/collectives/referendum/store.ts
@@ -35,6 +35,5 @@ export const referendum = {
   subscribe: subscriptionResource.subscribe,
   unsubscribe: subscriptionResource.unsubscribe,
   fulfilled: subscriptionResource.fulfilled,
-
   requestReferendumsWithEvidence: referendumsWithEvidenceResource.request,
 };

--- a/src/renderer/domains/collectives/referendum/store.ts
+++ b/src/renderer/domains/collectives/referendum/store.ts
@@ -1,6 +1,7 @@
 import { createStore } from 'effector';
 import { readonly } from 'patronum';
 
+import { populated } from '@/shared/effector';
 import { deriveFromResources } from '@/shared/resource';
 import { mergeNested } from '../_lib/helpers';
 import { type CollectivesStruct } from '../_lib/types';
@@ -28,9 +29,12 @@ deriveFromResources({
   },
 });
 
+const $referendumsWithEvidencePopulated = populated(referendumsWithEvidenceResource.request);
+
 export const referendum = {
   $list: readonly($list),
   $referendumsWithEvidence: readonly($referendumsWithEvidence),
+  $referendumsWithEvidencePopulated: readonly($referendumsWithEvidencePopulated),
   request: fetchResource.request,
   subscribe: subscriptionResource.subscribe,
   unsubscribe: subscriptionResource.unsubscribe,

--- a/src/renderer/domains/collectives/referendum/types.ts
+++ b/src/renderer/domains/collectives/referendum/types.ts
@@ -1,6 +1,6 @@
 import { type BN } from '@polkadot/util';
 
-import { type ChainId } from '@/shared/core';
+import { type ChainId, type HexString } from '@/shared/core';
 import { type ReferendumId, type TrackId } from '@/shared/pallet/referenda';
 import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
 import { type CollectivePalletsType } from '../_lib/types';
@@ -123,3 +123,13 @@ export type CompletedReferendum =
   | KilledReferendum;
 
 export type Referendum = OngoingReferendum | CompletedReferendum;
+
+export type ReferendumWithEvidence = {
+  index: ReferendumId;
+  evidence: {
+    hash: HexString;
+  }[];
+  completed: boolean;
+  pallet: CollectivePalletsType;
+  chainId: ChainId;
+};

--- a/src/renderer/features/fellowship-tasks/model/feature.ts
+++ b/src/renderer/features/fellowship-tasks/model/feature.ts
@@ -3,7 +3,7 @@ import { combine, sample } from 'effector';
 import { $features } from '@/shared/config/features';
 import { createFeature } from '@/shared/feature';
 import { nullable } from '@/shared/lib/utils';
-import { feed } from '@/domains/collectives';
+import { feed, referendum } from '@/domains/collectives';
 import { fellowshipMember } from '@/aggregates/fellowship-member';
 import { fellowshipNetwork } from '@/aggregates/fellowship-network';
 import { ERROR } from '../constants';
@@ -53,6 +53,11 @@ sample({
 sample({
   clock: fellowshipTasksFeature.running,
   target: feed.subscribe,
+});
+
+sample({
+  clock: fellowshipTasksFeature.running,
+  target: referendum.requestReferendumsWithEvidence,
 });
 
 sample({

--- a/src/renderer/features/fellowship-tasks/model/tasks.ts
+++ b/src/renderer/features/fellowship-tasks/model/tasks.ts
@@ -1,7 +1,7 @@
 import { combine } from 'effector';
 import { or } from 'patronum';
 
-import { groupBy, nonNullable, nullable, toAddress } from '@/shared/lib/utils';
+import { groupBy, nonNullable, nullable } from '@/shared/lib/utils';
 import {
   type CompletedReferendum,
   type OngoingReferendum,
@@ -226,11 +226,7 @@ const $evidenceTasks = combine(
 
     for (const evidence of evidences) {
       if (evidenceHashesWithReferendums.has(evidence.hash)) {
-        const referendumIndex = referendumsWithEvidence.find(r =>
-          r.evidence.some(e => e.hash === evidence.hash),
-        )?.index;
-        console.log('PETUH 1337', toAddress(evidence.accountId), referendumIndex);
-        // continue;
+        continue;
       }
 
       const proposer = members.find(m => m.accountId === evidence.accountId);

--- a/src/renderer/features/fellowship-tasks/model/tasks.ts
+++ b/src/renderer/features/fellowship-tasks/model/tasks.ts
@@ -1,7 +1,7 @@
 import { combine } from 'effector';
 import { or } from 'patronum';
 
-import { groupBy, nonNullable, nullable } from '@/shared/lib/utils';
+import { groupBy, nonNullable, nullable, toAddress } from '@/shared/lib/utils';
 import {
   type CompletedReferendum,
   type OngoingReferendum,
@@ -43,6 +43,7 @@ const $evidencePeriods = fellowship.$store.map(store => store?.evidencePeriods ?
 const $maxRank = fellowship.$store.map(input => input?.maxRank ?? 0);
 const $members = fellowship.$store.map(input => input?.members ?? []);
 const $chainName = $chain.map(chain => chain?.name ?? 'Unknown');
+const $referendumsWithEvidence = fellowship.$store.map(store => store?.referendumsWithEvidence ?? []);
 
 const $voting = fellowship.$store.map(store => store?.voting ?? []);
 const $accountsVotes = combine({ voting: $voting, account: $member }, ({ voting, account }) => {
@@ -210,15 +211,28 @@ const $evidenceTasks = combine(
     members: $members,
     evidencePopulated: evidence.$populated,
     currentBlock: fellowshipNetwork.$currentBlock,
+    referendumsWithEvidence: $referendumsWithEvidence,
   },
-  ({ evidences, periods, member, members, evidencePopulated, currentBlock }) => {
+  ({ evidences, periods, member, members, evidencePopulated, currentBlock, referendumsWithEvidence }) => {
     if (!evidencePopulated || nullable(member) || nullable(periods) || nullable(currentBlock)) {
       return [];
     }
 
+    const evidenceHashesWithReferendums = new Set(
+      referendumsWithEvidence.filter(r => r.completed).flatMap(r => r.evidence.map(e => e.hash)),
+    );
+
     const tasks: TaskDescription[] = [];
 
     for (const evidence of evidences) {
+      if (evidenceHashesWithReferendums.has(evidence.hash)) {
+        const referendumIndex = referendumsWithEvidence.find(r =>
+          r.evidence.some(e => e.hash === evidence.hash),
+        )?.index;
+        console.log('PETUH 1337', toAddress(evidence.accountId), referendumIndex);
+        // continue;
+      }
+
       const proposer = members.find(m => m.accountId === evidence.accountId);
       if (nullable(proposer)) continue;
 

--- a/src/renderer/shared/resource/createRemoteResource.ts
+++ b/src/renderer/shared/resource/createRemoteResource.ts
@@ -50,7 +50,7 @@ export const createRemoteResource = <Params, Response>({
       const cacheKey = getCacheKey(params);
       const cachedValue = cached[cacheKey];
       if (cachedValue) {
-        if (cache.ttl === Number.POSITIVE_INFINITY || cachedValue.ts + cache.ttl < Date.now()) {
+        if (cache.ttl === Number.POSITIVE_INFINITY || Date.now() < cachedValue.ts + cache.ttl) {
           return cachedValue.response;
         } else {
           delete cached[cacheKey];


### PR DESCRIPTION
## Description
filtering out evidences that already were referended

## Related Issues
Closes #4068 

## Changes Made
1. added gql resource that maps referendums with evidences
2. filtering proactive evidences tasks if evidence hash was already used in any of completed referendums

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
