### PR TITLE
refactor(notifications): generalise flow for proxy notifications

### DIFF
--- a/src/renderer/features/account-sync/model/sync.ts
+++ b/src/renderer/features/account-sync/model/sync.ts
@@ -17,6 +17,7 @@ import {
   type ProxiedConnection,
   type ProxiedWallet,
   type ProxyAccount,
+  type ProxyAction,
   type ProxyType,
   SigningType,
   type Wallet,
@@ -575,16 +576,31 @@ const createNotificationsFromWallets = (wallets: { wallet: { id: number }; accou
         } satisfies NoID<FlexibleMultisigOperationNotification>;
       }
 
+      if (accountUtils.isProxiedAccount(account)) {
+        return account.connections.map((connection) => {
+          return {
+            chainId: account.chainId,
+            dateCreated: Date.now(),
+            proxyType: connection.proxyType,
+            proxyAccountId: connection.proxyAccountId,
+            proxyVariant: account.proxyVariant,
+            proxiedAccountId: account.accountId,
+            read: false,
+            type: NotificationType.PROXY_CREATED,
+          } satisfies NoID<ProxyAction>;
+        });
+      }
+
       return null;
     });
   });
 
-  return notifications.filter(nonNullable);
+  return notifications.flat().filter(nonNullable);
 };
 
 sample({
   clock: createWalletsFx.doneData,
-  fn: createNotificationsFromWallets,
+  fn: (wallets) => createNotificationsFromWallets(wallets),
   target: notificationModel.events.notificationsAdded,
 });
 

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyCreatedNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyCreatedNotification.tsx
@@ -1,4 +1,4 @@
-import { useUnit } from 'effector-react';
+import { useStoreMap, useUnit } from 'effector-react';
 import { Trans } from 'react-i18next';
 
 import { type ProxyAction, ProxyVariant, WalletType } from '@/shared/core';
@@ -8,6 +8,8 @@ import { BodyText } from '@/shared/ui';
 import { Identicon, WalletIcon } from '@/shared/ui-entities';
 import { ChainTitle } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
+import { proxyUtils } from '@/entities/proxy';
+import { walletModel, walletUtils } from '@/entities/wallet';
 import { ProxyTypeOperation } from '../../lib/constants';
 
 type Props = {
@@ -19,10 +21,49 @@ export const ProxyCreatedNotification = ({ notification }: Props) => {
 
   const chains = useUnit(networkModel.$chains);
 
+  // Get proxy wallet from proxyAccountId
+  const proxyWallet = useStoreMap({
+    store: walletModel.$wallets,
+    keys: [notification.proxyAccountId],
+    fn: (wallets, [accountId]) => {
+      return walletUtils.getWalletFilteredAccounts(wallets, {
+        accountFn: (account) => account.accountId === accountId,
+      });
+    },
+  });
+
+  // Get proxied wallet from proxiedAccountId
+  const proxiedWallet = useStoreMap({
+    store: walletModel.$wallets,
+    keys: [notification.proxiedAccountId],
+    fn: (wallets, [accountId]) => {
+      return walletUtils.getWalletFilteredAccounts(wallets, {
+        accountFn: (account) => account.accountId === accountId,
+      });
+    },
+  });
+
   const accountId =
     notification.proxyVariant === ProxyVariant.PURE ? notification.proxiedAccountId : notification.proxyAccountId;
 
   const address = toAddress(accountId, { prefix: chains[notification.chainId]?.addressPrefix });
+
+  const chain = chains[notification.chainId];
+
+  // Determine the proxied wallet name
+  const proxiedWalletName =
+    proxiedWallet?.name ||
+    proxyUtils.getProxiedName(
+      {
+        accountId: notification.proxiedAccountId,
+        proxyVariant: notification.proxyVariant,
+        connections: [],
+      },
+      chain?.addressPrefix,
+    );
+
+  const proxyWalletName = proxyWallet?.name || '';
+  const proxyWalletType = proxyWallet?.type || WalletType.WATCH_ONLY;
 
   return (
     <div className="flex gap-x-2">
@@ -37,7 +78,7 @@ export const ProxyCreatedNotification = ({ notification }: Props) => {
           <Trans
             t={t}
             i18nKey="notifications.details.proxyWalletAction"
-            values={{ address, name: notification.proxiedWalletName }}
+            values={{ address, name: proxiedWalletName }}
             components={{
               identicon: (
                 <div className="mx-1 inline-flex">
@@ -53,14 +94,14 @@ export const ProxyCreatedNotification = ({ notification }: Props) => {
             t={t}
             i18nKey="notifications.details.proxyCreatedDetails"
             values={{
-              name: notification.proxyWalletName,
+              name: proxyWalletName,
               operations: t(ProxyTypeOperation[notification.proxyType]),
             }}
             components={{
               chain: <ChainTitle chainId={notification.chainId} fontClass="text-text-primary text-body" />,
               walletIcon: (
                 <span className="mx-1">
-                  <WalletIcon size={16} type={notification.proxyWalletType} />
+                  <WalletIcon size={16} type={proxyWalletType} />
                 </span>
               ),
               wallet: <p className="inline-flex" />,

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyCreatedNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyCreatedNotification.tsx
@@ -62,8 +62,8 @@ export const ProxyCreatedNotification = ({ notification }: Props) => {
       chain?.addressPrefix,
     );
 
-  const proxyWalletName = proxyWallet?.name || '';
-  const proxyWalletType = proxyWallet?.type || WalletType.WATCH_ONLY;
+  const proxyWalletName = proxyWallet?.name ?? toAddress(notification.proxyAccountId, { prefix: chain?.addressPrefix });
+  const proxyWalletType = proxyWallet?.type;
 
   return (
     <div className="flex gap-x-2">
@@ -100,9 +100,7 @@ export const ProxyCreatedNotification = ({ notification }: Props) => {
             components={{
               chain: <ChainTitle chainId={notification.chainId} fontClass="text-text-primary text-body" />,
               walletIcon: (
-                <span className="mx-1">
-                  <WalletIcon size={16} type={proxyWalletType} />
-                </span>
+                <span className="mx-1">{proxyWalletType && <WalletIcon size={16} type={proxyWalletType} />}</span>
               ),
               wallet: <p className="inline-flex" />,
             }}

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyRemovedNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyRemovedNotification.tsx
@@ -8,6 +8,8 @@ import { BodyText } from '@/shared/ui';
 import { Identicon, WalletIcon } from '@/shared/ui-entities';
 import { ChainTitle } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
+import { proxyUtils } from '@/entities/proxy';
+import { walletModel, walletUtils } from '@/entities/wallet';
 import { ProxyTypeOperation } from '../../lib/constants';
 
 type Props = {
@@ -23,12 +25,51 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
     fn: (chains, [id]) => chains[id] ?? null,
   });
 
+  // Get proxy wallet from proxyAccountId
+  const proxyWallet = useStoreMap({
+    store: walletModel.$wallets,
+    keys: [notification.proxyAccountId],
+    fn: (wallets, [accountId]) => {
+      return walletUtils.getWalletFilteredAccounts(wallets, {
+        accountFn: (account) => account.accountId === accountId,
+      });
+    },
+  });
+
+  // Get proxied wallet from proxiedAccountId
+  const proxiedWallet = useStoreMap({
+    store: walletModel.$wallets,
+    keys: [notification.proxiedAccountId],
+    fn: (wallets, [accountId]) => {
+      return walletUtils.getWalletFilteredAccounts(wallets, {
+        accountFn: (account) => account.accountId === accountId,
+      });
+    },
+  });
+
+  console.log({ proxiedWallet, proxyWallet });
+
   const address = toAddress(notification.proxyAccountId, { prefix: chain?.addressPrefix });
+
+  // Determine the proxied wallet name
+  const proxiedWalletName =
+    proxiedWallet?.name ||
+    proxyUtils.getProxiedName(
+      {
+        accountId: notification.proxiedAccountId,
+        proxyVariant: notification.proxyVariant,
+        connections: [],
+      },
+      chain?.addressPrefix,
+    );
+
+  const proxyWalletName = proxyWallet?.name || '';
+  const proxyWalletType = proxyWallet?.type || WalletType.WATCH_ONLY;
 
   return (
     <div className="flex gap-x-2">
       <div className="relative">
-        <WalletIcon type={WalletType.PROXIED} />
+        <WalletIcon type={proxyWalletType} />
         <div className="absolute top-[13px] -right-px h-2 w-2 rounded-full border border-white bg-icon-negative" />
       </div>
 
@@ -38,7 +79,7 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
           <Trans
             t={t}
             i18nKey="notifications.details.proxyWalletAction"
-            values={{ address, name: notification.proxiedWalletName }}
+            values={{ address, name: proxiedWalletName }}
             components={{
               identicon: (
                 <div className="mx-1 inline-flex">
@@ -54,14 +95,14 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
             t={t}
             i18nKey="notifications.details.proxyRemovedDetails"
             values={{
-              name: notification.proxyWalletName,
+              name: proxyWalletName,
               operations: t(ProxyTypeOperation[notification.proxyType]),
             }}
             components={{
               chain: <ChainTitle chainId={notification.chainId} fontClass="text-text-primary text-body" />,
               walletIcon: (
                 <span className="mx-1">
-                  <WalletIcon size={16} type={notification.proxyWalletType} />
+                  <WalletIcon size={16} type={proxyWalletType} />
                 </span>
               ),
               wallet: <p className="inline-flex" />,

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyRemovedNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/ProxyRemovedNotification.tsx
@@ -47,8 +47,6 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
     },
   });
 
-  console.log({ proxiedWallet, proxyWallet });
-
   const address = toAddress(notification.proxyAccountId, { prefix: chain?.addressPrefix });
 
   // Determine the proxied wallet name
@@ -63,13 +61,13 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
       chain?.addressPrefix,
     );
 
-  const proxyWalletName = proxyWallet?.name || '';
-  const proxyWalletType = proxyWallet?.type || WalletType.WATCH_ONLY;
+  const proxyWalletName = proxyWallet?.name || toAddress(notification.proxyAccountId, { prefix: chain?.addressPrefix });
+  const proxyWalletType = proxyWallet?.type;
 
   return (
     <div className="flex gap-x-2">
       <div className="relative">
-        <WalletIcon type={proxyWalletType} />
+        <WalletIcon type={WalletType.PROXIED} />
         <div className="absolute top-[13px] -right-px h-2 w-2 rounded-full border border-white bg-icon-negative" />
       </div>
 
@@ -101,9 +99,7 @@ export const ProxyRemovedNotification = ({ notification }: Props) => {
             components={{
               chain: <ChainTitle chainId={notification.chainId} fontClass="text-text-primary text-body" />,
               walletIcon: (
-                <span className="mx-1">
-                  <WalletIcon size={16} type={proxyWalletType} />
-                </span>
+                <span className="mx-1">{proxyWalletType && <WalletIcon size={16} type={proxyWalletType} />}</span>
               ),
               wallet: <p className="inline-flex" />,
             }}

--- a/src/renderer/features/proxies/lib/proxies-utils.ts
+++ b/src/renderer/features/proxies/lib/proxies-utils.ts
@@ -1,24 +1,11 @@
-import {
-  type Chain,
-  type ChainId,
-  ChainOptions,
-  type NoID,
-  type NotificationType,
-  type PartialProxiedAccount,
-  type ProxyAction,
-  type Wallet,
-  type WalletType,
-} from '@/shared/core';
-import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type Chain, ChainOptions } from '@/shared/core';
 import { type AnyAccount } from '@/domains/network';
-import { proxyUtils } from '@/entities/proxy';
-import { accountUtils, walletUtils } from '@/entities/wallet';
+import { accountUtils } from '@/entities/wallet';
 
 export const proxiesUtils = {
   isRegularProxy,
   isPureProxy,
   chainSupportProxy,
-  getNotification,
   isProxiedAvailable,
 };
 
@@ -32,51 +19,6 @@ function isPureProxy(chain: Chain): boolean {
 
 function chainSupportProxy(chain: Chain): boolean {
   return isRegularProxy(chain) || isPureProxy(chain);
-}
-
-type GetNotificationParams = {
-  wallets: Wallet[];
-  proxiedAccounts: PartialProxiedAccount[];
-  chains: Record<ChainId, Chain>;
-  type: NotificationType;
-};
-function getNotification({ wallets, proxiedAccounts, chains, type }: GetNotificationParams): NoID<ProxyAction>[] {
-  const filteredWallets = walletUtils.getWalletsFilteredAccounts(wallets, {
-    accountFn: (a) => proxiedAccounts.some((p) => p.connections.some((c) => c.proxyAccountId === a.accountId)),
-  });
-
-  if (!filteredWallets) return [];
-
-  const accountsMap = filteredWallets.reduce<Record<AccountId, { name: string; type: WalletType }>>((acc, wallet) => {
-    for (const account of wallet.accounts) {
-      acc[account.accountId] = { name: wallet.name, type: wallet.type };
-    }
-
-    return acc;
-  }, {});
-
-  return proxiedAccounts
-    .map((proxied) =>
-      proxied.connections.map((connection) => {
-        const addressPrefix = chains[proxied.chainId].addressPrefix;
-        const proxyAccount = accountsMap[connection.proxyAccountId];
-
-        return {
-          chainId: proxied.chainId,
-          dateCreated: Date.now(),
-          proxyType: connection.proxyType,
-          proxyAccountId: connection.proxyAccountId,
-          proxyVariant: proxied.proxyVariant,
-          proxyWalletName: proxyAccount.name,
-          proxyWalletType: proxyAccount.type,
-          proxiedAccountId: proxied.accountId,
-          proxiedWalletName: proxyUtils.getProxiedName(proxied, addressPrefix),
-          read: false,
-          type,
-        };
-      }),
-    )
-    .flat();
 }
 
 function isProxiedAvailable(account: AnyAccount): boolean {

--- a/src/renderer/features/proxies/model/proxies-model.ts
+++ b/src/renderer/features/proxies/model/proxies-model.ts
@@ -6,7 +6,6 @@ import {
   type ChainId,
   CryptoType,
   type NoID,
-  NotificationType,
   type PartialProxiedAccount,
   type ProxiedAccount,
   type ProxiedWallet,
@@ -17,10 +16,8 @@ import {
 import { series } from '@/shared/effector';
 import { type IdentityMap, accounts, identity, identityService } from '@/domains/network';
 import { networkModel, networkUtils } from '@/entities/network';
-import { notificationModel } from '@/entities/notification';
 import { proxyUtils } from '@/entities/proxy';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
-import { proxiesUtils } from '../lib/proxies-utils';
 
 const proxiedAccountsRemoved = createEvent<ProxiedAccount[]>();
 const proxiedAccountsUpdated = createEvent<ProxiedAccount[]>();
@@ -98,25 +95,6 @@ sample({
 sample({
   clock: createProxiedWalletsFx.doneData,
   target: series(walletModel.events.createProxied),
-});
-
-sample({
-  clock: createProxiedWalletsFx.doneData,
-  source: {
-    chains: networkModel.$chains,
-    wallets: walletModel.$wallets,
-  },
-  fn: ({ chains, wallets }, walletDrafts) => {
-    const proxiedAccounts = walletDrafts.flatMap(({ accounts }) => accounts);
-
-    return proxiesUtils.getNotification({
-      wallets,
-      proxiedAccounts,
-      chains,
-      type: NotificationType.PROXY_CREATED,
-    });
-  },
-  target: notificationModel.events.notificationsAdded,
 });
 
 // TODO remove

--- a/src/renderer/shared/core/types/notification.ts
+++ b/src/renderer/shared/core/types/notification.ts
@@ -2,7 +2,6 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 
 import { type CallHash, type ChainId, type ID, type Timepoint } from './general';
 import { type ProxyType, type ProxyVariant } from './proxy';
-import { type WalletType } from './wallet';
 
 export const enum NotificationType {
   MULTISIG_CREATED = 'MultisigCreatedNotification',
@@ -53,10 +52,7 @@ export type ProxyAction = BaseNotification & {
   proxyType: ProxyType;
   proxyVariant: ProxyVariant;
   proxyAccountId: AccountId;
-  proxyWalletName: string;
-  proxyWalletType: WalletType;
   proxiedAccountId: AccountId;
-  proxiedWalletName: string;
 };
 
 export type Notification =


### PR DESCRIPTION
## Description

Use general flow for proxied wallets notifications

## Related Issues

closes #4820

## Changes Made
- minimise required field in notification record
- add mapping to notification for proxied wallet created (the same way it is done for other wallets)
- remove custom notification call
- rm redundant utilities

## Screenshots/Recordings

<img width="742" height="120" alt="image" src="https://github.com/user-attachments/assets/2ec0f5ee-543d-4ebd-a61a-d160855184f2" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
