### PR TITLE
chore: issue explanation (NOT FOR MERGE)

### DIFF
--- a/src/renderer/features/operations/OperationsValidation/lib/transfer-rules.ts
+++ b/src/renderer/features/operations/OperationsValidation/lib/transfer-rules.ts
@@ -260,7 +260,10 @@ export const transferValidator = createTxValidator<{
       const initiator = accountService.findInitiator(route);
       assert(initiator, 'Initiator not found');
 
-      const balance = getBalance(initiator.accountId, sourceChain.chainId, asset.assetId);
+      // this is definitely not a final fix
+      // it only allows us to reuse burned from "sending amount"
+      // we still have incorrect burned amount bc after this subtract it should be smaller
+      const balance = getBalance(initiator.accountId, sourceChain.chainId, asset.assetId, { includeBurned: true });
       assert(balance, `Balance for account ${initiator.accountId} not found`);
 
       return {

--- a/src/renderer/shared/transactions/createTxValidator.ts
+++ b/src/renderer/shared/transactions/createTxValidator.ts
@@ -28,7 +28,12 @@ type ValidatorParams<A> = BaseParams<A> & {
 
 type RulesParams<A> = BaseParams<A> & {
   transaction: AnyTransaction;
-  getBalance(accountId: AccountId, chainId: ChainId, assetId: AssetId): Balance | null;
+  getBalance(
+    accountId: AccountId,
+    chainId: ChainId,
+    assetId: AssetId,
+    params?: { includeBurned: boolean },
+  ): Balance | null;
 };
 
 type ValidatorRule<A> = (
@@ -67,7 +72,12 @@ export function createTxValidator<A>(params?: {
     };
 
     try {
-      const getBalance = (accountId: AccountId, chainId: ChainId, assetId: AssetId) => {
+      const getBalance = (
+        accountId: AccountId,
+        chainId: ChainId,
+        assetId: AssetId,
+        params?: { includeBurned: boolean },
+      ) => {
         const validationResult = result.balanceValidationResults.findLast((r) => {
           return (
             r.account.accountId === accountId &&
@@ -77,7 +87,14 @@ export function createTxValidator<A>(params?: {
         });
 
         if (validationResult) {
-          return validationResult.balance.balance;
+          if (params?.includeBurned) {
+            return {
+              ...validationResult.balance.balance,
+              free: validationResult.balance.balance.free.add(validationResult.balance.burned),
+            };
+          } else {
+            return validationResult.balance.balance;
+          }
         }
 
         if (previousBalanceValidationResults) {


### PR DESCRIPTION
## Description

- burned amount in "sending amount" action is not necessarily the final burned amount and can be smaller in case of delivery fee
- we need an elegant mechanism to allow "delivery fee" action to use all the leftovers from "sending amount" without requesting the burned amount

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
