### PR TITLE
feat: use actual polkadot migration block for migration modals

### DIFF
--- a/src/renderer/features/assethub-migration-modal/model/constants.ts
+++ b/src/renderer/features/assethub-migration-modal/model/constants.ts
@@ -2,7 +2,7 @@ import { RelayChains } from '@/shared/lib/utils/constants';
 
 // Migration block numbers when AssetHub migration alerts should start showing
 export const KUSAMA_MIGRATION_BLOCK = 30_423_691;
-export const POLKADOT_MIGRATION_BLOCK = Infinity; // TODO: REPLACE WITH AN ACTUAL POLKADOT MIGRATION BLOCK!
+export const POLKADOT_MIGRATION_BLOCK = 28_490_502;
 
 // Hide alert after 5,000,000 blocks (~347 days)
 export const HIDE_AFTER_BLOCKS = 5_000_000;


### PR DESCRIPTION
## Description
Use actual polkadot migration block number to show migration modals: POLKADOT_MIGRATION_BLOCK = 28_490_502

https://polkadot.subscan.io/block/28490502

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
