### PR TITLE
feat(form): track fields touched

### DIFF
--- a/src/renderer/features/assets-balances/components/AmountInput.tsx
+++ b/src/renderer/features/assets-balances/components/AmountInput.tsx
@@ -36,6 +36,7 @@ type Props = {
   suffixElement?: ReactNode;
   testId?: string;
   onKeyDown?: () => void;
+  onBlur?: () => void;
   onChange?: (value: string) => void;
 };
 
@@ -52,6 +53,7 @@ export const AmountInput = ({
   testId,
   onChange,
   onKeyDown,
+  onBlur,
   suffixElement,
 }: Props) => {
   const { t } = useI18n();
@@ -193,6 +195,7 @@ export const AmountInput = ({
       testId={testId}
       onChange={handleChange}
       onKeyDown={onKeyDown}
+      onBlur={onBlur}
     />
   );
 };
@@ -212,6 +215,7 @@ type InputProps = {
   captionElement?: ReactNode;
   testId?: string;
   onKeyDown?: () => void;
+  onBlur?: () => void;
   onChange: (value: string) => void;
 };
 export const Input = ({
@@ -227,6 +231,7 @@ export const Input = ({
   testId,
   onKeyDown,
   onChange,
+  onBlur,
 }: InputProps) => {
   const id = useId();
 
@@ -279,6 +284,7 @@ export const Input = ({
           disabled={disabled}
           data-testid={testId}
           onKeyDown={onKeyDown}
+          onBlur={onBlur}
           onChange={(event) => onChange?.(event.target.value)}
         />
         {suffixElement && <div className="absolute top-3.5 right-3">{suffixElement}</div>}

--- a/src/renderer/shared/forms/createForm.test.ts
+++ b/src/renderer/shared/forms/createForm.test.ts
@@ -98,4 +98,55 @@ describe('createForm', () => {
     await allSettled(form.fields.name.change, { scope, params: 'Alice' });
     expect(scope.getState(form.fields.name.$errors)).toEqual([]);
   });
+
+  it('should track touched state on blur', async () => {
+    type Form = {
+      name: string;
+    };
+
+    const scope = fork();
+    const form = createForm<Form>({
+      fields: {
+        name: { defaultValue: 'Alice' },
+      },
+    });
+
+    expect(scope.getState(form.fields.name.$touched)).toEqual(false);
+
+    // Change should not mark as touched
+    await allSettled(form.fields.name.change, { scope, params: 'Bob' });
+    expect(scope.getState(form.fields.name.$touched)).toEqual(false);
+
+    // Blur should mark as touched
+    await allSettled(form.fields.name.markAsTouched, { scope });
+    expect(scope.getState(form.fields.name.$touched)).toEqual(true);
+
+    // Reset should clear touched state
+    await allSettled(form.fields.name.reset, { scope });
+    expect(scope.getState(form.fields.name.$touched)).toEqual(false);
+  });
+
+  it('should mark all fields as touched on submit', async () => {
+    type Form = {
+      name: string;
+      email: string;
+    };
+
+    const scope = fork();
+    const form = createForm<Form>({
+      fields: {
+        name: { defaultValue: '' },
+        email: { defaultValue: '' },
+      },
+    });
+
+    expect(scope.getState(form.fields.name.$touched)).toEqual(false);
+    expect(scope.getState(form.fields.email.$touched)).toEqual(false);
+
+    // Submit should mark all fields as touched
+    await allSettled(form.submit, { scope });
+
+    expect(scope.getState(form.fields.name.$touched)).toEqual(true);
+    expect(scope.getState(form.fields.email.$touched)).toEqual(true);
+  });
 });

--- a/src/renderer/shared/forms/createForm.ts
+++ b/src/renderer/shared/forms/createForm.ts
@@ -1,4 +1,14 @@
-import { type EventCallable, type Store, attach, combine, createEvent, restore, sample, scopeBind } from 'effector';
+import {
+  type EventCallable,
+  type Store,
+  attach,
+  combine,
+  createEvent,
+  createStore,
+  restore,
+  sample,
+  scopeBind,
+} from 'effector';
 import { readonly, spread } from 'patronum';
 
 import { entries } from '@/shared/lib/utils';
@@ -49,6 +59,7 @@ export const createForm = <Fields>(config: Config<Fields>): Form<Fields> => {
     if (!field) continue;
 
     const change = createEvent<any>();
+    const markAsTouched = createEvent<void>();
     const reset = createEvent<any>();
     const resetError = createEvent<any>();
     const $value = restore(change, field.defaultValue).reset(reset);
@@ -56,14 +67,21 @@ export const createForm = <Fields>(config: Config<Fields>): Form<Fields> => {
     const setErrors = createEvent<ValidationError[]>();
     const $errors = restore(setErrors, EMPTY_ARRAY).reset(reset, resetError, change);
 
+    const $touched = createStore(false)
+      .on(markAsTouched, () => true)
+      .reset(reset);
+
     fields[key] = {
       $value: readonly($value),
       change,
+      markAsTouched,
       reset,
       resetError,
 
       $errors: readonly($errors),
       setErrors,
+
+      $touched: readonly($touched),
     };
 
     values[key] = $value;
@@ -177,6 +195,7 @@ export const createForm = <Fields>(config: Config<Fields>): Form<Fields> => {
   );
 
   const resetSpread = Object.values(fields).map((field) => field.reset);
+  const markAsTouchedSpread = Object.values(fields).map((field) => field.markAsTouched);
 
   sample({
     clock: validateFx.doneData,
@@ -195,6 +214,11 @@ export const createForm = <Fields>(config: Config<Fields>): Form<Fields> => {
   sample({
     clock: reset,
     target: resetSpread,
+  });
+
+  sample({
+    clock: submitFx,
+    target: markAsTouchedSpread,
   });
 
   sample({

--- a/src/renderer/shared/forms/types.ts
+++ b/src/renderer/shared/forms/types.ts
@@ -3,8 +3,10 @@ import { type Effect, type EventCallable, type Store } from 'effector';
 export type FormField<Value> = {
   $value: Store<Value>;
   $errors: Store<ValidationError[]>;
+  $touched: Store<boolean>;
   setErrors: EventCallable<ValidationError[]>;
   change: EventCallable<Value>;
+  markAsTouched: EventCallable<void>;
   reset: EventCallable<void>;
   resetError: EventCallable<void>;
 };

--- a/src/renderer/shared/forms/useForm.ts
+++ b/src/renderer/shared/forms/useForm.ts
@@ -8,12 +8,14 @@ import { type Form, type ValidationError } from './types';
 type HookField<Value> = {
   value: Value;
   onChange(v: Value): void;
+  markAsTouched(): void;
   reset(): void;
   resetError(): void;
   hasError: boolean;
   errorMessage: string;
   errorValues?: Record<string, unknown>;
   errors: ValidationError[];
+  touched: boolean;
 };
 
 type Hook<Fields> = {
@@ -32,12 +34,15 @@ export const useForm = <Fields>(form: Form<Fields>): Hook<Fields> => {
   for (const [key, field] of fieldEntries) {
     const value = useUnit(field.$value);
     const errors = useUnit(field.$errors);
+    const touched = useUnit(field.$touched);
     fields[key] = {
       value,
       errors,
+      touched,
       reset: field.reset,
       resetError: field.resetError,
       onChange: field.change,
+      markAsTouched: field.markAsTouched,
       hasError: errors.length > 0,
       errorMessage: errors.at(0)?.message ?? '',
       errorValues: errors.at(0)?.values,

--- a/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
+++ b/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
@@ -38,7 +38,7 @@ const Context = createContext<ContextProps & ExpandedContextProps>({});
 
 type InputProps = Pick<
   ComponentProps<typeof Input>,
-  'disabled' | 'invalid' | 'placeholder' | 'height' | 'prefixElement' | 'onChange'
+  'disabled' | 'invalid' | 'placeholder' | 'height' | 'prefixElement' | 'onChange' | 'onBlur'
 >;
 
 type ControlledPopoverProps = {
@@ -81,7 +81,7 @@ const Root = ({ testId = 'Combobox', value, onChange, onInput, children, ...inpu
   );
 };
 
-const Trigger = ({ placeholder, ...inputProps }: InputProps) => {
+const Trigger = ({ placeholder, onBlur, ...inputProps }: InputProps) => {
   const { onOpenChange, comboboxRef, anchorRef } = useContext(Context);
 
   return (
@@ -93,7 +93,10 @@ const Trigger = ({ placeholder, ...inputProps }: InputProps) => {
           placeholder={placeholder}
           render={({ onChange, ...props }) => <Input {...props} {...inputProps} onChangeEvent={onChange} />}
           onFocus={() => onOpenChange?.(true)}
-          onBlur={() => onOpenChange?.(false)}
+          onBlur={event => {
+            onOpenChange?.(false);
+            onBlur?.(event);
+          }}
         />
       </div>
     </RadixPopover.Anchor>

--- a/src/renderer/widgets/Transfer/default/model/form-model.ts
+++ b/src/renderer/widgets/Transfer/default/model/form-model.ts
@@ -144,13 +144,6 @@ const form: Form<FormParams> = createForm<FormParams>({
   },
   validateOn: ['change'],
 });
-const $isFormSubmitted = createStore<boolean>(false).reset(formInitiated);
-
-sample({
-  clock: form.submit,
-  fn: () => true,
-  target: $isFormSubmitted,
-});
 
 const $destination = form.fields.destination.$value;
 const $destinationChain = form.fields.destinationChain.$value;
@@ -821,7 +814,6 @@ export const formModel = {
   $canSubmit,
   $asset,
 
-  $isFormSubmitted,
   $errors,
 
   $xcmConfig: xcmTransferModel.$config,

--- a/src/renderer/widgets/Transfer/default/ui/TransferForm.tsx
+++ b/src/renderer/widgets/Transfer/default/ui/TransferForm.tsx
@@ -266,7 +266,6 @@ const Destination = memo(() => {
   const wallets = useUnit(walletModel.$wallets);
   const accountsList = useUnit(walletModel.$availableAccounts);
   const network = useUnit(formModel.$networkStore);
-  const isFormSubmitted = useUnit(formModel.$isFormSubmitted);
 
   const walletsMap = useMemo(() => {
     return wallets.reduce<Record<number, Wallet>>((acc, wallet) => {
@@ -380,7 +379,7 @@ const Destination = memo(() => {
 
   const prefixElement = (
     <Identicon
-      invalid={isFormSubmitted && destination.hasError}
+      invalid={destination.touched && destination.hasError}
       size={20}
       address={toAddress(destination.value, { prefix: chain?.addressPrefix })}
       background={false}
@@ -398,11 +397,12 @@ const Destination = memo(() => {
         <Combobox
           data-testid={TEST_IDS.OPERATIONS.RECIPIENT_INPUT}
           placeholder={t('transfer.recipientPlaceholder')}
-          invalid={isFormSubmitted && destination.hasError}
+          invalid={destination.touched && destination.hasError}
           value={destination.value.trim()}
           prefixElement={prefixElement}
           height="md"
           onChange={destination.onChange}
+          onBlur={destination.markAsTouched}
           onInput={setQuery}
         >
           {options.map((group) => (
@@ -423,7 +423,7 @@ const Destination = memo(() => {
         )}
       </Box>
 
-      <InputHint active={isFormSubmitted && destination.hasError} variant="error">
+      <InputHint active={destination.touched && destination.hasError} variant="error">
         {t(destination.errorMessage, destination.errorValues)}
       </InputHint>
     </Field>
@@ -440,7 +440,6 @@ const Amount = memo(() => {
   const accountAvailableBalance = useUnit(formModel.$available);
   const network = useUnit(formModel.$networkStore);
   const isExistentialDepositEnabled = useUnit(formModel.$isExistentialDepositEnabled);
-  const isFormSubmitted = useUnit(formModel.$isFormSubmitted);
 
   const showMaxButton = accountAvailableBalance?.gtn(0) ?? false;
   const showEDSwitch = useUnit(formModel.$showEDSwitch);
@@ -452,7 +451,7 @@ const Amount = memo(() => {
   return (
     <div className="flex flex-col gap-y-2">
       <AmountInput
-        invalid={isFormSubmitted && amount.hasError}
+        invalid={amount.touched && amount.hasError}
         value={amount.value}
         balance={accountAvailableBalance?.toString() ?? null}
         balancePlaceholder={t('general.input.availableLabel')}
@@ -467,12 +466,12 @@ const Amount = memo(() => {
         }
         testId={TEST_IDS.OPERATIONS.AMOUNT_INPUT}
         onChange={(value: string) => amount.onChange(value)}
+        onBlur={amount.markAsTouched}
         onKeyDown={() => formModel.events.toggleMaxMode(false)}
       />
-      <InputHint active={isFormSubmitted && amount.hasError} variant="error">
+      <InputHint active={amount.touched && amount.hasError} variant="error">
         {t(amount.errorMessage)}
       </InputHint>
-
       {showEDSwitch && (
         <div className="flex justify-end">
           <Switch


### PR DESCRIPTION
## Description

Track touched state for fields to allow form validation without disturbing user with immediate error messages, but only after he touched&left  the field or submitted form

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- touched prop
- mark field as touched on blur
- mark field as touched on submit

## Screenshots/Recordings

https://github.com/user-attachments/assets/9bb8bc95-ea61-46cb-a701-c2854587c310

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
