### PR TITLE
fix: duplication of regular multisig when creating a flex multisig

### DIFF
--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/assign-model.ts
@@ -359,10 +359,11 @@ sample({
     signatories: signatoryModel.$signatories,
     chain: formModel.$chain,
     multisigAccountId: formModel.$multisigAccountId,
+    multisigAlreadyExists: formModel.$multisigAlreadyExists,
     successResult: $successResult,
   },
-  filter: ({ chain, multisigAccountId, successResult }) => {
-    return nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(successResult);
+  filter: ({ chain, multisigAccountId, successResult, multisigAlreadyExists }) => {
+    return nonNullable(chain) && nonNullable(multisigAccountId) && nonNullable(successResult) && !multisigAlreadyExists;
   },
   fn: ({ signatories, chain, name, threshold, multisigAccountId, successResult }) => {
     const timepoint = successResult!.params.timepoint;


### PR DESCRIPTION
## Description
Need to fix:
When creating a new flex multisig using the same parameters (signatories, threshold, and network) as an already existing flex multisig, the app adds a duplicate fixed multisig wallet.

This duplicate remains in the wallet list temporarily but then disappears after the next sync run, leaving only the original multisig.

## Related Issues
Closes #4748

## Changes Made
Fixed duplication of regular multisig when creating a flex multisig

## Screenshots/Recordings
<img width="297" height="244" alt="Снимок экрана 2025-11-07 в 12 43 03" src="https://github.com/user-attachments/assets/87b22092-b5be-491d-bddc-bcf49313a09a" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
