### PR TITLE
fix: multisig deposit when second approval

### DIFF
--- a/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
@@ -39,7 +39,7 @@ type Props = {
   valid: boolean;
   isFeeLoading: boolean;
   isDepositLoading: boolean;
-  isDepositRequired: boolean;
+  isDepositRequired?: boolean;
   onSign: () => void;
   onGoBack?: () => void;
   errors?: (
@@ -61,7 +61,7 @@ export const Confirmation = ({
   onSign,
   onGoBack,
   errors,
-  isDepositRequired,
+  isDepositRequired = false,
 }: Props) => {
   const { t } = useI18n();
 

--- a/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
@@ -39,6 +39,7 @@ type Props = {
   valid: boolean;
   isFeeLoading: boolean;
   isDepositLoading: boolean;
+  isDepositRequired: boolean;
   onSign: () => void;
   onGoBack?: () => void;
   errors?: (
@@ -60,6 +61,7 @@ export const Confirmation = ({
   onSign,
   onGoBack,
   errors,
+  isDepositRequired,
 }: Props) => {
   const { t } = useI18n();
 
@@ -67,6 +69,8 @@ export const Confirmation = ({
   const initiator = useUnit(operationsContextModel.$initiator);
 
   const signerWallet = wallets.find(w => w.id === signAccount?.walletId);
+
+  const depositPending = isDepositRequired && isDepositLoading;
 
   const xcmConfig = useUnit(xcmTransferModel.$config);
   const transaction = operation.transaction;
@@ -109,12 +113,10 @@ export const Confirmation = ({
       {initiator && signAccount && (
         <Details api={api} operation={operation} account={initiator} chain={chain} signatory={signAccount} />
       )}
-      {asset && (
-        <>
-          <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
-          <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />
-        </>
+      {asset && isDepositRequired && (
+        <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
       )}
+      {asset && <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />}
       {isXcmTransaction(transaction) && xcmConfig && xcmApi && asset && (
         <DetailRow label={t('operation.xcmFee')} className="text-text-primary">
           <XcmFee api={xcmApi} transaction={transaction} asset={asset} config={xcmConfig} />
@@ -127,7 +129,7 @@ export const Confirmation = ({
           </Button>
         )}
         <SignButton
-          disabled={isFeeLoading || isDepositLoading || !valid}
+          disabled={isFeeLoading || depositPending || !valid}
           className="ml-auto"
           type={signerWallet?.type}
           onClick={onSign}

--- a/src/renderer/features/multisig-operations/components/ApproveForm.tsx
+++ b/src/renderer/features/multisig-operations/components/ApproveForm.tsx
@@ -35,6 +35,7 @@ export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, as
   const fee = useUnit(approveModel.$fee);
   const isFeeLoading = useUnit(approveModel.$isFeeLoading);
   const isDepositLoading = useUnit(approveModel.$isDepositLoading);
+  const isDepositRequired = useUnit(approveModel.$isDepositRequired);
   const multisigDeposit = useUnit(approveModel.$multisigDeposit);
   const wallets = useUnit(walletModel.$wallets);
   const errors = useUnit(approveModel.$errors);
@@ -93,7 +94,9 @@ export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, as
 
       {asset && (
         <>
-          <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
+          {isDepositRequired && (
+            <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
+          )}
           {signatory && <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />}
         </>
       )}

--- a/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
@@ -53,6 +53,7 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
   const isFeeLoading = useUnit(approveModel.$isFeeLoading);
 
   const isDepositLoading = useUnit(approveModel.$isDepositLoading);
+  const isDepositRequired = useUnit(approveModel.$isDepositRequired);
   const multisigDeposit = useUnit(approveModel.$multisigDeposit);
   const signingPayloads = useUnit(approveModel.$signingPayloads);
   const unsignedAccounts = useUnit(approveModel.$unsignedAccounts);
@@ -153,6 +154,7 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
             fee={fee}
             isFeeLoading={isFeeLoading}
             isDepositLoading={isDepositLoading}
+            isDepositRequired={isDepositRequired}
             signAccount={signAccount}
             multisigDeposit={multisigDeposit}
             valid={valid}

--- a/src/renderer/features/multisig-operations/model/approve-model.ts
+++ b/src/renderer/features/multisig-operations/model/approve-model.ts
@@ -82,6 +82,14 @@ const $unsignedAccounts = combine(
   },
 );
 
+const $isDepositRequired = $operation.map(operation => {
+  if (nullable(operation)) return true;
+
+  const approvalsCount = operation.events.filter(event => event.status === 'approve').length;
+
+  return approvalsCount === 0;
+});
+
 const $signatories = createSignatoriesStore({
   chain: $chain,
   initiator: $initiator,
@@ -224,9 +232,15 @@ const $canSubmit = combine(
     isFeeLoading: $isFeeLoading,
     isDepositLoading: $isDepositLoading,
     signatory: $signatory,
+    isDepositRequired: $isDepositRequired,
   },
-  ({ valid, isFeeLoading, isDepositLoading, signatory }) =>
-    valid && !isFeeLoading && !isDepositLoading && nonNullable(signatory),
+  ({ valid, isFeeLoading, isDepositLoading, signatory, isDepositRequired }) => {
+    if (!nonNullable(signatory)) return false;
+
+    const depositPending = isDepositRequired && isDepositLoading;
+
+    return valid && !isFeeLoading && !depositPending;
+  },
 );
 
 export const approveModel = {
@@ -237,6 +251,7 @@ export const approveModel = {
   $isDepositLoading,
   $errors,
   $multisigDeposit,
+  $isDepositRequired,
   $signatory,
   $signingPayloads,
   $initiator,


### PR DESCRIPTION
## Description
When submitting a second approval for a multisig transaction, the transaction form requests a multisig deposit.

## Related Issues
Closes #4807

## Changes Made
Hidden Multisig deposit fee when approving multisig transactions

## Screenshots/Recordings

https://github.com/user-attachments/assets/0d26848d-5270-4551-a823-22e333057a15



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
