### PR TITLE
fix: sort fellowship tasks after voting

### DIFF
--- a/src/renderer/domains/collectives/votingHistory/hooks.ts
+++ b/src/renderer/domains/collectives/votingHistory/hooks.ts
@@ -2,11 +2,33 @@ import { type NullableMap } from '@/shared/core';
 import { nonNullableMap } from '@/shared/lib/utils';
 import { useResource } from '@/shared/query';
 
-import { type RequestAllVotesParams, type RequestVotesParams, allVotesResource, votesResource } from './resource';
+import {
+  type RequestAllVotesParams,
+  type RequestVotesParams,
+  allVotesResource,
+  votesResource,
+  votingSubscriptionResource,
+} from './resource';
 
 export const useVotes = (params: NullableMap<RequestVotesParams>) => {
+  const normalizedParams = nonNullableMap(params) ? params : null;
+
+  useResource(votingSubscriptionResource, {
+    params:
+      normalizedParams && normalizedParams.accounts.length > 0 && normalizedParams.referendums.length > 0
+        ? {
+            palletType: normalizedParams.palletType,
+            api: normalizedParams.api,
+            chainId: normalizedParams.chain.chainId,
+            accounts: normalizedParams.accounts,
+          }
+        : null,
+    defaultValue: [],
+    map: () => [],
+  });
+
   return useResource(votesResource, {
-    params: nonNullableMap(params) ? params : null,
+    params: normalizedParams,
     defaultValue: [],
     map(cache, { palletType, chain, accounts, referendums }) {
       const allVotes = cache[palletType]?.[chain.chainId];

--- a/src/renderer/domains/collectives/votingHistory/resource.ts
+++ b/src/renderer/domains/collectives/votingHistory/resource.ts
@@ -201,7 +201,7 @@ export const votingSubscriptionResource = createSubscriptionResource<VotingSubsc
     return unsubscribe;
   })
   .cache<CollectivesStruct<Vote[]>>({
-    store: createStore({}),
+    store: $sharedVotesCache,
     map(state, votes) {
       return mergeNested(state, votes, v => `${v.accountId}:${v.referendumId}`);
     },


### PR DESCRIPTION
## Description
When a user votes on a referendum, its position in the list should update immediately according to the sorting rules (e.g., voted items move to the bottom).
However, the list does not update in real time.
The referendum only moves to the bottom after a page switch/app reload.

## Related Issues
Closes #5101

## Changes Made
Updated fellowship tasks sorting after voting

## Screenshots/Recordings
<img width="817" height="788" alt="Снимок экрана 2025-11-18 в 19 37 43" src="https://github.com/user-attachments/assets/97173d72-7499-4e23-91ea-233c72b1c59b" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
