### PR TITLE
fix: added removed from basket message

### DIFF
--- a/src/renderer/features/fellowship-salary/components/SalaryInductModal.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryInductModal.tsx
@@ -31,6 +31,8 @@ export const SalaryInductModal = ({ disabled, children }: Props) => {
   const account = useUnit(salaryInduct.$account);
   const wallet = useUnit(salaryInduct.$wallet);
   const fee = useUnit(salaryInduct.$fee);
+  const inBasket = useUnit(salaryInduct.$inBasket);
+
   const { active: activeSalary, passive: passiveSalary } = useUnit(memberSalary.$memberSalary);
 
   let salary: string | null = null;
@@ -71,7 +73,7 @@ export const SalaryInductModal = ({ disabled, children }: Props) => {
         isOpen={open}
         variant="success"
         autoCloseTimeout={2000}
-        title={t('operation.addedToBasket')}
+        title={inBasket ? t('operation.addedToBasket') : t('operation.removedFromBasket')}
         onClose={() => handleToggle(false)}
       />
     );
@@ -116,7 +118,7 @@ export const SalaryInductModal = ({ disabled, children }: Props) => {
             <Modal.Footer>
               {wallet && basketUtils.isBasketAvailable(wallet) && (
                 <Button pallet="secondary" onClick={handleBasketSave}>
-                  {t('operation.addToBasket')}
+                  {inBasket ? t('operation.removeFromBasket') : t('operation.addToBasket')}
                 </Button>
               )}
               {nonNullable(wallet) && <SignButton type={wallet.type} onClick={handleSign} />}

--- a/src/renderer/features/fellowship-salary/components/SalaryPayoutModal.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryPayoutModal.tsx
@@ -14,6 +14,7 @@ import { OperationSign, OperationSubmit } from '@/features/operations';
 import { $beneficiary } from '../model/beneficiary';
 import { fellowshipSalaryFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
+import { salaryInduct } from '../model/salaryInduct';
 import { salaryPayout } from '../model/salaryPayout';
 
 import { SalaryPayoutConfirmation } from './SalaryPayoutConfirmation';
@@ -36,6 +37,8 @@ export const SalaryPayoutModal = ({ disabled, children }: Props) => {
   const account = useUnit(salaryPayout.$account);
   const wallet = useUnit(salaryPayout.$wallet);
   const fee = useUnit(salaryPayout.$fee);
+  const inBasket = useUnit(salaryInduct.$inBasket);
+
   const { active: activeSalary, passive: passiveSalary } = useUnit(memberSalary.$memberSalary);
 
   let salary: string | null = null;
@@ -69,7 +72,7 @@ export const SalaryPayoutModal = ({ disabled, children }: Props) => {
         isOpen={open}
         variant="success"
         autoCloseTimeout={2000}
-        title={t('operation.addedToBasket')}
+        title={inBasket ? t('operation.addedToBasket') : t('operation.removedFromBasket')}
         onClose={() => handleToggle(false)}
       />
     );
@@ -121,7 +124,7 @@ export const SalaryPayoutModal = ({ disabled, children }: Props) => {
             <Modal.Footer>
               {wallet && basketUtils.isBasketAvailable(wallet) && (
                 <Button pallet="secondary" onClick={handleBasketSave}>
-                  {t('operation.addToBasket')}
+                  {inBasket ? t('operation.removeFromBasket') : t('operation.addToBasket')}
                 </Button>
               )}
               {nonNullable(wallet) && <SignButton type={wallet.type} onClick={handleSign} />}

--- a/src/renderer/features/fellowship-salary/components/SalaryPayoutModal.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryPayoutModal.tsx
@@ -14,7 +14,6 @@ import { OperationSign, OperationSubmit } from '@/features/operations';
 import { $beneficiary } from '../model/beneficiary';
 import { fellowshipSalaryFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
-import { salaryInduct } from '../model/salaryInduct';
 import { salaryPayout } from '../model/salaryPayout';
 
 import { SalaryPayoutConfirmation } from './SalaryPayoutConfirmation';
@@ -37,7 +36,7 @@ export const SalaryPayoutModal = ({ disabled, children }: Props) => {
   const account = useUnit(salaryPayout.$account);
   const wallet = useUnit(salaryPayout.$wallet);
   const fee = useUnit(salaryPayout.$fee);
-  const inBasket = useUnit(salaryInduct.$inBasket);
+  const inBasket = useUnit(salaryPayout.$inBasket);
 
   const { active: activeSalary, passive: passiveSalary } = useUnit(memberSalary.$memberSalary);
 

--- a/src/renderer/features/fellowship-salary/components/SalaryRegisterModal.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryRegisterModal.tsx
@@ -13,6 +13,7 @@ import { OperationResult } from '@/entities/transaction';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { fellowshipSalaryFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
+import { salaryInduct } from '../model/salaryInduct';
 import { salaryRequest } from '../model/salaryRequest';
 
 import { SalaryRegisterConfirmation } from './SalaryRegisterConfirmation';
@@ -33,6 +34,8 @@ export const SalaryRegisterModal = ({ disabled, children }: Props) => {
   const account = useUnit(salaryRequest.$account);
   const wallet = useUnit(salaryRequest.$wallet);
   const fee = useUnit(salaryRequest.$fee);
+  const inBasket = useUnit(salaryInduct.$inBasket);
+
   const { active: activeSalary, passive: passiveSalary } = useUnit(memberSalary.$memberSalary);
 
   let salary: string | null = null;
@@ -66,7 +69,7 @@ export const SalaryRegisterModal = ({ disabled, children }: Props) => {
         isOpen={open}
         variant="success"
         autoCloseTimeout={2000}
-        title={t('operation.addedToBasket')}
+        title={inBasket ? t('operation.addedToBasket') : t('operation.removedFromBasket')}
         onClose={() => handleToggle(false)}
       />
     );
@@ -117,7 +120,7 @@ export const SalaryRegisterModal = ({ disabled, children }: Props) => {
             <Modal.Footer>
               {wallet && basketUtils.isBasketAvailable(wallet) && (
                 <Button pallet="secondary" onClick={handleBasketSave}>
-                  {t('operation.addToBasket')}
+                  {inBasket ? t('operation.removeFromBasket') : t('operation.addToBasket')}
                 </Button>
               )}
               {nonNullable(wallet) && <SignButton type={wallet.type} onClick={handleSign} />}

--- a/src/renderer/features/fellowship-salary/components/SalaryRegisterModal.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryRegisterModal.tsx
@@ -13,7 +13,6 @@ import { OperationResult } from '@/entities/transaction';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { fellowshipSalaryFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
-import { salaryInduct } from '../model/salaryInduct';
 import { salaryRequest } from '../model/salaryRequest';
 
 import { SalaryRegisterConfirmation } from './SalaryRegisterConfirmation';
@@ -34,7 +33,7 @@ export const SalaryRegisterModal = ({ disabled, children }: Props) => {
   const account = useUnit(salaryRequest.$account);
   const wallet = useUnit(salaryRequest.$wallet);
   const fee = useUnit(salaryRequest.$fee);
-  const inBasket = useUnit(salaryInduct.$inBasket);
+  const inBasket = useUnit(salaryRequest.$inBasket);
 
   const { active: activeSalary, passive: passiveSalary } = useUnit(memberSalary.$memberSalary);
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1825,6 +1825,8 @@
     "proxyFeeErrorTitle": "Not enough tokens to pay the fee",
     "rejectButton": "Reject",
     "rejectInProgress": "Submitting Rejection...",
+    "removeFromBasket": "Remove from basket",
+    "removedFromBasket": "Removed from basket",
     "selectAccount": "Select account",
     "selectAccountLabel": "Account",
     "selectSignatory": "Select signatory",


### PR DESCRIPTION
## Description

From the Salary widget, clicking “Add to basket” the activate salary action always shows a success alert with the text “Added to the basket”, regardless of the current state.

However, when the task is already in the basket, the behavior is incorrect:

The UI still shows “Added to the basket”.
In reality, clicking Add to basket in this state removes the task from the basket.
There is no indication in the modal that the task is already in the basket, nor an option to explicitly remove it.

So the button behaves like a toggle, but the text and UX always pretend it’s an “Add” action, which is misleading.

## Related Issues
Closes #5108

## Changes Made
Added removed from basket message

## Screenshots/Recordings

https://github.com/user-attachments/assets/75d92928-9c9b-4655-aa54-d6b1fc98470f



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
