### PR TITLE
fix: renamed General to Active

### DIFF
--- a/src/renderer/features/fellowship-tasks/components/Tasks.tsx
+++ b/src/renderer/features/fellowship-tasks/components/Tasks.tsx
@@ -25,7 +25,7 @@ export const Tasks = () => {
 
   const tasksCount = useMemo(() => {
     const personalCount = groups.personal?.length ?? 0;
-    const generalCount = groups.general?.filter(task => !task.hasVoted).length ?? 0;
+    const generalCount = groups.active?.filter(task => !task.hasVoted).length ?? 0;
     return personalCount + generalCount;
   }, [groups]);
 
@@ -45,8 +45,8 @@ export const Tasks = () => {
           {groups.personal ? (
             <TasksGroup key="pesonal" title={t('fellowship.tasks.personal')} group={groups.personal} />
           ) : null}
-          {groups.general ? (
-            <TasksGroup key="general" title={t('fellowship.tasks.general')} group={groups.general} />
+          {groups.active ? (
+            <TasksGroup key="active" title={t('fellowship.tasks.active')} group={groups.active} />
           ) : null}
           {groups.completed ? (
             <TasksGroup key="completed" title={t('fellowship.tasks.completed')} group={groups.completed} async />

--- a/src/renderer/features/fellowship-tasks/hooks/useEvidenceTasks.ts
+++ b/src/renderer/features/fellowship-tasks/hooks/useEvidenceTasks.ts
@@ -98,7 +98,7 @@ export const useEvidenceTasks = () => {
         tasks.push({
           id: `evidence_request_${proposer.accountId}`,
           weight: sortingScore,
-          group: 'general',
+          group: 'active',
           body: PromotionRetentionEvidenceVoting,
           meta: { evidence, transaction: evidenceTransaction, endBlock, tags },
           hasVoted: false,

--- a/src/renderer/features/fellowship-tasks/hooks/useOngoingReferendumTasks.ts
+++ b/src/renderer/features/fellowship-tasks/hooks/useOngoingReferendumTasks.ts
@@ -76,7 +76,7 @@ export const useOngoingReferendumTasks = () => {
           return {
             id: `referendum_${referendum.id}`,
             weight: weight.sortingScore,
-            group: 'general',
+            group: 'active',
             body: PromotionRetentionReferendumVoting,
             meta: {
               referendum,
@@ -94,7 +94,7 @@ export const useOngoingReferendumTasks = () => {
           return {
             id: `referendum_${referendum.id}`,
             weight: weight.sortingScore,
-            group: 'general',
+            group: 'active',
             body: OngoingReferendumVoting,
             meta: {
               referendum,

--- a/src/renderer/features/fellowship-tasks/types.ts
+++ b/src/renderer/features/fellowship-tasks/types.ts
@@ -16,7 +16,7 @@ export type OperationType =
 
 export type TaskDescription<T extends NonNullable<unknown> = any> = {
   id: OperationType;
-  group: 'personal' | 'general' | 'completed';
+  group: 'personal' | 'active' | 'completed';
   weight: number;
   body: ComponentType<T & { transaction: Transaction | null }>;
   meta: T & { transaction: Transaction | null; tags: string[] };


### PR DESCRIPTION
## Description
The section for active referenda in fellowship is called General, but should be Active.

## Related Issues
Closes #5111

## Changes Made
Renamed General to Active

## Screenshots/Recordings
<img width="822" height="646" alt="Снимок экрана 2025-11-19 в 13 27 11" src="https://github.com/user-attachments/assets/12d03384-91f1-4fe2-b739-7e2f2cd01d74" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
