### PR TITLE
Fix/salary widget passive salary

### DIFF
--- a/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { memo, useEffect, useState } from 'react';
+import { memo, useEffect, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
 import { getRelativeTimeFromApi, nonNullable, nullable, toAddress, toShortAddress } from '@/shared/lib/utils';
@@ -7,10 +7,11 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { Button, CaptionText, Duration, FootnoteText, Icon, SmallTitleText } from '@/shared/ui';
 import { Address } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
-import { salaryService } from '@/domains/collectives';
+import { memberService, salaryService } from '@/domains/collectives';
 import { accountService } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { walletModel } from '@/entities/wallet';
+import { useFellowshipMember, useFellowshipMemberSalary } from '@/aggregates/fellowship-member';
 import { beneficiary } from '../model/beneficiary';
 import { fellowshipSalaryFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
@@ -26,14 +27,30 @@ export const SalaryInfo = memo(() => {
   const [timeLeft, setTimeLeft] = useState(0);
 
   const input = useUnit(fellowshipSalaryFeature.input);
-  const currentMember = useUnit(profile.$member);
+  const currentMemberOld = useUnit(profile.$member);
   const account = useUnit(profile.$account);
   const currentPeriod = useUnit(memberSalary.$currentPeriod);
   const claimStatus = useUnit(memberSalary.$memberClaimStatus);
-  const salary = useUnit(memberSalary.$memberSalary);
+  const salaryOld = useUnit(memberSalary.$memberSalary);
   const beneficiaryValue = useUnit(beneficiary.$beneficiary);
   const contacts = useUnit(contactModel.$contacts);
   const wallets = useUnit(walletModel.$wallets);
+
+  const { data: salary } = useFellowshipMemberSalary();
+  const { data: currentMember } = useFellowshipMember();
+
+  console.log('salary', salary);
+  console.log('salaryOld', salaryOld);
+  console.log('currentMemberOld', currentMemberOld);
+  console.log('currentMember', currentMember);
+
+  const salaryAmount = useMemo(() => {
+    if (nonNullable(currentMember) && nonNullable(salary) && memberService.isCoreMember(currentMember)) {
+      return salaryService.formatSalaryAmount(currentMember.isActive ? salary.active : salary.passive);
+    }
+  }, [currentMember, salary]);
+
+  console.log('salaryAmount', salaryAmount);
 
   const getBeneficiaryName = (accountId: AccountId): string => {
     const finderFn = <T extends { accountId: AccountId }>(collection: T[]): T | undefined => {
@@ -95,7 +112,7 @@ export const SalaryInfo = memo(() => {
                           : t('fellowship.salary.salaryInfo.timeToRequest')}
                       </FootnoteText>
 
-                      <SmallTitleText>{salaryService.formatSalaryAmount(salary.active)}</SmallTitleText>
+                      <SmallTitleText>{salaryAmount}</SmallTitleText>
 
                       {isSalaryRequested && (
                         <FootnoteText className="mt-auto flex items-center gap-1 pt-2 pb-1 text-tab-text-accent">
@@ -122,7 +139,7 @@ export const SalaryInfo = memo(() => {
                           : t('fellowship.salary.salaryInfo.timeToWithdraw')}
                       </FootnoteText>
 
-                      <SmallTitleText>{salaryService.formatSalaryAmount(salary.active)}</SmallTitleText>
+                      <SmallTitleText>{salaryAmount}</SmallTitleText>
 
                       {isPayoutRequested && (
                         <FootnoteText className="mt-auto flex items-center gap-1 pt-2 pb-1 text-tab-text-accent">
@@ -148,7 +165,7 @@ export const SalaryInfo = memo(() => {
                     {t('fellowship.salary.salaryInfo.inductSalary')}
                   </FootnoteText>
 
-                  <SmallTitleText>{salaryService.formatSalaryAmount(salary.active)}</SmallTitleText>
+                  <SmallTitleText>{salaryAmount}</SmallTitleText>
 
                   <SalaryInductModal>
                     <Button className="mt-auto w-fit" size="sm" variant="fill" disabled={disabled}>

--- a/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
@@ -11,10 +11,14 @@ import { memberService, salaryService } from '@/domains/collectives';
 import { accountService } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { walletModel } from '@/entities/wallet';
-import { useFellowshipMember, useFellowshipMemberSalary } from '@/aggregates/fellowship-member';
+import {
+  useFellowshipMember,
+  useFellowshipMemberSalary,
+  useFellowshipMemberSalaryClaimStatus,
+} from '@/aggregates/fellowship-member';
+import { useCurrentSalaryPeriod } from '@/aggregates/fellowship-network';
 import { beneficiary } from '../model/beneficiary';
 import { fellowshipSalaryFeature } from '../model/feature';
-import { memberSalary } from '../model/memberSalary';
 import { profile } from '../model/profile';
 
 import { SalaryEditBeneficiaryModal } from './SalaryEditBeneficiaryModal';
@@ -27,30 +31,21 @@ export const SalaryInfo = memo(() => {
   const [timeLeft, setTimeLeft] = useState(0);
 
   const input = useUnit(fellowshipSalaryFeature.input);
-  const currentMemberOld = useUnit(profile.$member);
   const account = useUnit(profile.$account);
-  const currentPeriod = useUnit(memberSalary.$currentPeriod);
-  const claimStatus = useUnit(memberSalary.$memberClaimStatus);
-  const salaryOld = useUnit(memberSalary.$memberSalary);
   const beneficiaryValue = useUnit(beneficiary.$beneficiary);
   const contacts = useUnit(contactModel.$contacts);
   const wallets = useUnit(walletModel.$wallets);
 
-  const { data: salary } = useFellowshipMemberSalary();
   const { data: currentMember } = useFellowshipMember();
-
-  console.log('salary', salary);
-  console.log('salaryOld', salaryOld);
-  console.log('currentMemberOld', currentMemberOld);
-  console.log('currentMember', currentMember);
+  const { data: claimStatus } = useFellowshipMemberSalaryClaimStatus();
+  const { data: currentPeriod } = useCurrentSalaryPeriod();
+  const { data: salary } = useFellowshipMemberSalary();
 
   const salaryAmount = useMemo(() => {
     if (nonNullable(currentMember) && nonNullable(salary) && memberService.isCoreMember(currentMember)) {
       return salaryService.formatSalaryAmount(currentMember.isActive ? salary.active : salary.passive);
     }
   }, [currentMember, salary]);
-
-  console.log('salaryAmount', salaryAmount);
 
   const getBeneficiaryName = (accountId: AccountId): string => {
     const finderFn = <T extends { accountId: AccountId }>(collection: T[]): T | undefined => {


### PR DESCRIPTION
## Description
Currently, the Salary widget always displays the salary as if the user were active, even when the member’s actual state is inactive.

## Related Issues
Closes #5127

## Changes Made
Show passive salary when member is inactive

## Screenshots/Recordings
<img width="467" height="754" alt="Снимок экрана 2025-11-19 в 19 22 02" src="https://github.com/user-attachments/assets/0f4b4412-9987-4b01-8700-4696ebb90234" />

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
