### PR TITLE
fix: create the referendum modal title from the current rank

### DIFF
--- a/src/renderer/features/fellowship-referendum-details/components/ReferendumDetailsModal.tsx
+++ b/src/renderer/features/fellowship-referendum-details/components/ReferendumDetailsModal.tsx
@@ -2,15 +2,15 @@ import { type PropsWithChildren, memo, useMemo, useState } from 'react';
 
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
+import { toAddress, toRomanNumeral, toShortAddress } from '@/shared/lib/utils';
 import { type ReferendumId } from '@/shared/pallet/referenda';
 import { Box, Modal } from '@/shared/ui-kit';
-import { type Evidence, type Referendum, referendumService, trackService, useTracks } from '@/domains/collectives';
-import { useFellowshipApi } from '@/aggregates/fellowship-network';
+import { type Evidence, type Referendum, referendumService, trackService } from '@/domains/collectives';
+import { useFellowshipChain, useFellowshipIdentity } from '@/aggregates/fellowship-network';
 import { useEvidence } from '../hooks/useEvidence';
 import { useEvidenceHash } from '../hooks/useEvidenceHash';
 import { useProposer } from '../hooks/useProposer';
 import { useReferendum } from '../hooks/useReferendum';
-import { detailsService } from '../service';
 
 import { AdditionalInfo } from './AdditionalInfo';
 import { MemberProfile } from './MemberProfile';
@@ -36,29 +36,40 @@ export const ReferendumDetailsModal = memo(({ referendumId, children, title, isC
 
   const [isOpen, setIsOpen] = useState<boolean>(false);
 
-  const api = useFellowshipApi();
+  const chain = useFellowshipChain();
   const { data: referendum } = useReferendum(referendumId);
   const { data: proposer } = useProposer(referendum);
   const { data: evidence } = useEvidence(proposer?.accountId ?? null);
-  const { data: tracks } = useTracks({ palletType: 'fellowship', api });
   const { data: evidenceHash } = useEvidenceHash({ referendum, evidence });
+  const { data: identity } = useFellowshipIdentity(proposer?.accountId ?? null);
 
   const modalTitle = useMemo(() => {
     if (title) {
       return title;
     }
 
-    if (referendum && referendumService.isOngoing(referendum)) {
-      if (trackService.isPromotionTrack(referendum.track) || trackService.isRetentionTrack(referendum.track)) {
-        const rankTitle = detailsService.getRankTitle(referendum.track, tracks);
-        if (rankTitle) {
-          return rankTitle;
+    if (referendum && referendumService.isOngoing(referendum) && proposer) {
+      const isPromotionTrack = trackService.isPromotionTrack(referendum.track);
+      const isRetentionTrack = trackService.isRetentionTrack(referendum.track);
+
+      if (isPromotionTrack || isRetentionTrack) {
+        const rank = isPromotionTrack ? proposer.rank + 1 : proposer.rank;
+
+        if (rank > 0) {
+          const template = isPromotionTrack ? 'fellowship.tasks.titles.promote' : 'fellowship.tasks.titles.retain';
+          const name =
+            identity?.name ?? toShortAddress(toAddress(proposer.accountId, { prefix: chain?.addressPrefix }), 5);
+
+          return t(template, {
+            name,
+            rank: toRomanNumeral(rank),
+          });
         }
       }
     }
 
     return t('governance.referendums.referendumTitle', { index: referendumId });
-  }, [title, referendum, tracks, referendumId]);
+  }, [title, referendum, proposer, identity, chain, t, referendumId]);
 
   const handleToggle = (open: boolean) => {
     setIsOpen(open);


### PR DESCRIPTION
## Description
On the Fellowship dashboard, the referendum card title for a Retention referendum is generated using the user’s actual current rank, while the details modal incorrectly uses the rank specified by the referendum’s track origin.

## Related Issues
Closes #5123

## Changes Made
Creating the referendum modal title from the current rank

## Screenshots/Recordings
<img width="931" height="724" alt="Снимок экрана 2025-11-20 в 12 21 31" src="https://github.com/user-attachments/assets/27a201ae-8d65-4be1-94d9-837fc2afd5e5" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
