### PR TITLE
fix: update salary amount for inactive user

### DIFF
--- a/src/renderer/features/fellowship-tasks/components/tasks/RequestSalaryInduct.tsx
+++ b/src/renderer/features/fellowship-tasks/components/tasks/RequestSalaryInduct.tsx
@@ -1,13 +1,12 @@
-import { BN_ZERO } from '@polkadot/util';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { getCreatedDateFromApi } from '@/shared/lib/utils';
+import { getCreatedDateFromApi, nonNullable } from '@/shared/lib/utils';
 import { FootnoteText, SmallTitleText } from '@/shared/ui';
 import { Box, Skeleton } from '@/shared/ui-kit';
-import { salaryService } from '@/domains/collectives';
-import { useFellowshipMemberSalary } from '@/aggregates/fellowship-member';
+import { memberService, salaryService } from '@/domains/collectives';
+import { useFellowshipMember, useFellowshipMemberSalary } from '@/aggregates/fellowship-member';
 import { useCurrentSalaryPeriod, useFellowshipApi } from '@/aggregates/fellowship-network';
 import { BadgeIcon } from '../TaskBadge';
 
@@ -18,10 +17,17 @@ export const RequestSalaryInduct = () => {
   const [periodEnd, setPeriodEnd] = useState(0);
 
   const api = useFellowshipApi();
+
+  const { data: currentMember } = useFellowshipMember();
   const { data: currentPeriod } = useCurrentSalaryPeriod();
   const { data: salary, pending: pendingSalary } = useFellowshipMemberSalary();
-
   const currentPeriodExists = currentPeriod && currentPeriod.type !== 'unknown';
+
+  const salaryAmount = useMemo(() => {
+    if (nonNullable(currentMember) && nonNullable(salary) && memberService.isCoreMember(currentMember)) {
+      return salaryService.formatSalaryAmount(currentMember.isActive ? salary.active : salary.passive);
+    }
+  }, [currentMember, salary]);
 
   useEffect(() => {
     if (api && currentPeriodExists) {
@@ -38,9 +44,7 @@ export const RequestSalaryInduct = () => {
         <SmallTitleText>{t('fellowship.tasks.task.requestSalaryInduct.title')}</SmallTitleText>
         <Skeleton active={pendingSalary}>
           <FootnoteText>
-            {t('fellowship.tasks.task.requestSalaryInduct.description', {
-              salary: salaryService.formatSalaryAmount(salary?.active ?? BN_ZERO),
-            })}
+            {t('fellowship.tasks.task.requestSalaryInduct.description', { salary: salaryAmount })}
           </FootnoteText>
         </Skeleton>
         <FootnoteText className="text-text-secondary">


### PR DESCRIPTION
## Description
Currently, the Salary activation task always displays the salary as if the user is active, even when the member’s actual state is inactive.

## Related Issues
Closes #5127 

## Changes Made
Show passive salary in the activate task when member is inactive

## Screenshots/Recordings

<img width="985" height="379" alt="Снимок экрана 2025-11-20 в 17 57 09" src="https://github.com/user-attachments/assets/a5a63f99-7f1c-4ca7-96ee-c72e199ccdc3" />

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
