### PR TITLE
fix: fellowship overview ui issues

### DIFF
--- a/src/renderer/features/fellowship-overview/components/MembersTab/MembersTable.tsx
+++ b/src/renderer/features/fellowship-overview/components/MembersTab/MembersTable.tsx
@@ -11,6 +11,7 @@ import { useFellowshipApi, useFellowshipChain, useFellowshipIdentities } from '@
 
 export type MemberRow = CoreMember & {
   name?: string;
+  nameOrAccountId: string;
   salary: string;
   salaryAmount: number;
 };
@@ -45,7 +46,7 @@ export const MembersTable = memo(({ members }: MembersTableProps) => {
         },
       },
       {
-        key: 'name',
+        key: 'nameOrAccountId',
         title: t('fellowship.overview.members.table.account'),
         sortable: true,
         width: '452px',
@@ -109,9 +110,14 @@ export const MembersTable = memo(({ members }: MembersTableProps) => {
           salaryAmount = rawSalary.toNumber();
         }
 
+        const name = identities[member.accountId]
+          ? identityService.getFullName(identities[member.accountId])
+          : undefined;
+
         return {
           ...member,
-          name: identities[member.accountId] ? identityService.getFullName(identities[member.accountId]) : undefined,
+          name,
+          nameOrAccountId: name ?? member.accountId,
           salary: salaryText,
           salaryAmount,
         };

--- a/src/renderer/features/fellowship-overview/components/RankTab/RequirementsCard.tsx
+++ b/src/renderer/features/fellowship-overview/components/RankTab/RequirementsCard.tsx
@@ -1,5 +1,7 @@
+import { useUnit } from 'effector-react';
 import { memo } from 'react';
 
+import { $features } from '@/shared/config/features';
 import { useI18n } from '@/shared/i18n';
 import { FootnoteText, InfoLink, TitleText } from '@/shared/ui';
 import { Box, Markdown, Surface } from '@/shared/ui-kit';
@@ -13,6 +15,7 @@ interface RequirementsCardProps {
 
 export const RequirementsCard = memo(({ rankId }: RequirementsCardProps) => {
   const { t } = useI18n();
+  const features = useUnit($features);
   const rankData = getRankDataByRank(rankId);
 
   if (!rankData) {
@@ -53,11 +56,15 @@ export const RequirementsCard = memo(({ rankId }: RequirementsCardProps) => {
           {t('fellowship.ranks.activityDescription')}
           <br />
           {t('fellowship.ranks.agreementDescription')}
-          <br />
-          {t('fellowship.ranks.detailsInCodexText')}{' '}
-          <InfoLink url="#" onClick={handleCodexClick}>
-            {t('fellowship.ranks.codex')}
-          </InfoLink>
+          {features.codex && (
+            <>
+              <br />
+              {t('fellowship.ranks.detailsInCodexText')}{' '}
+              <InfoLink url="#" onClick={handleCodexClick}>
+                {t('fellowship.ranks.codex')}
+              </InfoLink>
+            </>
+          )}
         </FootnoteText>
 
         <div className="h-px w-full bg-filter-border" />

--- a/src/renderer/shared/ui-kit/Carousel/Carousel.tsx
+++ b/src/renderer/shared/ui-kit/Carousel/Carousel.tsx
@@ -1,15 +1,5 @@
-import { animated, useTransition } from '@react-spring/web';
-import {
-  type PropsWithChildren,
-  createContext,
-  memo,
-  useContext,
-  useDeferredValue,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-} from 'react';
+import { animated, useSpring } from '@react-spring/web';
+import { type PropsWithChildren, createContext, memo, useContext, useEffect, useMemo, useRef, useState } from 'react';
 
 import { usePrevious } from '@/shared/lib/hooks';
 import { cnTw } from '@/shared/lib/utils';
@@ -36,24 +26,23 @@ type RootProps = PropsWithChildren<{
 }>;
 
 const Root = memo(({ children, fixedHeight = false, item }: PropsWithChildren<RootProps>) => {
-  const deferred = useDeferredValue(item);
-  const prevItem = usePrevious(deferred);
+  const prevItem = usePrevious(item);
   const indecies = useRef<Record<string, number>>({});
 
-  const itemIndex = indecies.current[deferred] ?? 0;
+  const itemIndex = indecies.current[item] ?? 0;
   const prevItemIndex = indecies.current[prevItem] ?? 0;
   const direction = itemIndex - prevItemIndex;
 
   const value = useMemo(() => {
     return {
-      item: deferred,
+      item,
       direction,
       fixedHeight,
       registerItem: (id: string, index: number) => {
         indecies.current[id] = index;
       },
     };
-  }, [direction, deferred, fixedHeight]);
+  }, [direction, item, fixedHeight]);
 
   return (
     <Context.Provider value={value}>
@@ -72,42 +61,33 @@ const Item = memo(({ id, index, children }: ItemProps) => {
 
   useEffect(() => {
     registerItem(id, index);
-  }, [id, index]);
+  }, [id, index, registerItem]);
 
+  const isActive = id === item;
   const offset = 25;
-  const config = useMemo(() => {
-    return {
-      initial: { opacity: 1, transform: 'translateX(0%)' },
-      from: {
-        opacity: 0,
-        transform: `translateX(${direction > 0 ? offset : offset * -1}%)`,
-      },
-      enter: { opacity: 1, transform: 'translateX(0%)' },
-      leave: {
-        top: 0,
-        left: 0,
-        opacity: 0,
-        transform: `translateX(${direction > 0 ? offset * -1 : offset}%)`,
-        position: 'absolute',
-      },
-      config: {
-        duration: 300,
-        easing: defaultEasing,
-      },
-    };
-  }, [offset, direction]);
 
-  const transitions = useTransition(id === item, config);
+  const styles = useSpring({
+    opacity: isActive ? 1 : 0,
+    transform: isActive ? 'translateX(0%)' : `translateX(${direction > 0 ? offset * -1 : offset}%)`,
+    config: {
+      duration: 300,
+      easing: defaultEasing,
+    },
+  });
 
-  return transitions((styles, item) =>
-    item ? (
-      <animated.section
-        className={cnTw('relative min-h-full w-full', fixedHeight && 'h-full overflow-hidden')}
-        style={styles}
-      >
-        {children}
-      </animated.section>
-    ) : null,
+  return (
+    <animated.section
+      className={cnTw('relative min-h-full w-full', fixedHeight && 'h-full overflow-hidden')}
+      style={{
+        ...styles,
+        position: isActive ? 'relative' : 'absolute',
+        top: isActive ? undefined : 0,
+        left: isActive ? undefined : 0,
+        pointerEvents: isActive ? 'auto' : 'none',
+      }}
+    >
+      {children}
+    </animated.section>
   );
 });
 

--- a/src/renderer/shared/ui-kit/Table/Table.css
+++ b/src/renderer/shared/ui-kit/Table/Table.css
@@ -67,7 +67,7 @@
   text-align: right;
 }
 
-.table-header-cell:not(:first-child) .table-header-content {
+.table-header-cell:last-child .table-header-content {
   justify-content: flex-end;
 }
 

--- a/src/renderer/shared/ui-kit/Tabs/Tabs.tsx
+++ b/src/renderer/shared/ui-kit/Tabs/Tabs.tsx
@@ -1,5 +1,5 @@
 import * as RadixTabs from '@radix-ui/react-tabs';
-import { Children, type PropsWithChildren, cloneElement, isValidElement, useDeferredValue } from 'react';
+import { Children, type PropsWithChildren, cloneElement, isValidElement } from 'react';
 
 import { cnTw } from '@/shared/lib/utils';
 import { Carousel } from '../Carousel/Carousel';
@@ -15,11 +15,9 @@ const Root = ({ value, onChange, children }: RootProps) => {
     isValidElement(child) ? cloneElement(child, { __index: index }) : null,
   );
 
-  const deferred = useDeferredValue(value);
-
   return (
     <RadixTabs.Root value={value} asChild onValueChange={onChange}>
-      <Carousel item={deferred} fixedHeight>
+      <Carousel item={value} fixedHeight>
         {indexedChildren}
       </Carousel>
     </RadixTabs.Root>


### PR DESCRIPTION
Resolves #5145 

## Description

This PR fixes multiple UI issues in the Fellowship Overview modal

## Related Issues

Fixes Fellowship Overview issues:
- Fast tab switching resulting in blank page
- Codex link appearing when feature is disabled  
- Account sorting column naming
- Column names aligned to the right instead of left

## Changes Made

- Fixed blank content on fast tab switching, replaced `useTransition` with `useSpring` in Carousel to prevent active tabs from disappearing during rapid clicks
- Hide Codex link when feature disabled, added feature flag check so "Details can be found in the Codex" only shows when codex feature is enabled
- Added `nameOrAccountId` field to allow sorting by AccountId as well


## Screenshots/Recordings

No codex link on requirements card:
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="1109" height="806" alt="Screenshot 2025-11-22 at 11 06 01" src="https://github.com/user-attachments/assets/7486ee1c-e088-444a-90e3-f0595fd8364c" />

Sorted by account:

<img width="1127" height="812" alt="Screenshot 2025-11-22 at 11 14 53" src="https://github.com/user-attachments/assets/780b8eb7-582a-49ed-8bf0-bae9930f38fa" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
