### PR TITLE
fix: disable continue button on validation error, fix double signing

### DIFF
--- a/src/renderer/features/fellowship-evidence/components/IPFSUploadModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/IPFSUploadModal.tsx
@@ -23,6 +23,9 @@ export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
   const [fetchError, setFetchError] = useState<string | null>(null);
   const [isValidating, setIsValidating] = useState(false);
 
+  // Key to force InputFile remount when clearing is needed (resets internal fileName state)
+  const [fileInputKey, setFileInputKey] = useState(0);
+
   const handleFileChange = (file: File | null) => {
     setFile(file);
     if (file) {
@@ -87,6 +90,7 @@ export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
       setHash('');
       setShowValidationError(false);
       setFetchError(null);
+      setFileInputKey(prev => prev + 1);
     }
   }, [isOpen]);
 
@@ -123,7 +127,10 @@ export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
                   width="full"
                   onChange={value => {
                     setHash(value);
-                    setFile(null);
+                    if (file) {
+                      setFile(null);
+                      setFileInputKey(prev => prev + 1);
+                    }
                     setShowValidationError(false);
                     setFetchError(null);
                   }}
@@ -147,8 +154,8 @@ export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
 
             <div className="mt-2 min-h-0 flex-1">
               <InputFile
-                key={hash}
-                accept=".md,.txt"
+                key={fileInputKey}
+                accept=".md"
                 placeholder={t('fellowship.salary.evidence.ipfsUpload.dragDropFile')}
                 invalid={showValidationError}
                 onChange={handleFileChange}
@@ -176,7 +183,13 @@ export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
               ]}
             />
           </div>
-          <Button size="md" variant="fill" pallet="primary" disabled={isValidating} onClick={handleButtonSubmit}>
+          <Button
+            size="md"
+            variant="fill"
+            pallet="primary"
+            disabled={isValidating || showValidationError || !!fetchError}
+            onClick={handleButtonSubmit}
+          >
             {isValidating
               ? t('fellowship.salary.evidence.validating')
               : `⌘↵ ${t('fellowship.salary.evidence.continue')}`}

--- a/src/renderer/features/fellowship-evidence/index.tsx
+++ b/src/renderer/features/fellowship-evidence/index.tsx
@@ -132,9 +132,9 @@ fellowshipEvidenceFeature.inject(promotionEvidenceSubmitSlot, ({ mode, evidenceC
         <MarkdownPreviewModal isOpen={isOpen} evidenceContent={evidenceContent} wish="Promotion" onToggle={setIsOpen}>
           <Button size="sm">{t('fellowship.promotion.submitted.viewButton')}</Button>
         </MarkdownPreviewModal>
-        <EvidencePostFlowModal wish="Retention">
+        <EvidencePostFlowModal wish="Promotion">
           <Button size="sm" pallet="secondary" variant="fill" disabled={!canVote}>
-            {t('fellowship.retention.button.edit')}
+            {t('fellowship.promotion.submitted.editButton')}
           </Button>
         </EvidencePostFlowModal>
       </>


### PR DESCRIPTION
## Description

Closes #5172 , #5169 
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->
Fixes multiple UI bugs in the fellowship evidence IPFS upload flow 
## Changes Made

- Fixed continue button not disabling when validation errors are present
- Fixed file input not clearing when user switches to hash input (uses key prop to reset component internal state)
- Fixed wrong modal (promotion) opening after submitting retention report (corrected wish prop)

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

Continue button disabled on error
<img width="871" height="780" alt="Screenshot 2025-11-24 at 10 20 23" src="https://github.com/user-attachments/assets/56ca145f-48e1-4636-9eb8-06b9ee786131" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
