### PR TITLE
fix: download templates

### DIFF
--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -1,6 +1,7 @@
 import { useUnit } from 'effector-react';
 import { type FormEvent, memo, useMemo } from 'react';
 
+import vested_transfer_template_url from '@/shared/assets/templates/vested-transfer-template.csv?url';
 import { useForm } from '@/shared/forms';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
@@ -17,9 +18,6 @@ import { VestingCsvError, VestingSchedulePreview } from '@/entities/vesting';
 import { walletModel } from '@/entities/wallet';
 import { formModel } from '../model/form';
 import { vestedTransferUtils } from '../utils';
-
-const CSV_TEMPLATE_LINK =
-  'https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/templates/vested-transfer-template.csv';
 
 export const VestedTransferForm = () => {
   const { t } = useI18n();
@@ -170,7 +168,7 @@ const UploadCSV = () => {
       <div className="flex items-center justify-between gap-x-2">
         <FootnoteText className="text-text-tertiary">{t('vestedTransfer.form.fields.csvFile.label')}</FootnoteText>
         <div className="flex items-center gap-x-2">
-          <InfoLink url={CSV_TEMPLATE_LINK} className="ml-2" iconName="import" iconPosition="right">
+          <InfoLink url={vested_transfer_template_url} className="ml-2" iconName="import" iconPosition="right" download>
             {t('vestedTransfer.form.fields.csvFile.exampleButton')}
           </InfoLink>
           {showPreview && (

--- a/src/renderer/features/wallets/ImportKeys/lib/constants.ts
+++ b/src/renderer/features/wallets/ImportKeys/lib/constants.ts
@@ -5,6 +5,3 @@ export const PATH_ERRORS = [
   DerivationValidationError.PASSWORD_PATH,
   DerivationValidationError.ETHEREUM_SINGLE_SLASH,
 ];
-
-export const TEMPLATE_GITHUB_LINK =
-  'https://raw.githubusercontent.com/novasamatech/nova-spektr-utils/main/templates/dd-template.yaml';

--- a/src/renderer/features/wallets/ImportKeys/ui/ImportKeysModal.tsx
+++ b/src/renderer/features/wallets/ImportKeys/ui/ImportKeysModal.tsx
@@ -1,13 +1,13 @@
 import { useUnit } from 'effector-react';
 import { useEffect } from 'react';
 
+import derivations_template_url from '@/shared/assets/templates/polkadot-vault-derivations-template.yaml?url';
 import { type DraftAccount, type VaultChainAccount, type VaultShardAccount } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { Alert, Button, InfoLink, InputHint } from '@/shared/ui';
 import { InputFile, Modal } from '@/shared/ui-kit';
-import { TEMPLATE_GITHUB_LINK } from '../lib/constants';
 import { importKeysUtils } from '../lib/import-keys-utils';
 import { type DerivationKeyDraft } from '../lib/types';
 import { importKeysModel } from '../model/import-keys-model';
@@ -99,7 +99,7 @@ export const ImportKeysModal = ({ isOpen, rootAccountId, existingKeys, onConfirm
             ))}
           </Alert>
 
-          <InfoLink url={TEMPLATE_GITHUB_LINK} className="ml-2" iconName="import" iconPosition="right">
+          <InfoLink url={derivations_template_url} className="ml-2" iconName="import" iconPosition="right" download>
             {t('dynamicDerivations.importKeys.downloadTemplateButton')}
           </InfoLink>
         </div>

--- a/src/renderer/shared/assets/templates/polkadot-vault-derivations-template.yaml
+++ b/src/renderer/shared/assets/templates/polkadot-vault-derivations-template.yaml
@@ -1,0 +1,17 @@
+0x387aed21a43ed189c8f0d14aab6f05f715f1adfe670efa6090208ddd4efe991f: #vault public address
+  0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3: #polkadot genesis hash
+    - key:
+        derivation_path: "//polkadot"
+        type: "main"
+    - key:
+        derivation_path: "//polkadot//pub"
+        type: "pub"
+  0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe: #kusama genesis hash
+    - key:
+        derivation_path: "//kusama"
+        type: "main"
+    - key:
+        derivation_path: "//kusama//staking"
+        type: "staking"
+        sharded: 50
+version: 1

--- a/src/renderer/shared/assets/templates/vested-transfer-template.csv
+++ b/src/renderer/shared/assets/templates/vested-transfer-template.csv
@@ -1,0 +1,17 @@
+# Vested Transfer CSV Template
+# 
+# Column descriptions:
+# target             - Recipient address in SS58 format
+# locked             - Total locked amount in planks
+# starting_block     - Vesting start block number
+# per_block          - Amount in planks released per block
+#
+# Token Precision Reference:
+# 1 DOT  = 10000000000 (10^10 in planks)
+# Other tokens may have different precision levels
+#
+# Example for DOT: 10000000000 (1 DOT)
+# starting at block 123456 would release 100000 (0.00001 DOT) per block
+
+target,locked,starting_block,per_block
+5C5BDLw8tzzWB6XQbVPuzeL34d6GmPYPH1NaqsWBaJWzz42J,10000000000,123456,100000


### PR DESCRIPTION
## Description
Move templates to this repository. Make templates downloadable as a file instead of opening a github link.

## Related Issues
Closes [#5195](https://github.com/novasamatech/nova-spektr/issues/5195)

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
Download polkadot vault derivations template
https://github.com/user-attachments/assets/4e139107-81b3-4431-9146-ff2799db1f01

Download vested transfer template
https://github.com/user-attachments/assets/156d56ef-e4cc-4923-91fd-5e1f069d2029


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
