### PR TITLE
fix: vested transfer available chains

### DIFF
--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -63,7 +63,7 @@ export const VestedTransferForm = () => {
 export const NetworkSelect = memo(() => {
   const { t } = useI18n();
 
-  const allChains = useUnit(formModel.$allChains);
+  const availableChains = useUnit(formModel.$availableChains);
   const {
     fields: { chain },
   } = useForm(formModel.form);
@@ -73,7 +73,7 @@ export const NetworkSelect = memo(() => {
       <ChainSelect
         placeholder={t('vestedTransfer.form.fields.network.placeholder')}
         value={chain.value}
-        options={allChains}
+        options={availableChains}
         onChange={chain.onChange}
       />
       <InputHint variant="error" active={chain.hasError}>

--- a/src/renderer/features/vested-transfer/model/form.ts
+++ b/src/renderer/features/vested-transfer/model/form.ts
@@ -188,12 +188,21 @@ const $multisigDeposit = combine({ results: $balanceValidationResults }, ({ resu
   return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
 });
 
-const $availableChains = combine({ chains: networkModel.$chains }, ({ chains }) => {
-  const filteredChains = Object.values(chains).filter((chain) => {
-    return chain.options?.includes(ChainOptions.VESTED_TRANSFER);
-  });
-  return chainsService.sortChains(filteredChains);
-});
+const $availableChains = combine(
+  {
+    chains: networkModel.$chains,
+    selectedAccounts: walletSelect.$selectedAccounts,
+  },
+  ({ chains, selectedAccounts }) => {
+    const filteredChains = Object.values(chains).filter((chain) => {
+      return (
+        selectedAccounts.some((account) => accountService.isAccountAvailableOnChain(account, chain)) &&
+        chain.options?.includes(ChainOptions.VESTED_TRANSFER)
+      );
+    });
+    return chainsService.sortChains(filteredChains);
+  },
+);
 
 const $initiators = createInitiatorsStore({
   chain: form.fields.chain.$value,

--- a/src/renderer/features/vested-transfer/model/form.ts
+++ b/src/renderer/features/vested-transfer/model/form.ts
@@ -4,7 +4,7 @@ import { createGate } from 'effector-react';
 import { readonly, spread } from 'patronum';
 
 import { chainsService } from '@/shared/api/network';
-import { type Chain } from '@/shared/core';
+import { type Chain, ChainOptions } from '@/shared/core';
 import { createStoreFromEffect } from '@/shared/effector';
 import { type Form, createForm } from '@/shared/forms';
 import { assert, getNativeAsset, nonNullable, nonNullableMap, nullable } from '@/shared/lib/utils';
@@ -33,7 +33,6 @@ import { walletSelect } from '@/aggregates/wallet-select';
 import { balanceSubModel } from '@/features/assets-balances';
 import { signModel } from '@/features/operations/OperationSign';
 import { submitModel } from '@/features/operations/OperationSubmit';
-import { proxiesUtils } from '@/features/proxies';
 import { Step, type ValidationSchemaOptions } from '../types';
 import { vestedTransferUtils } from '../utils';
 
@@ -189,21 +188,12 @@ const $multisigDeposit = combine({ results: $balanceValidationResults }, ({ resu
   return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
 });
 
-const $allChains = networkModel.$chains.map((chains) => Object.values(chains));
-
-const $availableChains = combine(
-  {
-    chains: $allChains,
-    selectedAccounts: walletSelect.$selectedAccounts,
-  },
-  ({ chains, selectedAccounts }) => {
-    const proxyChains = chains.filter(proxiesUtils.isPureProxy);
-    const filteredChains = proxyChains.filter((chain) => {
-      return selectedAccounts.some((account) => accountService.isAccountAvailableOnChain(account, chain));
-    });
-    return chainsService.sortChains(filteredChains);
-  },
-);
+const $availableChains = combine({ chains: networkModel.$chains }, ({ chains }) => {
+  const filteredChains = Object.values(chains).filter((chain) => {
+    return chain.options?.includes(ChainOptions.VESTED_TRANSFER);
+  });
+  return chainsService.sortChains(filteredChains);
+});
 
 const $initiators = createInitiatorsStore({
   chain: form.fields.chain.$value,
@@ -519,7 +509,6 @@ export const formModel = {
   $parsedCsv,
   $csvError,
   $csvIssues,
-  $allChains: $allChains,
   $availableChains: $availableChains,
   $signatories: $signatories,
   $showSignatories: $showSignatories,

--- a/src/renderer/shared/core/types/chain.ts
+++ b/src/renderer/shared/core/types/chain.ts
@@ -33,6 +33,7 @@ export const enum ChainOptions {
   REGULAR_PROXY = 'regular_proxy',
   PURE_PROXY = 'pure_proxy',
   ETHEREUM_BASED = 'ethereum_based',
+  VESTED_TRANSFER = 'vested_transfer',
 }
 
 export type RpcNode = {


### PR DESCRIPTION
## Description
Filter available chains by `vested_transfer` option from chains config.

## Related Issues
Closes [#5200](https://github.com/novasamatech/nova-spektr/issues/5200)
Closes https://github.com/novasamatech/nova-spektr/issues/5216

## Changes Made
- Added  'vested_transfer' to ChainOptions enum
- Filter available chains in the network selector by vested_transfer' option and accounts available on chain

## Screenshots/Recordings
<img width="462" height="493" alt="Screenshot 2025-11-26 at 11 05 15 AM" src="https://github.com/user-attachments/assets/9769919c-d72d-4a88-8da6-520ede036605" />

when currently selected account is not available on vested transfer chains
<img width="473" height="377" alt="Screenshot 2025-11-26 at 11 23 10 AM" src="https://github.com/user-attachments/assets/6b361f23-50d0-4e32-8cdc-8c000e8962b3" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
