### PR TITLE
fix: vested transfer starting block warning

### DIFF
--- a/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
+++ b/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
@@ -197,7 +197,7 @@ export const VestingSchedulePreview = ({
       <Modal.Content>
         <div className="px-2 pb-3">
           <ScrollArea>
-            <Table columns={columns} data={tableData} className="w-full rounded-lg" />
+            <Table columns={columns} data={tableData} className="w-full rounded-lg [&_.table-cell]:!align-top" />
           </ScrollArea>
         </div>
       </Modal.Content>

--- a/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
+++ b/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
@@ -63,7 +63,7 @@ export const VestingSchedulePreview = ({
         ) : (
           <Component row={row} field={field} status={status} />
         )}
-        {fieldIssues.length > 0 && <FieldIssues issues={fieldIssues} />}
+        {fieldIssues.length > 0 && <FieldIssues issue={fieldIssues[0]} />}
       </div>
     );
   };
@@ -97,7 +97,7 @@ export const VestingSchedulePreview = ({
           return (
             <div className={cnTw('flex flex-col overflow-hidden', STATUS_TEXT_COLORS[status])}>
               <TargetAccount target={row.target} chain={chain} />
-              {fieldIssues.length > 0 && <FieldIssues issues={fieldIssues} />}
+              {fieldIssues.length > 0 && <FieldIssues issue={fieldIssues[0]} className="text-left" />}
             </div>
           );
         },
@@ -206,16 +206,14 @@ export const VestingSchedulePreview = ({
   );
 };
 
-const FieldIssues = ({ issues, className }: { issues: ValidationIssue[]; className?: string }) => {
+const FieldIssues = ({ issue, className }: { issue: ValidationIssue; className?: string }) => {
   const { t } = useI18n();
 
   return (
     <div className="flex flex-col">
-      {issues.map((issue) => (
-        <CaptionText key={issue.message} className={cnTw('text-inherit', className)}>
-          {t(`vestedTransfer.errors.csv.fieldErrors.${issue.message}`)}
-        </CaptionText>
-      ))}
+      <CaptionText className={cnTw('text-right text-inherit', className)}>
+        {t(`vestedTransfer.errors.csv.fieldErrors.${issue.message}`)}
+      </CaptionText>
     </div>
   );
 };

--- a/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
+++ b/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
@@ -197,7 +197,7 @@ export const VestingSchedulePreview = ({
       <Modal.Content>
         <div className="px-2 pb-3">
           <ScrollArea>
-            <Table columns={columns} data={tableData} className="w-full rounded-lg [&_.table-cell]:!align-top" />
+            <Table columns={columns} data={tableData} cellAlign="top" className="w-full rounded-lg" />
           </ScrollArea>
         </div>
       </Modal.Content>

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2597,7 +2597,7 @@
           "MAX_VESTING_SCHEDULES_REACHED": "Max vesting schedules reached",
           "MIN_VESTED_TRANSFER": "Min vested transfer",
           "OUT_OF_RANGE": "Value out of range",
-          "START_BLOCK_IN_PAST": "Block in the past. Must use relay chain blocks.",
+          "START_BLOCK_IN_PAST": "Block in the past. Make sure you are using relaychain block number",
           "UNKNOWN_ERROR": "Unknown error"
         },
         "invalidDataRow": "Row {row}",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2597,7 +2597,7 @@
           "MAX_VESTING_SCHEDULES_REACHED": "Max vesting schedules reached",
           "MIN_VESTED_TRANSFER": "Min vested transfer",
           "OUT_OF_RANGE": "Value out of range",
-          "START_BLOCK_IN_PAST": "Block in the past",
+          "START_BLOCK_IN_PAST": "Block in the past. Must use relay chain blocks.",
           "UNKNOWN_ERROR": "Unknown error"
         },
         "invalidDataRow": "Row {row}",

--- a/src/renderer/shared/ui-kit/Table/Table.tsx
+++ b/src/renderer/shared/ui-kit/Table/Table.tsx
@@ -14,14 +14,23 @@ export type Column<T> = {
   render?: (value: T[keyof T], item: T) => ReactNode;
 };
 
+const CELL_ALIGN_STYLES = {
+  top: 'align-top',
+  middle: 'align-middle',
+  bottom: 'align-bottom',
+} as const;
+
+export type CellAlign = keyof typeof CELL_ALIGN_STYLES;
+
 type TableProps<T> = {
   columns: Column<T>[];
   data: T[];
   className?: string;
+  cellAlign?: CellAlign;
   onSort?: (key: keyof T, direction: SortDirection) => void;
 };
 
-const TableComponent = <T,>({ columns, data, className, onSort }: TableProps<T>) => {
+const TableComponent = <T,>({ columns, data, className, cellAlign = 'middle', onSort }: TableProps<T>) => {
   const [sortKey, setSortKey] = useState<keyof T | null>(null);
   const [sortDirection, setSortDirection] = useState<SortDirection>(null);
 
@@ -99,7 +108,7 @@ const TableComponent = <T,>({ columns, data, className, onSort }: TableProps<T>)
           {sortedData.map((item, index) => (
             <tr key={index} className="table-row">
               {columns.map(column => (
-                <td key={String(column.key)} className="table-cell">
+                <td key={String(column.key)} className={cnTw('table-cell', CELL_ALIGN_STYLES[cellAlign])}>
                   {column.render ? column.render(item[column.key], item) : String(item[column.key])}
                 </td>
               ))}

--- a/src/renderer/shared/ui-kit/Table/index.ts
+++ b/src/renderer/shared/ui-kit/Table/index.ts
@@ -1,2 +1,2 @@
 export { Table } from './Table';
-export type { Column, SortDirection } from './Table';
+export type { CellAlign, Column, SortDirection } from './Table';


### PR DESCRIPTION
## Description
Update starting block warning message to tell the user that he must use the relay chain blocks.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5206

## Changes Made
- Update starting block warning message
- Override default table cell aligning
- Zod schema returns one error/warning per field, so render one issue

## Screenshots/Recordings
<img width="478" height="710" alt="Screenshot 2025-11-26 at 1 30 02 PM" src="https://github.com/user-attachments/assets/6054d690-0518-40c0-8d52-f32920c6d33a" />

<img width="970" height="399" alt="Screenshot 2025-11-26 at 1 30 18 PM" src="https://github.com/user-attachments/assets/3d93fedb-f7bf-4cde-ad95-c094a517ff08" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
