### PR TITLE
fix: doubling of flows when both retention and pomotion modals are rendered

### DIFF
--- a/src/renderer/features/fellowship-evidence/components/EvidenceFormModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/EvidenceFormModal.tsx
@@ -1,9 +1,8 @@
 /* eslint-disable i18next/no-literal-string */
 import { useForm } from 'effector-forms';
-import { useUnit } from 'effector-react';
+import { useGate, useUnit } from 'effector-react';
 import { type FormEventHandler, type PropsWithChildren, memo } from 'react';
 
-import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
 import { Alert, Button, InputHint, Separator } from '@/shared/ui';
 import { Box, Field, Modal, TextArea } from '@/shared/ui-kit';
@@ -16,7 +15,7 @@ type Props = PropsWithChildren<{
 }>;
 
 export const EvidenceFormModal = memo(({ isOpen, wish, children, onToggle }: Props) => {
-  useFlow(evidenceForm.flow, { wish });
+  useGate(evidenceForm.flow, { wish });
 
   const { t } = useI18n();
   const { fields, submit } = useForm(evidenceForm.form);

--- a/src/renderer/features/fellowship-evidence/components/EvidencePostFlowModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/EvidencePostFlowModal.tsx
@@ -14,31 +14,48 @@ type Props = PropsWithChildren<{
 
 export const EvidencePostFlowModal = ({ wish, children }: Props) => {
   const step = useUnit(evidencePost.$step);
+  const activeWish = useUnit(evidencePost.$activeWish);
   const evidence = useUnit(evidenceForm.$evidence);
+
+  const shouldShowForm = step === 'form' && activeWish === wish;
+  const shouldShowSubmit = step === 'submit' && activeWish === wish;
 
   const toggleForm = useCallback(
     (open: boolean) => {
-      evidencePost.setStep(open ? 'form' : 'closed');
+      if (open) {
+        evidenceForm.setFlowType('fromScratch');
+        evidencePost.setActiveWish(wish);
+        evidencePost.setStep('form');
+      } else {
+        evidencePost.setStep('closed');
+        evidencePost.setActiveWish(null);
+        evidenceForm.setFlowType(null);
+      }
     },
-    [evidencePost],
+    [wish],
   );
 
   const toggleConfirm = useCallback(
     (open: boolean, done: boolean) => {
       if (!open && step === 'submit') {
         evidencePost.setStep(done ? 'closed' : 'form');
+        if (done) {
+          evidencePost.setActiveWish(null);
+          evidenceForm.setFlowType(null);
+          evidenceForm.reset();
+        }
       }
     },
-    [step, evidencePost],
+    [step],
   );
 
   return (
     <>
-      <SubmitEvidenceFromScratch wish={wish} isOpen={step === 'form'} onToggle={toggleForm}>
+      <SubmitEvidenceFromScratch wish={wish} isOpen={shouldShowForm} onToggle={toggleForm}>
         {children}
       </SubmitEvidenceFromScratch>
       {nonNullable(evidence) && (
-        <EvidencePostModal wish={wish} evidence={evidence} isOpen={step === 'submit'} onToggle={toggleConfirm} />
+        <EvidencePostModal wish={wish} evidence={evidence} isOpen={shouldShowSubmit} onToggle={toggleConfirm} />
       )}
     </>
   );

--- a/src/renderer/features/fellowship-evidence/components/EvidencePostModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/EvidencePostModal.tsx
@@ -1,8 +1,7 @@
-import { useUnit } from 'effector-react';
+import { useGate, useUnit } from 'effector-react';
 import { type PropsWithChildren, useState } from 'react';
 
 import { type HexString } from '@/shared/core';
-import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable, nullable, toRomanNumeral } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
@@ -28,7 +27,7 @@ type Props = PropsWithChildren<{
 }>;
 
 export const EvidencePostModal = ({ isOpen, onToggle, evidence, wish, children }: Props) => {
-  useFlow(evidencePost.flow, null);
+  useGate(evidencePost.flow);
 
   const { t } = useI18n();
   const [step, setStep] = useState<Step>('confirm');

--- a/src/renderer/features/fellowship-evidence/components/IPFSUploadModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/IPFSUploadModal.tsx
@@ -1,6 +1,6 @@
+import { useGate } from 'effector-react';
 import { useEffect, useState } from 'react';
 
-import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
 import { Button, InputHint } from '@/shared/ui';
 import { Field, Input, InputFile, Modal, StepIndicator } from '@/shared/ui-kit';
@@ -14,7 +14,7 @@ type Props = {
 };
 
 export const IPFSUploadModal = ({ isOpen, onToggle, wish }: Props) => {
-  useFlow(evidenceForm.flow, { wish });
+  useGate(evidenceForm.flow, { wish });
 
   const { t } = useI18n();
   const [file, setFile] = useState<File | null>(null);

--- a/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
@@ -1,7 +1,6 @@
-import { useUnit } from 'effector-react';
+import { useGate, useUnit } from 'effector-react';
 import { type PropsWithChildren, useEffect, useRef } from 'react';
 
-import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
@@ -31,33 +30,43 @@ export const MarkdownPreviewModal = ({
   const { t } = useI18n();
   const { toast } = useNotification();
   const toastIdRef = useRef<string | number | undefined>(undefined);
+  const isShowingToastRef = useRef(false);
 
   const isViewingSubmittedEvidence = nonNullable(evidenceContent);
 
-  useFlow(evidenceForm.flow, isViewingSubmittedEvidence ? { wish: null } : { wish });
+  useGate(evidenceForm.flow, isViewingSubmittedEvidence ? { wish: null } : { wish });
 
   const ipfsFileContent = useUnit(evidenceIPFS.$fileContent);
   const pendingIPFSData = useUnit(evidenceIPFS.$pendingData);
   const isUploadPending = useUnit(evidenceIPFS.uploadFileToIPFS.pending);
   const uploadError = useUnit(evidenceIPFS.$uploadError);
+  const activeWish = useUnit(evidenceForm.$wish);
+  const activeFlowType = useUnit(evidenceForm.$flowType);
 
   const isLoading = isUploadPending;
   const contentToShow = evidenceContent || pendingIPFSData?.content || ipfsFileContent || '';
-  const isActiveFlow = !isViewingSubmittedEvidence && isOpen;
+  const isActiveFlow = !isViewingSubmittedEvidence && isOpen && activeWish === wish && activeFlowType === flowType;
 
   useEffect(() => {
     if (!isActiveFlow) {
+      if (toastIdRef.current) {
+        toast.dismiss(toastIdRef.current);
+        toastIdRef.current = undefined;
+        isShowingToastRef.current = false;
+      }
       return;
     }
 
-    if (isUploadPending && !toastIdRef.current) {
+    if (isUploadPending && !isShowingToastRef.current) {
+      isShowingToastRef.current = true;
       toastIdRef.current = toast.loading(t('fellowship.salary.evidence.uploadingToIPFS'));
       return;
     }
 
-    if (!isUploadPending && toastIdRef.current) {
+    if (!isUploadPending && isShowingToastRef.current && toastIdRef.current) {
       toast.dismiss(toastIdRef.current);
       toastIdRef.current = undefined;
+      isShowingToastRef.current = false;
 
       if (uploadError) {
         toast.error(uploadError);
@@ -65,7 +74,7 @@ export const MarkdownPreviewModal = ({
         toast.success(t('fellowship.salary.evidence.uploadSuccess'));
       }
     }
-  }, [isUploadPending, uploadError, toast, t, isActiveFlow]);
+  }, [isUploadPending, uploadError, toast, t, isActiveFlow, wish, activeWish, flowType, activeFlowType]);
 
   const handleConfirm = () => {
     if (!isActiveFlow || !pendingIPFSData) {

--- a/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
@@ -1,9 +1,11 @@
 import { useUnit } from 'effector-react';
 import { type PropsWithChildren, useEffect, useRef } from 'react';
 
+import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
 import { Button } from '@/shared/ui';
 import { Markdown, Modal, StepIndicator, useNotification } from '@/shared/ui-kit';
+import { evidenceForm } from '../model/evidenceForm';
 import { evidenceIPFS } from '../model/evidenceIPFS';
 import { evidencePost } from '../model/evidencePost';
 
@@ -29,16 +31,24 @@ export const MarkdownPreviewModal = ({
   const { toast } = useNotification();
   const toastIdRef = useRef<string | number | undefined>(undefined);
 
+  const isViewingSubmittedEvidence = !!evidenceContent;
+
+  useFlow(evidenceForm.flow, isViewingSubmittedEvidence ? { wish: null } : { wish });
+
   const ipfsFileContent = useUnit(evidenceIPFS.$fileContent);
   const pendingIPFSData = useUnit(evidenceIPFS.$pendingData);
   const isUploadPending = useUnit(evidenceIPFS.uploadFileToIPFS.pending);
   const uploadError = useUnit(evidenceIPFS.$uploadError);
 
   const isLoading = isUploadPending;
-
   const contentToShow = evidenceContent || pendingIPFSData?.content || ipfsFileContent || '';
+  const isActiveFlow = !isViewingSubmittedEvidence && isOpen;
 
   useEffect(() => {
+    if (!isActiveFlow) {
+      return;
+    }
+
     if (isUploadPending && !toastIdRef.current) {
       toastIdRef.current = toast.loading(t('fellowship.salary.evidence.uploadingToIPFS'));
       return;
@@ -52,25 +62,24 @@ export const MarkdownPreviewModal = ({
         toast.error(uploadError);
       } else {
         toast.success(t('fellowship.salary.evidence.uploadSuccess'));
-        evidencePost.openSubmitModal();
       }
     }
-  }, [isUploadPending, uploadError, toast, t]);
-
-  const isViewingSubmittedEvidence = !!evidenceContent;
+  }, [isUploadPending, uploadError, toast, t, isActiveFlow]);
 
   const handleConfirm = () => {
-    if (pendingIPFSData) {
-      if (pendingIPFSData.type === 'file' && pendingIPFSData.file) {
-        evidenceIPFS.uploadFileToIPFS({ file: pendingIPFSData.file });
-      } else if (pendingIPFSData.type === 'hash') {
-        evidencePost.openSubmitModal();
-      }
+    if (!isActiveFlow || !pendingIPFSData) {
+      return;
+    }
+
+    if (pendingIPFSData.type === 'file' && pendingIPFSData.file) {
+      evidenceIPFS.uploadFileToIPFS({ file: pendingIPFSData.file });
+    } else if (pendingIPFSData.type === 'hash') {
+      evidencePost.openSubmitModal();
     }
   };
 
   useEffect(() => {
-    if (!isOpen || isViewingSubmittedEvidence) {
+    if (!isActiveFlow) {
       return;
     }
 
@@ -86,7 +95,7 @@ export const MarkdownPreviewModal = ({
     return () => {
       document.removeEventListener('keydown', handleKeyDown);
     };
-  }, [isOpen, pendingIPFSData, isViewingSubmittedEvidence, handleConfirm]);
+  }, [isActiveFlow, handleConfirm]);
 
   const title =
     wish === 'Promotion'

--- a/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/MarkdownPreviewModal.tsx
@@ -3,6 +3,7 @@ import { type PropsWithChildren, useEffect, useRef } from 'react';
 
 import { useFlow } from '@/shared/effector';
 import { useI18n } from '@/shared/i18n';
+import { nonNullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { Markdown, Modal, StepIndicator, useNotification } from '@/shared/ui-kit';
 import { evidenceForm } from '../model/evidenceForm';
@@ -31,7 +32,7 @@ export const MarkdownPreviewModal = ({
   const { toast } = useNotification();
   const toastIdRef = useRef<string | number | undefined>(undefined);
 
-  const isViewingSubmittedEvidence = !!evidenceContent;
+  const isViewingSubmittedEvidence = nonNullable(evidenceContent);
 
   useFlow(evidenceForm.flow, isViewingSubmittedEvidence ? { wish: null } : { wish });
 

--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'effector-forms';
-import { useUnit } from 'effector-react';
+import { useGate, useUnit } from 'effector-react';
 import { type FormEventHandler, type PropsWithChildren, memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
@@ -14,6 +14,8 @@ type Props = PropsWithChildren<{
 }>;
 
 export const SubmitEvidenceFromScratch = memo(({ isOpen, wish, children, onToggle }: Props) => {
+  useGate(evidenceForm.flow, { wish });
+
   const { t } = useI18n();
   const { fields, submit } = useForm(evidenceForm.form);
   const uploadError = useUnit(evidenceForm.$uploadError);

--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
@@ -29,6 +29,10 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
   const fromScratchEvidence = useUnit(evidenceForm.$evidence);
   const ipfsEvidence = useUnit(evidenceIPFS.$evidence);
   const flowType = useUnit(evidenceForm.$flowType);
+  const activeWish = useUnit(evidenceForm.$wish);
+
+  const shouldRenderUpload = ipfsStep === 'upload' && activeWish === wish;
+  const shouldRenderPreview = ipfsStep === 'preview' && activeWish === wish;
 
   const handleFromScratch = useCallback(() => {
     evidenceForm.setFlowType('fromScratch');
@@ -38,10 +42,11 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
 
   const handleUploadFromIPFS = useCallback(() => {
     evidenceIPFS.reset();
+    evidenceForm.flow.open({ wish });
     evidenceForm.setFlowType('ipfsUpload');
     evidenceIPFS.startFlow();
     setPopoverOpen(false);
-  }, []);
+  }, [wish]);
 
   const handleFromScratchClose = useCallback((open: boolean) => {
     setFromScratchOpen(open);
@@ -132,17 +137,19 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
 
       <SubmitEvidenceFromScratch wish={wish} isOpen={fromScratchOpen} onToggle={handleFromScratchClose} />
 
-      <IPFSUploadModal isOpen={ipfsStep === 'upload'} wish={wish} onToggle={handleIPFSUploadClose} />
+      {shouldRenderUpload && <IPFSUploadModal isOpen={true} wish={wish} onToggle={handleIPFSUploadClose} />}
 
-      <MarkdownPreviewModal
-        isOpen={ipfsStep === 'preview'}
-        wish={wish}
-        flowType="ipfsUpload"
-        onToggle={handleIPFSPreviewClose}
-        onBack={handleBackToUpload}
-      />
+      {shouldRenderPreview && (
+        <MarkdownPreviewModal
+          isOpen={true}
+          wish={wish}
+          flowType="ipfsUpload"
+          onToggle={handleIPFSPreviewClose}
+          onBack={handleBackToUpload}
+        />
+      )}
 
-      {nonNullable(ipfsEvidence) && flowType === 'ipfsUpload' && (
+      {nonNullable(ipfsEvidence) && flowType === 'ipfsUpload' && activeWish === wish && (
         <EvidencePostModal
           wish={wish}
           evidence={ipfsEvidence}
@@ -151,7 +158,7 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
         />
       )}
 
-      {nonNullable(fromScratchEvidence) && flowType === 'fromScratch' && (
+      {nonNullable(fromScratchEvidence) && flowType === 'fromScratch' && activeWish === wish && (
         <EvidencePostModal
           wish={wish}
           evidence={fromScratchEvidence}

--- a/src/renderer/features/fellowship-evidence/model/evidenceForm.ts
+++ b/src/renderer/features/fellowship-evidence/model/evidenceForm.ts
@@ -1,9 +1,9 @@
 import { createEffect, createEvent, createStore, restore, sample } from 'effector';
 import { createForm } from 'effector-forms';
+import { createGate } from 'effector-react';
 import { t } from 'i18next';
 
 import { type HexString } from '@/shared/core';
-import { createFlow } from '@/shared/effector';
 import { nonNullable, nullable } from '@/shared/lib/utils';
 import { evidenceService } from '@/domains/collectives';
 
@@ -12,7 +12,7 @@ import { evidenceService } from '@/domains/collectives';
 const skipUploading = createEvent();
 const setFlowType = createEvent<'fromScratch' | 'ipfsUpload' | null>();
 
-const flow = createFlow<{ wish: 'Promotion' | 'Retention' | null }>({ wish: null });
+const flow = createGate<{ wish: 'Promotion' | 'Retention' | null }>({ defaultState: { wish: null } });
 const $wish = flow.state.map(x => x.wish);
 const $evidence = createStore<HexString | null>(null);
 const $flowType = restore(setFlowType, null);

--- a/src/renderer/features/fellowship-evidence/model/evidencePost.ts
+++ b/src/renderer/features/fellowship-evidence/model/evidencePost.ts
@@ -1,7 +1,7 @@
 import { combine, createEvent, createStore, restore, sample } from 'effector';
+import { createGate } from 'effector-react';
 import { reshape } from 'patronum';
 
-import { createFlow } from '@/shared/effector';
 import { nonNullable, nullable } from '@/shared/lib/utils';
 import { createTxStore } from '@/shared/transactions';
 import { evidenceService } from '@/domains/collectives';
@@ -13,7 +13,7 @@ import { evidenceForm } from './evidenceForm';
 import { evidenceIPFS } from './evidenceIPFS';
 import { fellowshipEvidenceFeature } from './feature';
 
-const flow = createFlow(null);
+const flow = createGate();
 
 const { $api, $chain, $wallet, $wallets, $account } = reshape({
   source: fellowshipEvidenceFeature.input,
@@ -125,6 +125,9 @@ sample({
 const setStep = createEvent<'closed' | 'form' | 'submit'>();
 const $step = restore(setStep, 'closed');
 
+const setActiveWish = createEvent<'Promotion' | 'Retention' | null>();
+const $activeWish = restore(setActiveWish, null);
+
 const openSubmitModal = createEvent();
 const closeSubmitModal = createEvent();
 const $submitModalOpen = createStore(false);
@@ -148,9 +151,15 @@ sample({
 });
 
 sample({
+  clock: evidenceForm.evidenceUploaded,
+  source: evidenceForm.$wish,
+  target: $activeWish,
+});
+
+sample({
   clock: $step,
   filter: step => step === 'closed',
-  target: evidenceForm.reset,
+  target: [evidenceForm.reset, $activeWish.reinit],
 });
 
 sample({
@@ -191,6 +200,7 @@ export const evidencePost = {
   flow,
   $fee,
   $step,
+  $activeWish,
   $submitModalOpen,
   $wallet,
   $account,
@@ -198,6 +208,7 @@ export const evidencePost = {
   sign,
   saveToBasket,
   setStep,
+  setActiveWish,
   openSubmitModal,
   closeSubmitModal,
 };

--- a/src/renderer/features/fellowship-evidence/model/evidencePost.ts
+++ b/src/renderer/features/fellowship-evidence/model/evidencePost.ts
@@ -155,6 +155,11 @@ sample({
 
 sample({
   clock: evidenceIPFS.uploadFileToIPFS.done,
+  source: {
+    ipfsStep: evidenceIPFS.$step,
+    flowType: evidenceForm.$flowType,
+  },
+  filter: ({ ipfsStep, flowType }) => ipfsStep === 'preview' && flowType === 'ipfsUpload',
   target: openSubmitModal,
 });
 


### PR DESCRIPTION
Closes #5172 

## Description
Fixed a bug where submitting evidence reports with IPFS uploads triggered duplicate toasts and confirmation modals. The issue occurred because multiple instances of the evidence submission modals (Promotion and Retention) were mounted simultaneously, and all instances subscribed to the same global Effector stores, causing them to react to state changes even when they weren't the active flow.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made

- SubmitEvidencePopover: Only render upload/preview modals when they match the active flow (activeWish === wish)
- SubmitEvidencePopover: Explicitly start flow when clicking "Upload from IPFS"
- MarkdownPreviewModal: Register with flow using useFlow to properly participate in lifecycle
- evidencePost: Filter submit modal opening to only trigger during active preview step

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
