### PR TITLE
feat: add retention and promotion submission warning modals

### DIFF
--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
@@ -13,6 +13,7 @@ import { EvidencePostModal } from './EvidencePostModal';
 import { IPFSUploadModal } from './IPFSUploadModal';
 import { MarkdownPreviewModal } from './MarkdownPreviewModal';
 import { SubmitEvidenceFromScratch } from './SubmitEvidenceFromScratch';
+import { SubmitPeriodWarningAlert } from './SubmitPeriodWarningAlert';
 
 type Props = PropsWithChildren<{
   wish: 'Promotion' | 'Retention';
@@ -110,22 +111,20 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
         <Popover.Trigger>{childWithIcon}</Popover.Trigger>
         <Popover.Content>
           <Box padding={[1, 1]} gap={1}>
-            <div
-              className="cursor-pointer rounded px-3 py-2 hover:bg-action-background-hover"
-              onClick={handleFromScratch}
-            >
-              <FootnoteText className="text-text-secondary">
-                {t('fellowship.salary.evidence.submitOptions.fromScratch')}
-              </FootnoteText>
-            </div>
-            <div
-              className="cursor-pointer rounded px-3 py-2 hover:bg-action-background-hover"
-              onClick={handleUploadFromIPFS}
-            >
-              <FootnoteText className="text-text-secondary">
-                {t('fellowship.salary.evidence.submitOptions.uploadFromIPFS')}
-              </FootnoteText>
-            </div>
+            <SubmitPeriodWarningAlert wish={wish} onConfirm={handleFromScratch}>
+              <div className="cursor-pointer rounded px-3 py-2 hover:bg-action-background-hover">
+                <FootnoteText className="text-text-secondary">
+                  {t('fellowship.salary.evidence.submitOptions.fromScratch')}
+                </FootnoteText>
+              </div>
+            </SubmitPeriodWarningAlert>
+            <SubmitPeriodWarningAlert wish={wish} onConfirm={handleUploadFromIPFS}>
+              <div className="cursor-pointer rounded px-3 py-2 hover:bg-action-background-hover">
+                <FootnoteText className="text-text-secondary">
+                  {t('fellowship.salary.evidence.submitOptions.uploadFromIPFS')}
+                </FootnoteText>
+              </div>
+            </SubmitPeriodWarningAlert>
           </Box>
         </Popover.Content>
       </Popover>

--- a/src/renderer/features/fellowship-evidence/components/SubmitPeriodWarningAlert.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitPeriodWarningAlert.tsx
@@ -1,5 +1,6 @@
+import { Slot } from '@radix-ui/react-slot';
 import { differenceInDays } from 'date-fns';
-import { type PropsWithChildren, useCallback, useMemo, useState } from 'react';
+import { type HTMLAttributes, type ReactElement, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
 import { nullable } from '@/shared/lib/utils';
@@ -8,16 +9,32 @@ import { ConfirmModal } from '@/shared/ui-kit';
 import { useRetentionPeriodDates } from '@/aggregates/fellowship-retention';
 import { PROMOTION_WARNING_THRESHOLD_DAYS, RETENTION_WARNING_THRESHOLD_DAYS } from '../constants';
 
-type Props = PropsWithChildren<{
+type RadixIntegration = Pick<
+  HTMLAttributes<Element>,
+  | 'onClick'
+  | 'onMouseDown'
+  | 'onMouseUp'
+  | 'onMouseEnter'
+  | 'onMouseLeave'
+  | 'onPointerDown'
+  | 'onPointerUp'
+  | 'onPointerMove'
+  | 'onPointerLeave'
+>;
+
+type Props = RadixIntegration & {
   wish: 'Promotion' | 'Retention';
   onConfirm: () => void;
-}>;
+  children: ReactElement;
+};
 
-export const SubmitPeriodWarningAlert = ({ wish, onConfirm, children }: Props) => {
+export const SubmitPeriodWarningAlert = ({ wish, onConfirm, children, ...radix }: Props) => {
   const { t } = useI18n();
   const [isOpen, setIsOpen] = useState(false);
 
   const { data: retentionPeriodDates } = useRetentionPeriodDates();
+
+  const translationKey = wish === 'Promotion' ? 'promotionPeriodWarning' : 'retentionPeriodWarning';
 
   const shouldShowWarning = useMemo(() => {
     if (nullable(retentionPeriodDates) || nullable(retentionPeriodDates.to)) {
@@ -27,7 +44,7 @@ export const SubmitPeriodWarningAlert = ({ wish, onConfirm, children }: Props) =
     const daysUntilEnd = differenceInDays(retentionPeriodDates.to, new Date());
 
     if (wish === 'Retention') {
-      return daysUntilEnd < RETENTION_WARNING_THRESHOLD_DAYS;
+      return daysUntilEnd > RETENTION_WARNING_THRESHOLD_DAYS;
     }
 
     if (wish === 'Promotion') {
@@ -37,29 +54,32 @@ export const SubmitPeriodWarningAlert = ({ wish, onConfirm, children }: Props) =
     return false;
   }, [wish, retentionPeriodDates]);
 
-  const translationKey = wish === 'Retention' ? 'retentionPeriodWarning' : 'promotionPeriodWarning';
+  const handleClick = (e: React.MouseEvent) => {
+    e.stopPropagation();
 
-  const handleClick = useCallback(() => {
     if (shouldShowWarning) {
       setIsOpen(true);
     } else {
       onConfirm();
     }
-  }, [shouldShowWarning, onConfirm]);
 
-  const handleConfirm = useCallback(() => {
+    radix.onClick?.(e);
+  };
+
+  const handleConfirm = () => {
     setIsOpen(false);
     onConfirm();
-  }, [onConfirm]);
+  };
 
-  const handleCancel = useCallback(() => {
+  const handleCancel = () => {
     setIsOpen(false);
-  }, []);
+  };
 
   return (
     <>
-      <div onClick={handleClick}>{children}</div>
-
+      <Slot {...radix} onClick={handleClick}>
+        {children}
+      </Slot>
       <ConfirmModal
         isOpen={isOpen}
         title={t(`fellowship.salary.evidence.${translationKey}.title`)}

--- a/src/renderer/features/fellowship-evidence/components/SubmitPeriodWarningAlert.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitPeriodWarningAlert.tsx
@@ -1,0 +1,79 @@
+import { differenceInDays } from 'date-fns';
+import { type PropsWithChildren, useCallback, useMemo, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { nullable } from '@/shared/lib/utils';
+import { FootnoteText } from '@/shared/ui';
+import { ConfirmModal } from '@/shared/ui-kit';
+import { useRetentionPeriodDates } from '@/aggregates/fellowship-retention';
+import { PROMOTION_WARNING_THRESHOLD_DAYS, RETENTION_WARNING_THRESHOLD_DAYS } from '../constants';
+
+type Props = PropsWithChildren<{
+  wish: 'Promotion' | 'Retention';
+  onConfirm: () => void;
+}>;
+
+export const SubmitPeriodWarningAlert = ({ wish, onConfirm, children }: Props) => {
+  const { t } = useI18n();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const { data: retentionPeriodDates } = useRetentionPeriodDates();
+
+  const shouldShowWarning = useMemo(() => {
+    if (nullable(retentionPeriodDates) || nullable(retentionPeriodDates.to)) {
+      return false;
+    }
+
+    const daysUntilEnd = differenceInDays(retentionPeriodDates.to, new Date());
+
+    if (wish === 'Retention') {
+      return daysUntilEnd < RETENTION_WARNING_THRESHOLD_DAYS;
+    }
+
+    if (wish === 'Promotion') {
+      return daysUntilEnd < PROMOTION_WARNING_THRESHOLD_DAYS;
+    }
+
+    return false;
+  }, [wish, retentionPeriodDates]);
+
+  const translationKey = wish === 'Retention' ? 'retentionPeriodWarning' : 'promotionPeriodWarning';
+
+  const handleClick = useCallback(() => {
+    if (shouldShowWarning) {
+      setIsOpen(true);
+    } else {
+      onConfirm();
+    }
+  }, [shouldShowWarning, onConfirm]);
+
+  const handleConfirm = useCallback(() => {
+    setIsOpen(false);
+    onConfirm();
+  }, [onConfirm]);
+
+  const handleCancel = useCallback(() => {
+    setIsOpen(false);
+  }, []);
+
+  return (
+    <>
+      <div onClick={handleClick}>{children}</div>
+
+      <ConfirmModal
+        isOpen={isOpen}
+        title={t(`fellowship.salary.evidence.${translationKey}.title`)}
+        description={
+          <FootnoteText className="text-text-tertiary" align="center">
+            {t(`fellowship.salary.evidence.${translationKey}.description`)}
+          </FootnoteText>
+        }
+        cancelText={t(`fellowship.salary.evidence.${translationKey}.cancel`)}
+        confirmText={t(`fellowship.salary.evidence.${translationKey}.submit`)}
+        onToggle={setIsOpen}
+        onCancel={handleCancel}
+        onConfirm={handleConfirm}
+      />
+    </>
+  );
+};

--- a/src/renderer/features/fellowship-evidence/constants.ts
+++ b/src/renderer/features/fellowship-evidence/constants.ts
@@ -1,3 +1,6 @@
 export const ERROR = {
   networkDisabled: 'Network disabled',
 };
+
+export const RETENTION_WARNING_THRESHOLD_DAYS = 28;
+export const PROMOTION_WARNING_THRESHOLD_DAYS = 30;

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -874,7 +874,7 @@
         "submitRetentionReport": "Submit retention report",
         "retentionPeriodWarning": {
           "title": "Are you sure you want to submit retention report?",
-          "description": "Retention period in progress. Submit only if confident that your work meets expectations defined for the current rank. Otherwise, continue contributing according to rank requirements.",
+          "description": "It might be too early to submit your retention report. We recommend submitting no earlier than month before the retention period ends. Please ensure you have gathered sufficient work evidence for the current retention period before submitting.",
           "cancel": "Cancel",
           "submit": "Submit"
         },

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -872,6 +872,18 @@
         },
         "submitPromotionReport": "Submit promotion report",
         "submitRetentionReport": "Submit retention report",
+        "retentionPeriodWarning": {
+          "title": "Are you sure you want to submit retention report?",
+          "description": "Retention period in progress. Submit only if confident that your work meets expectations defined for the current rank. Otherwise, continue contributing according to rank requirements.",
+          "cancel": "Cancel",
+          "submit": "Submit"
+        },
+        "promotionPeriodWarning": {
+          "title": "Are you sure you want to submit promotion report?",
+          "description": "Retention period in progress. Submit only if confident that your work meets expectations defined for the higher rank. Otherwise, continue contributing according to current rank requirements.",
+          "cancel": "Cancel",
+          "submit": "Submit"
+        },
         "uploadSuccess": "Upload successful",
         "uploadingToIPFS": "Uploading to IPFS...",
         "validating": "Validating..."

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -879,8 +879,8 @@
           "submit": "Submit"
         },
         "promotionPeriodWarning": {
-          "title": "Are you sure you want to submit promotion report?",
-          "description": "Retention period in progress. Submit only if confident that your work meets expectations defined for the higher rank. Otherwise, continue contributing according to current rank requirements.",
+          "title": "Retention period ends in 30 days",
+          "description": "It is recommended to prioritize submitting the retention report before submitting promotion evidence to avoid being bumped.",
           "cancel": "Cancel",
           "submit": "Submit"
         },

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -866,24 +866,24 @@
           "step2": "Review and submit",
           "title": "Preview Evidence"
         },
+        "promotionPeriodWarning": {
+          "cancel": "Cancel",
+          "description": "It is recommended to prioritize submitting the retention report before submitting promotion evidence to avoid being bumped.",
+          "submit": "Submit",
+          "title": "Retention period ends in 30 days"
+        },
+        "retentionPeriodWarning": {
+          "cancel": "Cancel",
+          "description": "It might be too early to submit your retention report. We recommend submitting no earlier than month before the retention period ends. Please ensure you have gathered sufficient work evidence for the current retention period before submitting.",
+          "submit": "Submit",
+          "title": "Are you sure you want to submit retention report?"
+        },
         "submitOptions": {
           "fromScratch": "From scratch",
           "uploadFromIPFS": "Upload from IPFS"
         },
         "submitPromotionReport": "Submit promotion report",
         "submitRetentionReport": "Submit retention report",
-        "retentionPeriodWarning": {
-          "title": "Are you sure you want to submit retention report?",
-          "description": "It might be too early to submit your retention report. We recommend submitting no earlier than month before the retention period ends. Please ensure you have gathered sufficient work evidence for the current retention period before submitting.",
-          "cancel": "Cancel",
-          "submit": "Submit"
-        },
-        "promotionPeriodWarning": {
-          "title": "Retention period ends in 30 days",
-          "description": "It is recommended to prioritize submitting the retention report before submitting promotion evidence to avoid being bumped.",
-          "cancel": "Cancel",
-          "submit": "Submit"
-        },
         "uploadSuccess": "Upload successful",
         "uploadingToIPFS": "Uploading to IPFS...",
         "validating": "Validating..."


### PR DESCRIPTION
## Description
Closes #5176 #5192

Implemented confirmation alerts that warn users when submitting evidence reports with limited time remaining in the retention period. This helps ensure users are confident their work meets rank expectations before submission.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
Created a reusable wrapper component that displays a confirmation modal when users attempt to submit evidence with  time remaining:

Retention reports: Shows warning when > 28 days remain until the end of the current retention period
Promotion reports: Shows warning when < 30 days remain until the end of the current retention period

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
Promotion submit warning (shown when there is <30 days left until the end of the current retention period)
<img width="658" height="599" alt="Screenshot 2025-11-26 at 3 52 34 PM" src="https://github.com/user-attachments/assets/932620c5-b6d8-4ac8-aa02-54560382f08f" />

Retention submit warning (shown when there is >28 days left until the end of the current retention period)
<img width="659" height="518" alt="Screenshot 2025-11-26 at 3 52 27 PM" src="https://github.com/user-attachments/assets/54c93995-5ecf-4eb8-9457-9c9d44e15c94" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
