### PR TITLE
feat: disable submit button when there is a form error in from scratch submit evidence flow

### DIFF
--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
@@ -15,7 +15,7 @@ type Props = PropsWithChildren<{
 
 export const SubmitEvidenceFromScratch = memo(({ isOpen, wish, children, onToggle }: Props) => {
   const { t } = useI18n();
-  const { fields, submit } = useForm(evidenceForm.form);
+  const { fields, submit, hasError } = useForm(evidenceForm.form);
   const uploadError = useUnit(evidenceForm.$uploadError);
   const pending = useUnit(evidenceForm.post.pending);
 
@@ -90,7 +90,7 @@ export const SubmitEvidenceFromScratch = memo(({ isOpen, wish, children, onToggl
           {t('general.button.closeButton')}
         </Button>
         <Box grow={1} />
-        <Button isLoading={pending} disabled={pending} onClick={() => submit()}>
+        <Button isLoading={pending} disabled={pending || hasError()} onClick={() => submit()}>
           {t('general.button.submitButton')}
         </Button>
       </Modal.Footer>


### PR DESCRIPTION
Closes #5169 

## Description
This PR disables Submit button when there are errors in submit evidence from scratch form

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="924" height="677" alt="Screenshot 2025-11-26 at 4 13 35 PM" src="https://github.com/user-attachments/assets/095aee3f-c0d2-485a-a380-4af39997a38f" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
