### PR TITLE
fix: show ready for promotion text when left to promotion is zero

### DIFF
--- a/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
+++ b/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
@@ -43,12 +43,12 @@ const useTimeToNextRank = () => {
   const promotionProgress = useUnit(promotion.$promotionProgress);
 
   useEffect(() => {
-    if (promotionProgress && promotionProgress.progressPercentage >= 100) {
+    if ((promotionProgress && promotionProgress.progressPercentage >= 100) || leftToPromotion === 0) {
       setTimeToNextRank(READY_FOR_PROMOTION);
       return;
     }
 
-    if (leftToPromotion && currentBlock && api) {
+    if (leftToPromotion !== null && leftToPromotion !== undefined && currentBlock && api) {
       getRelativeTimeFromApi(leftToPromotion, api).then(setTimeToNextRank);
       return;
     }

--- a/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
+++ b/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
@@ -2,7 +2,7 @@ import { useUnit } from 'effector-react';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { getRelativeTimeFromApi, nullable } from '@/shared/lib/utils';
+import { getRelativeTimeFromApi, nonNullable, nullable } from '@/shared/lib/utils';
 import { Button, Duration } from '@/shared/ui';
 import { ProgressWithSegments, Skeleton } from '@/shared/ui-kit';
 import { type CoreMember, memberService } from '@/domains/collectives';
@@ -48,7 +48,7 @@ const useTimeToNextRank = () => {
       return;
     }
 
-    if (leftToPromotion !== null && leftToPromotion !== undefined && currentBlock && api) {
+    if (nonNullable(leftToPromotion) && currentBlock && api) {
       getRelativeTimeFromApi(leftToPromotion, api).then(setTimeToNextRank);
       return;
     }

--- a/src/renderer/features/fellowship-overview/model/promotion.ts
+++ b/src/renderer/features/fellowship-overview/model/promotion.ts
@@ -79,7 +79,8 @@ const $promotionProgress = combine(
     const promotionPeriod = evidenceService.getPromotionPeriod(memberWithPromotionStart, periods);
     const windowStart = promotionWindow?.from ?? memberWithPromotionStart.lastPromotion;
     const blocksPassed = currentBlock - windowStart;
-    const progressPercentage = Math.min(100, (blocksPassed / promotionPeriod) * 100);
+    const calculatedProgress = (blocksPassed / promotionPeriod) * 100;
+    const progressPercentage = leftToPromotion === 0 ? 100 : Math.min(100, calculatedProgress);
 
     return {
       progressPercentage,


### PR DESCRIPTION
Closes [#5235](https://github.com/novasamatech/nova-spektr/issues/5235)
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->
This PR fixes issues with the Fellowship promotion progress display

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->



## Changes Made
- Fixed progress bar to display 100% when `leftToPromotion === 0`
- Fixed time-to-next-rank to show "Ready for promotion" instead of null
- Changed falsy check `if (leftToPromotion && ...)` to explicit null check `if (leftToPromotion !== null && leftToPromotion !== undefined && ...)`
- Added condition to force `progressPercentage = 100` when ready for promotion

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="338" height="120" alt="Screenshot 2025-11-27 at 12 22 45 PM" src="https://github.com/user-attachments/assets/145b357d-4d18-4fca-a2dc-7546e8777269" />

<img width="351" height="139" alt="Screenshot 2025-11-27 at 12 44 50 PM" src="https://github.com/user-attachments/assets/a79778a7-9723-46bb-9ff4-a71d703213e9" />



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
