### PR TITLE
fix: set salary to zero to rank 0

### DIFF
--- a/src/renderer/domains/collectives/salary/service.ts
+++ b/src/renderer/domains/collectives/salary/service.ts
@@ -69,8 +69,8 @@ function getMemberSalary(member: Member, salaries: Salaries) {
     };
   }
   return {
-    active: salaries.active.at(Math.max(0, member.rank - 1)) ?? BN_ZERO,
-    passive: salaries.passive.at(Math.max(0, member.rank - 1)) ?? BN_ZERO,
+    active: salaries.active.at(member.rank - 1) ?? BN_ZERO,
+    passive: salaries.passive.at(member.rank - 1) ?? BN_ZERO,
   };
 }
 

--- a/src/renderer/domains/collectives/salary/service.ts
+++ b/src/renderer/domains/collectives/salary/service.ts
@@ -62,6 +62,12 @@ function getCycleEnd(salaryCycle: SalaryCycle) {
 }
 
 function getMemberSalary(member: Member, salaries: Salaries) {
+  if (member.rank === 0) {
+    return {
+      active: BN_ZERO,
+      passive: BN_ZERO,
+    };
+  }
   return {
     active: salaries.active.at(Math.max(0, member.rank - 1)) ?? BN_ZERO,
     passive: salaries.passive.at(Math.max(0, member.rank - 1)) ?? BN_ZERO,


### PR DESCRIPTION
Closes #5186 

## Description

This PR adjusts the salary mapping logic for fellowship members to ensure that rank 0 members always receive a salary of 0, and shifts all other ranks up by one position.

The problem:
For rank 0: member.rank - 1 = -1
Math.max(0, -1) = 0
So rank 0 accessed salaries.active.at(0), which is the salary intended for rank 1


## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
Explicitly check if (member.rank === 0) and return BN_ZERO

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="1005" height="769" alt="Screenshot 2025-11-28 at 06 25 55" src="https://github.com/user-attachments/assets/3faa2036-816a-46e2-bb11-2107f6f5d726" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
