### PR TITLE
fix: doubling of confirmation modal

### DIFF
--- a/src/renderer/features/fellowship-evidence/components/EvidencePostFlowModal.tsx
+++ b/src/renderer/features/fellowship-evidence/components/EvidencePostFlowModal.tsx
@@ -1,5 +1,5 @@
-import { useUnit } from 'effector-react';
-import { type PropsWithChildren, useCallback } from 'react';
+import { useGate, useUnit } from 'effector-react';
+import { useCallback } from 'react';
 
 import { nonNullable } from '@/shared/lib/utils';
 import { evidenceForm } from '../model/evidenceForm';
@@ -8,32 +8,27 @@ import { evidencePost } from '../model/evidencePost';
 import { EvidencePostModal } from './EvidencePostModal';
 import { SubmitEvidenceFromScratch } from './SubmitEvidenceFromScratch';
 
-type Props = PropsWithChildren<{
-  wish: 'Promotion' | 'Retention';
-}>;
-
-export const EvidencePostFlowModal = ({ wish, children }: Props) => {
+export const EvidencePostFlowModal = () => {
   const step = useUnit(evidencePost.$step);
   const activeWish = useUnit(evidencePost.$activeWish);
   const evidence = useUnit(evidenceForm.$evidence);
 
-  const shouldShowForm = step === 'form' && activeWish === wish;
-  const shouldShowSubmit = step === 'submit' && activeWish === wish;
+  const shouldShowForm = step === 'form' && nonNullable(activeWish);
+  const shouldShowSubmit = step === 'submit' && nonNullable(activeWish) && nonNullable(evidence);
 
-  const toggleForm = useCallback(
-    (open: boolean) => {
-      if (open) {
-        evidenceForm.setFlowType('fromScratch');
-        evidencePost.setActiveWish(wish);
-        evidencePost.setStep('form');
-      } else {
-        evidencePost.setStep('closed');
-        evidencePost.setActiveWish(null);
-        evidenceForm.setFlowType(null);
-      }
-    },
-    [wish],
-  );
+  useGate(evidenceForm.flow, { wish: activeWish });
+
+  const toggleForm = useCallback((open: boolean) => {
+    if (open) {
+      evidenceForm.setFlowType('fromScratch');
+      evidencePost.setStep('form');
+    } else {
+      evidencePost.setStep('closed');
+      evidencePost.setActiveWish(null);
+      evidenceForm.setFlowType(null);
+      evidenceForm.flow.close({ wish: null });
+    }
+  }, []);
 
   const toggleConfirm = useCallback(
     (open: boolean, done: boolean) => {
@@ -43,19 +38,22 @@ export const EvidencePostFlowModal = ({ wish, children }: Props) => {
           evidencePost.setActiveWish(null);
           evidenceForm.setFlowType(null);
           evidenceForm.reset();
+          evidenceForm.flow.close({ wish: null });
         }
       }
     },
     [step],
   );
 
+  if (!activeWish) {
+    return null;
+  }
+
   return (
     <>
-      <SubmitEvidenceFromScratch wish={wish} isOpen={shouldShowForm} onToggle={toggleForm}>
-        {children}
-      </SubmitEvidenceFromScratch>
-      {nonNullable(evidence) && (
-        <EvidencePostModal wish={wish} evidence={evidence} isOpen={shouldShowSubmit} onToggle={toggleConfirm} />
+      {shouldShowForm && <SubmitEvidenceFromScratch wish={activeWish} isOpen={true} onToggle={toggleForm} />}
+      {shouldShowSubmit && (
+        <EvidencePostModal wish={activeWish} evidence={evidence!} isOpen={true} onToggle={toggleConfirm} />
       )}
     </>
   );

--- a/src/renderer/features/fellowship-evidence/components/EvidencePostFlowTrigger.tsx
+++ b/src/renderer/features/fellowship-evidence/components/EvidencePostFlowTrigger.tsx
@@ -1,0 +1,43 @@
+import { Slot } from '@radix-ui/react-slot';
+import { type HTMLAttributes, type MouseEvent, type ReactElement, memo, useCallback } from 'react';
+
+import { evidenceForm } from '../model/evidenceForm';
+import { evidencePost } from '../model/evidencePost';
+
+type RadixIntegration = Pick<
+  HTMLAttributes<Element>,
+  | 'onClick'
+  | 'onMouseDown'
+  | 'onMouseUp'
+  | 'onMouseEnter'
+  | 'onMouseLeave'
+  | 'onPointerDown'
+  | 'onPointerUp'
+  | 'onPointerMove'
+  | 'onPointerLeave'
+>;
+
+type Props = RadixIntegration & {
+  wish: 'Promotion' | 'Retention';
+  children: ReactElement;
+};
+
+export const EvidencePostFlowTrigger = memo(({ wish, children, ...radix }: Props) => {
+  const handleClick = useCallback(
+    (e: MouseEvent) => {
+      e.stopPropagation();
+      evidenceForm.setFlowType('fromScratch');
+      evidencePost.setActiveWish(wish);
+      evidencePost.setStep('form');
+      evidenceForm.flow.open({ wish });
+      radix.onClick?.(e);
+    },
+    [wish],
+  );
+
+  return (
+    <Slot {...radix} onClick={handleClick}>
+      {children}
+    </Slot>
+  );
+});

--- a/src/renderer/features/fellowship-evidence/components/PromotionInfo.tsx
+++ b/src/renderer/features/fellowship-evidence/components/PromotionInfo.tsx
@@ -13,7 +13,7 @@ import { fellowshipEvidenceFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
 import { profile } from '../model/profile';
 
-import { EvidencePostFlowModal } from './EvidencePostFlowModal';
+import { EvidencePostFlowTrigger } from './EvidencePostFlowTrigger';
 
 export const PromotionInfo = memo(() => {
   const { t } = useI18n();
@@ -71,9 +71,9 @@ export const PromotionInfo = memo(() => {
             )}
           </Box>
           {timeLeft === 0 && (
-            <EvidencePostFlowModal wish="Promotion">
+            <EvidencePostFlowTrigger wish="Promotion">
               <Button disabled={disabled}>{t('general.button.applyButton')}</Button>
-            </EvidencePostFlowModal>
+            </EvidencePostFlowTrigger>
           )}
         </Box>
       )}
@@ -85,9 +85,9 @@ export const PromotionInfo = memo(() => {
           </Box>
           <Box direction="row" gap={4}>
             <IconButton name="eye" size={16} onClick={openEvidence} />
-            <EvidencePostFlowModal wish="Promotion">
+            <EvidencePostFlowTrigger wish="Promotion">
               <IconButton name="editKeys" size={16} />
-            </EvidencePostFlowModal>
+            </EvidencePostFlowTrigger>
           </Box>
         </Box>
       )}

--- a/src/renderer/features/fellowship-evidence/components/RetentionInfo.tsx
+++ b/src/renderer/features/fellowship-evidence/components/RetentionInfo.tsx
@@ -12,7 +12,7 @@ import { evidenceInfo } from '../model/evidence';
 import { fellowshipEvidenceFeature } from '../model/feature';
 import { profile } from '../model/profile';
 
-import { EvidencePostFlowModal } from './EvidencePostFlowModal';
+import { EvidencePostFlowTrigger } from './EvidencePostFlowTrigger';
 
 export const RetentionInfo = memo(() => {
   const { t } = useI18n();
@@ -53,9 +53,9 @@ export const RetentionInfo = memo(() => {
               {timeLeft === 0 ? t('general.timeout.expired') : <Duration seconds={timeLeft / 1000} />}
             </SmallTitleText>
           </Box>
-          <EvidencePostFlowModal wish="Retention">
+          <EvidencePostFlowTrigger wish="Retention">
             <Button disabled={disabled}>{t('fellowship.salary.retentionSubmit')}</Button>
-          </EvidencePostFlowModal>
+          </EvidencePostFlowTrigger>
         </Box>
       )}
 
@@ -75,9 +75,9 @@ export const RetentionInfo = memo(() => {
                 }
               }}
             />
-            <EvidencePostFlowModal wish="Retention">
+            <EvidencePostFlowTrigger wish="Retention">
               <IconButton name="editKeys" size={16} />
-            </EvidencePostFlowModal>
+            </EvidencePostFlowTrigger>
           </Box>
         </Box>
       )}

--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidenceFromScratch.tsx
@@ -1,5 +1,5 @@
 import { useForm } from 'effector-forms';
-import { useGate, useUnit } from 'effector-react';
+import { useUnit } from 'effector-react';
 import { type FormEventHandler, type PropsWithChildren, memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
@@ -14,8 +14,6 @@ type Props = PropsWithChildren<{
 }>;
 
 export const SubmitEvidenceFromScratch = memo(({ isOpen, wish, children, onToggle }: Props) => {
-  useGate(evidenceForm.flow, { wish });
-
   const { t } = useI18n();
   const { fields, submit, hasError } = useForm(evidenceForm.form);
   const uploadError = useUnit(evidenceForm.$uploadError);

--- a/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
+++ b/src/renderer/features/fellowship-evidence/components/SubmitEvidencePopover.tsx
@@ -23,7 +23,6 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
   const { t } = useI18n();
   const [popoverOpen, setPopoverOpen] = useState(false);
   const [fromScratchOpen, setFromScratchOpen] = useState(false);
-  const [fromScratchSubmitOpen, setFromScratchSubmitOpen] = useState(false);
 
   const ipfsStep = useUnit(evidenceIPFS.$step);
   const submitModalOpen = useUnit(evidencePost.$submitModalOpen);
@@ -37,9 +36,11 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
 
   const handleFromScratch = useCallback(() => {
     evidenceForm.setFlowType('fromScratch');
-    setFromScratchOpen(true);
+    evidencePost.setActiveWish(wish);
+    evidencePost.setStep('form');
+    evidenceForm.flow.open({ wish });
     setPopoverOpen(false);
-  }, []);
+  }, [wish]);
 
   const handleUploadFromIPFS = useCallback(() => {
     evidenceIPFS.reset();
@@ -54,13 +55,16 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
     if (!open) {
       evidenceForm.setFlowType(null);
       evidenceForm.reset();
+      evidencePost.setActiveWish(null);
+      evidencePost.setStep('closed');
+      evidenceForm.flow.close({ wish: null });
     }
   }, []);
 
   useEffect(() => {
     if (nonNullable(fromScratchEvidence) && flowType === 'fromScratch' && fromScratchOpen) {
       setFromScratchOpen(false);
-      setFromScratchSubmitOpen(true);
+      evidencePost.setStep('submit');
     }
   }, [fromScratchEvidence, flowType, fromScratchOpen]);
 
@@ -93,14 +97,6 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
         evidenceForm.reset();
         evidenceIPFS.reset();
       }
-    }
-  }, []);
-
-  const handleFromScratchSubmitClose = useCallback((open: boolean, done: boolean) => {
-    setFromScratchSubmitOpen(open);
-    if (!open && done) {
-      evidenceForm.setFlowType(null);
-      evidenceForm.reset();
     }
   }, []);
 
@@ -154,15 +150,6 @@ export const SubmitEvidencePopover = ({ wish, children }: Props) => {
           evidence={ipfsEvidence}
           isOpen={submitModalOpen}
           onToggle={handleIPFSSubmitModalClose}
-        />
-      )}
-
-      {nonNullable(fromScratchEvidence) && flowType === 'fromScratch' && activeWish === wish && (
-        <EvidencePostModal
-          wish={wish}
-          evidence={fromScratchEvidence}
-          isOpen={fromScratchSubmitOpen}
-          onToggle={handleFromScratchSubmitClose}
         />
       )}
     </>

--- a/src/renderer/features/fellowship-evidence/index.tsx
+++ b/src/renderer/features/fellowship-evidence/index.tsx
@@ -15,6 +15,7 @@ import {
 } from '@/features/fellowship-tasks';
 
 import { EvidencePostFlowModal } from './components/EvidencePostFlowModal';
+import { EvidencePostFlowTrigger } from './components/EvidencePostFlowTrigger';
 import { EvidenceVotingConfirmation } from './components/EvidenceVotingConfirmation';
 import { MarkdownPreviewModal } from './components/MarkdownPreviewModal';
 import { RetentionInfo } from './components/RetentionInfo';
@@ -31,10 +32,16 @@ export {
   SubmitEvidenceConfirmation,
   EvidenceVotingConfirmation,
   SubmitEvidencePopover,
+  EvidencePostFlowTrigger,
 };
 
 fellowshipEvidenceFeature.inject(evidenceSlot, () => {
-  return <RetentionInfo />;
+  return (
+    <>
+      <RetentionInfo />
+      <EvidencePostFlowModal />
+    </>
+  );
 });
 
 fellowshipEvidenceFeature.inject(requestPromotionTaskActionSlot, () => {
@@ -103,11 +110,11 @@ fellowshipEvidenceFeature.inject(retentionEvidenceSubmitSlot, ({ mode, evidenceC
         <MarkdownPreviewModal isOpen={isOpen} evidenceContent={evidenceContent} wish="Retention" onToggle={setIsOpen}>
           <Button size="sm">{t('fellowship.retention.button.view')}</Button>
         </MarkdownPreviewModal>
-        <EvidencePostFlowModal wish="Retention">
+        <EvidencePostFlowTrigger wish="Retention">
           <Button className="shrink-0" size="sm" pallet="secondary" variant="fill" disabled={!canVote}>
             {t('fellowship.retention.button.edit')}
           </Button>
-        </EvidencePostFlowModal>
+        </EvidencePostFlowTrigger>
       </>
     );
   }
@@ -132,11 +139,11 @@ fellowshipEvidenceFeature.inject(promotionEvidenceSubmitSlot, ({ mode, evidenceC
         <MarkdownPreviewModal isOpen={isOpen} evidenceContent={evidenceContent} wish="Promotion" onToggle={setIsOpen}>
           <Button size="sm">{t('fellowship.promotion.submitted.viewButton')}</Button>
         </MarkdownPreviewModal>
-        <EvidencePostFlowModal wish="Promotion">
+        <EvidencePostFlowTrigger wish="Promotion">
           <Button size="sm" pallet="secondary" variant="fill" disabled={!canVote}>
             {t('fellowship.promotion.submitted.editButton')}
           </Button>
-        </EvidencePostFlowModal>
+        </EvidencePostFlowTrigger>
       </>
     );
   }

--- a/src/renderer/features/fellowship-evidence/model/evidenceForm.ts
+++ b/src/renderer/features/fellowship-evidence/model/evidenceForm.ts
@@ -1,4 +1,4 @@
-import { createEffect, createEvent, createStore, restore, sample } from 'effector';
+import { createEffect, createEvent, createStore, merge, restore, sample } from 'effector';
 import { createForm } from 'effector-forms';
 import { createGate } from 'effector-react';
 import { t } from 'i18next';
@@ -10,6 +10,7 @@ import { evidenceService } from '@/domains/collectives';
 // flow
 
 const skipUploading = createEvent();
+const skipUploadingWithWish = createEvent<'Promotion' | 'Retention'>();
 const setFlowType = createEvent<'fromScratch' | 'ipfsUpload' | null>();
 
 const flow = createGate<{ wish: 'Promotion' | 'Retention' | null }>({ defaultState: { wish: null } });
@@ -132,14 +133,22 @@ sample({
 
 sample({
   clock: form.formValidated,
-  source: $evidence,
-  filter: nonNullable,
-  target: skipUploading,
+  source: { evidence: $evidence, wish: $wish },
+  filter: ({ evidence }) => nonNullable(evidence),
+  fn: data => data.wish!,
+  target: skipUploadingWithWish,
 });
 
 sample({
   clock: $evidence.updates,
-  filter: nonNullable,
+  source: { evidence: $evidence, wish: $wish },
+  filter: ({ evidence, wish }) => nonNullable(evidence) && nonNullable(wish),
+  fn: ({ wish }) => wish!,
+  target: skipUploadingWithWish,
+});
+
+sample({
+  clock: skipUploadingWithWish,
   target: skipUploading,
 });
 
@@ -155,9 +164,9 @@ sample({
   target: $evidence,
 });
 
-const evidenceUploaded = sample({
-  clock: [postEvidenceFx.done, skipUploading],
-}).map(() => undefined);
+const postEvidenceDoneWithWish = postEvidenceFx.done.map(result => result.params.wish);
+
+const evidenceUploaded = merge([postEvidenceDoneWithWish, skipUploadingWithWish]);
 
 // reset
 

--- a/src/renderer/features/fellowship-evidence/model/evidencePost.ts
+++ b/src/renderer/features/fellowship-evidence/model/evidencePost.ts
@@ -152,7 +152,6 @@ sample({
 
 sample({
   clock: evidenceForm.evidenceUploaded,
-  source: evidenceForm.$wish,
   target: $activeWish,
 });
 


### PR DESCRIPTION
## Description

Closes #5172 
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->
## Root Cause

Multiple `EvidencePostFlowModal` components were rendered simultaneously (one for Promotion, one for Retention), both using the same `evidenceForm.flow` Effector gate. This caused state conflicts where:

1. The gate state could be overwritten by whichever component rendered last
2. `evidenceUploaded` was reading the wish from the gate state at execution time, which could differ from the wish used during form submission
3. `SubmitEvidenceFromScratch` was using `useGate` even when not visible, further overriding the gate state

## Solution

Refactored to a single unified modal instance that handles both Promotion and Retention:

1. **Single Modal Instance**: `EvidencePostFlowModal` now uses `activeWish` from the `evidencePost` store instead of props, ensuring only one modal controls the flow
2. **Fixed Wish Value Flow**: Modified `evidenceUploaded` to carry the wish value directly from form submission instead of reading from the gate state
3. **Removed Gate Conflicts**: Removed `useGate` from `SubmitEvidenceFromScratch` and conditionally render modals only when needed
4. **Trigger Component**: Created `EvidencePostFlowTrigger` as a Radix Slot component to consistently set `activeWish` and start the flow

This ensures the wish type is captured at submission time and preserved through the entire flow, preventing modal conflicts.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
