### PR TITLE
fix: latest events divider and text updates

### DIFF
--- a/src/renderer/features/fellowship-activity-feed/components/ActivityListView.tsx
+++ b/src/renderer/features/fellowship-activity-feed/components/ActivityListView.tsx
@@ -2,6 +2,7 @@ import { type PropsWithChildren, memo, useMemo } from 'react';
 
 import { useClock, useDeferredList } from '@/shared/lib/hooks';
 import { nullable } from '@/shared/lib/utils';
+import { Separator } from '@/shared/ui';
 import { AsyncItem } from '@/shared/ui-kit';
 import { useFellowshipChain } from '@/aggregates/fellowship-network';
 
@@ -28,23 +29,35 @@ export const ActivityListView = memo(
     if (nullable(chain)) return null;
 
     return (
-      <div className="flex h-full flex-col gap-y-5 pt-2 pb-4">
+      <div className="flex h-full flex-col pt-2 pb-4">
         {isLoading && placeholders}
 
-        {list.map(event => (
-          <AsyncItem key={`${event.block}-${event.accountId}-${event.type}`} fallback={placeholder}>
-            <EventRecord
-              event={event}
-              description={event.description}
-              duration={(now - event.at.getTime()) / 1000}
-              name={event.actorName || event.name}
-              actorAccountId={event.actorAccountId}
-              chain={chain}
-              withFullAccountInfo={withFullAccountInfo}
-              referendumDetails={event.referendumDetails}
-            />
-          </AsyncItem>
-        ))}
+        {list.map((event, index) => {
+          const key = `${event.block}-${event.accountId}-${event.type}`;
+          const isLast = index === list.length - 1;
+
+          return (
+            <div key={key} className="flex flex-col">
+              <AsyncItem fallback={placeholder}>
+                <EventRecord
+                  event={event}
+                  description={event.description}
+                  duration={(now - event.at.getTime()) / 1000}
+                  name={event.actorName || event.name}
+                  actorAccountId={event.actorAccountId}
+                  chain={chain}
+                  withFullAccountInfo={withFullAccountInfo}
+                  referendumDetails={event.referendumDetails}
+                />
+              </AsyncItem>
+              {!isLast && (
+                <div className="px-5">
+                  <Separator className="py-2.5" />
+                </div>
+              )}
+            </div>
+          );
+        })}
       </div>
     );
   },

--- a/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
+++ b/src/renderer/features/fellowship-salary/components/SalaryInfo.tsx
@@ -130,7 +130,7 @@ export const SalaryInfo = memo(() => {
                       <FootnoteText className="text-text-secondary">
                         <Duration shortFormat seconds={timeLeft / 1000} />{' '}
                         {isPayoutRequested
-                          ? t('fellowship.salary.salaryInfo.timeToNextCircle')
+                          ? t('fellowship.salary.salaryInfo.timeToNextCycle')
                           : t('fellowship.salary.salaryInfo.timeToWithdraw')}
                       </FootnoteText>
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -953,7 +953,7 @@
         "requestSalaryCall": "Request a {salary} salary within:",
         "requestSalarySuccess": "Salary requested",
         "selectBeneficiary": "Select beneficiary",
-        "timeToNextCircle": "until next circle",
+        "timeToNextCycle": "until next cycle",
         "timeToNextPayout": "to the next payout",
         "timeToRequest": "left to request",
         "timeToWithdraw": "left to withdraw"
@@ -987,8 +987,8 @@
         "importantVote": "OPINION MATTERS",
         "urgent": "LAST CALL"
       },
-      "noAccountDescription": "Account not found. Please add or create account to the {chain} network.",
-      "noAccountTitle": "List tasks is empty",
+      "noAccountDescription": "Account not found. Please add or create an account on the {chain} network.",
+      "noAccountTitle": "Task list is empty",
       "personal": "Personal",
       "reviewBasket": "Confirm now",
       "reviewBasketTitle_one": "Decision",
@@ -1061,7 +1061,7 @@
     },
     "title": "Fellowship",
     "tooltips": {
-      "noAccount": "Please add or create account to the { chain } network",
+      "noAccount": "Please add or create an account on the { chain } network",
       "noProfile": "You are not a fellowship member"
     },
     "voting": {


### PR DESCRIPTION
## Description
This PR improves the Latest Events list and wordings of the fellowship empty state.

What was done:

- Added a visual divider between event cards in the Latest Events list.
- Updated the empty state text on the dashboard.
- Updated the tooltip message shown when no account is available (empty state).
- Updated the salary widget wording (until next circle -> until next cycle).

## Related Issues
Closes #5248 

## Changes Made

- Added <Separator /> for event card dividers and aligned it with card content width.
- Updated dashboard empty state message: “Please add or create an account on the {chain} network.”
- Updated tooltip text for missing account scenario with the same improved phrasing.
- Updated the salary widget wording.

## Screenshots/Recordings
<img width="1233" height="664" alt="Снимок экрана 2025-11-28 в 18 54 52" src="https://github.com/user-attachments/assets/69d9c5ca-2f06-4600-acff-4b14673cae39" />
<img width="350" height="143" alt="Снимок экрана 2025-11-28 в 18 50 12" src="https://github.com/user-attachments/assets/81dc08c8-6321-4ba2-84a4-d56cd2ad8990" />
<img width="272" height="363" alt="Снимок экрана 2025-11-28 в 18 49 57" src="https://github.com/user-attachments/assets/5290b760-22dc-4794-812d-01bd0db5cc3d" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
