### PR TITLE
fix: vested transfer input file name

### DIFF
--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -131,6 +131,7 @@ const UploadCSV = () => {
 
   const chain = useUnit(formModel.$chain);
   const asset = useUnit(formModel.$asset);
+  const fileName = useUnit(formModel.$fileName);
   const parsedCsv = useUnit(formModel.$parsedCsv);
   const csvError = useUnit(formModel.$csvError);
   const csvIssues = useUnit(formModel.$csvIssues);
@@ -191,6 +192,7 @@ const UploadCSV = () => {
       <InputFile
         key={chain?.chainId}
         accept=".csv"
+        defaultFileName={fileName ?? undefined}
         placeholder={t('vestedTransfer.form.fields.csvFile.placeholder')}
         invalid={hasError}
         onChange={(file) => formModel.fileUploaded(file)}

--- a/src/renderer/features/vested-transfer/model/form.ts
+++ b/src/renderer/features/vested-transfer/model/form.ts
@@ -231,6 +231,7 @@ sample({
 });
 
 const fileUploaded = createEvent<File>();
+const $fileName = createStore<string | null>(null);
 const $parsedCsv = createStore<VestingScheduleRaw[] | null>(null).reset(flowStarted);
 const $csvError = createStore<VestingCsvError | null>(null).reset(flowStarted);
 const $csvIssues = createStore<ValidationIssue[] | null>(null).reset(flowStarted);
@@ -294,6 +295,12 @@ const validateFileFx = attach({
     } satisfies ValidateFileParams;
   },
   effect: rootValidateFileFx,
+});
+
+sample({
+  clock: fileUploaded,
+  fn: (file: File) => file.name,
+  target: $fileName,
 });
 
 sample({
@@ -403,6 +410,7 @@ sample({
     form.fields.signatory.resetError,
     form.fields.vestingSchedule.resetError,
     form.fields.vestingSchedule.reset,
+    $fileName.reinit,
     $parsedCsv.reinit,
     $csvError.reinit,
     $csvIssues.reinit,
@@ -517,6 +525,7 @@ export const formModel = {
   $txErrors,
   $asset,
   $amount,
+  $fileName,
   $parsedCsv,
   $csvError,
   $csvIssues,

--- a/src/renderer/features/vested-transfer/model/form.ts
+++ b/src/renderer/features/vested-transfer/model/form.ts
@@ -231,10 +231,11 @@ sample({
 });
 
 const fileUploaded = createEvent<File>();
-const $fileName = createStore<string | null>(null);
-const $parsedCsv = createStore<VestingScheduleRaw[] | null>(null).reset(flowStarted);
-const $csvError = createStore<VestingCsvError | null>(null).reset(flowStarted);
-const $csvIssues = createStore<ValidationIssue[] | null>(null).reset(flowStarted);
+const csvReset = [flowStarted, fileUploaded, form.fields.chain.change];
+const $fileName = createStore<string | null>(null).reset(csvReset);
+const $parsedCsv = createStore<VestingScheduleRaw[] | null>(null).reset(csvReset);
+const $csvError = createStore<VestingCsvError | null>(null).reset(csvReset);
+const $csvIssues = createStore<ValidationIssue[] | null>(null).reset(csvReset);
 
 const parseFileFx = createEffect<File, VestingScheduleRaw[]>(async (file) => {
   const parsed = await vestedTransferUtils.parseCSV(file);
@@ -410,11 +411,6 @@ sample({
     form.fields.signatory.resetError,
     form.fields.vestingSchedule.resetError,
     form.fields.vestingSchedule.reset,
-    $fileName.reinit,
-    $parsedCsv.reinit,
-    $csvError.reinit,
-    $csvIssues.reinit,
-    $fee.reinit,
   ],
 });
 

--- a/src/renderer/shared/ui-kit/InputFile/InputFile.tsx
+++ b/src/renderer/shared/ui-kit/InputFile/InputFile.tsx
@@ -7,12 +7,13 @@ export type HTMLInputFileProps = 'required' | 'disabled' | 'accept' | 'placehold
 
 type Props = Pick<ComponentPropsWithoutRef<'input'>, HTMLInputFileProps> & {
   invalid?: boolean;
+  defaultFileName?: string;
   onChange?: (file: File) => void;
 };
 
 export const InputFile = forwardRef<HTMLInputElement, Props>(
-  ({ placeholder, invalid = false, onChange, ...props }, ref) => {
-    const [fileName, setFileName] = useState('');
+  ({ placeholder, invalid = false, defaultFileName = '', onChange, ...props }, ref) => {
+    const [fileName, setFileName] = useState(defaultFileName);
 
     const handleFileChange = (event: ChangeEvent<HTMLInputElement>) => {
       const files = event.target.files;


### PR DESCRIPTION
## Description
Persists file name between modal screens.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5205

## Changes Made
- Persist file name in the vested transfer model
- Add defaultFileName prop to the `InputFile` component

## Screenshots/Recordings
https://github.com/user-attachments/assets/bdf21427-356e-4b9b-8b9b-985687c1a68e


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
