### PR TITLE
fix: resolve account name after DB import

### DIFF
--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -176,6 +176,10 @@ export const exportDb = async () => {
 
 export const importDb = async (blob: Blob) => {
   await importInto(dexie, blob, { acceptVersionDiff: true });
+
+  await dexie.transaction('rw', dexie.accounts2, async (t) => {
+    await addAccountNameType(t);
+  });
 };
 
 export const deleteDb = async () => {


### PR DESCRIPTION
## Description
Account names are resolved incorrectly after database import
<img width="329" height="838" alt="Снимок экрана 2025-12-02 в 13 35 46" src="https://github.com/user-attachments/assets/8c1f5cbe-118c-4092-b411-a95948879893" />

## Changes Made
run addAccountNameType migration after DB import

## Screenshots/Recordings
<img width="355" height="865" alt="Снимок экрана 2025-12-02 в 13 37 43" src="https://github.com/user-attachments/assets/9da8880a-5525-44b7-9bfb-43fe1ec6bf46" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
