### PR TITLE
Fix/Show the retention report task during the last call stage

### DIFF
--- a/src/renderer/aggregates/fellowship-retention/hooks.ts
+++ b/src/renderer/aggregates/fellowship-retention/hooks.ts
@@ -179,7 +179,8 @@ export const useRetentionRequest = () => {
     data:
       retentionState === RetentionWidgetState.WARNING_APPROACHING ||
       retentionState === RetentionWidgetState.WARNING_URGENT ||
-      retentionState === RetentionWidgetState.CRITICAL_LAST_CALL,
+      retentionState === RetentionWidgetState.CRITICAL_LAST_CALL ||
+      retentionState === RetentionWidgetState.CRITICAL_EXPIRED,
     pending,
   };
 };

--- a/src/renderer/features/fellowship-tasks/hooks/useMemberEvidenceTasks.ts
+++ b/src/renderer/features/fellowship-tasks/hooks/useMemberEvidenceTasks.ts
@@ -30,7 +30,7 @@ export const useMemberEvidenceTasks = () => {
     const tasks: TaskDescription[] = [];
 
     if (nonNullable(member) && memberService.isCoreMember(member)) {
-      if (nonNullable(leftToDemotion) && leftToDemotion > 0 && hasRetentionEvidence && shouldRetentionRequest) {
+      if (shouldRetentionRequest && !hasRetentionEvidence) {
         tasks.push({
           id: 'evidence',
           weight: 1,
@@ -55,7 +55,15 @@ export const useMemberEvidenceTasks = () => {
       }
     }
     return tasks;
-  }, [operations, member, leftToDemotion, leftToPromotion, hasPromotionEvidence, hasRetentionEvidence]);
+  }, [
+    operations,
+    member,
+    leftToDemotion,
+    leftToPromotion,
+    hasPromotionEvidence,
+    hasRetentionEvidence,
+    shouldRetentionRequest,
+  ]);
 
   return {
     data: tasks,

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -176,6 +176,10 @@ export const exportDb = async () => {
 
 export const importDb = async (blob: Blob) => {
   await importInto(dexie, blob, { acceptVersionDiff: true });
+
+  await dexie.transaction('rw', dexie.accounts2, async (t) => {
+    await addAccountNameType(t);
+  });
 };
 
 export const deleteDb = async () => {


### PR DESCRIPTION
## Description
Retention report task should be shown during the last call stage. If a user is eligible for both retention and promotion report submission, only retention should be shown as higher priority

## Related Issues
Closes #5154

## Changes Made
Fixed the retention report task not showing during the last call stage

## Screenshots/Recordings
<img width="1711" height="869" alt="Снимок экрана 2025-12-02 в 15 51 04" src="https://github.com/user-attachments/assets/1a0fc3e8-4773-433a-bf18-82d78b7ce34e" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
