### PR TITLE
fix: vested transfer multisig operation approve modal

### DIFF
--- a/src/renderer/features/multisig-operations/components/ApproveForm.tsx
+++ b/src/renderer/features/multisig-operations/components/ApproveForm.tsx
@@ -22,11 +22,10 @@ type Props = {
   chain: Chain;
   nativeAsset: Asset;
   onSubmit: () => void;
-  asset: Asset | null;
   operation: MultisigOperation;
 };
 
-export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, asset, operation }: Props) => {
+export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, operation }: Props) => {
   const { t } = useI18n();
 
   const balances = useUnit(balanceModel.$balanceMap);
@@ -92,12 +91,12 @@ export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, as
 
       <Separator className="my-1 w-full" />
 
-      {asset && (
+      {nativeAsset && (
         <>
           {isDepositRequired && (
-            <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
+            <MultisigDepositFee asset={nativeAsset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
           )}
-          {signatory && <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />}
+          {signatory && <FeeWithLabel fee={fee} asset={nativeAsset} isLoading={isFeeLoading} />}
         </>
       )}
 

--- a/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
@@ -141,7 +141,6 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
             unsignedAccounts={unsignedAccounts}
             chain={chain}
             nativeAsset={nativeAsset}
-            asset={asset}
             operation={operation}
             onSubmit={onFormSubmit}
           />

--- a/src/renderer/features/multisig-operations/model/approve-model.ts
+++ b/src/renderer/features/multisig-operations/model/approve-model.ts
@@ -1,16 +1,18 @@
 import { type ApiPromise } from '@polkadot/api';
 import { type Weight } from '@polkadot/types/interfaces';
+import { BN_ZERO } from '@polkadot/util';
 import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
 import { createGate } from 'effector-react';
 
 import { type Chain } from '@/shared/core';
+import { createStoreFromEffect } from '@/shared/effector';
 import { getNativeAsset, nonNullable, nullable, validateCallData } from '@/shared/lib/utils';
 import {
   createComplexTxStore,
-  createMultisigDeposit,
   createSignatoriesStore,
   createTxValidationStore,
   createTxValidator,
+  getActionRequiredAmount,
 } from '@/shared/transactions';
 import {
   type AnyAccount,
@@ -188,11 +190,6 @@ const $extrinsic = combine($api, $tx, (api, tx) => {
   return getExtrinsic[tx.type](tx.args, api);
 });
 
-const { $multisigDeposit, $pending: $isDepositLoading } = createMultisigDeposit({
-  $api: $api,
-  $threshold: operationsContextModel.$multisigAccount.map(account => account?.threshold ?? null),
-});
-
 const $signingPayloads = combine(
   {
     api: $api,
@@ -215,7 +212,7 @@ const $signingPayloads = combine(
 );
 
 const validator = createTxValidator();
-const { $errors, $valid } = createTxValidationStore({
+const { $errors, $valid, $balanceValidationResults } = createTxValidationStore({
   validator,
   params: {
     api: $api,
@@ -223,6 +220,15 @@ const { $errors, $valid } = createTxValidationStore({
     balances: balanceModel.$balanceMap,
     route: $route,
     transaction: $tx,
+  },
+});
+
+const { $: $multisigDeposit, $pending: $isDepositLoading } = createStoreFromEffect({
+  defaultValue: BN_ZERO,
+  params: { results: $balanceValidationResults },
+  fn: ({ results }) => {
+    const actions = getActionRequiredAmount(results, 'multisig deposit');
+    return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
   },
 });
 

--- a/src/renderer/features/vested-transfer-operation-details/components/TransactionAmount.tsx
+++ b/src/renderer/features/vested-transfer-operation-details/components/TransactionAmount.tsx
@@ -1,0 +1,46 @@
+import { BN, BN_ZERO } from '@polkadot/util';
+import { useUnit } from 'effector-react';
+
+import { TransactionType } from '@/shared/core';
+import { getNativeAsset } from '@/shared/lib/utils';
+import { AssetBalance } from '@/shared/ui-entities';
+import { type MultisigOperation } from '@/domains/network';
+import { networkModel } from '@/entities/network';
+import { AssetFiatBalance } from '@/entities/price';
+import { getTransactionAmount } from '@/entities/transaction';
+
+type Props = {
+  operation: MultisigOperation;
+};
+
+export const TransactionAmount = ({ operation }: Props) => {
+  const chains = useUnit(networkModel.$chains);
+
+  const chain = chains[operation.chainId];
+  const asset = chain ? getNativeAsset(chain.assets) : null;
+  const transaction = operation.transaction;
+
+  let amount: BN | null = null;
+  if (transaction?.type === TransactionType.BATCH_ALL) {
+    const batchAmounts: string[] = transaction.args?.transactions?.map(getTransactionAmount);
+    amount = batchAmounts.reduce((amount, currentAmount) => amount.add(new BN(currentAmount)), BN_ZERO);
+  } else {
+    const txAmount = transaction && getTransactionAmount(transaction);
+    amount = txAmount ? new BN(txAmount) : null;
+  }
+
+  if (!asset || !amount) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-col items-center gap-y-1">
+      <AssetBalance
+        value={amount}
+        asset={asset}
+        className="font-manrope text-[32px] leading-[36px] font-bold text-text-primary"
+      />
+      <AssetFiatBalance asset={asset} amount={amount} className="text-headline" />
+    </div>
+  );
+};

--- a/src/renderer/features/vested-transfer-operation-details/index.tsx
+++ b/src/renderer/features/vested-transfer-operation-details/index.tsx
@@ -7,12 +7,18 @@ import { nullable } from '@/shared/lib/utils';
 import { type IconNames } from '@/shared/ui';
 import { TransactionTitle, findCoreBatchAll, findCoreTransaction } from '@/entities/transaction';
 import { multisigOperationsSDK } from '@/sdk/multisig-operations';
+import { confirmTransactionInfoSlot } from '@/features/multisig-operations';
 
+import { TransactionAmount } from './components/TransactionAmount';
 import { VestedTransferOperationDetails } from './components/VestedTransferOperationDetails';
 import { VestedTransferOperationTitle } from './components/VestedTransferOperationTitle';
 
 export const vestedTransferOperationDetailFeature = createFeature({
   name: 'vested-transfer/operation-details',
+});
+
+vestedTransferOperationDetailFeature.inject(confirmTransactionInfoSlot, ({ operation }) => {
+  return <TransactionAmount operation={operation} />;
 });
 
 const getOperationTitle = (transactionType: TransactionType): string | undefined => {


### PR DESCRIPTION
## Description
Show network fee and tx amount on the multisig approve modal.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5269

## Changes Made
- Use native asset for network fee
- Show tx amount via slot
- Fix deposit fee calculation

## Screenshots/Recordings
<img width="458" height="446" alt="Screenshot 2025-12-02 at 12 40 29 PM" src="https://github.com/user-attachments/assets/95d8633b-5f89-4845-9882-3af190cf8ecc" />
<img width="467" height="519" alt="Screenshot 2025-12-02 at 12 40 37 PM" src="https://github.com/user-attachments/assets/838f070e-5c1d-4f20-9704-48b2a595ef72" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
