### PR TITLE
fix: show fiat value on vesting schedule preview

### DIFF
--- a/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
+++ b/src/renderer/entities/vesting/ui/VestingSchedulePreview.tsx
@@ -13,6 +13,7 @@ import { Account, AssetBalance } from '@/shared/ui-entities';
 import { Modal, ScrollArea, Tooltip } from '@/shared/ui-kit';
 import { type Column, Table } from '@/shared/ui-kit/Table';
 import { useBlockTimestamp, useIdentity } from '@/domains/network';
+import { AssetFiatBalance } from '@/entities/price';
 import { type ValidationIssue, VestingFieldError, type VestingScheduleRaw } from '../lib/types';
 
 type TableData = VestingScheduleRaw & {
@@ -151,13 +152,14 @@ export const VestingSchedulePreview = memo(
               row.locked && asset ? (
                 <Tooltip>
                   <Tooltip.Trigger>
-                    <div>
+                    <div className="flex flex-col items-end">
                       <AssetBalance
                         value={row.locked}
                         asset={asset}
                         showSymbol
                         className="border-b border-filter-border text-inherit"
                       />
+                      <AssetFiatBalance asset={asset} amount={row.locked} className="text-inherit" />
                     </div>
                   </Tooltip.Trigger>
                   <Tooltip.Content>
@@ -213,13 +215,14 @@ export const VestingSchedulePreview = memo(
               row.perBlock && asset ? (
                 <Tooltip>
                   <Tooltip.Trigger>
-                    <div>
+                    <div className="flex flex-col items-end">
                       <AssetBalance
                         value={row.perBlock}
                         asset={asset}
                         showSymbol
                         className="border-b border-filter-border text-inherit"
                       />
+                      <AssetFiatBalance asset={asset} amount={row.perBlock} className="text-inherit" />
                     </div>
                   </Tooltip.Trigger>
                   <Tooltip.Content>


### PR DESCRIPTION
## Description
Show fiat value in the vesting schedule table.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5207

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="988" height="282" alt="Screenshot 2025-12-02 at 4 59 02 PM" src="https://github.com/user-attachments/assets/a8ac47ef-7ff0-4d0e-837d-9540c2c04e5e" />
<img width="958" height="400" alt="Screenshot 2025-12-02 at 4 59 40 PM" src="https://github.com/user-attachments/assets/75d6e27a-cb3d-484a-8429-aedae2070e81" />
<img width="974" height="398" alt="Screenshot 2025-12-02 at 5 00 17 PM" src="https://github.com/user-attachments/assets/4c12ab70-127d-41ad-9e87-7a1d4cc6f93a" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
