### PR TITLE
fix: multisig deposit for operations approve/reject form

### DIFF
--- a/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
@@ -38,7 +38,6 @@ type Props = {
   multisigDeposit: BN;
   valid: boolean;
   isFeeLoading: boolean;
-  isDepositLoading: boolean;
   isDepositRequired?: boolean;
   onSign: () => void;
   onGoBack?: () => void;
@@ -57,7 +56,6 @@ export const Confirmation = ({
   multisigDeposit,
   valid,
   isFeeLoading,
-  isDepositLoading,
   onSign,
   onGoBack,
   errors,
@@ -70,7 +68,8 @@ export const Confirmation = ({
 
   const signerWallet = wallets.find(w => w.id === signAccount?.walletId);
 
-  const depositPending = isDepositRequired && isDepositLoading;
+  const hasRequiredDeposit = !isDepositRequired || !multisigDeposit.isZero();
+  const canSign = !isFeeLoading && hasRequiredDeposit && valid;
 
   const xcmConfig = useUnit(xcmTransferModel.$config);
   const transaction = operation.transaction;
@@ -113,9 +112,7 @@ export const Confirmation = ({
       {initiator && signAccount && (
         <Details api={api} operation={operation} account={initiator} chain={chain} signatory={signAccount} />
       )}
-      {asset && isDepositRequired && (
-        <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
-      )}
+      {asset && isDepositRequired && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
       {asset && <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />}
       {isXcmTransaction(transaction) && xcmConfig && xcmApi && asset && (
         <DetailRow label={t('operation.xcmFee')} className="text-text-primary">
@@ -128,12 +125,7 @@ export const Confirmation = ({
             {t('operation.goBackButton')}
           </Button>
         )}
-        <SignButton
-          disabled={isFeeLoading || depositPending || !valid}
-          className="ml-auto"
-          type={signerWallet?.type}
-          onClick={onSign}
-        />
+        <SignButton disabled={!canSign} className="ml-auto" type={signerWallet?.type} onClick={onSign} />
       </div>
     </div>
   );

--- a/src/renderer/features/multisig-operations/components/ApproveForm.tsx
+++ b/src/renderer/features/multisig-operations/components/ApproveForm.tsx
@@ -33,7 +33,6 @@ export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, op
   const allWallets = useUnit(walletModel.$wallets);
   const fee = useUnit(approveModel.$fee);
   const isFeeLoading = useUnit(approveModel.$isFeeLoading);
-  const isDepositLoading = useUnit(approveModel.$isDepositLoading);
   const isDepositRequired = useUnit(approveModel.$isDepositRequired);
   const multisigDeposit = useUnit(approveModel.$multisigDeposit);
   const wallets = useUnit(walletModel.$wallets);
@@ -93,9 +92,7 @@ export const ApproveForm = ({ unsignedAccounts, chain, nativeAsset, onSubmit, op
 
       {nativeAsset && (
         <>
-          {isDepositRequired && (
-            <MultisigDepositFee asset={nativeAsset} multisigDeposit={multisigDeposit} isLoading={isDepositLoading} />
-          )}
+          {isDepositRequired && <MultisigDepositFee asset={nativeAsset} multisigDeposit={multisigDeposit} />}
           {signatory && <FeeWithLabel fee={fee} asset={nativeAsset} isLoading={isFeeLoading} />}
         </>
       )}

--- a/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
@@ -52,7 +52,6 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
   const fee = useUnit(approveModel.$fee);
   const isFeeLoading = useUnit(approveModel.$isFeeLoading);
 
-  const isDepositLoading = useUnit(approveModel.$isDepositLoading);
   const isDepositRequired = useUnit(approveModel.$isDepositRequired);
   const multisigDeposit = useUnit(approveModel.$multisigDeposit);
   const signingPayloads = useUnit(approveModel.$signingPayloads);
@@ -152,7 +151,6 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
             chain={chain}
             fee={fee}
             isFeeLoading={isFeeLoading}
-            isDepositLoading={isDepositLoading}
             isDepositRequired={isDepositRequired}
             signAccount={signAccount}
             multisigDeposit={multisigDeposit}

--- a/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
@@ -54,7 +54,6 @@ export const RejectTxModal = memo(({ api, operation, chain, children }: Props) =
   const errors = useUnit(rejectModel.$errors);
   const fee = useUnit(rejectModel.$fee);
   const isFeeLoading = useUnit(rejectModel.$isFeeLoading);
-  const isDepositLoading = useUnit(rejectModel.$isDepositLoading);
   const multisigDeposit = useUnit(rejectModel.$multisigDeposit);
   const signAccount = useUnit(rejectModel.$signatory);
   const initiator = useUnit(rejectModel.$initiator);
@@ -151,7 +150,6 @@ export const RejectTxModal = memo(({ api, operation, chain, children }: Props) =
             chain={chain}
             fee={fee}
             isFeeLoading={isFeeLoading}
-            isDepositLoading={isDepositLoading}
             signAccount={signAccount}
             multisigDeposit={multisigDeposit}
             errors={errors}

--- a/src/renderer/features/multisig-operations/model/approve-model.ts
+++ b/src/renderer/features/multisig-operations/model/approve-model.ts
@@ -5,7 +5,6 @@ import { combine, createEffect, createEvent, createStore, restore, sample } from
 import { createGate } from 'effector-react';
 
 import { type Chain } from '@/shared/core';
-import { createStoreFromEffect } from '@/shared/effector';
 import { getNativeAsset, nonNullable, nullable, validateCallData } from '@/shared/lib/utils';
 import {
   createComplexTxStore,
@@ -223,29 +222,25 @@ const { $errors, $valid, $balanceValidationResults } = createTxValidationStore({
   },
 });
 
-const { $: $multisigDeposit, $pending: $isDepositLoading } = createStoreFromEffect({
-  defaultValue: BN_ZERO,
-  params: { results: $balanceValidationResults },
-  fn: ({ results }) => {
-    const actions = getActionRequiredAmount(results, 'multisig deposit');
-    return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
-  },
+const $multisigDeposit = combine({ results: $balanceValidationResults }, ({ results }) => {
+  const actions = getActionRequiredAmount(results, 'multisig deposit');
+  return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
 });
 
 const $canSubmit = combine(
   {
     valid: $valid,
     isFeeLoading: $isFeeLoading,
-    isDepositLoading: $isDepositLoading,
     signatory: $signatory,
     isDepositRequired: $isDepositRequired,
+    multisigDeposit: $multisigDeposit,
   },
-  ({ valid, isFeeLoading, isDepositLoading, signatory, isDepositRequired }) => {
+  ({ valid, isFeeLoading, signatory, isDepositRequired, multisigDeposit }) => {
     if (!nonNullable(signatory)) return false;
 
-    const depositPending = isDepositRequired && isDepositLoading;
+    const isDepositReady = !isDepositRequired || !multisigDeposit.isZero();
 
-    return valid && !isFeeLoading && !depositPending;
+    return valid && !isFeeLoading && isDepositReady;
   },
 );
 
@@ -254,7 +249,6 @@ export const approveModel = {
   $transaction: $tx,
   $fee,
   $isFeeLoading,
-  $isDepositLoading,
   $errors,
   $multisigDeposit,
   $isDepositRequired,

--- a/src/renderer/features/multisig-operations/model/reject-model.ts
+++ b/src/renderer/features/multisig-operations/model/reject-model.ts
@@ -1,3 +1,4 @@
+import { BN_ZERO } from '@polkadot/util';
 import { combine, createStore, sample } from 'effector';
 import { createGate } from 'effector-react';
 
@@ -5,10 +6,10 @@ import { type Chain, type Transaction } from '@/shared/core';
 import { getNativeAsset, nonNullable } from '@/shared/lib/utils';
 import {
   createComplexTxStore,
-  createMultisigDeposit,
   createSignatoriesStore,
   createTxValidationStore,
   createTxValidator,
+  getActionRequiredAmount,
 } from '@/shared/transactions';
 import {
   type AnyAccount,
@@ -113,13 +114,8 @@ const {
   transaction: $transaction,
 });
 
-const { $multisigDeposit, $pending: $pendingMultisigDepositFee } = createMultisigDeposit({
-  $api: $api,
-  $threshold: operationsContextModel.$multisigAccount.map(account => account?.threshold ?? null),
-});
-
 const validator = createTxValidator();
-const { $errors, $valid } = createTxValidationStore({
+const { $errors, $valid, $balanceValidationResults } = createTxValidationStore({
   validator,
   params: {
     api: $api,
@@ -130,12 +126,16 @@ const { $errors, $valid } = createTxValidationStore({
   },
 });
 
+const $multisigDeposit = combine({ results: $balanceValidationResults }, ({ results }) => {
+  const actions = getActionRequiredAmount(results, 'multisig deposit');
+  return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
+});
+
 export const rejectModel = {
   flow,
   $transaction: $tx,
   $fee,
   $isFeeLoading,
-  $isDepositLoading: $pendingMultisigDepositFee,
   $multisigDeposit,
   $signatory,
   $initiator,


### PR DESCRIPTION
## Description
Refactor multisig deposit handling in operations approve/reject forms.
Calculating multisig operation is a sync operation, therefore no need to use `$pending` stores.

## Related Issues
Addresses this PR comment https://github.com/novasamatech/nova-spektr/pull/5183#discussion_r2585355475

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
https://github.com/user-attachments/assets/bfb786ca-88c8-4203-a84e-63554fb87fe1

https://github.com/user-attachments/assets/19700e47-671f-41fb-bdd8-d53211c9daf8


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
