### PR TITLE
fix: timeline api for vested transfer preview

### DIFF
--- a/src/renderer/features/vested-transfer-operation-details/components/VestedTransferOperationDetails.tsx
+++ b/src/renderer/features/vested-transfer-operation-details/components/VestedTransferOperationDetails.tsx
@@ -25,7 +25,7 @@ export const VestedTransferOperationDetails = ({ operation }: Props) => {
   if (nullable(transaction) || nullable(chain)) return null;
 
   const timelineChainId = chain.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? apis[chain.chainId] ?? null;
+  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
   const asset = getNativeAsset(chain.assets);
 
   const vestingSchedule: VestingScheduleRaw[] =

--- a/src/renderer/features/vested-transfer-operation-details/components/VestedTransferOperationDetails.tsx
+++ b/src/renderer/features/vested-transfer-operation-details/components/VestedTransferOperationDetails.tsx
@@ -2,7 +2,7 @@ import { useUnit } from 'effector-react';
 
 import { type DecodedTransaction, type Transaction, TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { getNativeAsset, nullable } from '@/shared/lib/utils';
+import { getNativeAsset, nonNullable, nullable } from '@/shared/lib/utils';
 import { Button, DetailRow } from '@/shared/ui';
 import { type MultisigOperation } from '@/domains/network';
 import { networkModel } from '@/entities/network';
@@ -25,7 +25,7 @@ export const VestedTransferOperationDetails = ({ operation }: Props) => {
   if (nullable(transaction) || nullable(chain)) return null;
 
   const timelineChainId = chain.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
+  const timelineApi = nonNullable(timelineChainId) ? apis[timelineChainId] : apis[chain.chainId];
   const asset = getNativeAsset(chain.assets);
 
   const vestingSchedule: VestingScheduleRaw[] =

--- a/src/renderer/features/vested-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/vested-transfer/components/Confirmation.tsx
@@ -2,7 +2,7 @@ import { useUnit } from 'effector-react';
 import { memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { getNativeAsset } from '@/shared/lib/utils';
+import { getNativeAsset, nonNullable } from '@/shared/lib/utils';
 import { Button, DetailRow, Icon, Separator } from '@/shared/ui';
 import { AssetBalance, TransactionDetails } from '@/shared/ui-entities';
 import { Box, Modal } from '@/shared/ui-kit';
@@ -38,7 +38,7 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
   }));
 
   const timelineChainId = chain.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
+  const timelineApi = nonNullable(timelineChainId) ? apis[timelineChainId] : apis[chain.chainId];
   const asset = getNativeAsset(chain.assets);
 
   return (

--- a/src/renderer/features/vested-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/vested-transfer/components/Confirmation.tsx
@@ -38,7 +38,7 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
   }));
 
   const timelineChainId = chain.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? apis[chain.chainId] ?? null;
+  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
   const asset = getNativeAsset(chain.assets);
 
   return (

--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -139,7 +139,7 @@ const UploadCSV = () => {
   const minVestedTransfer = useUnit(formModel.$minVestedTransfer);
 
   const timelineChainId = chain?.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
+  const timelineApi = nonNullable(timelineChainId) ? apis[timelineChainId] : ((chain && apis[chain.chainId]) ?? null);
 
   const hasError = nonNullable(csvError);
   const hasParsedCsv = parsedCsv && parsedCsv.length > 0;

--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -139,7 +139,7 @@ const UploadCSV = () => {
   const minVestedTransfer = useUnit(formModel.$minVestedTransfer);
 
   const timelineChainId = chain?.additional?.timelineChain;
-  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? (chain && apis[chain.chainId]) ?? null;
+  const timelineApi = (timelineChainId && apis[timelineChainId]) ?? null;
 
   const hasError = nonNullable(csvError);
   const hasParsedCsv = parsedCsv && parsedCsv.length > 0;


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->
Fix getting timeline chain api when relay chain is not available.
Tooltips with block time and date will be hidden when timeline chain api is not available.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

Before it may be flaky:
<img width="1024" height="726" alt="Screenshot 2025-12-04 at 16 50 27" src="https://github.com/user-attachments/assets/fccef386-7ee3-4c35-a07e-38e7a88a45ec" />

After it always shows right:
<img width="1511" height="909" alt="Screenshot 2025-12-04 at 16 50 41" src="https://github.com/user-attachments/assets/3f5efcc1-d2f6-432f-88d2-a007a37246eb" />

If there is no api, tooltip won't be shown

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
