### PR TITLE
fix: vested transfer fee flickering

### DIFF
--- a/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
+++ b/src/renderer/features/vested-transfer/components/VestedTransferForm.tsx
@@ -327,7 +327,7 @@ const FeeSection = () => {
   const multisigDeposit = useUnit(formModel.$multisigDeposit);
   const hasMultisigAccount = useUnit(formModel.$hasMultisigAccount);
 
-  if (!asset || !fee) return null;
+  if (!asset) return null;
 
   return (
     <>


### PR DESCRIPTION
## Description
Always show network fee section in vested transfers. When fee is null, it shows shimmering/loading state.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5203

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
https://github.com/user-attachments/assets/57f86e27-3286-47c5-bceb-4253b2334e7c



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
