### PR TITLE
fix: promotion widget bugs

### DIFF
--- a/src/renderer/aggregates/fellowship-member/hooks.ts
+++ b/src/renderer/aggregates/fellowship-member/hooks.ts
@@ -147,7 +147,7 @@ export const useFellowshipMemberEndPromotionBlock = () => {
     const memberWithPromotionStart = evidenceService.getMemberWithPromotionStart(member, feed);
 
     if (nonNullable(memberWithPromotionStart)) {
-      const window = evidenceService.getPromotionWindow(memberWithPromotionStart, periods, block);
+      const window = evidenceService.getPromotionWindow(memberWithPromotionStart, periods);
       data = window.to;
     }
   }

--- a/src/renderer/aggregates/fellowship-promotion/constants.ts
+++ b/src/renderer/aggregates/fellowship-promotion/constants.ts
@@ -1,0 +1,7 @@
+export const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Days before promotion window ends when submission/green zone starts. Single
+ * source for all calculations (widget, timeline, tasks, overviews).
+ */
+export const PROMOTION_SUBMISSION_THRESHOLD_DAYS = 30;

--- a/src/renderer/aggregates/fellowship-promotion/hooks.ts
+++ b/src/renderer/aggregates/fellowship-promotion/hooks.ts
@@ -2,9 +2,16 @@ import { useMemo } from 'react';
 
 import { nullable } from '@/shared/lib/utils';
 import { evidenceService, memberService, useEvidencePeriod, useFeed } from '@/domains/collectives';
-import { useBlock } from '@/domains/network';
+import { useBlock, useBlockTime } from '@/domains/network';
 import { useFellowshipMember } from '@/aggregates/fellowship-member';
 import { useFellowshipApi, useFellowshipChain } from '@/aggregates/fellowship-network';
+
+import { MS_PER_DAY, PROMOTION_SUBMISSION_THRESHOLD_DAYS } from './constants';
+
+export type PromotionCountdown = {
+  daysLeft: number;
+  canSubmitPromotionEvidence: boolean;
+};
 
 export const useLeftToPromotion = () => {
   const api = useFellowshipApi();
@@ -29,4 +36,30 @@ export const useLeftToPromotion = () => {
   }, [periods, member, currentBlock, feed]);
 
   return { data: leftToPromotion, pending: memberPending || periodPending || blockPending || feedPending };
+};
+
+export const usePromotionCountdown = () => {
+  const api = useFellowshipApi();
+  const { data: leftToPromotion, pending: leftPending } = useLeftToPromotion();
+  const { data: blockTime, pending: blockPending } = useBlockTime(api);
+
+  const countdown = useMemo<PromotionCountdown | null>(() => {
+    if (nullable(leftToPromotion) || nullable(blockTime)) return null;
+
+    const blockTimeMs = blockTime.toNumber();
+    if (!Number.isFinite(blockTimeMs) || blockTimeMs <= 0) return null;
+
+    const daysLeft = (leftToPromotion * blockTimeMs) / MS_PER_DAY;
+    const canSubmitPromotionEvidence = daysLeft <= PROMOTION_SUBMISSION_THRESHOLD_DAYS || leftToPromotion <= 0;
+
+    return {
+      daysLeft,
+      canSubmitPromotionEvidence,
+    };
+  }, [leftToPromotion, blockTime]);
+
+  return {
+    data: countdown,
+    pending: leftPending || blockPending,
+  };
 };

--- a/src/renderer/aggregates/fellowship-promotion/index.ts
+++ b/src/renderer/aggregates/fellowship-promotion/index.ts
@@ -1,0 +1,3 @@
+export * from './constants';
+export * from './hooks';
+export * from './service';

--- a/src/renderer/aggregates/fellowship-promotion/service.ts
+++ b/src/renderer/aggregates/fellowship-promotion/service.ts
@@ -1,0 +1,10 @@
+import { MS_PER_DAY, PROMOTION_SUBMISSION_THRESHOLD_DAYS } from './constants';
+
+export const getPromotionThresholdBlocks = (blockTimeMs: number): number => {
+  return Math.max(1, Math.ceil((PROMOTION_SUBMISSION_THRESHOLD_DAYS * MS_PER_DAY) / blockTimeMs));
+};
+
+export const getPromotionGreenStartBlock = (from: number, to: number, blockTimeMs: number): number => {
+  const thresholdBlocks = getPromotionThresholdBlocks(blockTimeMs);
+  return Math.max(from, to - thresholdBlocks);
+};

--- a/src/renderer/domains/collectives/evidence/service.ts
+++ b/src/renderer/domains/collectives/evidence/service.ts
@@ -69,24 +69,14 @@ function getMemberWithPromotionStart(member: Member, feeds?: FeedRecord[]) {
   };
 }
 
-function getPromotionWindow(member: CoreMember, periods: EvidencePeriods, currentBlock: BlockHeight) {
+function getPromotionWindow(member: CoreMember, periods: EvidencePeriods) {
   const promotionPeriod = getPromotionPeriod(member, periods);
   const start = member.lastPromotion;
-
-  if (currentBlock <= start) {
-    return {
-      from: start,
-      to: start + promotionPeriod,
-    };
-  }
-
-  const blocksPassed = currentBlock - start;
-  const periodsPassed = Math.floor(blocksPassed / promotionPeriod);
-  const windowStart = start + periodsPassed * promotionPeriod;
+  const end = start + promotionPeriod;
 
   return {
-    from: windowStart,
-    to: windowStart + promotionPeriod,
+    from: start,
+    to: end,
   };
 }
 
@@ -100,9 +90,8 @@ function getEndPromotionBlock(member: Member, periods: EvidencePeriods) {
 }
 
 function getBlockUntilNextPromotion(member: CoreMember, periods: EvidencePeriods, currentBlock: BlockHeight) {
-  const promotionPeriod = getPromotionPeriod(member, periods);
-  const gone = currentBlock - member.lastPromotion;
-  return Math.max(0, promotionPeriod - gone) as BlockHeight;
+  const window = getPromotionWindow(member, periods);
+  return Math.max(0, window.to - currentBlock) as BlockHeight;
 }
 
 function getDemotionPeriod(member: CoreMember, periods: EvidencePeriods) {

--- a/src/renderer/features/fellowship-evidence/components/PromotionInfo.tsx
+++ b/src/renderer/features/fellowship-evidence/components/PromotionInfo.tsx
@@ -8,6 +8,7 @@ import { CollectiveRank, TrackDescription } from '@/shared/ui-entities';
 import { Box } from '@/shared/ui-kit';
 import { evidenceService, memberService, salaryService } from '@/domains/collectives';
 import { accountService } from '@/domains/network';
+import { usePromotionCountdown } from '@/aggregates/fellowship-promotion';
 import { evidenceInfo } from '../model/evidence';
 import { fellowshipEvidenceFeature } from '../model/feature';
 import { memberSalary } from '../model/memberSalary';
@@ -27,6 +28,7 @@ export const PromotionInfo = memo(() => {
   const claimStatus = useUnit(memberSalary.$memberClaimStatus);
   const currentMember = useUnit(profile.$member);
   const account = useUnit(profile.$account);
+  const { data: promotionCountdown } = usePromotionCountdown();
 
   const isCoreMember = nonNullable(currentMember) && memberService.isCoreMember(currentMember);
   const isInducted = nonNullable(claimStatus) && salaryService.isInducted(claimStatus);
@@ -59,24 +61,33 @@ export const PromotionInfo = memo(() => {
         <CaptionText className="text-text-secondary uppercase">{t('fellowship.salary.promotionNextRank')}</CaptionText>
         <CollectiveRank showName rank={nextTrack?.id ?? 0} />
       </Box>
-      {!hasPromotionEvidence && (
-        <Box direction="row">
-          <Box gap={1} grow={1}>
-            <FootnoteText className="text-text-secondary">{t('fellowship.salary.promotionUntilNext')}</FootnoteText>
-            {timeLeft === 0 && <SmallTitleText>{t('fellowship.salary.promotionReadyToApply')}</SmallTitleText>}
-            {timeLeft > 0 && (
-              <SmallTitleText>
-                <Duration seconds={timeLeft / 1000} />
-              </SmallTitleText>
-            )}
-          </Box>
-          {timeLeft === 0 && (
+      {!hasPromotionEvidence &&
+        (promotionCountdown?.canSubmitPromotionEvidence ? (
+          <Box direction="row">
+            <Box gap={1} grow={1}>
+              <FootnoteText className="text-text-secondary">
+                {t('fellowship.promotion.canSubmit.submitAnytime')}
+              </FootnoteText>
+              <SmallTitleText>{t('fellowship.salary.promotionReadyToApply')}</SmallTitleText>
+            </Box>
             <EvidencePostFlowTrigger wish="Promotion">
               <Button disabled={disabled}>{t('general.button.applyButton')}</Button>
             </EvidencePostFlowTrigger>
-          )}
-        </Box>
-      )}
+          </Box>
+        ) : (
+          <Box direction="row">
+            <Box gap={1} grow={1}>
+              <FootnoteText className="text-text-secondary">{t('fellowship.salary.promotionUntilNext')}</FootnoteText>
+              {timeLeft > 0 ? (
+                <SmallTitleText>
+                  <Duration seconds={timeLeft / 1000} />
+                </SmallTitleText>
+              ) : (
+                <SmallTitleText>{t('fellowship.salary.promotionReadyToApply')}</SmallTitleText>
+              )}
+            </Box>
+          </Box>
+        ))}
       {hasPromotionEvidence && (
         <Box direction="row" verticalAlign="center">
           <Box gap={1} grow={1}>

--- a/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
+++ b/src/renderer/features/fellowship-overview/components/FellowshipOverview.tsx
@@ -8,6 +8,7 @@ import { ProgressWithSegments, Skeleton } from '@/shared/ui-kit';
 import { type CoreMember, memberService } from '@/domains/collectives';
 import { useFellowshipMember, useFellowshipMemberLeftToPromotion } from '@/aggregates/fellowship-member';
 import { useFellowshipApi, useFellowshipBlock } from '@/aggregates/fellowship-network';
+import { usePromotionCountdown } from '@/aggregates/fellowship-promotion';
 import { READY_FOR_PROMOTION } from '../model/constants';
 import { modal } from '../model/modal';
 import { promotion } from '../model/promotion';
@@ -39,11 +40,16 @@ const useTimeToNextRank = () => {
   const api = useFellowshipApi();
   const { data: currentBlock } = useFellowshipBlock();
   const { data: leftToPromotion } = useFellowshipMemberLeftToPromotion();
+  const { data: promotionCountdown } = usePromotionCountdown();
 
   const promotionProgress = useUnit(promotion.$promotionProgress);
 
   useEffect(() => {
-    if ((promotionProgress && promotionProgress.progressPercentage >= 100) || leftToPromotion === 0) {
+    if (
+      promotionCountdown?.canSubmitPromotionEvidence ||
+      (promotionProgress && promotionProgress.progressPercentage >= 100) ||
+      leftToPromotion === 0
+    ) {
       setTimeToNextRank(READY_FOR_PROMOTION);
       return;
     }
@@ -54,7 +60,7 @@ const useTimeToNextRank = () => {
     }
 
     setTimeToNextRank(null);
-  }, [leftToPromotion, currentBlock, api, promotionProgress]);
+  }, [leftToPromotion, currentBlock, api, promotionProgress, promotionCountdown?.canSubmitPromotionEvidence]);
 
   return timeToNextRank;
 };

--- a/src/renderer/features/fellowship-overview/model/promotion.ts
+++ b/src/renderer/features/fellowship-overview/model/promotion.ts
@@ -53,7 +53,7 @@ const $promotionWindow = combine(
       return null;
     }
 
-    return evidenceService.getPromotionWindow(memberWithPromotionStart, periods, currentBlock);
+    return evidenceService.getPromotionWindow(memberWithPromotionStart, periods);
   },
 );
 

--- a/src/renderer/features/fellowship-promotion/hooks/usePromotionPeriod.ts
+++ b/src/renderer/features/fellowship-promotion/hooks/usePromotionPeriod.ts
@@ -26,7 +26,7 @@ export const usePromotionPeriod = () => {
       return null;
     }
 
-    const window = evidenceService.getPromotionWindow(memberWithPromotionStart, periods, currentBlock);
+    const window = evidenceService.getPromotionWindow(memberWithPromotionStart, periods);
     const from = Number(window.from);
     const to = Number(window.to);
 

--- a/src/renderer/features/fellowship-promotion/hooks/useWidgetState.ts
+++ b/src/renderer/features/fellowship-promotion/hooks/useWidgetState.ts
@@ -2,8 +2,8 @@ import { useMemo } from 'react';
 
 import { nonNullable, nullable } from '@/shared/lib/utils';
 import { useMemberPromotionReferendum } from '@/aggregates/fellowship-member';
+import { usePromotionCountdown } from '@/aggregates/fellowship-promotion';
 
-import { useLeftToPromotion } from './useLeftToPromotion';
 import { usePromotionEvidence } from './usePromotionEvidence';
 
 export enum PromotionWidgetState {
@@ -14,14 +14,14 @@ export enum PromotionWidgetState {
 }
 
 export const useWidgetState = () => {
-  const { data: leftToPromotion, pending: leftPending } = useLeftToPromotion();
+  const { data: countdown, pending: countdownPending } = usePromotionCountdown();
   const { data: evidence, pending: evidencePending } = usePromotionEvidence();
   const { data: referendum, pending: referendumPending } = useMemberPromotionReferendum();
 
   const hasPromotionEvidence = evidence?.wish === 'Promotion';
 
   const state = useMemo(() => {
-    if (nullable(leftToPromotion) || leftToPromotion > 0) {
+    if (nullable(countdown) || !countdown.canSubmitPromotionEvidence) {
       return PromotionWidgetState.WAITING_OPPORTUNITY;
     }
 
@@ -34,10 +34,10 @@ export const useWidgetState = () => {
     }
 
     return PromotionWidgetState.EVIDENCE_CAN_BE_SUBMITTED;
-  }, [leftToPromotion, hasPromotionEvidence, referendum]);
+  }, [countdown, hasPromotionEvidence, referendum]);
 
   return {
     data: state,
-    pending: leftPending || evidencePending || referendumPending,
+    pending: countdownPending || evidencePending || referendumPending,
   };
 };

--- a/src/renderer/features/fellowship-promotion/ui/PromotionWidget.tsx
+++ b/src/renderer/features/fellowship-promotion/ui/PromotionWidget.tsx
@@ -13,9 +13,10 @@ import {
   useEvidencesContent,
   votingHistoryService,
 } from '@/domains/collectives';
-import { useBlock } from '@/domains/network';
+import { useBlock, useBlockTime } from '@/domains/network';
 import { useFellowshipMember, useMemberPromotionReferendum } from '@/aggregates/fellowship-member';
 import { useFellowshipApi, useFellowshipChain } from '@/aggregates/fellowship-network';
+import { getPromotionGreenStartBlock } from '@/aggregates/fellowship-promotion';
 import { usePromotionEvidence, usePromotionEvidenceSubmissionDate } from '../hooks/usePromotionEvidence';
 import { usePromotionPeriod, usePromotionPeriodDates } from '../hooks/usePromotionPeriod';
 import { useVotes } from '../hooks/useVotes';
@@ -53,7 +54,7 @@ export const PromotionWidget = memo(({ member }: Props) => {
       {
         baseColorClass: cnTw('bg-badge-green-background'),
         filledColorClass: cnTw('bg-text-positive'),
-        onHoverTooltipText: t('fellowship.promotion.canSubmit.submitEvidenceTooltip', { to: toDateFormatted }),
+        onHoverTooltipText: t('fellowship.promotion.canSubmit.submitAnytime'),
         length: 2,
       },
     ],
@@ -252,6 +253,7 @@ const usePromotionData = () => {
   const { data: promotionPeriodDates } = usePromotionPeriodDates();
   const { data: promotionPeriod } = usePromotionPeriod();
   const { data: currentBlock } = useBlock(api);
+  const { data: blockTime } = useBlockTime(api);
   const { data: member } = useFellowshipMember();
 
   const fromDateFormatted =
@@ -263,13 +265,38 @@ const usePromotionData = () => {
       ? formatDate(promotionPeriodDates.to, 'dd.MM.yy')
       : null;
 
-  const timelineValue = useMemo(
-    () =>
-      promotionPeriod && currentBlock
-        ? (10 * (currentBlock - promotionPeriod.from)) / (promotionPeriod.to - promotionPeriod.from)
-        : 0,
-    [promotionPeriod, currentBlock],
-  );
+  const timelineValue = useMemo(() => {
+    if (nullable(promotionPeriod) || nullable(currentBlock) || nullable(blockTime)) return 0;
+
+    const blockTimeMs = blockTime.toNumber();
+    if (!Number.isFinite(blockTimeMs) || blockTimeMs <= 0) return 0;
+
+    const from = Number(promotionPeriod.from);
+    const to = Number(promotionPeriod.to);
+    const now = Number(currentBlock);
+
+    if (!Number.isFinite(from) || !Number.isFinite(to) || to <= from) return 0;
+
+    const greenStart = getPromotionGreenStartBlock(from, to, blockTimeMs);
+
+    const clampedNow = Math.min(Math.max(now, from), to);
+
+    const firstSegment = Math.max(0, greenStart - from);
+    const secondSegment = Math.max(1, to - greenStart);
+
+    if (firstSegment === 0) {
+      const progress = (clampedNow - from) / secondSegment;
+      return Math.min(10, 8 + progress * 2);
+    }
+
+    if (clampedNow <= greenStart) {
+      const progress = (clampedNow - from) / firstSegment;
+      return Math.min(8, Math.max(0, progress * 8));
+    }
+
+    const progress = (clampedNow - greenStart) / secondSegment;
+    return Math.min(10, 8 + progress * 2);
+  }, [promotionPeriod, currentBlock, blockTime]);
 
   return {
     promotionPeriod,

--- a/src/renderer/features/fellowship-tasks/components/tasks/RequestPromotion.tsx
+++ b/src/renderer/features/fellowship-tasks/components/tasks/RequestPromotion.tsx
@@ -1,30 +1,16 @@
-import { useEffect, useState } from 'react';
-
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { getCreatedDateFromApi, toRomanNumeral } from '@/shared/lib/utils';
+import { toRomanNumeral } from '@/shared/lib/utils';
 import { FootnoteText, SmallTitleText } from '@/shared/ui';
 import { Box } from '@/shared/ui-kit';
-import { useFellowshipMemberEndPromotionBlock, useFellowshipMemberNextTrack } from '@/aggregates/fellowship-member';
-import { useFellowshipApi } from '@/aggregates/fellowship-network';
-import { PromotionEndTimer } from '../PromotionEndTimer';
+import { useFellowshipMemberNextTrack } from '@/aggregates/fellowship-member';
 import { BadgeIcon } from '../TaskBadge';
 
 export const requestPromotionTaskActionSlot = createSlot();
 
 export const RequestPromotion = () => {
-  const { t, formatDate } = useI18n();
-  const [periodEnd, setPeriodEnd] = useState<number>(0);
-
-  const api = useFellowshipApi();
+  const { t } = useI18n();
   const { data: nextTrack } = useFellowshipMemberNextTrack();
-  const { data: endPromotionPeriod } = useFellowshipMemberEndPromotionBlock();
-
-  useEffect(() => {
-    if (api && endPromotionPeriod) {
-      getCreatedDateFromApi(endPromotionPeriod, api).then(setPeriodEnd);
-    }
-  }, [api, endPromotionPeriod]);
 
   return (
     <Box direction="row" padding={4} gap={2} verticalAlign="flex-end">
@@ -36,14 +22,9 @@ export const RequestPromotion = () => {
         <FootnoteText>
           {t('fellowship.tasks.task.promotion.description', { rank: toRomanNumeral(nextTrack?.id ?? 0) })}
         </FootnoteText>
-        <FootnoteText className="text-text-secondary">
-          {t('fellowship.tasks.task.promotion.until', {
-            date: periodEnd ? formatDate(periodEnd, 'dd.MM.yyyy') : null,
-          })}
-        </FootnoteText>
+        <FootnoteText className="text-text-secondary">{t('fellowship.promotion.canSubmit.submitAnytime')}</FootnoteText>
       </Box>
-      <Box alignSelf="flex-start" gap={8} horizontalAlign="end" shrink={0} height="100%">
-        <PromotionEndTimer endDate={periodEnd} shortDateFormat />
+      <Box gap={8} horizontalAlign="end" shrink={0} height="100%">
         <Slot id={requestPromotionTaskActionSlot} />
       </Box>
     </Box>

--- a/src/renderer/features/fellowship-tasks/hooks/useMemberEvidenceTasks.ts
+++ b/src/renderer/features/fellowship-tasks/hooks/useMemberEvidenceTasks.ts
@@ -6,8 +6,8 @@ import {
   useFellowshipMember,
   useFellowshipMemberEvidence,
   useFellowshipMemberLeftToDemotion,
-  useFellowshipMemberLeftToPromotion,
 } from '@/aggregates/fellowship-member';
+import { usePromotionCountdown } from '@/aggregates/fellowship-promotion';
 import { useRetentionRequest } from '@/aggregates/fellowship-retention';
 import { RequestPromotion } from '../components/tasks/RequestPromotion';
 import { RequestRetention } from '../components/tasks/RequestRetention';
@@ -20,7 +20,7 @@ export const useMemberEvidenceTasks = () => {
   const { data: member, pending: pendingMember } = useFellowshipMember();
   const { data: evidence, pending: pendingEvidence } = useFellowshipMemberEvidence();
   const { data: leftToDemotion, pending: pendingDemotion } = useFellowshipMemberLeftToDemotion();
-  const { data: leftToPromotion, pending: pendingPromotion } = useFellowshipMemberLeftToPromotion();
+  const { data: promotionCountdown, pending: pendingPromotion } = usePromotionCountdown();
   const { data: shouldRetentionRequest } = useRetentionRequest();
 
   const hasPromotionEvidence = evidence?.wish === 'Promotion';
@@ -40,10 +40,8 @@ export const useMemberEvidenceTasks = () => {
         });
       } else if (
         memberService.canPromote(member) &&
-        nonNullable(leftToPromotion) &&
-        leftToPromotion <= 0 &&
-        hasPromotionEvidence &&
-        hasRetentionEvidence
+        promotionCountdown?.canSubmitPromotionEvidence &&
+        !hasPromotionEvidence
       ) {
         tasks.push({
           id: 'evidence',
@@ -59,7 +57,7 @@ export const useMemberEvidenceTasks = () => {
     operations,
     member,
     leftToDemotion,
-    leftToPromotion,
+    promotionCountdown,
     hasPromotionEvidence,
     hasRetentionEvidence,
     shouldRetentionRequest,


### PR DESCRIPTION
## Description
User  who is ready for promotion according to the Fellowship overview is displayed incorrectly in their profile timeline and dashboard tasks:

In the profile widget, the promotion timeline segment should be spotted in green zone to indicate readiness, but it is instead shown in blue, which normally represents an ongoing or upcoming stage.

On the Fellowship dashboard, the corresponding “Submit promotion evidence” task does not appear, even though the user is eligible and the overview indicates they are ready.

## Related Issues
Closes #5270

## Changes Made
Fixed timeline calculation, added common promotion hooks, fixed evidence task appearance.

## Screenshots/Recordings
<img width="1714" height="861" alt="Снимок экрана 2025-12-09 в 20 53 31" src="https://github.com/user-attachments/assets/2e1c1412-3b02-48ce-8b54-c91ae505a8ae" />
<img width="1691" height="842" alt="Снимок экрана 2025-12-09 в 20 50 53" src="https://github.com/user-attachments/assets/83141636-28e4-4f6e-809e-285e1aa1f6ab" />
<img width="1717" height="868" alt="Снимок экрана 2025-12-10 в 09 12 04" src="https://github.com/user-attachments/assets/e285f9d7-781b-4341-952c-5090eab8f736" />



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
