### PR TITLE
fix: json viewer initial render level limit

### DIFF
--- a/src/renderer/entities/transaction/lib/__tests__/callDataDecoder.test.ts
+++ b/src/renderer/entities/transaction/lib/__tests__/callDataDecoder.test.ts
@@ -2,7 +2,7 @@ import { ApiPromise } from '@polkadot/api';
 import { MockProvider } from '@polkadot/rpc-provider/mock';
 import { TypeRegistry } from '@polkadot/types';
 
-import { type Chain, type ChainId } from '@/shared/core';
+import { type Chain, type ChainId, type HexString } from '@/shared/core';
 import { TEST_ADDRESS, toAccountId } from '@/shared/lib/utils';
 import { polkadotChain } from '@/shared/mocks';
 import { decodeCallData } from '../callDataDecoder';
@@ -287,4 +287,25 @@ describe('entities/transaction/lib/callDataDecoder', () => {
       type: 'payee',
     });
   });
+
+  test('should decode deeply nested batch calls', async () => {
+    const DEPTH = 200;
+    const BATCH_HEX = '180004';
+    const REMARK_HEX = '00000c313233';
+    const callData = ('0x' + BATCH_HEX.repeat(DEPTH) + REMARK_HEX) as HexString;
+    const transaction = decodeCallData(api, TEST_ACCOUNT_ID, callData, chains);
+
+    function isValidTransaction(tx: any): boolean {
+      const hasChildren = tx.args?.transactions?.length > 0;
+
+      if (hasChildren && tx.method !== 'batch') return false;
+      if (tx.method === 'batch' && !hasChildren) return false;
+      if (tx.method === 'remark' && hasChildren) return false;
+
+      return hasChildren ? tx.args.transactions.every(isValidTransaction) : true;
+    }
+
+    expect(transaction).toBeDefined();
+    expect(isValidTransaction(transaction)).toBe(true);
+  }, 30000);
 });

--- a/src/renderer/shared/ui-kit/Json/Json.tsx
+++ b/src/renderer/shared/ui-kit/Json/Json.tsx
@@ -5,6 +5,8 @@ import { type CSSProperties, memo, useMemo } from 'react';
 
 import { useTheme } from '../Theme/useTheme';
 
+const DEFAULT_JSON_EXPAND_DEPTH = 10;
+
 type Props = {
   value: object;
   name?: string;
@@ -36,6 +38,7 @@ export const Json = memo(({ value, name, sortKeys }: Props) => {
       shortenTextAfterLength={50}
       style={viewerTheme}
       objectSortKeys={sortKeys}
+      shouldExpandNodeInitially={(_, { level }) => level <= DEFAULT_JSON_EXPAND_DEPTH}
     >
       <ReactJsonViewer.Null render={() => <span style={{ color: 'var(--w-rjv-type-null-color)' }}>null</span>} />
     </ReactJsonViewer>


### PR DESCRIPTION
## Description
Fix json renderer for call data.
ReactJsonViewer crashes with `Uncaught RangeError: Maximum call stack size exceeded`.

## Related Issues
https://github.com/novasamatech/srl_novaspektr/issues/9

## Changes Made
- As a quick fix, I've limited initial json expanded depth to 10 levels
- Added a test for decodeCallData with a deeply nested 200 batch calls.

## Screenshots/Recordings

https://github.com/user-attachments/assets/c309e3aa-d0db-4424-ae36-0d2cda3ad7c4



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
