### PR TITLE
feat: request fees with fake data on destination change

### DIFF
--- a/src/renderer/widgets/Transfer/default/model/xcm-spell-transfer-model.ts
+++ b/src/renderer/widgets/Transfer/default/model/xcm-spell-transfer-model.ts
@@ -44,12 +44,26 @@ const destinationChangedDebounced = debounce({
 
 const $networkStore = restore(xcmStarted, null);
 const $xcmChainId = restore(xcmChainSelected, null).reset(xcmStarted, xcmStopped);
-const $originFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
-const $destinationFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
+const $realOriginFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
+const $realDestinationFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
+const $fakeOriginFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
+const $fakeDestinationFee = createStore<BN | null>(null).reset(xcmStarted, xcmStopped);
 const $destination = restore(destinationChanged, null).reset(xcmStarted, xcmStopped);
+
 const $rawAmount = restore(rawAmountChanged, null).reset(xcmStarted, xcmStopped);
 const $initiatorAccountId = restore(initiatorAccountIdChanged, null).reset(xcmStarted, xcmStopped);
 const $buildTransferDryRunResult = restore(buildTransferDryRunResult, null).reset(xcmStarted, xcmStopped);
+
+const $originFee = combine({ realFee: $realOriginFee, fakeFee: $fakeOriginFee }, ({ realFee, fakeFee }) => {
+  return realFee ?? fakeFee;
+});
+
+const $destinationFee = combine(
+  { realFee: $realDestinationFee, fakeFee: $fakeDestinationFee },
+  ({ realFee, fakeFee }) => {
+    return realFee ?? fakeFee;
+  },
+);
 
 const $xcmChain = combine(
   {
@@ -420,7 +434,7 @@ const $feeCalculationParams = combine(
 );
 
 sample({
-  clock: xcmChainSelected,
+  clock: [xcmChainSelected, destinationChanged, $fakeFeeCalculationParams],
   source: $fakeFeeCalculationParams,
   filter: (params): params is FakeFeeCalculationParams => params !== null,
   target: getXcmFeesWithFakeDataFx,
@@ -437,72 +451,66 @@ const isAbortError = (err: unknown) => err && typeof err === 'object' && 'name' 
 
 sample({
   clock: getXcmFeesWithFakeDataFx.doneData,
-  source: { destination: $destination, rawAmount: $rawAmount },
-  filter: ({ destination, rawAmount }) => !destination || !rawAmount,
-  fn: (_source, fees) => fees?.destinationFee ?? null,
-  target: $destinationFee,
+  fn: (fees) => fees?.destinationFee ?? null,
+  target: $fakeDestinationFee,
 });
 
 sample({
   clock: getXcmFeesWithFakeDataFx.doneData,
-  source: { destination: $destination, rawAmount: $rawAmount },
-  filter: ({ destination, rawAmount }) => !destination || !rawAmount,
-  fn: (_source, fees) => fees?.originFee ?? null,
-  target: $originFee,
+  fn: (fees) => fees?.originFee ?? null,
+  target: $fakeOriginFee,
 });
 
 sample({
   clock: getXcmFeesFx.doneData,
   fn: (fees) => fees?.destinationFee ?? null,
-  target: $destinationFee,
+  target: $realDestinationFee,
 });
 
 sample({
   clock: getXcmFeesFx.doneData,
   fn: (fees) => fees?.originFee ?? null,
-  target: $originFee,
+  target: $realOriginFee,
 });
 
 sample({
   clock: getXcmFeesWithFakeDataFx.failData,
-  source: { destination: $destination, rawAmount: $rawAmount },
-  filter: ({ destination, rawAmount }, error) => !isAbortError(error) && (!destination || !rawAmount),
+  filter: (error) => !isAbortError(error),
   fn: () => null,
-  target: $destinationFee,
+  target: $fakeDestinationFee,
 });
 
 sample({
   clock: getXcmFeesWithFakeDataFx.failData,
-  source: { destination: $destination, rawAmount: $rawAmount },
-  filter: ({ destination, rawAmount }, error) => !isAbortError(error) && (!destination || !rawAmount),
+  filter: (error) => !isAbortError(error),
   fn: () => null,
-  target: $originFee,
+  target: $fakeOriginFee,
 });
 
 sample({
   clock: getXcmFeesFx.failData,
   filter: (error) => !isAbortError(error),
   fn: () => null,
-  target: $destinationFee,
+  target: $realDestinationFee,
 });
 
 sample({
   clock: getXcmFeesFx.failData,
   filter: (error) => !isAbortError(error),
   fn: () => null,
-  target: $originFee,
+  target: $realOriginFee,
 });
 
 sample({
   clock: xcmChainSelected,
   fn: () => null,
-  target: $destinationFee,
+  target: [$fakeDestinationFee, $realDestinationFee],
 });
 
 sample({
   clock: xcmChainSelected,
   fn: () => null,
-  target: $originFee,
+  target: [$fakeOriginFee, $realOriginFee],
 });
 
 const $isDestinationFeeLoading = combine(
@@ -511,20 +519,17 @@ const $isDestinationFeeLoading = combine(
     isFakePending: getXcmFeesWithFakeDataFx.pending,
     feeParams: $feeCalculationParams,
     fakeFeeParams: $fakeFeeCalculationParams,
-    destination: $destination,
-    rawAmount: $rawAmount,
   },
-  ({ isPending, isFakePending, feeParams, fakeFeeParams, destination, rawAmount }) => {
+  ({ isPending, isFakePending, feeParams, fakeFeeParams }) => {
     const hasRealData = feeParams !== null;
-    const hasFakeData = fakeFeeParams !== null && !hasRealData;
-    const hasBothRealFields = destination !== null && rawAmount !== null;
+    const hasFakeData = fakeFeeParams !== null;
 
-    if (hasRealData) {
-      return isPending;
+    if (isFakePending && hasFakeData) {
+      return true;
     }
 
-    if (hasFakeData && !hasBothRealFields) {
-      return isFakePending;
+    if (isPending && hasRealData) {
+      return true;
     }
 
     return false;

--- a/src/renderer/widgets/Transfer/default/model/xcm-spell-transfer-model.ts
+++ b/src/renderer/widgets/Transfer/default/model/xcm-spell-transfer-model.ts
@@ -1,7 +1,7 @@
 import { type ApiPromise } from '@polkadot/api';
 import { type SubmittableExtrinsic } from '@polkadot/api/types';
 import { type BN } from '@polkadot/util';
-import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
+import { combine, createEvent, createStore, restore, sample } from 'effector';
 import { debounce } from 'patronum';
 
 import { spellXcmService } from '@/shared/api/xcm/service/spellXcmService';
@@ -267,6 +267,57 @@ type FeeCalculationParams = {
   hopApiOverrides: Record<string, ApiPromise>;
 };
 
+type FakeFeeCalculationParams = {
+  api: ApiPromise;
+  apiDestination: ApiPromise;
+  network: { chain: Chain; asset: Asset };
+  xcmChain: Chain;
+  hopApiOverrides: Record<string, ApiPromise>;
+};
+
+const getXcmFeesWithFakeDataFx = takeLast({
+  fn: async (params: FakeFeeCalculationParams, abortSignal: AbortSignal) => {
+    const { api, apiDestination, network, xcmChain, hopApiOverrides } = params;
+
+    if (network.chain.chainId === xcmChain.chainId) {
+      return null;
+    }
+
+    const fromChainName = spellXcmService.getSpellChainName(network.chain);
+    const toChainName = spellXcmService.getSpellChainName(xcmChain);
+
+    if (!fromChainName || !toChainName) {
+      return null;
+    }
+
+    const isDestinationEvm = isEvmChain(xcmChain);
+    const isSourceEvm = isEvmChain(network.chain);
+
+    const testDestination = isDestinationEvm ? toAccountId(TEST_EVM_ADDRESS) : TEST_ACCOUNTS[0];
+    const testSender = isSourceEvm ? toAccountId(TEST_EVM_ADDRESS) : TEST_ACCOUNTS[0];
+    const testDestinationAddress = spellXcmService.prepareAddressForChain(testDestination, xcmChain, toChainName);
+    const testSenderAddress = spellXcmService.prepareAddressForChain(testSender, network.chain, fromChainName);
+
+    const testAmount = '1';
+
+    return spellXcmService.getXcmFees(
+      {
+        fromChain: network.chain,
+        toChain: xcmChain,
+        asset: network.asset,
+        amount: testAmount,
+        destinationAddress: testDestinationAddress,
+        senderAddress: testSenderAddress,
+        fromChainApi: api,
+        toChainApi: apiDestination,
+        hopApiOverrides,
+      },
+      abortSignal,
+    );
+  },
+  key: ({ network, xcmChain }) => `fakeXcmFeeCalculation-${network.chain.chainId}-${xcmChain.chainId}`,
+});
+
 const getXcmFeesFx = takeLast({
   fn: async (params: FeeCalculationParams, abortSignal: AbortSignal) => {
     const { api, apiDestination, network, xcmChain, destination, rawAmount, initiatorAccountId, hopApiOverrides } =
@@ -308,6 +359,33 @@ const getXcmFeesFx = takeLast({
   key: () => 'xcmFeeCalculation',
 });
 
+const $fakeFeeCalculationParams = combine(
+  {
+    api: $api,
+    apiDestination: $apiDestination,
+    network: $networkStore,
+    xcmChain: $xcmChain,
+    hopApiOverrides: $hopApiOverrides,
+  },
+  ({ api, apiDestination, network, xcmChain, hopApiOverrides }) => {
+    if (!api || !apiDestination || !network || !xcmChain) {
+      return null;
+    }
+
+    if (network.chain.chainId === xcmChain.chainId) {
+      return null;
+    }
+
+    return {
+      api,
+      apiDestination,
+      network,
+      xcmChain,
+      hopApiOverrides,
+    };
+  },
+);
+
 const $feeCalculationParams = combine(
   {
     api: $api,
@@ -342,6 +420,13 @@ const $feeCalculationParams = combine(
 );
 
 sample({
+  clock: xcmChainSelected,
+  source: $fakeFeeCalculationParams,
+  filter: (params): params is FakeFeeCalculationParams => params !== null,
+  target: getXcmFeesWithFakeDataFx,
+});
+
+sample({
   clock: [rawAmountChangedDebounced, destinationChangedDebounced],
   source: $feeCalculationParams,
   filter: (params): params is FeeCalculationParams => params !== null,
@@ -349,6 +434,22 @@ sample({
 });
 
 const isAbortError = (err: unknown) => err && typeof err === 'object' && 'name' in err && err.name === 'AbortError';
+
+sample({
+  clock: getXcmFeesWithFakeDataFx.doneData,
+  source: { destination: $destination, rawAmount: $rawAmount },
+  filter: ({ destination, rawAmount }) => !destination || !rawAmount,
+  fn: (_source, fees) => fees?.destinationFee ?? null,
+  target: $destinationFee,
+});
+
+sample({
+  clock: getXcmFeesWithFakeDataFx.doneData,
+  source: { destination: $destination, rawAmount: $rawAmount },
+  filter: ({ destination, rawAmount }) => !destination || !rawAmount,
+  fn: (_source, fees) => fees?.originFee ?? null,
+  target: $originFee,
+});
 
 sample({
   clock: getXcmFeesFx.doneData,
@@ -363,6 +464,22 @@ sample({
 });
 
 sample({
+  clock: getXcmFeesWithFakeDataFx.failData,
+  source: { destination: $destination, rawAmount: $rawAmount },
+  filter: ({ destination, rawAmount }, error) => !isAbortError(error) && (!destination || !rawAmount),
+  fn: () => null,
+  target: $destinationFee,
+});
+
+sample({
+  clock: getXcmFeesWithFakeDataFx.failData,
+  source: { destination: $destination, rawAmount: $rawAmount },
+  filter: ({ destination, rawAmount }, error) => !isAbortError(error) && (!destination || !rawAmount),
+  fn: () => null,
+  target: $originFee,
+});
+
+sample({
   clock: getXcmFeesFx.failData,
   filter: (error) => !isAbortError(error),
   fn: () => null,
@@ -377,13 +494,13 @@ sample({
 });
 
 sample({
-  clock: [xcmChainSelected, rawAmountChangedDebounced, destinationChangedDebounced],
+  clock: xcmChainSelected,
   fn: () => null,
   target: $destinationFee,
 });
 
 sample({
-  clock: [xcmChainSelected, rawAmountChangedDebounced, destinationChangedDebounced],
+  clock: xcmChainSelected,
   fn: () => null,
   target: $originFee,
 });
@@ -391,17 +508,26 @@ sample({
 const $isDestinationFeeLoading = combine(
   {
     isPending: getXcmFeesFx.pending,
+    isFakePending: getXcmFeesWithFakeDataFx.pending,
     feeParams: $feeCalculationParams,
-    originFee: $originFee,
-    destinationFee: $destinationFee,
+    fakeFeeParams: $fakeFeeCalculationParams,
+    destination: $destination,
+    rawAmount: $rawAmount,
   },
-  ({ isPending, feeParams, originFee, destinationFee }) => {
-    if (!feeParams) return false;
-    if (!isPending) return false;
-    if (originFee !== null || destinationFee !== null) {
-      return false;
+  ({ isPending, isFakePending, feeParams, fakeFeeParams, destination, rawAmount }) => {
+    const hasRealData = feeParams !== null;
+    const hasFakeData = fakeFeeParams !== null && !hasRealData;
+    const hasBothRealFields = destination !== null && rawAmount !== null;
+
+    if (hasRealData) {
+      return isPending;
     }
-    return true;
+
+    if (hasFakeData && !hasBothRealFields) {
+      return isFakePending;
+    }
+
+    return false;
   },
 );
 
@@ -416,23 +542,11 @@ const $shouldShowFees = combine(
   },
 );
 
-const getAvailableTransfersFx = createEffect(
-  async ({ network }: { network: { chain: Chain; asset: Asset } | null }) => {
-    if (!network) return [];
-    return spellXcmService.getAvailableTransfers(network.chain, network.asset);
-  },
-);
-
 const $transferDirections = createStore<string[]>([]).reset(xcmStarted, xcmStopped);
 
 sample({
   clock: xcmStarted,
-  source: { network: $networkStore },
-  target: getAvailableTransfersFx,
-});
-
-sample({
-  clock: getAvailableTransfersFx.doneData,
+  fn: ({ chain, asset }) => spellXcmService.getAvailableTransfers(chain, asset),
   target: $transferDirections,
 });
 

--- a/src/renderer/widgets/Transfer/default/ui/TransferForm.tsx
+++ b/src/renderer/widgets/Transfer/default/ui/TransferForm.tsx
@@ -540,8 +540,8 @@ const FeeSection = memo(() => {
               const showDestinationFee =
                 destinationFeeAvailable || (!destinationFeeAvailable && !originFeeAvailable && isDestinationFeeLoading);
 
-              const originFeeLoading = isDestinationFeeLoading && !originFeeAvailable && !destinationFeeAvailable;
-              const destinationFeeLoading = isDestinationFeeLoading && !destinationFeeAvailable && !originFeeAvailable;
+              const originFeeLoading = isDestinationFeeLoading;
+              const destinationFeeLoading = isDestinationFeeLoading;
 
               return (
                 <>


### PR DESCRIPTION
Closes #5327 

## Description

Improves XCM transfer fee calculation UX by calculating fees immediately when a destination chain is selected using mock data.

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
- Added `getXcmFeesWithFakeDataFx` to calculate fees with test accounts/amount when destination chain is selected
- Changed `getAvailableTransfersFx` from effect to store since it's synchronous

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
