### PR TITLE
feat: add multi-transfer feature folder, flag and csv utils

### DIFF
--- a/src/renderer/app/bootstrap/index.ts
+++ b/src/renderer/app/bootstrap/index.ts
@@ -19,6 +19,7 @@ import { callDataExecuteFeature } from '@/features/call-data-execute';
 import { contactsNavigationFeature } from '@/features/contacts-navigation';
 import { fellowshipNavigationFeature } from '@/features/fellowship-navigation';
 import { governanceNavigationFeature } from '@/features/governance-navigation';
+import { multiTransferFeature } from '@/features/multi-transfer';
 import { notificationsNavigationFeature } from '@/features/notifications-navigation';
 import { operationsNavigationFeature } from '@/features/operations-navigation';
 import { settingsNavigationFeature } from '@/features/settings-navigation';
@@ -76,6 +77,7 @@ export const bootstrap = () => {
     stakingNavigationFeature,
     governanceNavigationFeature,
     vestedTransferFeature,
+    multiTransferFeature,
     appCustomOperationsFeature,
 
     import('@/features/wallet-select').then(({ walletSelectFeature }) => walletSelectFeature.feature),

--- a/src/renderer/entities/multi-transfer/index.ts
+++ b/src/renderer/entities/multi-transfer/index.ts
@@ -1,0 +1,1 @@
+export * from './lib/types';

--- a/src/renderer/entities/multi-transfer/lib/types.ts
+++ b/src/renderer/entities/multi-transfer/lib/types.ts
@@ -1,0 +1,34 @@
+import { type BN } from '@polkadot/util';
+
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+
+export type MultiTransferRowRaw = {
+  recipient: string;
+  amount: string;
+};
+
+export type MultiTransferRow = {
+  recipient: AccountId;
+  amount: BN;
+};
+
+export enum MultiTransferCsvError {
+  STRUCTURE = 'STRUCTURE',
+  DATA = 'DATA',
+}
+
+export enum MultiTransferFieldError {
+  INVALID_SS58_ADDRESS = 'INVALID_SS58_ADDRESS',
+  INVALID_VALUE = 'INVALID_VALUE',
+  OUT_OF_RANGE = 'OUT_OF_RANGE',
+  UNKNOWN_ERROR = 'UNKNOWN_ERROR',
+}
+
+export type RowIndex = number;
+export type RowValues = 'recipient' | 'amount';
+export type ValidationIssue = {
+  row: RowIndex;
+  path: RowValues;
+  severity: 'error';
+  message: MultiTransferFieldError;
+};

--- a/src/renderer/entities/multi-transfer/lib/types.ts
+++ b/src/renderer/entities/multi-transfer/lib/types.ts
@@ -1,16 +1,19 @@
 import { type BN } from '@polkadot/util';
 
+import { type Serializable } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 
-export type MultiTransferRowRaw = {
-  recipient: string;
-  amount: string;
+type Row<T> = {
+  raw: string;
+  parsed: T | null;
 };
 
 export type MultiTransferRow = {
-  recipient: AccountId;
-  amount: BN;
+  recipient: Row<AccountId>;
+  amount: Row<BN>;
 };
+
+export type MultiTransferRowSerialized = Serializable<MultiTransferRow>;
 
 export enum MultiTransferCsvError {
   STRUCTURE = 'STRUCTURE',
@@ -25,7 +28,7 @@ export enum MultiTransferFieldError {
 }
 
 export type RowIndex = number;
-export type RowValues = 'recipient' | 'amount';
+export type RowValues = keyof MultiTransferRow;
 export type ValidationIssue = {
   row: RowIndex;
   path: RowValues;

--- a/src/renderer/features/multi-transfer/components/MultiTransferModal.tsx
+++ b/src/renderer/features/multi-transfer/components/MultiTransferModal.tsx
@@ -1,0 +1,8 @@
+import { useI18n } from '@/shared/i18n';
+import { Dropdown } from '@/shared/ui-kit';
+
+export const MultiTransferModal = () => {
+  const { t } = useI18n();
+
+  return <Dropdown.Item>{t('navigation.multiTransferLabel')}</Dropdown.Item>;
+};

--- a/src/renderer/features/multi-transfer/index.tsx
+++ b/src/renderer/features/multi-transfer/index.tsx
@@ -1,0 +1,11 @@
+import { customOperationsSlot } from '@/features/app-custom-operations';
+
+import { MultiTransferModal } from './components/MultiTransferModal';
+import { multiTransferFeature } from './model/feature';
+
+export { multiTransferFeature };
+
+multiTransferFeature.inject(customOperationsSlot, {
+  order: 2,
+  render: () => <MultiTransferModal />,
+});

--- a/src/renderer/features/multi-transfer/model/feature.ts
+++ b/src/renderer/features/multi-transfer/model/feature.ts
@@ -2,6 +2,6 @@ import { $features } from '@/shared/config/features';
 import { createFeature } from '@/shared/feature';
 
 export const multiTransferFeature = createFeature({
-  name: 'multi/transfer',
+  name: 'transfer/multi',
   enable: $features.map(({ multiTransfer }) => multiTransfer),
 });

--- a/src/renderer/features/multi-transfer/model/feature.ts
+++ b/src/renderer/features/multi-transfer/model/feature.ts
@@ -1,0 +1,7 @@
+import { $features } from '@/shared/config/features';
+import { createFeature } from '@/shared/feature';
+
+export const multiTransferFeature = createFeature({
+  name: 'multi/transfer',
+  enable: $features.map(({ multiTransfer }) => multiTransfer),
+});

--- a/src/renderer/features/multi-transfer/types.ts
+++ b/src/renderer/features/multi-transfer/types.ts
@@ -1,0 +1,13 @@
+import { type Chain } from '@/shared/core';
+
+export const enum Step {
+  NONE,
+  INIT,
+  CONFIRM,
+  SIGN,
+  SUBMIT,
+}
+
+export type ValidationSchemaOptions = {
+  chain: Chain;
+};

--- a/src/renderer/features/multi-transfer/utils.ts
+++ b/src/renderer/features/multi-transfer/utils.ts
@@ -1,0 +1,163 @@
+import { BN } from '@polkadot/util';
+import { parse } from 'csv-parse/sync';
+import { z } from 'zod';
+
+import { downloadFiles, toAccountId, validateAddress } from '@/shared/lib/utils';
+import {
+  MultiTransferCsvError,
+  MultiTransferFieldError,
+  type MultiTransferRowRaw,
+  type ValidationIssue,
+} from '@/entities/multi-transfer';
+
+import { type ValidationSchemaOptions } from './types';
+
+const MAX_U128 = new BN(2).pow(new BN(128));
+const CSV_HEADERS = ['recipient', 'amount'];
+const CSV_FIELDS = ['recipient', 'amount'];
+const MAX_CSV_ROWS = 1000;
+
+export const multiTransferUtils = {
+  parseCSV,
+  createValidationSchema,
+  validateCSV,
+  downloadCsvWithIssues,
+};
+
+type ParseResult = { success: true; data: MultiTransferRowRaw[] } | { success: false; error: MultiTransferCsvError };
+
+async function parseCSV(file: File): Promise<ParseResult> {
+  const fileContent = await file.text();
+
+  try {
+    const headerCheck = parse(fileContent, {
+      to: 1,
+      trim: true,
+      comment: '#',
+      skip_empty_lines: true,
+    });
+
+    const parsedHeaders = headerCheck[0];
+    const isHeaderValid =
+      Array.isArray(parsedHeaders) &&
+      parsedHeaders.length >= CSV_HEADERS.length &&
+      CSV_HEADERS.every(
+        (expected, index) => expected.toLowerCase().trim() === parsedHeaders[index]?.toLowerCase().trim(),
+      );
+
+    if (!isHeaderValid) {
+      return { success: false, error: MultiTransferCsvError.STRUCTURE };
+    }
+
+    const data = parse<MultiTransferRowRaw>(fileContent, {
+      columns: CSV_FIELDS,
+      relax_column_count_more: true,
+      skip_empty_lines: true,
+      comment: '#',
+      trim: true,
+      from: 2,
+      to: MAX_CSV_ROWS + 1,
+    });
+
+    return { success: true, data };
+  } catch (error) {
+    console.error('multi-transfer CSV parsing error:', error);
+    return { success: false, error: MultiTransferCsvError.DATA };
+  }
+}
+
+const safeBN = () =>
+  z.string().transform((value, ctx) => {
+    try {
+      return new BN(value);
+    } catch {
+      ctx.addIssue({
+        code: 'custom',
+        message: MultiTransferFieldError.INVALID_VALUE,
+      });
+      return z.NEVER;
+    }
+  });
+
+function createValidationSchema(options: ValidationSchemaOptions) {
+  const { chain } = options;
+
+  return z.object({
+    recipient: z
+      .string()
+      .refine((value) => validateAddress(value, chain), MultiTransferFieldError.INVALID_SS58_ADDRESS)
+      .transform(toAccountId),
+    amount: safeBN()
+      .refine((bn) => bn.gt(new BN(0)), MultiTransferFieldError.OUT_OF_RANGE)
+      .refine((bn) => bn.lt(MAX_U128), MultiTransferFieldError.OUT_OF_RANGE),
+  });
+}
+
+function isFieldError(value: unknown): value is MultiTransferFieldError {
+  return typeof value === 'string' && Object.values(MultiTransferFieldError).includes(value as MultiTransferFieldError);
+}
+
+function validateCSV(records: MultiTransferRowRaw[], options: ValidationSchemaOptions) {
+  const issues: ValidationIssue[] = [];
+
+  for (let i = 0; i < records.length; i++) {
+    const record = records[i];
+    const rowIndex = i + 1;
+
+    try {
+      const schema = createValidationSchema(options);
+      schema.parse(record);
+    } catch (error) {
+      if (error instanceof z.ZodError) {
+        for (const issue of error.issues) {
+          const path = issue.path[0] as ValidationIssue['path'];
+          let message: ValidationIssue['message'] = MultiTransferFieldError.UNKNOWN_ERROR;
+
+          if (isFieldError(issue.message)) {
+            message = issue.message;
+          }
+
+          issues.push({ row: rowIndex, path, severity: 'error', message });
+        }
+      } else {
+        issues.push({
+          row: rowIndex,
+          path: 'recipient',
+          severity: 'error',
+          message: MultiTransferFieldError.UNKNOWN_ERROR,
+        });
+      }
+    }
+  }
+
+  const hasErrors = issues.length > 0;
+
+  return {
+    success: !hasErrors,
+    issues,
+  };
+}
+
+function downloadCsvWithIssues(rows: MultiTransferRowRaw[], issues: ValidationIssue[]) {
+  const columns = [...CSV_HEADERS, 'errors'];
+  const header = columns.join(',');
+
+  const dataRows = rows.map((row, index) => {
+    const rowIndex = index + 1;
+    const errorMessages = issues
+      .filter((issue) => issue.row === rowIndex)
+      .map((error) => `${error.path}: ${error.message}`)
+      .join(' | ');
+
+    return [row.recipient, row.amount, errorMessages].join(',');
+  });
+
+  const csvContent = [header, ...dataRows].join('\n');
+
+  downloadFiles([
+    {
+      blob: new Blob([csvContent], { type: 'text/csv' }),
+      fileName: 'multi-transfer-with-errors.csv',
+    },
+  ]);
+}

--- a/src/renderer/features/multi-transfer/utils.ts
+++ b/src/renderer/features/multi-transfer/utils.ts
@@ -6,7 +6,7 @@ import { downloadFiles, toAccountId, validateAddress } from '@/shared/lib/utils'
 import {
   MultiTransferCsvError,
   MultiTransferFieldError,
-  type MultiTransferRowRaw,
+  type MultiTransferRowSerialized,
   type ValidationIssue,
 } from '@/entities/multi-transfer';
 
@@ -24,7 +24,9 @@ export const multiTransferUtils = {
   downloadCsvWithIssues,
 };
 
-type ParseResult = { success: true; data: MultiTransferRowRaw[] } | { success: false; error: MultiTransferCsvError };
+type ParseResult =
+  | { success: true; data: MultiTransferRowSerialized[] }
+  | { success: false; error: MultiTransferCsvError };
 
 async function parseCSV(file: File): Promise<ParseResult> {
   const fileContent = await file.text();
@@ -49,7 +51,7 @@ async function parseCSV(file: File): Promise<ParseResult> {
       return { success: false, error: MultiTransferCsvError.STRUCTURE };
     }
 
-    const data = parse<MultiTransferRowRaw>(fileContent, {
+    const data = parse<MultiTransferRowSerialized>(fileContent, {
       columns: CSV_FIELDS,
       relax_column_count_more: true,
       skip_empty_lines: true,
@@ -97,7 +99,7 @@ function isFieldError(value: unknown): value is MultiTransferFieldError {
   return typeof value === 'string' && Object.values(MultiTransferFieldError).includes(value as MultiTransferFieldError);
 }
 
-function validateCSV(records: MultiTransferRowRaw[], options: ValidationSchemaOptions) {
+function validateCSV(records: MultiTransferRowSerialized[], options: ValidationSchemaOptions) {
   const issues: ValidationIssue[] = [];
 
   for (let i = 0; i < records.length; i++) {
@@ -138,7 +140,7 @@ function validateCSV(records: MultiTransferRowRaw[], options: ValidationSchemaOp
   };
 }
 
-function downloadCsvWithIssues(rows: MultiTransferRowRaw[], issues: ValidationIssue[]) {
+function downloadCsvWithIssues(rows: MultiTransferRowSerialized[], issues: ValidationIssue[]) {
   const columns = [...CSV_HEADERS, 'errors'];
   const header = columns.join(',');
 

--- a/src/renderer/shared/config/features/index.ts
+++ b/src/renderer/shared/config/features/index.ts
@@ -36,6 +36,7 @@ export const $defaultFeatures = createStore({
   callData: true,
   hiddenWallets: true,
   vestedTransfer: true,
+  multiTransfer: false,
   appCustomOperations: true,
 
   // experimental feature

--- a/src/renderer/shared/core/types/chain.ts
+++ b/src/renderer/shared/core/types/chain.ts
@@ -34,6 +34,7 @@ export const enum ChainOptions {
   PURE_PROXY = 'pure_proxy',
   ETHEREUM_BASED = 'ethereum_based',
   VESTED_TRANSFER = 'vested_transfer',
+  MULTI_TRANSFER = 'multi_transfer',
 }
 
 export type RpcNode = {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1619,6 +1619,7 @@
     "governance": "Governance",
     "historyLabel": "History",
     "mstOperationLabel": "Operations",
+    "multiTransferLabel": "Multi-transfer",
     "multipleWalletsLabel": "Multiple wallets",
     "notificationsLabel": "Notifications",
     "settingsLabel": "Settings",


### PR DESCRIPTION
## Description
Add the initial multi-transfer scaffold: feature flag, empty feature folder with placeholder entry point, and CSV parsing/validation utilities for recipient/amount. This sets up the base for the upcoming multi-transfer flow under a gated flag

## Related Issues
Closes #5337

## Changes Made
Added navigation button, feature folder, feature flag and csv utils

## Screenshots/Recordings
<img width="592" height="870" alt="Снимок экрана 2025-12-12 в 11 00 11" src="https://github.com/user-attachments/assets/6c80125e-a389-4eab-afb1-ce359a392ab3" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
