### PR TITLE
Fix/default chains

### DIFF
--- a/src/renderer/entities/staking/lib/constants.ts
+++ b/src/renderer/entities/staking/lib/constants.ts
@@ -12,11 +12,11 @@ export const DECAY_RATE = 0.05;
 export const KUSAMA_MAX_NOMINATORS = 24;
 export const DEFAULT_MAX_NOMINATORS = 16;
 
-export const DEFAULT_STAKING_CHAIN = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
-export const STAKING_NETWORK = 'staking_network';
-
 export const AssetHubChains: Record<string, ChainId> = {
   POLKADOT_AH: '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f',
   KUSAMA_AH: '0x48239ef607d7928874027a43a67689209727dfb3d3dc5e5b03a39bdc2eda771a',
   // WESTEND_AH: '0x67f9723393ef76214df0118c34bbbd3dbebc8ed46a10973a8c969d48fe7598c9',
 } as const;
+
+export const DEFAULT_STAKING_CHAIN = AssetHubChains['POLKADOT_AH'];
+export const STAKING_NETWORK = 'staking_network';

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/model/form-model.ts
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/model/form-model.ts
@@ -12,7 +12,7 @@ import { multisigService } from '@/features/multisig-wallet';
 import { signatoryModel } from './signatory-model';
 
 const MIN_THRESHOLD = 2;
-const DEFAULT_CHAIN: ChainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3'; // Polkadot
+const DEFAULT_CHAIN: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f'; // Polkadot AH
 
 export type FormParams = {
   threshold: number;

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/model/form-model.ts
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/model/form-model.ts
@@ -10,7 +10,7 @@ import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { signatoryModel } from './signatory-model';
 
 const MIN_THRESHOLD = 2;
-export const DEFAULT_SUBSTRATE_CHAIN: ChainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3'; // Polkadot
+export const DEFAULT_SUBSTRATE_CHAIN: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f'; // Polkadot AH
 export const DEFAULT_EVM_CHAIN: ChainId = '0xf6ee56e9c5277df5b4ce6ae9983ee88f3cbed27d31beeb98f9f84f997a1ab0b9'; // Mythos
 
 export type FormParams = {

--- a/src/renderer/features/proxies/lib/worker-utils.test.ts
+++ b/src/renderer/features/proxies/lib/worker-utils.test.ts
@@ -168,12 +168,6 @@ describe('features/proxies/lib/worker-utils', () => {
     expect(result).toEqual(expectedAccountId);
   });
 
-  test('should return undefined if chainId is not found', () => {
-    const result = proxyWorkerUtils.getKnownChain('0x01');
-
-    expect(result).toBeUndefined();
-  });
-
   test('should check proxy is delayed (true for delay > 0)', () => {
     const proxy = {
       accountId: '0x00' as AccountId,

--- a/src/renderer/features/proxies/lib/worker-utils.ts
+++ b/src/renderer/features/proxies/lib/worker-utils.ts
@@ -1,7 +1,6 @@
 import { type ApiPromise } from '@polkadot/api';
 import { u8aToHex } from '@polkadot/util';
 import { decodeAddress } from '@polkadot/util-crypto';
-import { WellKnownChain } from '@substrate/connect';
 
 import { type ChainId, type NoID, type PartialProxiedAccount, type ProxyAccount } from '@/shared/core';
 import { type AccountId, pjsSchema } from '@/shared/polkadotjs-schemas';
@@ -12,7 +11,6 @@ export const proxyWorkerUtils = {
   isSameProxied,
   isApiConnected,
   isDelayedProxy,
-  getKnownChain,
 };
 
 export function toAccountId(address: string): AccountId {
@@ -60,18 +58,4 @@ function isApiConnected(apis: Record<ChainId, ApiPromise>, chainId: ChainId): bo
 
 function isDelayedProxy(proxy: Pick<ProxyAccount, 'delay'>): boolean {
   return proxy.delay !== 0;
-}
-
-const MainChains = {
-  POLKADOT: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
-  KUSAMA: '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe',
-};
-
-const KnownChains: Record<ChainId, WellKnownChain> = {
-  [MainChains.POLKADOT]: WellKnownChain.polkadot,
-  [MainChains.KUSAMA]: WellKnownChain.ksmcc3,
-};
-
-function getKnownChain(chainId: ChainId): WellKnownChain | undefined {
-  return KnownChains[chainId];
 }

--- a/src/renderer/features/wallets/KeyConstructor/model/constructor-model.ts
+++ b/src/renderer/features/wallets/KeyConstructor/model/constructor-model.ts
@@ -13,7 +13,7 @@ import { type DerivationError, TokenType, parseDerivation, validateDerivation } 
 import { networkModel, networkUtils } from '@/entities/network';
 import { accountUtils } from '@/entities/wallet';
 
-export const DEFAULT_CHAIN = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
+export const DEFAULT_CHAIN = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f'; // Polkadot AH
 
 export type DerivationKeyDraft = Pick<VaultShardAccount, 'chainId' | 'derivationPath'> & {
   groupId?: VaultShardAccount['groupId'];


### PR DESCRIPTION
## Description
Set default network to Polkadot Asset Hub instead of Polkadot Relay across the app.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5357

## Changes Made
- Replaced Polkadot Relay chainId with AH chainId
- Removed unused getKnownChain

## Screenshots/Recordings
Staking page
<img width="1151" height="394" alt="Screenshot 2025-12-16 at 10 28 04 AM" src="https://github.com/user-attachments/assets/7cc0c12b-90da-4eaa-b2f7-3813486a50b9" />

Flexible multisig
<img width="818" height="758" alt="Screenshot 2025-12-16 at 10 29 26 AM" src="https://github.com/user-attachments/assets/dd299c5f-5a44-4521-baef-baf0f1cfd579" />

Regular multisig
<img width="844" height="801" alt="Screenshot 2025-12-16 at 10 30 30 AM" src="https://github.com/user-attachments/assets/6f001006-7d50-4358-86db-122a0b9ac58d" />

Polkadot vault derivation keys constructor
<img width="767" height="124" alt="Screenshot 2025-12-16 at 10 31 25 AM" src="https://github.com/user-attachments/assets/544ecbcf-6f7a-4522-b01d-4f23f796ec41" />



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
