### PR TITLE
refactor: filter only any multisig for notifications

### DIFF
--- a/src/renderer/features/notifications/NotificationsSettings/model/notifications-settings-model.ts
+++ b/src/renderer/features/notifications/NotificationsSettings/model/notifications-settings-model.ts
@@ -1,7 +1,10 @@
 import { sample } from 'effector';
 
 import { notificationModel } from '@/entities/notification';
-import { walletModel } from '@/entities/wallet';
+import { walletModel, walletUtils } from '@/entities/wallet';
+
+// Filter wallets to only include multisig and flexible multisig types
+const $multisigWallets = walletModel.$allWallets.map((wallets) => wallets.filter(walletUtils.isMultisig));
 
 // Re-export settings state from notification entity
 const $notificationEvents = notificationModel.$notificationEvents;
@@ -9,9 +12,9 @@ const $disabledWalletIds = notificationModel.$disabledWalletIds;
 const $soundEnabled = notificationModel.$soundEnabled;
 
 // Connect wallet updates to notification model
-// This bridges the two entities from the feature layer
+// This bridges the two entities from the feature layer (only multisig wallets)
 sample({
-  clock: walletModel.$allWallets,
+  clock: $multisigWallets,
   target: notificationModel.events.walletsUpdated,
 });
 
@@ -20,6 +23,9 @@ export const notificationsSettingsModel = {
   $notificationEvents,
   $disabledWalletIds,
   $soundEnabled,
+
+  // Filtered wallets for notifications (only multisig types)
+  $wallets: $multisigWallets,
 
   // Events (from entity)
   events: {

--- a/src/renderer/features/notifications/NotificationsSettings/ui/NotificationsSettingsModal.tsx
+++ b/src/renderer/features/notifications/NotificationsSettings/ui/NotificationsSettingsModal.tsx
@@ -17,7 +17,6 @@ import {
 } from '@/shared/ui';
 import { WalletIcon } from '@/shared/ui-entities';
 import { Modal } from '@/shared/ui-kit';
-import { walletModel } from '@/entities/wallet';
 import { notificationsSettingsModel } from '../model/notifications-settings-model';
 
 const EVENT_OPTIONS = [
@@ -36,7 +35,7 @@ type Props = {
 export const NotificationsSettingsModal = ({ isOpen: controlledIsOpen, onToggle, showTrigger = true }: Props) => {
   const { t } = useI18n();
 
-  const wallets = useUnit(walletModel.$allWallets);
+  const wallets = useUnit(notificationsSettingsModel.$wallets);
   const savedDisabledWalletIds = useUnit(notificationsSettingsModel.$disabledWalletIds);
   const savedNotificationEvents = useUnit(notificationsSettingsModel.$notificationEvents);
   const savedSoundEnabled = useUnit(notificationsSettingsModel.$soundEnabled);


### PR DESCRIPTION
## Description

filter notifications only by multisig/flex multisig wallets since we only have msig operations notifications atm

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
