### PR TITLE
refactor: deduplicate by data instead of id

### DIFF
--- a/src/renderer/domains/network/multisig-operation/service.ts
+++ b/src/renderer/domains/network/multisig-operation/service.ts
@@ -54,16 +54,6 @@ function getOperationId(chainId: ChainId, callHash: string, accountId: AccountId
   return `${chainId}-${callHash}-${accountId}-${block}-${index}`;
 }
 
-function getOperationKey(operation: {
-  chainId: ChainId;
-  callHash: string;
-  accountId: AccountId;
-  blockCreated: number;
-  indexCreated: number;
-}) {
-  return `${operation.chainId}:${operation.callHash}:${operation.accountId}:${operation.blockCreated}:${operation.indexCreated}`;
-}
-
 function getEventId(operationId: string, signer: string, status: 'approve' | 'reject') {
   return `${operationId}-${signer}-${status}`;
 }
@@ -254,7 +244,6 @@ function generateMultisigOperationRelativeLink(params: MultisigOperationDeepLink
 
 export const multisigOperationService = {
   getOperationId,
-  getOperationKey,
   getEventId,
   getTransactionFromChain,
   getMultisigAccountId,

--- a/src/renderer/domains/network/multisig-operation/service.ts
+++ b/src/renderer/domains/network/multisig-operation/service.ts
@@ -54,6 +54,16 @@ function getOperationId(chainId: ChainId, callHash: string, accountId: AccountId
   return `${chainId}-${callHash}-${accountId}-${block}-${index}`;
 }
 
+function getOperationKey(operation: {
+  chainId: ChainId;
+  callHash: string;
+  accountId: AccountId;
+  blockCreated: number;
+  indexCreated: number;
+}) {
+  return `${operation.chainId}:${operation.callHash}:${operation.accountId}:${operation.blockCreated}:${operation.indexCreated}`;
+}
+
 function getEventId(operationId: string, signer: string, status: 'approve' | 'reject') {
   return `${operationId}-${signer}-${status}`;
 }
@@ -244,6 +254,7 @@ function generateMultisigOperationRelativeLink(params: MultisigOperationDeepLink
 
 export const multisigOperationService = {
   getOperationId,
+  getOperationKey,
   getEventId,
   getTransactionFromChain,
   getMultisigAccountId,

--- a/src/renderer/domains/network/multisig-operation/store.test.ts
+++ b/src/renderer/domains/network/multisig-operation/store.test.ts
@@ -67,7 +67,6 @@ describe('multisig operation store notifications', () => {
       expect(notifications).toHaveLength(1);
       expect(notifications[0]).toMatchObject({
         type: NotificationType.MULTISIG_OPERATION,
-        operationId: operation.id,
       });
     });
 
@@ -99,7 +98,6 @@ describe('multisig operation store notifications', () => {
       expect(notifications).toHaveLength(1);
       expect(notifications[0]).toMatchObject({
         type: NotificationType.MULTISIG_OPERATION,
-        operationId: operation.id,
       });
     });
 
@@ -212,7 +210,7 @@ describe('multisig operation store notifications', () => {
 
       expect(notifications).toHaveLength(1);
       expect(notifications[0]).toMatchObject({
-        operationId: 'op-new',
+        callHash: newOperation.callHash,
       });
     });
   });
@@ -278,8 +276,20 @@ describe('multisig operation store notifications', () => {
 
     it('should send notification for new pending operation', async () => {
       const accountId = createAccountId('1');
-      const operation1 = createTestOperation({ id: 'op-1', accountId, status: 'executed', timestamp: 1000, callHash: '0x1111' });
-      const operation2 = createTestOperation({ id: 'op-2', accountId, status: 'pending', timestamp: 1000, callHash: '0x2222' });
+      const operation1 = createTestOperation({
+        id: 'op-1',
+        accountId,
+        status: 'executed',
+        timestamp: 1000,
+        callHash: '0x1111',
+      });
+      const operation2 = createTestOperation({
+        id: 'op-2',
+        accountId,
+        status: 'pending',
+        timestamp: 1000,
+        callHash: '0x2222',
+      });
       const account = createTestAccount({ accountId, createdAt: 500 });
 
       const notifications: unknown[] = [];
@@ -304,7 +314,7 @@ describe('multisig operation store notifications', () => {
       // The new pending operation should trigger notification
       expect(notifications).toHaveLength(1);
       expect(notifications[0]).toMatchObject({
-        operationId: 'op-2',
+        callHash: operation2.callHash,
         status: 'info',
       });
     });

--- a/src/renderer/domains/network/multisig-operation/store.test.ts
+++ b/src/renderer/domains/network/multisig-operation/store.test.ts
@@ -16,7 +16,7 @@ const createTestOperation = (params: Partial<MultisigOperation> = {}): MultisigO
   transaction: null,
   method: null,
   section: null,
-  callHash: '0x1234',
+  callHash: params.callHash ?? '0x1234',
   callData: null,
   chainId: polkadotChainId,
   accountId: params.accountId ?? createAccountId('1'),
@@ -278,8 +278,8 @@ describe('multisig operation store notifications', () => {
 
     it('should send notification for new pending operation', async () => {
       const accountId = createAccountId('1');
-      const operation1 = createTestOperation({ id: 'op-1', accountId, status: 'executed', timestamp: 1000 });
-      const operation2 = createTestOperation({ id: 'op-2', accountId, status: 'pending', timestamp: 1000 });
+      const operation1 = createTestOperation({ id: 'op-1', accountId, status: 'executed', timestamp: 1000, callHash: '0x1111' });
+      const operation2 = createTestOperation({ id: 'op-2', accountId, status: 'pending', timestamp: 1000, callHash: '0x2222' });
       const account = createTestAccount({ accountId, createdAt: 500 });
 
       const notifications: unknown[] = [];
@@ -307,6 +307,59 @@ describe('multisig operation store notifications', () => {
         operationId: 'op-2',
         status: 'info',
       });
+    });
+  });
+
+  describe('notification deduplication', () => {
+    it('should not produce duplicate notification when same operation is added with different id', async () => {
+      const accountId = createAccountId('1');
+      const callHash = '0xabcd1234';
+
+      // First operation
+      const operation1 = {
+        ...createTestOperation({
+          id: 'op-block100-index0',
+          accountId,
+          timestamp: 1000,
+        }),
+        callHash,
+      };
+
+      // Same operation but with different id (e.g., from different block/index)
+      const operation2 = {
+        ...createTestOperation({
+          id: 'op-block200-index1',
+          accountId,
+          timestamp: 1000,
+        }),
+        callHash, // Same callHash means it's the same logical operation
+      };
+
+      const account = createTestAccount({ accountId, createdAt: 500 });
+
+      const notifications: unknown[] = [];
+      const scope = fork({
+        values: [
+          [accounts.__test.$list, [account]],
+          [multisigOperation.__test.$populated, true],
+        ],
+      });
+
+      createWatch({
+        unit: notificationModel.events.notificationsAdded,
+        fn: params => notifications.push(...params),
+        scope,
+      });
+
+      // Initial state
+      await allSettled(multisigOperation.__test.$list, { scope, params: [] });
+      // Add first operation - should trigger notification
+      await allSettled(multisigOperation.__test.$list, { scope, params: [operation1] });
+      // Add second operation with different id but same callHash - should NOT trigger duplicate
+      await allSettled(multisigOperation.__test.$list, { scope, params: [operation1, operation2] });
+
+      // Should only have 1 notification, not 2
+      expect(notifications).toHaveLength(1);
     });
   });
 });

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -147,7 +147,7 @@ const createOperationNotification = (
   });
 
   return {
-    key: `${NotificationType.MULTISIG_OPERATION}:${multisigOperationService.getOperationKey(operation)}:${operation.status}`,
+    key: `${NotificationType.MULTISIG_OPERATION}-${multisigOperationService.getOperationId(operation.chainId, operation.callHash, operation.accountId, operation.blockCreated, operation.indexCreated)}-${operation.status}`,
     type: NotificationType.MULTISIG_OPERATION,
     status: getNotificationStatus(operation.status),
     issuer: operation.accountId,
@@ -176,11 +176,18 @@ const createOperationNotification = (
 
 const operationChanges = pairwise($list)
   .map(({ prev: prevState, current: update }) => {
-    const previousOpsMap = new Map(prevState.map(op => [multisigOperationService.getOperationKey(op), op]));
+    const previousOpsMap = new Map(
+      prevState.map(op => [
+        multisigOperationService.getOperationId(op.chainId, op.callHash, op.accountId, op.blockCreated, op.indexCreated),
+        op,
+      ]),
+    );
     const changes: MultisigOperation[] = [];
 
     for (const item of update) {
-      const previousOp = previousOpsMap.get(multisigOperationService.getOperationKey(item));
+      const previousOp = previousOpsMap.get(
+        multisigOperationService.getOperationId(item.chainId, item.callHash, item.accountId, item.blockCreated, item.indexCreated),
+      );
 
       if (!previousOp) {
         changes.push(item);

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -161,7 +161,6 @@ const createOperationNotification = (
       index: operation.indexCreated,
     },
     chainId: operation.chainId,
-    operationId: operation.id,
     link: {
       title: 'notifications.details.viewOperation',
       path: relativeLink,
@@ -176,15 +175,13 @@ const createOperationNotification = (
   };
 };
 
-const getOperationKey = (op: MultisigOperation) => `${op.chainId}:${op.callHash}:${op.accountId}`;
-
 const operationChanges = pairwise($list)
   .map(({ prev: prevState, current: update }) => {
-    const previousOpsMap = new Map(prevState.map(op => [getOperationKey(op), op]));
+    const previousOpsMap = new Map(prevState.map(op => [multisigOperationService.getOperationKey(op), op]));
     const changes: MultisigOperation[] = [];
 
     for (const item of update) {
-      const previousOp = previousOpsMap.get(getOperationKey(item));
+      const previousOp = previousOpsMap.get(multisigOperationService.getOperationKey(item));
 
       if (!previousOp) {
         changes.push(item);

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -147,8 +147,7 @@ const createOperationNotification = (
   });
 
   return {
-    // Don't use operation.id which can change when operation is re-added,
-    key: `${NotificationType.MULTISIG_OPERATION}:${operation.chainId}:${operation.callHash}:${operation.accountId}:${operation.status}`,
+    key: `${NotificationType.MULTISIG_OPERATION}:${multisigOperationService.getOperationKey(operation)}:${operation.status}`,
     type: NotificationType.MULTISIG_OPERATION,
     status: getNotificationStatus(operation.status),
     issuer: operation.accountId,

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -147,7 +147,8 @@ const createOperationNotification = (
   });
 
   return {
-    key: `${NotificationType.MULTISIG_OPERATION}:${operation.id}:${operation.status}`,
+    // Don't use operation.id which can change when operation is re-added,
+    key: `${NotificationType.MULTISIG_OPERATION}:${operation.chainId}:${operation.callHash}:${operation.accountId}:${operation.status}`,
     type: NotificationType.MULTISIG_OPERATION,
     status: getNotificationStatus(operation.status),
     issuer: operation.accountId,
@@ -175,13 +176,15 @@ const createOperationNotification = (
   };
 };
 
+const getOperationKey = (op: MultisigOperation) => `${op.chainId}:${op.callHash}:${op.accountId}`;
+
 const operationChanges = pairwise($list)
   .map(({ prev: prevState, current: update }) => {
-    const previousOpsMap = new Map(prevState.map(op => [op.id, op]));
+    const previousOpsMap = new Map(prevState.map(op => [getOperationKey(op), op]));
     const changes: MultisigOperation[] = [];
 
     for (const item of update) {
-      const previousOp = previousOpsMap.get(item.id);
+      const previousOp = previousOpsMap.get(getOperationKey(item));
 
       if (!previousOp) {
         changes.push(item);

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
@@ -39,15 +39,23 @@ const iconConfig: Record<NotificationStatus, { name: IconNames; className: strin
 };
 
 export const MultisigOperationNotificationComponent = ({
-  notification: { callHash, callTimepoint, chainId, issuer, status, operationId },
+  notification: { callHash, callTimepoint, chainId, issuer, status },
 }: Props) => {
   const { t } = useI18n();
   const navigate = useNavigate();
 
   const operation = useStoreMap({
     store: multisigOperation.$list,
-    keys: [operationId],
-    fn: (operations) => operations.find((op) => op.id === operationId),
+    keys: [callHash, callTimepoint.height, callTimepoint.index, chainId, issuer],
+    fn: (operations) =>
+      operations.find(
+        (op) =>
+          op.callHash === callHash &&
+          op.blockCreated === callTimepoint.height &&
+          op.indexCreated === callTimepoint.index &&
+          op.chainId === chainId &&
+          op.accountId === issuer,
+      ),
   });
 
   const multisigAccount = useStoreMap({

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
@@ -10,7 +10,7 @@ import { formatSectionAndMethod, nonNullable } from '@/shared/lib/utils';
 import { Paths } from '@/shared/routes';
 import { BodyText, Button, Icon, type IconNames } from '@/shared/ui';
 import { AssetBalance, WalletIcon } from '@/shared/ui-entities';
-import { accounts, multisigOperation } from '@/domains/network';
+import { accounts, multisigOperation, multisigOperationService } from '@/domains/network';
 import { ChainTitle } from '@/entities/chain';
 import { findCoreTransaction, getTransactionAmount, useTransactionAsset } from '@/entities/transaction';
 import { accountUtils, walletModel } from '@/entities/wallet';
@@ -44,18 +44,18 @@ export const MultisigOperationNotificationComponent = ({
   const { t } = useI18n();
   const navigate = useNavigate();
 
+  const operationKey = multisigOperationService.getOperationKey({
+    chainId,
+    callHash,
+    accountId: issuer,
+    blockCreated: callTimepoint.height,
+    indexCreated: callTimepoint.index,
+  });
+
   const operation = useStoreMap({
     store: multisigOperation.$list,
-    keys: [callHash, callTimepoint.height, callTimepoint.index, chainId, issuer],
-    fn: (operations) =>
-      operations.find(
-        (op) =>
-          op.callHash === callHash &&
-          op.blockCreated === callTimepoint.height &&
-          op.indexCreated === callTimepoint.index &&
-          op.chainId === chainId &&
-          op.accountId === issuer,
-      ),
+    keys: [operationKey],
+    fn: (operations) => operations.find((op) => multisigOperationService.getOperationKey(op) === operationKey),
   });
 
   const multisigAccount = useStoreMap({

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
@@ -44,18 +44,28 @@ export const MultisigOperationNotificationComponent = ({
   const { t } = useI18n();
   const navigate = useNavigate();
 
-  const operationKey = multisigOperationService.getOperationKey({
+  const operationId = multisigOperationService.getOperationId(
     chainId,
     callHash,
-    accountId: issuer,
-    blockCreated: callTimepoint.height,
-    indexCreated: callTimepoint.index,
-  });
+    issuer,
+    callTimepoint.height,
+    callTimepoint.index,
+  );
 
   const operation = useStoreMap({
     store: multisigOperation.$list,
-    keys: [operationKey],
-    fn: (operations) => operations.find((op) => multisigOperationService.getOperationKey(op) === operationKey),
+    keys: [operationId],
+    fn: (operations) =>
+      operations.find(
+        (op) =>
+          multisigOperationService.getOperationId(
+            op.chainId,
+            op.callHash,
+            op.accountId,
+            op.blockCreated,
+            op.indexCreated,
+          ) === operationId,
+      ),
   });
 
   const multisigAccount = useStoreMap({

--- a/src/renderer/shared/core/types/notification.ts
+++ b/src/renderer/shared/core/types/notification.ts
@@ -75,7 +75,6 @@ export type FlexibleMultisigOperationNotification = MultisigBaseNotification & {
 export type MultisigOperationNotification = MultisigBaseNotification & {
   callHash: CallHash;
   callTimepoint: Timepoint;
-  operationId: string;
 };
 
 export type ProxyAction = BaseNotification & {


### PR DESCRIPTION
## Description

Use operation data and not id (that can be changed after operation re-added) for deduplication of notifications

## Related Issues

closes #5322

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
