### PR TITLE
fix: react hooks call order in msig title

### DIFF
--- a/src/renderer/features/flexible-operation-details/index.tsx
+++ b/src/renderer/features/flexible-operation-details/index.tsx
@@ -1,5 +1,4 @@
 import { createFeature } from '@/shared/feature';
-import { useI18n } from '@/shared/i18n';
 import { nullable } from '@/shared/lib/utils';
 import { isEditFlexibleTransaction } from '@/entities/transaction';
 import { multisigOperationsSDK } from '@/sdk/multisig-operations';
@@ -16,10 +15,8 @@ multisigOperationsSDK(flexibleOperationDetailFeature, {
       return 'proxyMst';
     }
   },
-  title({ operation }) {
-    const { t } = useI18n();
-
-    if (nullable(operation)) return null;
+  title({ operation, t }) {
+    if (nullable(operation) || nullable(t)) return null;
 
     if (isEditFlexibleTransaction(operation.transaction)) {
       return {

--- a/src/renderer/features/governance-operation-details/index.tsx
+++ b/src/renderer/features/governance-operation-details/index.tsx
@@ -1,4 +1,3 @@
-import { useUnit } from 'effector-react';
 import { t } from 'i18next';
 
 import { TransactionType } from '@/shared/core';
@@ -6,7 +5,6 @@ import { createFeature } from '@/shared/feature';
 import { useI18n } from '@/shared/i18n';
 import { getAssetById, nullable } from '@/shared/lib/utils';
 import { type IconNames } from '@/shared/ui';
-import { networkModel } from '@/entities/network';
 import { TransactionTitle, findCoreTransaction, getTransactionAmount } from '@/entities/transaction';
 import { multisigOperationsSDK } from '@/sdk/multisig-operations';
 
@@ -51,11 +49,8 @@ multisigOperationsSDK(governanceOperationDetailFeature, {
       return icon;
     }
   },
-  title({ operation, showCoreTransaction }) {
-    const { t } = useI18n();
-    const chains = useUnit(networkModel.$chains);
-
-    if (nullable(operation)) return null;
+  title({ operation, showCoreTransaction, chains, t }) {
+    if (nullable(operation) || nullable(chains) || nullable(t)) return null;
 
     const transaction = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
     const title = transaction?.type && getOperationTitle(transaction.type);

--- a/src/renderer/features/multisig-operations/components/Operation.tsx
+++ b/src/renderer/features/multisig-operations/components/Operation.tsx
@@ -1,9 +1,12 @@
 import { type BN } from '@polkadot/util';
+import { useUnit } from 'effector-react';
+import { type TFunction } from 'i18next';
 import { memo, useMemo } from 'react';
 
 import {
   type Asset,
   type AssetByChains,
+  type Chain,
   type ChainId,
   type FlexibleMultisigAccount,
   type MultisigAccount,
@@ -17,6 +20,7 @@ import { AssetBalance, AssetIcon } from '@/shared/ui-entities';
 import { Box, Copy, Tooltip } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
 import { ChainTitle, XcmChains } from '@/entities/chain';
+import { networkModel } from '@/entities/network';
 import { OperationTitleDate, OperationTitleStatus } from '@/entities/operations';
 import {
   TransactionTitle,
@@ -47,12 +51,19 @@ export type OperationTitle = {
 };
 
 export const operationTitleTransformer = createTransformer<
-  { operation?: MultisigOperation; showCoreTransaction?: boolean },
+  {
+    operation?: MultisigOperation;
+    showCoreTransaction?: boolean;
+    chains?: Record<ChainId, Chain>;
+    asset?: Asset | null;
+    t?: TFunction;
+  },
   OperationTitle
 >();
 
 export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = false }: Props) => {
   const { t } = useI18n();
+  const chains = useUnit(networkModel.$chains);
 
   const showCoreTransaction = accountUtils.isFlexibleMultisigAccount(multisigAccount);
   const coreTx = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
@@ -66,6 +77,9 @@ export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = fal
   const externalTitle = useTransformer(operationTitleTransformer, {
     operation,
     showCoreTransaction,
+    chains,
+    asset,
+    t,
   });
 
   let titleData: OperationTitle;

--- a/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
+++ b/src/renderer/features/notifications/NotificationsList/ui/notifies/MultisigOperationNotification.tsx
@@ -1,4 +1,4 @@
-import { useStoreMap } from 'effector-react';
+import { useStoreMap, useUnit } from 'effector-react';
 import { useMemo } from 'react';
 import { Trans } from 'react-i18next';
 import { useNavigate } from 'react-router-dom';
@@ -12,6 +12,7 @@ import { BodyText, Button, Icon, type IconNames } from '@/shared/ui';
 import { AssetBalance, WalletIcon } from '@/shared/ui-entities';
 import { accounts, multisigOperation } from '@/domains/network';
 import { ChainTitle } from '@/entities/chain';
+import { networkModel } from '@/entities/network';
 import { findCoreTransaction, getTransactionAmount, useTransactionAsset } from '@/entities/transaction';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { operationTitleTransformer } from '@/features/multisig-operations';
@@ -43,6 +44,7 @@ export const MultisigOperationNotificationComponent = ({
 }: Props) => {
   const { t } = useI18n();
   const navigate = useNavigate();
+  const chains = useUnit(networkModel.$chains);
 
   const operation = useStoreMap({
     store: multisigOperation.$list,
@@ -76,6 +78,9 @@ export const MultisigOperationNotificationComponent = ({
   const externalTitle = useTransformer(operationTitleTransformer, {
     operation,
     showCoreTransaction: showCoreTransaction,
+    chains,
+    asset,
+    t,
   });
 
   const titleData = useMemo(() => {

--- a/src/renderer/features/proxy-operation-details/index.tsx
+++ b/src/renderer/features/proxy-operation-details/index.tsx
@@ -44,11 +44,8 @@ multisigOperationsSDK(proxyOperationDetailFeature, {
       return 'proxyMst';
     }
   },
-  title({ operation, showCoreTransaction }) {
-    const { t } = useI18n();
-    const chains = useUnit(networkModel.$chains);
-
-    if (nullable(operation)) return null;
+  title({ operation, showCoreTransaction, chains, t }) {
+    if (nullable(operation) || nullable(chains) || nullable(t)) return null;
 
     const transaction = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
     const title = transaction?.type && getOperationTitle(transaction.type);

--- a/src/renderer/features/staking-operation-details/index.tsx
+++ b/src/renderer/features/staking-operation-details/index.tsx
@@ -1,4 +1,3 @@
-import { useUnit } from 'effector-react';
 import { t } from 'i18next';
 
 import { TransactionType } from '@/shared/core';
@@ -6,7 +5,6 @@ import { createFeature } from '@/shared/feature';
 import { useI18n } from '@/shared/i18n';
 import { getAssetById, nullable } from '@/shared/lib/utils';
 import { type IconNames } from '@/shared/ui';
-import { networkModel } from '@/entities/network';
 import { TransactionTitle, findCoreTransaction, getTransactionAmount } from '@/entities/transaction';
 import { multisigOperationsSDK } from '@/sdk/multisig-operations';
 
@@ -53,11 +51,8 @@ multisigOperationsSDK(stakingOperationDetailFeature, {
       return icon;
     }
   },
-  title({ operation, showCoreTransaction }) {
-    const { t } = useI18n();
-    const chains = useUnit(networkModel.$chains);
-
-    if (nullable(operation)) return null;
+  title({ operation, showCoreTransaction, chains, t }) {
+    if (nullable(operation) || nullable(chains) || nullable(t)) return null;
 
     const transaction = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
     const title = transaction?.type && getOperationTitle(transaction.type);

--- a/src/renderer/features/transfer-operation-details/index.tsx
+++ b/src/renderer/features/transfer-operation-details/index.tsx
@@ -34,19 +34,16 @@ multisigOperationsSDK(transferOperationDetailFeature, {
       return 'crossChain';
     }
   },
-  title({ operation, showCoreTransaction }) {
-    const { t } = useI18n();
-
-    if (nullable(operation)) return null;
+  title({ operation, showCoreTransaction, asset, t }) {
+    if (nullable(operation) || nullable(asset) || nullable(t)) return null;
 
     const transaction = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
 
     if (isTransferTransaction(transaction)) {
-      const asset = useTransactionAsset(transaction, operation.chainId);
       const amount = transaction ? getTransactionAmount(transaction) : null;
 
       return {
-        title: t('operations.titles.transfer', { asset: asset?.symbol }),
+        title: t('operations.titles.transfer', { asset: asset.symbol }),
         amount: asset && amount ? { value: amount, asset } : undefined,
         sourceChainId: operation.chainId,
       };
@@ -54,7 +51,6 @@ multisigOperationsSDK(transferOperationDetailFeature, {
 
     if (isXcmTransaction(transaction)) {
       const coreTx = findCoreTransaction(transaction);
-      const asset = useTransactionAsset(coreTx, operation.chainId);
       const amount = coreTx ? getTransactionAmount(coreTx) : null;
 
       return {
@@ -64,6 +60,8 @@ multisigOperationsSDK(transferOperationDetailFeature, {
         destinationChainId: transaction?.args.destinationChain,
       };
     }
+
+    return null;
   },
   logTitle({ operation, showCoreTransaction }) {
     const { t } = useI18n();

--- a/src/renderer/features/vested-transfer-operation-details/index.tsx
+++ b/src/renderer/features/vested-transfer-operation-details/index.tsx
@@ -1,5 +1,4 @@
 import { BN } from '@polkadot/util';
-import { useUnit } from 'effector-react';
 import { t } from 'i18next';
 
 import { TransactionType } from '@/shared/core';
@@ -7,7 +6,6 @@ import { createFeature } from '@/shared/feature';
 import { useI18n } from '@/shared/i18n';
 import { getNativeAsset, nullable } from '@/shared/lib/utils';
 import { type IconNames } from '@/shared/ui';
-import { networkModel } from '@/entities/network';
 import { TransactionTitle, findCoreBatchAll, findCoreTransaction, getTransactionAmount } from '@/entities/transaction';
 import { multisigOperationsSDK } from '@/sdk/multisig-operations';
 import { confirmTransactionInfoSlot } from '@/features/multisig-operations';
@@ -57,10 +55,8 @@ multisigOperationsSDK(vestedTransferOperationDetailFeature, {
       return icon;
     }
   },
-  title({ operation, showCoreTransaction }) {
-    const chains = useUnit(networkModel.$chains);
-
-    if (nullable(operation)) return null;
+  title({ operation, showCoreTransaction, chains }) {
+    if (nullable(operation) || nullable(chains)) return null;
 
     const transaction = showCoreTransaction ? findCoreTransaction(operation.transaction) : operation.transaction;
 


### PR DESCRIPTION
## Description
Switching between multisig and flex msig breaks operations page.
Hooks were called conditionally. Moved hooks calls out of the title handlers

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5376

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

https://github.com/user-attachments/assets/ac5500b2-3071-458a-9a19-2e1d3da972ab



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
