### PR TITLE
fix: update polkadot vault version for parity signer

### DIFF
--- a/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
@@ -180,7 +180,7 @@ export const ScanMultiframeQr = ({
             <Box shrink={0} fitContainer>
               <Tabs.List>
                 <Tabs.Trigger value="new">
-                  {t('signing.qrNewVaultTitle', { version: getPolkadotVaultVersion(signingType) })}
+                  {t('signing.qrNewVaultTitle', { version: getPolkadotVaultVersion({ signingType, isBulkTx: true }) })}
                 </Tabs.Trigger>
                 <Tabs.Trigger value="legacy">{t('signing.qrLegacyVaultTitle')}</Tabs.Trigger>
               </Tabs.List>

--- a/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
@@ -22,6 +22,8 @@ import {
 import { QrGeneratorContainer } from '../QrCode/QrGeneratorContainer/QrGeneratorContainer';
 import { TRANSACTION_BULK } from '../QrCode/common/constants';
 
+import { getPolkadotVaultVersion } from './common/utils';
+
 type Props = {
   signingPayloads: ExtrinsicSigningPayload[];
   countdown: number;
@@ -46,7 +48,7 @@ export const ScanMultiframeQr = ({
   const [txPayloads, setTxPayloads] = useState<Uint8Array[]>([]);
   const [qrPayload, setQrPayload] = useState<Uint8Array>();
 
-  const isPV = signingPayloads[0].signatory.signingType === SigningType.POLKADOT_VAULT;
+  const signingType = signingPayloads[0].signatory.signingType;
   const isMetadataProofsSupported = signingPayloads[0].chain.additional?.supportsGenericLedgerApp ?? false;
 
   useEffect(() => {
@@ -91,7 +93,7 @@ export const ScanMultiframeQr = ({
         );
 
         let signPayload: Uint8Array;
-        if (isPV) {
+        if (signingType === SigningType.POLKADOT_VAULT) {
           assert(derivationPath, 'Derivation path not found');
           signPayload = createDynamicDerivationsSignWithProofPayload(
             rootAccountId,
@@ -127,7 +129,7 @@ export const ScanMultiframeQr = ({
         metadataMap[signatory.accountId][chainId] = upgradeNonce(metadataMap[signatory.accountId][chainId], 1);
 
         let signPayload: Uint8Array;
-        if (isPV) {
+        if (signingType === SigningType.POLKADOT_VAULT) {
           assert(derivationPath, 'Derivation path not found');
           signPayload = createDynamicDerivationsSignPayload(
             rootAccountId,
@@ -178,7 +180,7 @@ export const ScanMultiframeQr = ({
             <Box shrink={0} fitContainer>
               <Tabs.List>
                 <Tabs.Trigger value="new">
-                  {t('signing.qrNewVaultTitle', { version: isPV ? '7.1' : '7.0' })}
+                  {t('signing.qrNewVaultTitle', { version: getPolkadotVaultVersion(signingType) })}
                 </Tabs.Trigger>
                 <Tabs.Trigger value="legacy">{t('signing.qrLegacyVaultTitle')}</Tabs.Trigger>
               </Tabs.List>

--- a/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
@@ -146,7 +146,9 @@ export const ScanSingleframeQr = ({
             <Box shrink={0} fitContainer>
               <Tabs.List>
                 <Tabs.Trigger value="new">
-                  {t('signing.qrNewVaultTitle', { version: getPolkadotVaultVersion(account.signingType) })}
+                  {t('signing.qrNewVaultTitle', {
+                    version: getPolkadotVaultVersion({ signingType: account.signingType, isBulkTx: false }),
+                  })}
                 </Tabs.Trigger>
                 <Tabs.Trigger value="legacy">{t('signing.qrLegacyVaultTitle')}</Tabs.Trigger>
               </Tabs.List>

--- a/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
@@ -22,6 +22,8 @@ import {
 } from '../QrCode/QrGenerator/common/utils';
 import { QrGeneratorContainer } from '../QrCode/QrGeneratorContainer/QrGeneratorContainer';
 
+import { getPolkadotVaultVersion } from './common/utils';
+
 type Props = {
   api: ApiPromise;
   chain: Chain;
@@ -52,7 +54,6 @@ export const ScanSingleframeQr = ({
   const [txPayload, setTxPayload] = useState<Uint8Array>();
   const [qrPayload, setQrPayload] = useState<Uint8Array>();
 
-  const isPV = account.signingType === SigningType.POLKADOT_VAULT;
   const isMetadataProofsSupported = chain.additional?.supportsGenericLedgerApp ?? false;
   const isEthereumAccount = accountUtils.isEthereumBased(account);
 
@@ -77,7 +78,7 @@ export const ScanSingleframeQr = ({
         );
 
         let signPayload: Uint8Array;
-        if (isPV) {
+        if (account.signingType === SigningType.POLKADOT_VAULT) {
           assert(derivationPath, 'Derivation path not found');
           signPayload = createDynamicDerivationsSignWithProofPayload(
             rootAccountId,
@@ -106,7 +107,7 @@ export const ScanSingleframeQr = ({
         const { payload } = transactionService.createPayloadWithMetadata(extrinsic, api, metadata);
 
         let signPayload: Uint8Array;
-        if (isPV && !isEthereumAccount) {
+        if (account.signingType === SigningType.POLKADOT_VAULT && !isEthereumAccount) {
           assert(derivationPath, 'Derivation path not found');
           signPayload = createDynamicDerivationsSignPayload(
             rootAccountId,
@@ -145,7 +146,7 @@ export const ScanSingleframeQr = ({
             <Box shrink={0} fitContainer>
               <Tabs.List>
                 <Tabs.Trigger value="new">
-                  {t('signing.qrNewVaultTitle', { version: isPV ? '7.1' : '7.0' })}
+                  {t('signing.qrNewVaultTitle', { version: getPolkadotVaultVersion(account.signingType) })}
                 </Tabs.Trigger>
                 <Tabs.Trigger value="legacy">{t('signing.qrLegacyVaultTitle')}</Tabs.Trigger>
               </Tabs.List>

--- a/src/renderer/entities/transaction/ui/Scanning/common/utils.ts
+++ b/src/renderer/entities/transaction/ui/Scanning/common/utils.ts
@@ -1,0 +1,11 @@
+import { SigningType } from '@/shared/core';
+
+export const getPolkadotVaultVersion = (signingType: SigningType) => {
+  switch (signingType) {
+    case SigningType.POLKADOT_VAULT:
+      return '7.1';
+    case SigningType.PARITY_SIGNER:
+    default:
+      return '7.2';
+  }
+};

--- a/src/renderer/entities/transaction/ui/Scanning/common/utils.ts
+++ b/src/renderer/entities/transaction/ui/Scanning/common/utils.ts
@@ -1,11 +1,11 @@
 import { SigningType } from '@/shared/core';
 
-export const getPolkadotVaultVersion = (signingType: SigningType) => {
+export const getPolkadotVaultVersion = ({ signingType, isBulkTx }: { signingType: SigningType; isBulkTx: boolean }) => {
   switch (signingType) {
     case SigningType.POLKADOT_VAULT:
       return '7.1';
     case SigningType.PARITY_SIGNER:
     default:
-      return '7.2';
+      return isBulkTx ? '7.2' : '7.0';
   }
 };


### PR DESCRIPTION
## Description
Update minimum recommended version for Vault single account signer from 7.0 to 7.2

## Related Issues
https://github.com/novasamatech/nova-spektr/issues/5398

## Changes Made
- Updated version from 7.0 to 7.2
- Version helper function shared between single and bulk tx QRs

## Screenshots/Recordings
SigningType.PARITY_SIGNER with 1 transaction
<img width="518" height="784" alt="Screenshot 2025-12-19 at 3 10 12 PM" src="https://github.com/user-attachments/assets/a92c921b-cff8-4e3f-82a8-67b20dd7dc6b" />

SigningType.POLKADOT_VAULT with 1 transaction
<img width="511" height="835" alt="Screenshot 2025-12-19 at 3 10 35 PM" src="https://github.com/user-attachments/assets/835efe86-7b46-4afd-b291-fed7dd9dc1ae" />

SigningType.PARITY_SIGNER with bulk transactions
<img width="513" height="614" alt="Screenshot 2025-12-19 at 3 11 25 PM" src="https://github.com/user-attachments/assets/499affc1-429e-482f-902d-6b7ac214e2da" />

SigningType.POLKADOT_VAULT with bulk transactions
<img width="503" height="614" alt="Screenshot 2025-12-19 at 3 13 50 PM" src="https://github.com/user-attachments/assets/2eb0e63b-0c26-40bc-8dbb-deb7ebe74196" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
