### PR TITLE
fix: sort relay chains to bottom of the group

### DIFF
--- a/src/renderer/shared/api/network/service/chainsService.ts
+++ b/src/renderer/shared/api/network/service/chainsService.ts
@@ -75,8 +75,8 @@ function sortChains<T extends Pick<Chain, 'name' | 'options' | 'chainId' | 'pare
   // Helper to sort relaychain groups: relay first, then parachains (priority: name starts with relay), then alpha
   function sortRelayGroup(chains: T[], relayChainId: string, relayName: 'polkadot' | 'kusama') {
     chains.sort((a, b) => {
-      if (a.chainId === relayChainId) return -1;
-      if (b.chainId === relayChainId) return 1;
+      if (a.chainId === relayChainId) return 1;
+      if (b.chainId === relayChainId) return -1;
       const pa = parachainPriority(a, relayName);
       const pb = parachainPriority(b, relayName);
       if (pa !== pb) return pa - pb;


### PR DESCRIPTION
## Description
Sort relay chains to the bottom within the relay group.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5357

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="667" height="808" alt="Screenshot 2025-12-19 at 3 53 45 PM" src="https://github.com/user-attachments/assets/dea04033-b68e-4947-9d2e-9733b467e65e" />
<img width="654" height="804" alt="Screenshot 2025-12-19 at 3 54 08 PM" src="https://github.com/user-attachments/assets/0c481853-7a1a-49f2-b3b6-ca157403d659" />
<img width="637" height="788" alt="Screenshot 2025-12-19 at 3 54 23 PM" src="https://github.com/user-attachments/assets/127fed02-567c-4f4f-8551-80f4c872c156" />
<img width="631" height="783" alt="Screenshot 2025-12-19 at 3 54 29 PM" src="https://github.com/user-attachments/assets/d8f9db87-1531-4cad-9acb-268fe3c4ae9e" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
