### PR TITLE
fix: prevent networks from getting stuck in CONNECTING state

### DIFF
--- a/src/renderer/entities/network/model/network-model.ts
+++ b/src/renderer/entities/network/model/network-model.ts
@@ -157,12 +157,23 @@ type CreateApiParams = {
   provider: ProviderWithMetadata;
   existingApi: ApiPromise | null;
 };
-const createApiFx = createEffect(({ chainId, provider, existingApi }: CreateApiParams): Promise<ApiPromise> => {
+
+const API_READY_TIMEOUT = 30000; // 30 seconds
+
+const createApiFx = createEffect(async ({ chainId, provider, existingApi }: CreateApiParams): Promise<ApiPromise> => {
   if (nonNullable(existingApi)) {
     return Promise.resolve(existingApi);
   }
 
-  return networkService.createApi(chainId, provider).isReady;
+  const api = networkService.createApi(chainId, provider);
+
+  // Create timeout promise to prevent indefinite hanging
+  const timeoutPromise = new Promise<never>((_, reject) => {
+    setTimeout(() => reject(new Error(`API connection timeout for chain ${chainId}`)), API_READY_TIMEOUT);
+  });
+
+  // Race between API ready and timeout
+  return Promise.race([api.isReady, timeoutPromise]);
 });
 
 type DisconnectParams = {
@@ -176,6 +187,14 @@ const disconnectConnectionFx = createEffect(async ({ api, provider }: Disconnect
   await provider.disconnect();
 
   return chainId;
+});
+
+const cleanupProviderFx = createEffect(async (provider: ProviderWithMetadata): Promise<void> => {
+  try {
+    await provider.disconnect();
+  } catch (error) {
+    console.warn('Failed to disconnect provider during cleanup:', error);
+  }
 });
 
 const startNetworksFx = createEffect(() => {
@@ -364,6 +383,60 @@ sample({
   target: spread({
     newStatuses: $connectionStatuses,
     event: connectionStatusChanged,
+  }),
+});
+
+// Handle API creation failures (timeout or rejection)
+sample({
+  clock: createApiFx.fail,
+  source: $connectionStatuses,
+  fn: (statuses, { params, error }) => {
+    console.error(`Failed to create API for chain ${params.chainId}:`, error);
+
+    return {
+      newStatuses: { ...statuses, [params.chainId]: ConnectionStatus.ERROR },
+      event: { chainId: params.chainId, status: ConnectionStatus.ERROR },
+    };
+  },
+  target: spread({
+    newStatuses: $connectionStatuses,
+    event: connectionStatusChanged,
+  }),
+});
+
+// Cleanup provider when API creation fails
+sample({
+  clock: createApiFx.fail,
+  source: $providers,
+  filter: (providers, { params }) => nonNullable(providers[params.chainId]),
+  fn: (providers, { params }) => providers[params.chainId],
+  target: cleanupProviderFx,
+});
+
+// Remove failed provider from store after cleanup
+sample({
+  clock: cleanupProviderFx.done,
+  source: {
+    providers: $providers,
+    apis: $apis,
+  },
+  fn: ({ providers, apis }, { params: provider }) => {
+    // Find chainId by matching provider instance
+    const chainId = Object.keys(providers).find((id) => providers[id as ChainId] === provider) as ChainId | undefined;
+
+    if (!chainId) return { providers, apis };
+
+    const { [chainId]: _p, ...restProviders } = providers;
+    const { [chainId]: _a, ...restApis } = apis;
+
+    return {
+      newProviders: restProviders,
+      newApis: restApis,
+    };
+  },
+  target: spread({
+    newProviders: $providers,
+    newApis: $apis,
   }),
 });
 


### PR DESCRIPTION
## Problem

Networks were getting stuck in the `CONNECTING` state with no recovery mechanism except page reload. This occurred due to a race condition in the network connection lifecycle where API creation could hang indefinitely.

### Root Cause Analysis

The issue was caused by three missing error handling mechanisms in `network-model.ts`:

1. **No timeout on API.isReady promise** - The `createApiFx` effect waited indefinitely for `api.isReady` to resolve. If the provider never emitted a ready event, the promise would hang forever.

2. **No error handler for createApiFx.fail** - When API creation failed (rejected promise), there was no sample block listening to `createApiFx.fail`, so the connection status remained in `CONNECTING` state instead of transitioning to `ERROR`.

3. **No cleanup of failed providers** - Failed providers remained in the `$providers` store, causing resource leaks and preventing proper reconnection attempts.

### When This Occurred

- During app startup when multiple networks connect simultaneously
- When RPC nodes are slow, rate-limited, or temporarily unavailable
- When WebSocket connections timeout (5s hardcoded in `WsProvider`)
- When metadata fetching hangs in `CachedProvider`

## Solution

Implemented **Option 1** from the investigation: Timeout Wrapper + Error Handling

### Changes Made

1. **Added 30-second timeout to API creation** (`network-model.ts:161-176`)
   - Wraps `api.isReady` with `Promise.race()` against a timeout promise
   - Prevents indefinite hanging on slow or unresponsive nodes

2. **Added error handler for createApiFx.fail** (`network-model.ts:389-405`)
   - Transitions connection status from `CONNECTING` → `ERROR` on failure
   - Logs error details for debugging
   - Emits `connectionStatusChanged` event to notify dependent systems

3. **Added provider cleanup mechanism** (`network-model.ts:407-440`)
   - Disconnects failed providers to prevent resource leaks
   - Removes failed providers and APIs from stores
   - Enables clean reconnection attempts

### Benefits

✅ Networks that fail to connect within 30s transition to ERROR state  
✅ Failed providers are properly cleaned up to prevent resource leaks  
✅ Connection status is updated correctly on all failure paths  
✅ Reconnection logic can kick in after failures (via `networkSelectorModel`)  
✅ Better error visibility with console logging  

## Testing

- ✅ TypeScript type checking passes
- ✅ Build succeeds in dev mode
- ✅ Pre-commit hooks pass (lint-staged, prettier, eslint)

### Manual Testing Recommendations

1. **Test timeout scenario**: Modify `API_READY_TIMEOUT` to 5s and connect to slow nodes
2. **Test rejection scenario**: Use invalid RPC endpoints to trigger immediate failures
3. **Test reconnection**: Verify networks can reconnect after transitioning to ERROR state
4. **Test resource cleanup**: Check browser DevTools for WebSocket connection leaks

🤖 Generated with [Claude Code](https://claude.com/claude-code)