### PR TITLE
Feat/multisig operations account filters

### DIFF
--- a/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
@@ -1,20 +1,20 @@
 import { useUnit } from 'effector-react';
 import { type TFunction } from 'i18next';
-import { memo, useEffect, useState } from 'react';
+import { memo, useMemo } from 'react';
 
 import { TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
+import { toAddress } from '@/shared/lib/utils';
 import { Button, MultiSelect } from '@/shared/ui';
 import { type DropdownOption, type DropdownResult } from '@/shared/ui/types';
+import { Address } from '@/shared/ui-entities';
 import { type DateRange, DateRangePicker } from '@/shared/ui-kit';
-import { type MultisigOperation, multisigOperation } from '@/domains/network';
+import { type MultisigOperation, multisigOperation, useAccountsNames } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { TransferTypes, XcmTypes, findCoreBatchAll } from '@/entities/transaction';
 import { operationsContextModel } from '../model/context';
 
-type FilterName = 'network' | 'type';
-
-type FiltersOptions = Record<FilterName, Set<DropdownOption>>;
+type FilterName = 'account' | 'network' | 'type';
 
 const getFilterableTxType = (op: MultisigOperation): TransactionType | 'UNKNOWN_TYPE' => {
   if (!op.transaction?.type) {
@@ -37,18 +37,16 @@ const getFilterableTxType = (op: MultisigOperation): TransactionType | 'UNKNOWN_
   return op.transaction.type;
 };
 
-const EmptyOptions: FiltersOptions = {
-  network: new Set<DropdownOption>(),
-  type: new Set<DropdownOption>(),
-};
-
 export const OperationsFilter = memo(() => {
   const { t } = useI18n();
 
   const operations = useUnit(multisigOperation.$list);
-  const [filtersOptions, setFiltersOptions] = useState<FiltersOptions>(EmptyOptions);
   const selectedOptions = useUnit(operationsContextModel.$filter);
   const chains = useUnit(networkModel.$chains);
+  const multisigAccountsMap = useUnit(operationsContextModel.$multisigAccountsMap);
+
+  const multisigAccounts = useMemo(() => Array.from(multisigAccountsMap.values()), [multisigAccountsMap]);
+  const resolvedMultisigAccounts = useAccountsNames(multisigAccounts);
 
   const TransactionOptions = getTransactionOptions(t);
   const NetworkOptions = Object.values(chains).map(({ chainId, name }) => ({
@@ -57,19 +55,19 @@ export const OperationsFilter = memo(() => {
     element: name,
   }));
 
-  useEffect(() => {
-    setFiltersOptions(getAvailableFiltersOptions(operations));
-  }, [operations, chains]);
-
-  const getAvailableFiltersOptions = (transactions: MultisigOperation[]) => {
+  const getAvailableNetworkAndTypeFiltersOptions = (
+    transactions: MultisigOperation[],
+    networkOptions: DropdownOption[],
+    transactionOptions: DropdownOption[],
+  ) => {
     return transactions.reduce(
       (acc, tx) => {
         const txType = getFilterableTxType(tx);
         const xcmDestination = tx.transaction?.args.destinationChain;
 
-        const originNetworkOption = NetworkOptions.find(s => s.value === tx.chainId);
-        const destNetworkOption = NetworkOptions.find(s => s.value === xcmDestination);
-        const typeOption = TransactionOptions.find(s => s.value === txType);
+        const originNetworkOption = networkOptions.find(s => s.value === tx.chainId);
+        const destNetworkOption = networkOptions.find(s => s.value === xcmDestination);
+        const typeOption = transactionOptions.find(s => s.value === txType);
 
         if (originNetworkOption) {
           acc.network.add(originNetworkOption);
@@ -90,6 +88,25 @@ export const OperationsFilter = memo(() => {
     );
   };
 
+  const filtersOptions = useMemo(() => {
+    const AccountOptions = resolvedMultisigAccounts.map(account => ({
+      id: account.accountId,
+      value: account.accountId,
+      element: <Address showIcon variant="truncate" address={toAddress(account.accountId)} title={account.name} />,
+    }));
+
+    const networkAndTypeOptions = getAvailableNetworkAndTypeFiltersOptions(
+      operations,
+      NetworkOptions,
+      TransactionOptions,
+    );
+
+    return {
+      account: AccountOptions,
+      ...networkAndTypeOptions,
+    };
+  }, [operations, resolvedMultisigAccounts, NetworkOptions, TransactionOptions]);
+
   const handleFilterChange = (values: DropdownResult[], filterName: FilterName) => {
     const newSelectedOptions = { ...selectedOptions, [filterName]: values.map(v => v.id) };
     operationsContextModel.setFilters(newSelectedOptions);
@@ -105,6 +122,7 @@ export const OperationsFilter = memo(() => {
   };
 
   const filtersSelected =
+    selectedOptions.account.length ||
     selectedOptions.network.length ||
     selectedOptions.type.length ||
     selectedOptions.dateRange?.from ||
@@ -112,7 +130,12 @@ export const OperationsFilter = memo(() => {
 
   return (
     <div className="flex h-9 items-center gap-2">
-      <div className="w-[200px]">
+      {Boolean(filtersSelected) && (
+        <Button variant="text" className="h-8.5 py-0" onClick={clearFilters}>
+          {t('operations.filters.clearAll')}
+        </Button>
+      )}
+      <div className="w-[136px]">
         <DateRangePicker
           value={selectedOptions.dateRange}
           placeholder={t('operations.filters.dateRangePlaceholder')}
@@ -120,25 +143,27 @@ export const OperationsFilter = memo(() => {
         />
       </div>
       <MultiSelect
-        className="w-[200px]"
+        showSelectAll
+        className="w-[136px]"
+        placeholder={t('operations.filters.accountPlaceholder')}
+        selectedIds={selectedOptions.account}
+        options={[...filtersOptions.account]}
+        onChange={value => handleFilterChange(value, 'account')}
+      />
+      <MultiSelect
+        className="w-[136px]"
         placeholder={t('operations.filters.networkPlaceholder')}
         selectedIds={selectedOptions.network}
         options={[...filtersOptions.network]}
         onChange={value => handleFilterChange(value, 'network')}
       />
       <MultiSelect
-        className="w-[200px]"
+        className="w-[136px]"
         placeholder={t('operations.filters.operationTypePlaceholder')}
         selectedIds={selectedOptions.type}
         options={[...filtersOptions.type]}
         onChange={value => handleFilterChange(value, 'type')}
       />
-
-      {Boolean(filtersSelected) && (
-        <Button variant="text" className="h-8.5 py-0" onClick={clearFilters}>
-          {t('operations.filters.clearAll')}
-        </Button>
-      )}
     </div>
   );
 });

--- a/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/RejectTx.tsx
@@ -1,6 +1,6 @@
 import { type ApiPromise } from '@polkadot/api';
-import { useUnit } from 'effector-react';
-import { memo, useMemo, useState } from 'react';
+import { useGate, useUnit } from 'effector-react';
+import { memo, useState } from 'react';
 
 import {
   type Asset,
@@ -12,16 +12,15 @@ import {
 import { TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
-import { getAssetByTypeExtras, getNativeAsset, nonNullable, nullable } from '@/shared/lib/utils';
+import { getAssetByTypeExtras, getNativeAsset, nonNullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { Modal } from '@/shared/ui-kit';
 import { type MultisigOperation } from '@/domains/network';
 import { OperationTitle } from '@/entities/chain';
 import { operationDetailsUtils } from '@/entities/operations';
-import { OperationResult, getExtrinsic, isXcmTransaction } from '@/entities/transaction';
+import { OperationResult, isXcmTransaction } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
 import { SigningSwitch } from '@/features/operations';
-import { type ExtrinsicSigningPayload } from '@/features/operations/OperationSign';
 import { rejectModel } from '../../model/reject-model';
 import { Confirmation } from '../ActionSteps/Confirmation';
 import { Submit } from '../ActionSteps/Submit';
@@ -45,6 +44,8 @@ const enum Step {
 const AllSteps = [Step.CONFIRMATION, Step.SIGNING, Step.SUBMIT];
 
 export const RejectTxModal = memo(({ api, operation, account, chain, children }: Props) => {
+  useGate(rejectModel.flow, { chain, operation, account });
+
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
@@ -56,6 +57,7 @@ export const RejectTxModal = memo(({ api, operation, account, chain, children }:
   const isFeeLoading = useUnit(rejectModel.$isFeeLoading);
   const multisigDeposit = useUnit(rejectModel.$multisigDeposit);
   const signAccount = useUnit(rejectModel.$signatory);
+  const signingPayloads = useUnit(rejectModel.$signingPayloads);
   const initiator = useUnit(rejectModel.$initiator);
 
   const [isFeeModalOpen, toggleFeeModal] = useToggle();
@@ -80,18 +82,6 @@ export const RejectTxModal = memo(({ api, operation, account, chain, children }:
     }
   }
 
-  const signingPayloads = useMemo<ExtrinsicSigningPayload[]>(() => {
-    if (nullable(rejectTx) || nullable(signAccount)) return [];
-    return [
-      {
-        api,
-        chain: chain,
-        extrinsic: getExtrinsic[rejectTx.type](rejectTx.args, api),
-        signatory: signAccount,
-      },
-    ];
-  }, [chain, signAccount, rejectTx]);
-
   const goBack = () => {
     setActiveStep(AllSteps.indexOf(activeStep) - 1);
   };
@@ -103,10 +93,7 @@ export const RejectTxModal = memo(({ api, operation, account, chain, children }:
   };
 
   const toggleModal = (open: boolean) => {
-    if (open) {
-      rejectModel.flow.open({ chain, signer: signAccount, operation, account });
-    } else {
-      rejectModel.flow.close({ chain: null, signer: null, operation: null, account: null });
+    if (!open) {
       setActiveStep(Step.CONFIRMATION);
     }
   };
@@ -157,7 +144,7 @@ export const RejectTxModal = memo(({ api, operation, account, chain, children }:
             onSign={handleConfirm}
           />
         )}
-        {activeStep === Step.SIGNING && rejectTx && api && signAccount && (
+        {activeStep === Step.SIGNING && signingPayloads && signAccount && (
           <SigningSwitch
             signerWallet={wallets.find(w => w.id === signAccount.walletId)}
             signingPayloads={signingPayloads}

--- a/src/renderer/features/multisig-operations/model/approve-model.ts
+++ b/src/renderer/features/multisig-operations/model/approve-model.ts
@@ -190,23 +190,10 @@ const $extrinsic = combine($api, $tx, (api, tx) => {
 });
 
 const $signingPayloads = combine(
-  {
-    api: $api,
-    chain: $chain,
-    extrinsic: $extrinsic,
-    signatory: $signatory,
-  },
+  { api: $api, chain: $chain, extrinsic: $extrinsic, signatory: $signatory },
   ({ api, chain, extrinsic, signatory }) => {
-    if (nullable(extrinsic) || nullable(signatory) || nullable(api) || nullable(chain)) return null;
-
-    return [
-      {
-        api,
-        chain,
-        extrinsic,
-        signatory,
-      },
-    ];
+    if (nullable(api) || nullable(chain) || nullable(extrinsic) || nullable(signatory)) return null;
+    return [{ api, chain, extrinsic, signatory }];
   },
 );
 

--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -22,6 +22,7 @@ import { deepLinkModel } from './deep-link';
 import { multisigOperationsFeature } from './feature';
 
 interface SelectedFilters {
+  account: string[];
   network: string[];
   type: string[];
   dateRange?: DateRange;
@@ -31,6 +32,7 @@ export type TabFilter = 'pending' | 'history';
 const filterTx = (tx: MultisigOperation, filters: SelectedFilters, tab: TabFilter) => {
   const xcmDestination = tx.transaction?.args.destinationChain;
 
+  const hasAccount = !filters.account.length || filters.account.includes(tx.accountId);
   const hasOrigin = !filters.network.length || filters.network.includes(tx.chainId);
   const hasDestination = !filters.network.length || filters.network.includes(xcmDestination);
   const hasTxType = !filters.type.length || filters.type.includes(getFilterableTxType(tx));
@@ -53,7 +55,7 @@ const filterTx = (tx: MultisigOperation, filters: SelectedFilters, tab: TabFilte
   const statusMatchesTab =
     tab === 'pending' ? tx.status === 'pending' : ['executed', 'cancelled', 'error'].includes(tx.status);
 
-  return (hasOrigin || hasDestination) && hasTxType && isInDateRange && statusMatchesTab;
+  return hasAccount && (hasOrigin || hasDestination) && hasTxType && isInDateRange && statusMatchesTab;
 };
 
 const getFilterableTxType = (op: MultisigOperation): TransactionType | 'UNKNOWN_TYPE' => {
@@ -82,6 +84,7 @@ const resetFilters = createEvent();
 const setTab = createEvent<TabFilter>();
 
 const $filter = restore(setFilters, {
+  account: [],
   network: [],
   type: [],
   dateRange: undefined,

--- a/src/renderer/features/multisig-operations/model/reject-model.ts
+++ b/src/renderer/features/multisig-operations/model/reject-model.ts
@@ -1,9 +1,9 @@
 import { BN_ZERO } from '@polkadot/util';
-import { combine, createStore, sample } from 'effector';
+import { combine } from 'effector';
 import { createGate } from 'effector-react';
 
-import { type Chain, type FlexibleMultisigAccount, type MultisigAccount, type Transaction } from '@/shared/core';
-import { getNativeAsset, nonNullable } from '@/shared/lib/utils';
+import { type Chain, type FlexibleMultisigAccount, type MultisigAccount } from '@/shared/core';
+import { getNativeAsset, nullable } from '@/shared/lib/utils';
 import {
   createComplexTxStore,
   createSignatoriesStore,
@@ -11,29 +11,20 @@ import {
   createTxValidator,
   getActionRequiredAmount,
 } from '@/shared/transactions';
-import {
-  type AnyAccount,
-  type MultisigOperation,
-  accountService,
-  accounts,
-  multisigOperationService,
-} from '@/domains/network';
+import { type MultisigOperation, accountService, accounts, multisigOperationService } from '@/domains/network';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
-import { transactionBuilder } from '@/entities/transaction';
+import { getExtrinsic, transactionBuilder } from '@/entities/transaction';
 
 type GetMultisigType = {
-  signer: AnyAccount | null;
   chain: Chain | null;
   operation: MultisigOperation | null;
   account: MultisigAccount | FlexibleMultisigAccount | null;
 };
 
 const flow = createGate<GetMultisigType>({
-  defaultState: { chain: null, signer: null, operation: null, account: null },
+  defaultState: { chain: null, operation: null, account: null },
 });
-
-const $transaction = createStore<Transaction | null>(null).reset(flow.open);
 
 const $chain = flow.state.map(state => state.chain);
 const $operation = flow.state.map(state => state.operation);
@@ -75,17 +66,15 @@ const $signatories = createSignatoriesStore({
 
 const $signatory = $signatories.map(s => s.at(0) ?? null);
 
-sample({
-  clock: flow.open,
-  source: {
+const $transaction = combine(
+  {
     multisigAccount: $multisigAccount,
     signatory: $signatory,
     chain: $chain,
     operation: $operation,
     initiator: $initiator,
   },
-  filter: ({ multisigAccount }) => nonNullable(multisigAccount),
-  fn: ({ multisigAccount, chain, operation, signatory, initiator }) => {
+  ({ multisigAccount, chain, operation, signatory, initiator }) => {
     if (!operation || !chain || !signatory || !multisigAccount || !initiator) return null;
     const otherSignatories = multisigOperationService.getOtherSignatories(multisigAccount, initiator.accountId);
 
@@ -97,8 +86,7 @@ sample({
       tx: operation,
     });
   },
-  target: $transaction,
-});
+);
 
 const {
   $tx,
@@ -131,6 +119,19 @@ const $multisigDeposit = combine({ results: $balanceValidationResults }, ({ resu
   return actions.reduce((deposit, action) => deposit.add(action.required), BN_ZERO);
 });
 
+const $extrinsic = combine($api, $tx, (api, tx) => {
+  if (nullable(api) || nullable(tx)) return null;
+  return getExtrinsic[tx.type](tx.args, api);
+});
+
+const $signingPayloads = combine(
+  { api: $api, chain: $chain, extrinsic: $extrinsic, signatory: $signatory },
+  ({ api, chain, extrinsic, signatory }) => {
+    if (nullable(api) || nullable(chain) || nullable(extrinsic) || nullable(signatory)) return null;
+    return [{ api, chain, extrinsic, signatory }];
+  },
+);
+
 export const rejectModel = {
   flow,
   $transaction: $tx,
@@ -139,6 +140,7 @@ export const rejectModel = {
   $multisigDeposit,
   $multisigAccount,
   $signatory,
+  $signingPayloads,
   $initiator,
   $errors,
   $valid,

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2094,6 +2094,7 @@
     },
     "createdOperationDescription": "The changes will take effect after the other signatories sign.",
     "filters": {
+      "accountPlaceholder": "Account",
       "clearAll": "Clear all",
       "dateRangePlaceholder": "Date range",
       "networkPlaceholder": "Network",

--- a/src/renderer/shared/ui/Dropdowns/MultiSelect/MultiSelect.tsx
+++ b/src/renderer/shared/ui/Dropdowns/MultiSelect/MultiSelect.tsx
@@ -190,7 +190,7 @@ export const MultiSelect = ({
             sideOffset={4}
             className={cnTw(
               'pointer-events-auto z-50 max-h-60 overflow-auto rounded-sm border px-1 py-1 shadow-card-shadow',
-              'w-[var(--radix-popover-trigger-width)]',
+              'w-max min-w-[var(--radix-popover-trigger-width)]',
               OptionsContainerStyleTheme[theme],
             )}
             onOpenAutoFocus={(e) => e.preventDefault()}

--- a/src/renderer/shared/ui/Dropdowns/MultiSelect/MultiSelect.tsx
+++ b/src/renderer/shared/ui/Dropdowns/MultiSelect/MultiSelect.tsx
@@ -77,16 +77,6 @@ export const MultiSelect = ({
       );
     }
 
-    if (selectedOptions.length === 1) {
-      return typeof selectedOptions[0].element === 'string' ? (
-        <FootnoteText as="span" className="truncate">
-          {selectedOptions[0].element}
-        </FootnoteText>
-      ) : (
-        selectedOptions[0].element
-      );
-    }
-
     return (
       <span className="flex items-center gap-x-2">
         <FootnoteText as="span">{multiPlaceholder || placeholder}</FootnoteText>


### PR DESCRIPTION
## Description
Add accounts filter to the multisig operations page.

## Related Issues
Closes https://github.com/novasamatech/nova-spektr/issues/5484
Closes https://github.com/novasamatech/nova-spektr/issues/5538

## Changes Made
- Updated `MultiSelect` to show always selected options count (for 1 selected option as well) to avoid 
- Refactor Approve / Reject models data flows. Fixes the problem of Reject modal content being empty while loading
- Move `Clear Filters` button to the left according to design to avoid UI jumps when its enabled

## Screenshots/Recordings

https://github.com/user-attachments/assets/ff0016d6-f6b7-4bfb-9074-67f6d80decbf



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
