### PR TITLE
fix: use centralized name resolution for address book contacts globally

### DIFF
--- a/src/renderer/entities/operations/lib/operationDetailsUtils.ts
+++ b/src/renderer/entities/operations/lib/operationDetailsUtils.ts
@@ -6,17 +6,14 @@ import {
   type Address,
   type Chain,
   type ChainId,
-  type Contact,
   type DecodedTransaction,
   type Explorer,
   type HexString,
   type ProxyType,
-  type Signatory,
   type Transaction,
-  type Wallet,
   TransactionType,
 } from '@/shared/core';
-import { toAccountId, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { toAccountId, toAddress } from '@/shared/lib/utils';
 import { convictionVotingPallet } from '@/shared/pallet/convictionVoting';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type MultisigEvent, type MultisigOperation } from '@/domains/network';
@@ -56,31 +53,6 @@ export const getMultisigEventLink = (
   if (!multisigLink) return;
 
   return multisigLink.replace('{hash}', `${blockCreated}-${indexCreated}`);
-};
-
-export const getSignatoryName = (
-  signatoryId: AccountId,
-  txSignatories: Signatory[],
-  contacts: Contact[],
-  wallets: Wallet[],
-  addressPrefix?: number,
-): string => {
-  const finderFn = <T extends { accountId: AccountId }>(collection: T[]): T | undefined => {
-    return collection.find((c) => c.accountId === signatoryId);
-  };
-
-  // signatory data source priority: transaction -> contacts -> wallets -> address
-  const fromTx = finderFn(txSignatories)?.name;
-  if (fromTx) return fromTx;
-
-  const fromContact = finderFn(contacts)?.name;
-  if (fromContact) return fromContact;
-
-  const accounts = wallets.map((wallet) => wallet.accounts).flat();
-  const fromAccount = finderFn(accounts)?.name;
-  if (fromAccount) return fromAccount;
-
-  return toShortAddress(toAddress(signatoryId, { prefix: addressPrefix }), 5);
 };
 
 export const getAssetId = (operation: MultisigOperation) => {

--- a/src/renderer/entities/staking/ui/AccountsModal/AccountsModal.tsx
+++ b/src/renderer/entities/staking/ui/AccountsModal/AccountsModal.tsx
@@ -1,4 +1,5 @@
 import { BN_ZERO } from '@polkadot/util';
+import { useUnit } from 'effector-react';
 
 import { type Asset, type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -7,8 +8,9 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { BodyText, HelpText } from '@/shared/ui';
 import { AssetBalance, Hash, Identicon } from '@/shared/ui-entities';
 import { Modal } from '@/shared/ui-kit';
-import { type AnyAccount } from '@/domains/network';
+import { type AnyAccount, useAccountsNames } from '@/domains/network';
 import { useAssetBalances } from '@/entities/balance';
+import { networkModel } from '@/entities/network';
 
 type Props = {
   isOpen: boolean;
@@ -22,6 +24,9 @@ type Props = {
 
 export const AccountsModal = ({ isOpen, accounts, asset, chainId, addressPrefix, onClose }: Props) => {
   const { t } = useI18n();
+  const chains = useUnit(networkModel.$chains);
+  const chain = chains[chainId] ?? null;
+  const resolvedAccounts = useAccountsNames(accounts, chain);
 
   const accountIds = accounts.map((account) => account.accountId);
   const balances = useAssetBalances({
@@ -39,8 +44,13 @@ export const AccountsModal = ({ isOpen, accounts, asset, chainId, addressPrefix,
     <Modal isOpen={isOpen} size="sm" onToggle={onClose}>
       <Modal.Title close>{t('staking.confirmation.accountsTitle')}</Modal.Title>
       <Modal.Content>
-        <ul className={cnTw('flex flex-col gap-y-3 px-3 pb-3', accounts.length > 7 && 'max-h-[388px] overflow-y-auto')}>
-          {accounts.map((account) => {
+        <ul
+          className={cnTw(
+            'flex flex-col gap-y-3 px-3 pb-3',
+            resolvedAccounts.length > 7 && 'max-h-[388px] overflow-y-auto',
+          )}
+        >
+          {resolvedAccounts.map((account) => {
             const address = toAddress(account.accountId, { prefix: addressPrefix });
             return (
               <li key={account.accountId} className="flex items-center justify-between" data-testid="account">

--- a/src/renderer/entities/staking/ui/AccountsModal/AccountsModal.tsx
+++ b/src/renderer/entities/staking/ui/AccountsModal/AccountsModal.tsx
@@ -1,5 +1,4 @@
 import { BN_ZERO } from '@polkadot/util';
-import { useUnit } from 'effector-react';
 
 import { type Asset, type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -10,7 +9,7 @@ import { AssetBalance, Hash, Identicon } from '@/shared/ui-entities';
 import { Modal } from '@/shared/ui-kit';
 import { type AnyAccount, useAccountsNames } from '@/domains/network';
 import { useAssetBalances } from '@/entities/balance';
-import { networkModel } from '@/entities/network';
+import { useChain } from '@/entities/network';
 
 type Props = {
   isOpen: boolean;
@@ -24,8 +23,7 @@ type Props = {
 
 export const AccountsModal = ({ isOpen, accounts, asset, chainId, addressPrefix, onClose }: Props) => {
   const { t } = useI18n();
-  const chains = useUnit(networkModel.$chains);
-  const chain = chains[chainId] ?? null;
+  const chain = useChain(chainId);
   const resolvedAccounts = useAccountsNames(accounts, chain);
 
   const accountIds = accounts.map((account) => account.accountId);

--- a/src/renderer/entities/wallet/ui/ProxyWalletAlert/ProxyWalletAlert.tsx
+++ b/src/renderer/entities/wallet/ui/ProxyWalletAlert/ProxyWalletAlert.tsx
@@ -4,6 +4,7 @@ import { type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { Alert, FootnoteText } from '@/shared/ui';
 import { WalletIcon } from '@/shared/ui-entities';
+import { useWalletName } from '@/domains/network';
 
 type Props = {
   wallet: Wallet;
@@ -15,12 +16,13 @@ type Props = {
 
 export const ProxyWalletAlert = ({ wallet, fee, balance, symbol, onClose }: Props) => {
   const { t } = useI18n();
+  const walletName = useWalletName(wallet);
 
   const component = (
     <span className="mx-1 inline-flex max-w-[200px] items-center gap-x-1 align-bottom">
       <WalletIcon type={wallet.type} size={16} />
       <FootnoteText as="span" className="truncate text-text-secondary transition-colors">
-        {wallet.name}
+        {walletName}
       </FootnoteText>
     </span>
   );

--- a/src/renderer/features/accounts-structure/components/AccountStructureNode.tsx
+++ b/src/renderer/features/accounts-structure/components/AccountStructureNode.tsx
@@ -8,8 +8,7 @@ import { cnTw, toAddress } from '@/shared/lib/utils';
 import { LabelText, SmallTitleText } from '@/shared/ui/Typography';
 import { Address } from '@/shared/ui-entities/Address/Address';
 import { AsyncItem, useIntersectionObserver } from '@/shared/ui-kit';
-import { type AccountNode, identity, identityService } from '@/domains/network';
-import { contactModel } from '@/entities/contact';
+import { type AccountNode, useAccountName } from '@/domains/network';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { accountNodeConfigTransformer } from '@/sdk/account';
 import { accountsStructureModel } from '../model/accountsStructureModel';
@@ -25,30 +24,16 @@ type AccountStructureNodeProps = {
 export const AccountStructureNode = memo(({ data, id }: AccountStructureNodeProps) => {
   const { t } = useI18n();
   const highlightedNodesIds = useUnit(accountsStructureModel.$highlightedNodesIds);
-  const identities = useUnit(identity.$list);
   const chain = useUnit(accountsStructureModel.$selectedChain);
   const heldAccountNode = useUnit(accountsStructureModel.$heldAccountNode);
   const wallets = useUnit(walletModel.$wallets);
-  const contacts = useUnit(contactModel.$contacts);
 
   const [isIntersecting, setIsIntersecting] = useState(true);
 
   const connections = useNodeConnections();
   const hasIncoming = useMemo(() => connections.some((conn) => conn.target === id), [connections, id]);
   const hasOutgoing = useMemo(() => connections.some((conn) => conn.source === id), [connections, id]);
-  const title = useMemo(() => {
-    const contact = contacts.find((c) => c.accountId === data.node.account.accountId);
-    if (contact) {
-      return contact.name;
-    }
-
-    if (data.node.account.name) {
-      return data.node.account.name;
-    }
-
-    const accountIdentity = chain ? identities[chain.chainId]?.[data.node.account.accountId] : undefined;
-    return accountIdentity ? identityService.getFullName(accountIdentity) : '';
-  }, [contacts, identities, chain, data.node.account]);
+  const title = useAccountName({ accountId: data.node.account.accountId, chain });
 
   const wallet = walletUtils.getWalletById(wallets, data.node.account.walletId);
   const config = useTransformer(accountNodeConfigTransformer, { account: data.node.account, wallet: wallet, t });

--- a/src/renderer/features/call-data-execute/ui/InitiatorSelect.tsx
+++ b/src/renderer/features/call-data-execute/ui/InitiatorSelect.tsx
@@ -15,7 +15,7 @@ import {
 import { FootnoteText, InputHint } from '@/shared/ui';
 import { Address, AssetBalance, WalletIcon } from '@/shared/ui-entities';
 import { Box, Field, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
+import { accountService, useWalletsNames } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { walletModel } from '@/entities/wallet';
 import { formModel } from '../model/form';
@@ -26,6 +26,7 @@ export const InitiatorSelect = memo(() => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
+  const resolvedWallets = useWalletsNames(wallets);
   const allAccounts = useUnit(walletModel.$availableAccounts);
   const balancesMap = useUnit(balanceModel.$balanceMap);
   const chain = useUnit(formModel.form.fields.chain.$value);
@@ -55,7 +56,7 @@ export const InitiatorSelect = memo(() => {
     // Filter wallets based on search query
     const filteredWallets = performSearch({
       query: searchQuery.trim(),
-      records: wallets,
+      records: resolvedWallets,
       getMeta: (wallet) => ({
         name: wallet.name,
         allAddresses: accountService
@@ -144,7 +145,7 @@ export const InitiatorSelect = memo(() => {
     }
 
     return options;
-  }, [wallets, balancesMap, chain, asset, allAccounts, searchQuery, t]);
+  }, [resolvedWallets, balancesMap, chain, asset, allAccounts, searchQuery, t]);
 
   const selectedWallet = useMemo(() => {
     if (initiator.value) {

--- a/src/renderer/features/call-data-execute/ui/SignatorySelect.tsx
+++ b/src/renderer/features/call-data-execute/ui/SignatorySelect.tsx
@@ -8,7 +8,7 @@ import { getNativeAsset, nonNullable, nullable, toAddress, transferableAmountBN 
 import { FootnoteText, InputHint } from '@/shared/ui';
 import { Address, AssetBalance, WalletIcon } from '@/shared/ui-entities';
 import { Box, Field, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
+import { accountService, useWalletsNames } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
 import { walletModel } from '@/entities/wallet';
 import { formModel } from '../model/form';
@@ -19,6 +19,7 @@ export const SignatorySelect = memo(() => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
+  const resolvedWallets = useWalletsNames(wallets);
   const signatories = useUnit(formModel.$signatories);
   const balancesMap = useUnit(balanceModel.$balanceMap);
   const chain = useUnit(formModel.form.fields.chain.$value);
@@ -45,7 +46,7 @@ export const SignatorySelect = memo(() => {
     const options: ReactNode[] = [];
     if (nullable(chain) || nullable(asset)) return options;
 
-    const walletsByType = wallets.reduce(
+    const walletsByType = resolvedWallets.reduce(
       (groups, wallet) => {
         const walletSignatories = accountService.filterAccountsByWallet(signatories, wallet.id);
         const hasMatchingSignatories = walletSignatories.some((account) =>
@@ -119,7 +120,7 @@ export const SignatorySelect = memo(() => {
     }
 
     return options;
-  }, [wallets, balancesMap, chain, asset, signatories, t]);
+  }, [resolvedWallets, balancesMap, chain, asset, signatories, t]);
 
   const selectedSignatoryWallet = useMemo(() => {
     if (signatory.value) {

--- a/src/renderer/features/flexible-change-signatories/ui/components/Signatory.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/components/Signatory.tsx
@@ -9,7 +9,7 @@ import { includesMultiple, performSearch, toAccountId, toAddress, validateAddres
 import { FootnoteText, IconButton, InputHint } from '@/shared/ui';
 import { Address, Identicon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
+import { accountService, useAccountsNames, useWalletsNames } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { changeSignatoriesModel } from '../../model/change-signatories-model';
@@ -52,9 +52,11 @@ export const Signatory = ({
 
   const contacts = useUnit(contactModel.$contacts);
   const wallets = useUnit(walletModel.$wallets);
+  const resolvedWallets = useWalletsNames(wallets);
   const chain = useUnit(changeSignatoriesModel.$chain);
   const selectedSignatories = useUnit(signatoryModel.$signatories);
   const accountsList = useUnit(walletModel.$availableAccounts);
+  const resolvedAccounts = useAccountsNames(accountsList, chain);
 
   const filteredContacts = useMemo(() => {
     if (isOwnAccount) return [];
@@ -94,9 +96,11 @@ export const Signatory = ({
 
       if (!isOwnAccount && selectedSignatories.some((s) => toAccountId(s.address) === account.accountId)) continue;
       if (accountOptions.has(address)) continue;
-      const wallet = wallets.find((w) => w.id === account.walletId);
+      const wallet = resolvedWallets.find((w) => w.id === account.walletId);
+      const resolvedAccount = resolvedAccounts.find((a) => a.accountId === account.accountId);
+      const accountName = resolvedAccount?.name ?? account.name;
 
-      const title = !wallet || wallet.name === account.name ? account.name : `${wallet.name} (${account.name})`;
+      const title = !wallet || wallet.name === accountName ? accountName : `${wallet.name} (${accountName})`;
 
       accountOptions.set(address, {
         id: address,
@@ -114,7 +118,7 @@ export const Signatory = ({
         items: Array.from(accountOptions.values()),
       },
     ];
-  }, [query, chain, wallets, isOwnAccount, selectedSignatories]);
+  }, [query, chain, resolvedWallets, resolvedAccounts, isOwnAccount, selectedSignatories]);
 
   // Contacts
   const contactOptions = useMemo<ComboboxGroup[]>(() => {

--- a/src/renderer/features/multisig-operations/components/Details.tsx
+++ b/src/renderer/features/multisig-operations/components/Details.tsx
@@ -30,7 +30,7 @@ import {
 } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
-import { NamedAccount } from '@/widgets/NameResolver';
+import { NamedAccount, WalletName } from '@/widgets/NameResolver';
 
 type Props = {
   operation: MultisigOperation;
@@ -158,7 +158,9 @@ export const Details = ({ api, operation, account, chain, signatory }: Props) =>
           <DetailRow label={t('operation.details.senderProxiedWallet')}>
             <div className="flex max-w-none items-center gap-x-2">
               <WalletIcon type={proxied.wallet.type} size={16} />
-              <FootnoteText>{proxied.wallet.name}</FootnoteText>
+              <FootnoteText>
+                <WalletName wallet={proxied.wallet} />
+              </FootnoteText>
             </div>
           </DetailRow>
 
@@ -174,7 +176,9 @@ export const Details = ({ api, operation, account, chain, signatory }: Props) =>
         <DetailRow label={t('operation.details.multisigWallet')}>
           <div className="flex max-w-none items-center gap-x-2">
             <WalletIcon type={activeWallet.type} size={16} />
-            <FootnoteText>{activeWallet.name}</FootnoteText>
+            <FootnoteText>
+              <WalletName wallet={activeWallet} />
+            </FootnoteText>
           </div>
         </DetailRow>
       )}
@@ -183,7 +187,9 @@ export const Details = ({ api, operation, account, chain, signatory }: Props) =>
         <DetailRow label={t('transfer.signatoryLabel')} className="text-text-secondary">
           <Box direction="row" gap={2}>
             <WalletIcon type={signatoryWallet.type} size={16} />
-            <span>{signatoryWallet.name}</span>
+            <span>
+              <WalletName wallet={signatoryWallet} />
+            </span>
             {chain ? <AccountExplorers accountId={signatory.accountId} chain={chain} /> : null}
           </Box>
         </DetailRow>

--- a/src/renderer/features/multisig-operations/components/LogModal.tsx
+++ b/src/renderer/features/multisig-operations/components/LogModal.tsx
@@ -4,7 +4,6 @@ import { type ReactNode, useMemo } from 'react';
 
 import {
   type Chain,
-  type Contact,
   type FlexibleMultisigAccount,
   type MultisigAccount,
   type Wallet,
@@ -17,7 +16,7 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { BodyText, ContextMenu, ExplorerLink, FootnoteText, IconButton } from '@/shared/ui';
 import { Identicon, WalletIcon } from '@/shared/ui-entities';
 import { Modal } from '@/shared/ui-kit';
-import { type AnyAccount, type MultisigEvent, type MultisigOperation } from '@/domains/network';
+import { type AnyAccount, type MultisigEvent, type MultisigOperation, useAccountName } from '@/domains/network';
 import { Status, operationDetailsUtils } from '@/entities/operations';
 import { TransactionTitle } from '@/entities/transaction';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
@@ -28,16 +27,36 @@ type Props = {
   operation: MultisigOperation;
   account: MultisigAccount | FlexibleMultisigAccount;
   chain: Chain | null;
-  contacts: Contact[];
   isOpen: boolean;
   onClose: () => void;
 };
 
-const EventMessage = {
+const EventMessageKeys = {
   initiated: 'log.initiatedMessage',
   approve: 'log.signedMessage',
   reject: 'log.cancelledMessage',
 } as const;
+
+type EventMessageProps = {
+  event: MultisigEvent;
+  operation: MultisigOperation;
+  chain: Chain | null;
+};
+
+const EventMessage = ({ event, operation, chain }: EventMessageProps) => {
+  const { t } = useI18n();
+  const signatoryName = useAccountName({ accountId: event.accountId, chain });
+
+  const isCreatedEvent = event.accountId === operation.depositor && event.status === 'approve';
+  const eventType = isCreatedEvent ? 'initiated' : event.status;
+  const eventMessage = EventMessageKeys[eventType] || 'log.unknownMessage';
+
+  return (
+    <>
+      {signatoryName} {t(eventMessage)}
+    </>
+  );
+};
 
 const getFilteredWalletsMap = (wallets: Wallet[]): WalletsMap => {
   return wallets.reduce<WalletsMap>((acc, wallet) => {
@@ -64,7 +83,7 @@ export const operationLogTitleTransformer = createTransformer<
   ReactNode
 >();
 
-const LogModal = ({ isOpen, onClose, operation, account, chain, contacts }: Props) => {
+const LogModal = ({ isOpen, onClose, operation, account, chain }: Props) => {
   const { t, formatDate } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
@@ -94,24 +113,6 @@ const LogModal = ({ isOpen, onClose, operation, account, chain, contacts }: Prop
         : t('operations.titles.unknown');
     titleNode = <TransactionTitle className="flex-1" title={title} />;
   }
-
-  const getEventMessage = (event: MultisigEvent): string => {
-    const isCreatedEvent = event.accountId === operation.depositor && event.status === 'approve';
-
-    if (!account) return '';
-
-    const signatoryName = operationDetailsUtils.getSignatoryName(
-      event.accountId,
-      account?.signatories,
-      contacts,
-      wallets,
-      chain?.addressPrefix,
-    );
-    const eventType = isCreatedEvent ? 'initiated' : event.status;
-    const eventMessage = EventMessage[eventType] || 'log.unknownMessage';
-
-    return `${signatoryName} ${t(eventMessage)}`;
-  };
 
   return (
     <Modal size="md" isOpen={isOpen} onToggle={onClose}>
@@ -162,7 +163,9 @@ const LogModal = ({ isOpen, onClose, operation, account, chain, contacts }: Prop
                           ) : (
                             <Identicon size={16} address={toAddress(event.accountId)} background={false} />
                           )}
-                          <BodyText className="flex-1 text-text-secondary">{getEventMessage(event)}</BodyText>
+                          <BodyText className="flex-1 text-text-secondary">
+                            <EventMessage event={event} operation={operation} chain={chain} />
+                          </BodyText>
                           <BodyText className="text-text-tertiary">{formatDate(Number(event.timestamp), 'p')}</BodyText>
 
                           {explorerLinks.length > 0 && (

--- a/src/renderer/features/multisig-operations/components/Operation.tsx
+++ b/src/renderer/features/multisig-operations/components/Operation.tsx
@@ -18,7 +18,7 @@ import { Accordion, FootnoteText, HelpText } from '@/shared/ui';
 import { IconButton } from '@/shared/ui/Buttons';
 import { AssetBalance, AssetIcon, WalletAccountIcon } from '@/shared/ui-entities';
 import { Copy, Tooltip } from '@/shared/ui-kit';
-import { type MultisigOperation } from '@/domains/network';
+import { type MultisigOperation, useWalletName } from '@/domains/network';
 import { ChainTitle, XcmChains } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
 import { OperationTitleStatus } from '@/entities/operations';
@@ -74,6 +74,7 @@ export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = fal
     () => wallets.find(w => w.id === multisigAccount.walletId),
     [wallets, multisigAccount.walletId],
   );
+  const walletName = useWalletName(wallet);
 
   const isFlexibleMultisigAccount = accountUtils.isFlexibleMultisigAccount(multisigAccount);
   const coreTx = isFlexibleMultisigAccount ? findCoreTransaction(operation.transaction) : operation.transaction;
@@ -148,7 +149,7 @@ export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = fal
                 <div className="flex w-[240px] items-center gap-x-2">
                   <WalletAccountIcon address={accountAddress} type={wallet.type} size={32} iconSize={14} />
                   <div className="flex min-w-0 flex-col items-start gap-y-0.5">
-                    <FootnoteText className="truncate text-text-primary">{wallet.name}</FootnoteText>
+                    <FootnoteText className="truncate text-text-primary">{walletName}</FootnoteText>
                     <HelpText className="text-text-tertiary">{toShortAddress(accountAddress, 6)}</HelpText>
                   </div>
                 </div>

--- a/src/renderer/features/multisig-operations/components/OperationSignatories.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationSignatories.tsx
@@ -1,20 +1,46 @@
 import { useUnit } from 'effector-react';
 import { useCallback, useMemo, useState } from 'react';
 
-import { type FlexibleMultisigAccount, type MultisigAccount, type Signatory, type Wallet } from '@/shared/core';
+import {
+  type Chain,
+  type FlexibleMultisigAccount,
+  type MultisigAccount,
+  type Signatory,
+  type Wallet,
+} from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable, toAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { BodyText, Button, CaptionText, FootnoteText, Icon, SmallTitleText } from '@/shared/ui';
 import { Address, WalletIcon } from '@/shared/ui-entities';
-import { type AnyAccount, type MultisigOperation, accounts } from '@/domains/network';
-import { contactModel } from '@/entities/contact';
+import { type AnyAccount, type MultisigOperation, accounts, useAccountName } from '@/domains/network';
 import { useChain } from '@/entities/network';
 import { operationDetailsUtils } from '@/entities/operations';
 import { SignatoryCard } from '@/entities/signatory';
 import { walletModel } from '@/entities/wallet';
+import { WalletName } from '@/widgets/NameResolver';
 
 import LogModal from './LogModal';
+
+type SignatoryAddressProps = {
+  accountId: AccountId;
+  chain: Chain | null;
+};
+
+const SignatoryAddress = ({ accountId, chain }: SignatoryAddressProps) => {
+  const name = useAccountName({ accountId, chain });
+
+  return (
+    <Address
+      title={name}
+      address={toAddress(accountId, { prefix: chain?.addressPrefix })}
+      variant="short"
+      canCopy={false}
+      showIcon
+    />
+  );
+};
 
 export const operationOverviewSlot = createSlot<{
   walletAccounts: AnyAccount[];
@@ -34,7 +60,6 @@ export const OperationSignatories = ({ operation, account }: Props) => {
 
   const wallets = useUnit(walletModel.$wallets);
   const accountsList = useUnit(accounts.$list);
-  const contacts = useUnit(contactModel.$contacts);
 
   const [isLogModalOpen, setIsLogModalOpen] = useState(false);
   const closeLogModal = useCallback(() => setIsLogModalOpen(false), []);
@@ -120,7 +145,9 @@ export const OperationSignatories = ({ operation, account }: Props) => {
                   status={operationDetailsUtils.getSignatoryStatus(operation.events, signatory.accountId)}
                 >
                   <WalletIcon type={signatory.wallet.type} size={20} />
-                  <BodyText className="mr-auto truncate text-inherit">{signatory.wallet.name}</BodyText>
+                  <BodyText className="mr-auto truncate text-inherit">
+                    <WalletName wallet={signatory.wallet} />
+                  </BodyText>
                 </SignatoryCard>
               ))}
             </ul>
@@ -138,19 +165,7 @@ export const OperationSignatories = ({ operation, account }: Props) => {
                   key={signatory.accountId}
                   status={operationDetailsUtils.getSignatoryStatus(operation.events, signatory.accountId)}
                 >
-                  <Address
-                    title={operationDetailsUtils.getSignatoryName(
-                      signatory.accountId,
-                      account.signatories,
-                      contacts,
-                      wallets,
-                      chain?.addressPrefix,
-                    )}
-                    address={toAddress(signatory.accountId, { prefix: chain?.addressPrefix })}
-                    variant="short"
-                    canCopy={false}
-                    showIcon
-                  />
+                  <SignatoryAddress accountId={signatory.accountId} chain={chain} />
                 </SignatoryCard>
               ))}
             </ul>
@@ -158,14 +173,7 @@ export const OperationSignatories = ({ operation, account }: Props) => {
         )}
       </div>
 
-      <LogModal
-        isOpen={isLogModalOpen}
-        operation={operation}
-        account={account}
-        chain={chain}
-        contacts={contacts}
-        onClose={closeLogModal}
-      />
+      <LogModal isOpen={isLogModalOpen} operation={operation} account={account} chain={chain} onClose={closeLogModal} />
     </div>
   );
 };

--- a/src/renderer/features/multisig-wallet-create/common/Signer.tsx
+++ b/src/renderer/features/multisig-wallet-create/common/Signer.tsx
@@ -7,6 +7,7 @@ import { BodyText, Icon } from '@/shared/ui';
 import { AccountExplorers, AssetBalance, WalletIcon } from '@/shared/ui-entities';
 import { type AnyAccount } from '@/domains/network';
 import { useBalance } from '@/entities/balance';
+import { WalletName } from '@/widgets/NameResolver';
 
 interface Props {
   onSubmit: (event: FormEvent, account: AnyAccount) => void;
@@ -31,7 +32,9 @@ export const Signer = ({ account, wallet, onSubmit, chain }: Props) => {
     >
       <div className="flex items-center gap-x-2 truncate">
         <WalletIcon type={wallet.type} />
-        {wallet.name && <BodyText className="truncate text-inherit">{wallet.name}</BodyText>}
+        <BodyText className="truncate text-inherit">
+          <WalletName wallet={wallet} />
+        </BodyText>
         <AccountExplorers accountId={account.accountId} chain={chain} />
       </div>
       <AssetBalance

--- a/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/flexible-multisig/components/components/Signatory.tsx
@@ -9,7 +9,7 @@ import { includesMultiple, performSearch, toAccountId, toAddress, validateAddres
 import { FootnoteText, IconButton, InputHint } from '@/shared/ui';
 import { Address, Identicon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Input, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
+import { accountService, useAccountsNames, useWalletsNames } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { type SignatoryInfo } from '../../../types';
@@ -53,9 +53,11 @@ export const Signatory = ({
 
   const contacts = useUnit(contactModel.$contacts);
   const wallets = useUnit(walletModel.$wallets);
+  const resolvedWallets = useWalletsNames(wallets);
   const chain = useUnit(formModel.$chain);
   const selectedSignatories = useUnit(signatoryModel.$signatories);
   const accountsList = useUnit(walletModel.$availableAccounts);
+  const resolvedAccounts = useAccountsNames(accountsList, chain);
 
   const filteredContacts = useMemo(() => {
     if (isOwnAccount) return [];
@@ -127,9 +129,11 @@ export const Signatory = ({
 
       if (!isOwnAccount && selectedSignatories.some(s => toAccountId(s.address) === account.accountId)) continue;
       if (accountOptions.has(address)) continue;
-      const wallet = wallets.find(w => w.id === account.walletId);
+      const wallet = resolvedWallets.find(w => w.id === account.walletId);
+      const resolvedAccount = resolvedAccounts.find(a => a.accountId === account.accountId);
+      const accountName = resolvedAccount?.name ?? account.name;
 
-      const title = !wallet || wallet.name === account.name ? account.name : `${wallet.name} (${account.name})`;
+      const title = !wallet || wallet.name === accountName ? accountName : `${wallet.name} (${accountName})`;
 
       accountOptions.set(address, {
         id: address,
@@ -147,7 +151,7 @@ export const Signatory = ({
         items: Array.from(accountOptions.values()),
       },
     ];
-  }, [query, signatoryQuery, chain, wallets, isOwnAccount, selectedSignatories]);
+  }, [query, signatoryQuery, chain, resolvedWallets, resolvedAccounts, isOwnAccount, selectedSignatories]);
 
   // Contacts
   const contactOptions = useMemo<ComboboxGroup[]>(() => {

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/components/components/Signatory.tsx
@@ -9,7 +9,7 @@ import { includesMultiple, performSearch, toAccountId, toAddress, validateAddres
 import { FootnoteText, IconButton, InputHint } from '@/shared/ui';
 import { Address, Identicon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Input, Select } from '@/shared/ui-kit';
-import { accountService } from '@/domains/network';
+import { accountService, useAccountsNames, useWalletsNames } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { type SignatoryInfo } from '../../../types';
@@ -52,8 +52,10 @@ export const Signatory = ({
   const chain = useUnit(formModel.$chain);
   const contacts = useUnit(contactModel.$contacts);
   const wallets = useUnit(walletModel.$wallets);
+  const resolvedWallets = useWalletsNames(wallets);
   const selectedSignatories = useUnit(signatoryModel.$signatories);
   const accountsList = useUnit(walletModel.$availableAccounts);
+  const resolvedAccounts = useAccountsNames(accountsList, chain);
 
   const [query, setQuery] = useState(signatoryAddress);
   const [signatoryQuery, setSignatoryQuery] = useState('');
@@ -124,9 +126,11 @@ export const Signatory = ({
       if (!isOwnAccount && selectedSignatories.some(s => toAccountId(s.address) === toAccountId(address))) continue;
       if (accountOptions.has(address)) continue;
 
-      const wallet = wallets.find(w => w.id === account.walletId);
+      const wallet = resolvedWallets.find(w => w.id === account.walletId);
+      const resolvedAccount = resolvedAccounts.find(a => a.accountId === account.accountId);
+      const accountName = resolvedAccount?.name ?? account.name;
 
-      const title = !wallet || wallet.name === account.name ? account.name : `${wallet.name} (${account.name})`;
+      const title = !wallet || wallet.name === accountName ? accountName : `${wallet.name} (${accountName})`;
 
       accountOptions.set(address, {
         id: address,
@@ -144,7 +148,7 @@ export const Signatory = ({
         items: Array.from(accountOptions.values()),
       },
     ];
-  }, [query, signatoryQuery, chain, wallets, isOwnAccount, selectedSignatories]);
+  }, [query, signatoryQuery, chain, resolvedWallets, resolvedAccounts, isOwnAccount, selectedSignatories]);
 
   // Build Contacts options
   const contactOptions = useMemo<ComboboxGroup[]>(() => {

--- a/src/renderer/features/wallet-details/lib/utils.ts
+++ b/src/renderer/features/wallet-details/lib/utils.ts
@@ -1,6 +1,4 @@
-import { type Contact, type PolkadotVaultWallet, type Signatory, type Wallet } from '@/shared/core';
-import { toAddress, toShortAddress } from '@/shared/lib/utils';
-import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type PolkadotVaultWallet } from '@/shared/core';
 import { accountUtils } from '@/entities/wallet';
 
 import { ForgetStep, ReconnectStep } from './constants';
@@ -17,7 +15,6 @@ export const wcDetailsUtils = {
 export const walletDetailsUtils = {
   isForgetModalOpen,
   getVaultAccountsMap,
-  getSignatoryName,
 };
 
 function isNotStarted(step: ReconnectStep, connected: boolean): boolean {
@@ -59,29 +56,4 @@ function getVaultAccountsMap(accounts: PolkadotVaultWallet['accounts']): VaultMa
 
     return acc;
   }, {});
-}
-
-function getSignatoryName(
-  signatoryId: AccountId,
-  txSignatories: Signatory[],
-  contacts: Contact[],
-  wallets: Wallet[],
-  addressPrefix?: number,
-): string {
-  const finderFn = <T extends { accountId: AccountId }>(collection: T[]): T | undefined => {
-    return collection.find(c => c.accountId === signatoryId);
-  };
-
-  // signatory data source priority: transaction -> contacts -> wallets -> address
-  const fromTx = finderFn(txSignatories)?.name;
-  if (fromTx) return fromTx;
-
-  const fromContact = finderFn(contacts)?.name;
-  if (fromContact) return fromContact;
-
-  const accounts = wallets.map(wallet => wallet.accounts).flat();
-  const fromAccount = finderFn(accounts)?.name;
-  if (fromAccount) return fromAccount;
-
-  return toShortAddress(toAddress(signatoryId, { prefix: addressPrefix }), 5);
 }

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -1,7 +1,7 @@
 import { useGate, useUnit } from 'effector-react';
 import { type ReactNode, useEffect, useMemo, useState } from 'react';
 
-import { type FlexibleMultisigWallet, type MultisigWallet, WalletType } from '@/shared/core';
+import { type Chain, type FlexibleMultisigWallet, type MultisigWallet, WalletType } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { useModalClose, useToggle } from '@/shared/lib/hooks';
@@ -10,17 +10,15 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HeadlineText, Icon, IconButton, Separator } from '@/shared/ui';
 import { AccountExplorers, Address, ChainIcon, WalletAccountIcon, WalletIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
-import { type AnyAccount, accountService, accounts } from '@/domains/network';
+import { type AnyAccount, accountService, accounts, useAccountName } from '@/domains/network';
 import { useWalletName } from '@/domains/network';
-import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { ContactItem, WalletCardMd, accountUtils, permissionUtils, walletModel } from '@/entities/wallet';
+import { ContactItem, WalletCardMd, accountUtils, permissionUtils } from '@/entities/wallet';
 import { ChangeSignatories } from '@/features/flexible-change-signatories';
 import { AddPureProxied } from '@/features/proxied-add-pure';
 import { AddProxy } from '@/features/proxy-add';
 import { RenameWallet } from '@/features/wallets/RenameWallet';
 import { NamedAccount } from '@/widgets/NameResolver';
-import { walletDetailsUtils } from '../../lib/utils';
 import { multisigWalletDetailsModel } from '../../model/multisig-wallet-details';
 import { walletDetailsModel } from '../../model/wallet-details-model';
 import { walletProxiesModel } from '../../model/wallet-proxies-model';
@@ -28,6 +26,22 @@ import { WalletFiatBalance } from '../components';
 import { ProxiesCount } from '../components/ProxiesCount';
 import { ProxiesList } from '../components/ProxiesList';
 import { type WalletAction, Action, WalletActions } from '../components/WalletActions';
+
+type SignatoryContactItemProps = {
+  accountId: AccountId;
+  chain: Chain | null;
+  children?: React.ReactNode;
+};
+
+const SignatoryContactItem = ({ accountId, chain, children }: SignatoryContactItemProps) => {
+  const name = useAccountName({ accountId, chain });
+
+  return (
+    <ContactItem address={accountId} addressPrefix={chain?.addressPrefix} name={name}>
+      {children}
+    </ContactItem>
+  );
+};
 
 type Props = {
   wallet: MultisigWallet | FlexibleMultisigWallet;
@@ -49,8 +63,6 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const signatories = useUnit(multisigWalletDetailsModel.$signatories);
   const accountList = useUnit(accounts.$list);
   const proxiesCount = useUnit(walletProxiesModel.$walletProxiesCount);
-  const contacts = useUnit(contactModel.$contacts);
-  const walletsList = useUnit(walletModel.$wallets);
 
   const [isModalOpen, closeModal] = useModalClose(true, onClose);
   const [isRenameInputOpen, toggleIsRenameInputOpen] = useToggle();
@@ -65,14 +77,6 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
       closeModal();
     }
   }, [multisigAccount, closeModal]);
-
-  const getSignatoryName = (accountId: AccountId) => {
-    if (nullable(multisigAccount)) {
-      return '';
-    }
-
-    return walletDetailsUtils.getSignatoryName(accountId, multisigAccount.signatories, contacts, walletsList);
-  };
 
   let chain = null;
   if (nonNullable(multisigAccount)) {
@@ -180,9 +184,9 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
             ))}
             {signatories.people.map(accountId => (
               <li key={accountId} className="-mx-2">
-                <ContactItem address={accountId} addressPrefix={chain.addressPrefix} name={getSignatoryName(accountId)}>
+                <SignatoryContactItem accountId={accountId} chain={chain}>
                   <AccountExplorers accountId={accountId} chain={chain} />
-                </ContactItem>
+                </SignatoryContactItem>
               </li>
             ))}
           </ul>

--- a/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/MultisigWalletDetails.tsx
@@ -10,16 +10,14 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HeadlineText, IconButton, Separator } from '@/shared/ui';
 import { Address, ChainAccountsList, RootExplorers, WalletAccountIcon } from '@/shared/ui-entities';
 import { Box, Modal, ScrollArea, Tabs } from '@/shared/ui-kit';
-import { accountService, accounts, useWalletName } from '@/domains/network';
+import { accountService, accounts, useAccountName, useWalletName } from '@/domains/network';
 import { type AnyAccount } from '@/domains/network';
-import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
-import { ContactItem, WalletCardMd, accountUtils, permissionUtils, walletModel } from '@/entities/wallet';
+import { ContactItem, WalletCardMd, accountUtils, permissionUtils } from '@/entities/wallet';
 import { AddPureProxied } from '@/features/proxied-add-pure';
 import { AddProxy } from '@/features/proxy-add';
 import { ForgetWalletConfirm } from '@/features/wallets/ForgetWallet';
 import { RenameWallet } from '@/features/wallets/RenameWallet';
-import { walletDetailsUtils } from '../../lib/utils';
 import { multisigWalletDetailsModel } from '../../model/multisig-wallet-details';
 import { walletDetailsModel } from '../../model/wallet-details-model';
 import { walletProxiesModel } from '../../model/wallet-proxies-model';
@@ -29,6 +27,21 @@ import { ProxiesList } from '../components/ProxiesList';
 import { type WalletAction, Action, WalletActions } from '../components/WalletActions';
 
 export const overviewSlot = createSlot<{ walletAccounts: AnyAccount[] }>();
+
+type SignatoryContactItemProps = {
+  accountId: AccountId;
+  children?: React.ReactNode;
+};
+
+const SignatoryContactItem = ({ accountId, children }: SignatoryContactItemProps) => {
+  const name = useAccountName({ accountId, chain: null });
+
+  return (
+    <ContactItem address={accountId} name={name}>
+      {children}
+    </ContactItem>
+  );
+};
 
 type Props = {
   wallet: MultisigWallet | FlexibleMultisigWallet;
@@ -45,8 +58,6 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const chains = useUnit(networkModel.$chains);
   const hasProxies = useUnit(multisigWalletDetailsModel.$hasProxies);
   const signatories = useUnit(multisigWalletDetailsModel.$signatories);
-  const contacts = useUnit(contactModel.$contacts);
-  const walletsList = useUnit(walletModel.$wallets);
 
   const accountList = useUnit(accounts.$list);
   const proxiesCount = useUnit(walletProxiesModel.$walletProxiesCount);
@@ -57,10 +68,6 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
   const walletAccounts = accountService.filterAccountsByWallet(accountList, wallet.id);
   const multisigAccount = walletAccounts.find(accountUtils.isMultisigAccount);
   assert(multisigAccount, 'Multisig account not found.');
-
-  const getSignatoryName = (accountId: AccountId) => {
-    return walletDetailsUtils.getSignatoryName(accountId, multisigAccount.signatories, contacts, walletsList);
-  };
 
   // Check for deprecated multichain multisig accounts
   const multisigChains = useMemo(() => {
@@ -199,9 +206,9 @@ export const MultisigWalletDetails = ({ wallet, onClose }: Props) => {
                 <ul className="flex flex-col gap-y-2 text-footnote text-text-secondary">
                   {signatories.people.map(accountId => (
                     <li key={accountId} className="px-3">
-                      <ContactItem address={accountId} name={getSignatoryName(toAccountId(accountId))}>
+                      <SignatoryContactItem accountId={toAccountId(accountId)}>
                         <RootExplorers accountId={accountId} />
-                      </ContactItem>
+                      </SignatoryContactItem>
                     </li>
                   ))}
                 </ul>

--- a/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
+++ b/src/renderer/features/wallets/ForgetWallet/ui/ForgetWalletConfirm.tsx
@@ -5,6 +5,7 @@ import { type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { Animation, FootnoteText, SmallTitleText } from '@/shared/ui';
 import { Box, Checkbox, ConfirmModal, useNotification } from '@/shared/ui-kit';
+import { useWalletName } from '@/domains/network';
 import { walletUtils } from '@/entities/wallet';
 import { selectedWalletMultisigOperations } from '@/aggregates/selected-wallet-multisig-operations';
 import { forgetWalletModel } from '../model/forget-wallet-model';
@@ -134,6 +135,7 @@ type ForgetWalletProps = Props & {
 
 const ForgetWallet = ({ wallet, onClose, onForget, children, isModalOpen, setIsModalOpen }: ForgetWalletProps) => {
   const { t } = useI18n();
+  const walletName = useWalletName(wallet);
 
   const notification = useNotification();
 
@@ -196,9 +198,7 @@ const ForgetWallet = ({ wallet, onClose, onForget, children, isModalOpen, setIsM
       confirmText={t('walletDetails.common.forgetButton')}
       type="warning"
       title={t('walletDetails.common.removeWalletTitle')}
-      description={
-        <span className="break-all">{t('walletDetails.common.removeWalletDesc', { walletName: wallet.name })}</span>
-      }
+      description={<span className="break-all">{t('walletDetails.common.removeWalletDesc', { walletName })}</span>}
       onCancel={onClose}
       onConfirm={forgetWallet}
     >

--- a/src/renderer/widgets/NameResolver/index.ts
+++ b/src/renderer/widgets/NameResolver/index.ts
@@ -1,1 +1,3 @@
+export { AccountName } from './ui/AccountName';
 export { NamedAccount } from './ui/NamedAccount';
+export { WalletName } from './ui/WalletName';

--- a/src/renderer/widgets/NameResolver/ui/AccountName.tsx
+++ b/src/renderer/widgets/NameResolver/ui/AccountName.tsx
@@ -1,0 +1,17 @@
+import { memo } from 'react';
+
+import { type Chain } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { useAccountName } from '@/domains/network';
+
+type Props = {
+  accountId: AccountId | null | undefined;
+  chain?: Chain | null;
+  title?: string;
+};
+
+export const AccountName = memo(({ accountId, chain, title }: Props) => {
+  const name = useAccountName({ accountId, chain, title });
+
+  return name ?? null;
+});

--- a/src/renderer/widgets/NameResolver/ui/WalletName.tsx
+++ b/src/renderer/widgets/NameResolver/ui/WalletName.tsx
@@ -1,0 +1,14 @@
+import { memo } from 'react';
+
+import { type Wallet } from '@/shared/core';
+import { useWalletName } from '@/domains/network';
+
+type Props = {
+  wallet: Wallet | null | undefined;
+};
+
+export const WalletName = memo(({ wallet }: Props) => {
+  const name = useWalletName(wallet);
+
+  return name;
+});


### PR DESCRIPTION
Description

  Address book contact names were not being displayed in multisig operations and other places throughout the
  application. When viewing signatories, the old names stored when the multisig was created were shown instead
  of the contact names from the address book.

  The root cause was duplicate getSignatoryName() functions with incorrect priority order that prioritized
  transaction signatories over contacts. This PR refactors all name resolution to use the centralized
  useAccountName and useWalletName hooks from @/domains/network, which correctly prioritize contacts over stored
   names.

  Related Issues

  Related to address book name resolution issues in multisig operations.

  Changes Made

  New Components

  - Added AccountName component in widgets/NameResolver - encapsulates account name resolution
  - Added WalletName component in widgets/NameResolver - encapsulates wallet name resolution

  Refactored Components

  - Multisig Operations: OperationSignatories, LogModal, Operation, Details - now use centralized name
  resolution hooks
  - Signatory Selection: All 3 Signatory.tsx components (multisig-wallet, flexible-multisig,
  flexible-change-signatories) - use useWalletsNames and useAccountsNames
  - Call Data Execute: InitiatorSelect, SignatorySelect - use useWalletsNames
  - Wallet Details: MultisigWalletDetails, FlexibleWalletDetails - created SignatoryContactItem component using
  useAccountName
  - Other: ForgetWalletConfirm, Signer, ProxyWalletAlert, AccountStructureNode, AccountsModal - use centralized
  hooks

  Cleanup

  - Removed duplicate getSignatoryName function from operationDetailsUtils.ts
  - Removed duplicate getSignatoryName function from walletDetailsUtils.ts
## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->
<img width="1494" height="812" alt="image" src="https://github.com/user-attachments/assets/6db4e39d-9d57-4065-8f9f-5ee7dde6ea86" />

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
