### PR TITLE
fix: electron app after new proxy setup

### DIFF
--- a/src/main/factories/proxy.ts
+++ b/src/main/factories/proxy.ts
@@ -10,10 +10,8 @@ type FetchResult = Pick<Response, 'ok' | 'status' | 'statusText'> & {
 };
 
 export function setupProxy() {
-  const authSession = session.fromPartition('persist:auth');
-
   ipcMain.handle(IPC.PROXY.FETCH, async (_, url: string, init?: FetchInit): Promise<FetchResult> => {
-    const response = await authSession.fetch(url, {
+    const response = await session.fromPartition('persist:auth').fetch(url, {
       method: init?.method,
       headers: init?.headers,
       body: init?.body,


### PR DESCRIPTION
## Description
Fixes a crash on startup where the Electron app threw TypeError: Session can only be received when app is ready. The session.fromPartition('persist:auth') call in setupProxy() was executed at module load time, before app.whenReady() resolved. Moving it inside the IPC handler ensures it's only called after the app is ready.

## Related Issues
Closes SPEK-153

## Changes Made
Deferred session.fromPartition('persist:auth') from eager initialization at setupProxy() call time to lazy evaluation inside the ipcMain.handle callback in src/main/factories/proxy.ts

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
