### PR TITLE
fix(contacts): add read-only indicator on backend contacts (SPEK-165)

### DIFF
--- a/src/renderer/entities/contact/ui/BackendContactRow.tsx
+++ b/src/renderer/entities/contact/ui/BackendContactRow.tsx
@@ -2,9 +2,9 @@ import { Fragment } from 'react';
 
 import { type BackendContact, type Contact } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { FootnoteText, IconButton, Plate } from '@/shared/ui';
+import { FootnoteText, Icon, IconButton, Plate } from '@/shared/ui';
 import { Address } from '@/shared/ui-entities';
-import { Copy, Label } from '@/shared/ui-kit';
+import { Copy, Label, Tooltip } from '@/shared/ui-kit';
 
 type Props = {
   contact: BackendContact;
@@ -30,6 +30,15 @@ export const BackendContactRow = ({ contact, onSendTo }: Props) => {
             <Copy value={contact.address} notification={t('general.notifications.addressCopied')}>
               <IconButton className="shrink-0 text-icon-default" name="copy" />
             </Copy>
+            <Tooltip enableHover delay={200}>
+              <Tooltip.Trigger>
+                <div className="flex items-center gap-x-1 text-text-tertiary">
+                  <Icon name="lock" size={14} />
+                  <FootnoteText className="text-text-tertiary">{t('addressBook.backendContact.synced')}</FootnoteText>
+                </div>
+              </Tooltip.Trigger>
+              <Tooltip.Content>{t('addressBook.backendContact.managedTooltip')}</Tooltip.Content>
+            </Tooltip>
           </div>
         </div>
 
@@ -39,10 +48,7 @@ export const BackendContactRow = ({ contact, onSendTo }: Props) => {
           {contact.chainName && <Label variant="lightBlue">{contact.chainName}</Label>}
           {contact.entityNames.map((entityName) => (
             <Fragment key={entityName}>
-              <FootnoteText className="text-text-tertiary">
-                {/* eslint-disable-next-line i18next/no-literal-string */}
-                {'\u00b7'}
-              </FootnoteText>
+              <FootnoteText className="text-text-tertiary">{'\u00b7'}</FootnoteText>
               <Label variant="purple">{entityName}</Label>
             </Fragment>
           ))}

--- a/src/renderer/entities/contact/ui/__tests__/BackendContactRow.test.tsx
+++ b/src/renderer/entities/contact/ui/__tests__/BackendContactRow.test.tsx
@@ -1,0 +1,44 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { type Address } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { BackendContactRow } from '../BackendContactRow';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: jest.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+const mockContact = {
+  id: '1',
+  name: 'Alice',
+  address: '5GrwvaEF5zXb26Fz9rcQpDWS57CtERHpNehXCPcNoHGKutQY' as Address,
+  accountId: '0xd43593c715fdd31c61141abd04a99fd6822c8558854ccde39a5684e7a56da27d' as AccountId,
+  source: 'backend' as const,
+  entityNames: ['Parity'],
+  chainId: '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3',
+  chainName: 'Polkadot',
+  categoryName: 'Internal',
+  contactTypeName: 'Validator',
+  derivationPath: null,
+  ownerAccountId: null,
+};
+
+describe('entities/contact/ui/BackendContactRow', () => {
+  test('should render contact with lock icon and synced label', () => {
+    render(<BackendContactRow contact={mockContact} />);
+
+    expect(screen.getByText('addressBook.backendContact.synced')).toBeInTheDocument();
+  });
+
+  test('should render contact labels', () => {
+    render(<BackendContactRow contact={mockContact} />);
+
+    expect(screen.getByText('Internal')).toBeInTheDocument();
+    expect(screen.getByText('Validator')).toBeInTheDocument();
+    expect(screen.getByText('Polkadot')).toBeInTheDocument();
+    expect(screen.getByText('Parity')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -139,7 +139,9 @@
       "category": "Category",
       "contactType": "Type",
       "chain": "Chain",
-      "entity": "Entity"
+      "entity": "Entity",
+      "synced": "Synced",
+      "managedTooltip": "This contact is managed by the backend server"
     },
     "title": "Address Book",
     "undo": "Undo"


### PR DESCRIPTION
## Description

Add a lock icon and "Synced" label to `BackendContactRow` with a tooltip explaining the contact is managed by the backend server — making it clear which contacts are read-only.

## Related Issues

SPEK-165

## Changes Made

- Added lock icon + "Synced" badge to `BackendContactRow`
- Tooltip on hover explains the contact is server-managed
- New i18n keys for the read-only indicator

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines