### PR TITLE
fix(settings): add backend configuration section to Settings page (SP…

### DIFF
--- a/src/renderer/pages/Settings/Overview/Overview.tsx
+++ b/src/renderer/pages/Settings/Overview/Overview.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 import { useI18n } from '@/shared/i18n';
 import { Header } from '@/shared/ui';
 
-import { GeneralActions, SocialLinks, Version } from './components';
+import { BackendSyncSettings, GeneralActions, SocialLinks, Version } from './components';
 
 export const Overview = () => {
   const { t } = useI18n();
@@ -16,6 +16,7 @@ export const Overview = () => {
         <section className="mt-4 h-full w-full overflow-y-auto">
           <div className="mx-auto flex w-[546px] flex-col gap-y-4">
             <GeneralActions />
+            <BackendSyncSettings />
             <SocialLinks />
             <Version />
           </div>

--- a/src/renderer/pages/Settings/Overview/components/BackendSyncSettings/BackendSyncSettings.tsx
+++ b/src/renderer/pages/Settings/Overview/components/BackendSyncSettings/BackendSyncSettings.tsx
@@ -1,0 +1,52 @@
+import { useUnit } from 'effector-react';
+
+import { useI18n } from '@/shared/i18n';
+import { BodyText, Button, FootnoteText, Icon } from '@/shared/ui';
+import { Plate } from '@/shared/ui';
+import { authModel, backendConfigurationModel } from '@/features/contacts';
+
+export const BackendSyncSettings = () => {
+  const { t } = useI18n();
+
+  const hasBackend = useUnit(backendConfigurationModel.$hasBackend);
+  const backendUrl = useUnit(backendConfigurationModel.$backendUrl);
+  const isAuthenticated = useUnit(authModel.$isAuthenticated);
+
+  const handleConfigure = () => {
+    backendConfigurationModel.events.editStarted();
+  };
+
+  const handleAdd = () => {
+    backendConfigurationModel.events.modalOpened();
+  };
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <FootnoteText className="text-text-tertiary">{t('settings.backendSync.title')}</FootnoteText>
+      <Plate className="p-0">
+        {hasBackend ? (
+          <div className="flex w-full items-center gap-x-2 rounded-sm p-3">
+            <Icon name="globe" size={36} />
+            <div className="flex min-w-0 flex-1 flex-col">
+              <BodyText className="truncate">{backendUrl}</BodyText>
+              <FootnoteText className={isAuthenticated ? 'text-icon-positive' : 'text-text-tertiary'}>
+                {isAuthenticated ? t('settings.backendSync.connected') : t('settings.backendSync.disconnected')}
+              </FootnoteText>
+            </div>
+            <Button variant="text" size="sm" onClick={handleConfigure}>
+              {t('settings.backendSync.configureButton')}
+            </Button>
+          </div>
+        ) : (
+          <div className="flex w-full items-center gap-x-2 rounded-sm p-3">
+            <Icon name="globe" size={36} />
+            <BodyText className="flex-1 text-text-tertiary">{t('settings.backendSync.notConfigured')}</BodyText>
+            <Button variant="text" size="sm" onClick={handleAdd}>
+              {t('settings.backendSync.addButton')}
+            </Button>
+          </div>
+        )}
+      </Plate>
+    </div>
+  );
+};

--- a/src/renderer/pages/Settings/Overview/components/index.ts
+++ b/src/renderer/pages/Settings/Overview/components/index.ts
@@ -1,3 +1,4 @@
+export { BackendSyncSettings } from './BackendSyncSettings/BackendSyncSettings';
 export { GeneralActions, generalActionsSlot } from './GeneralActions/GeneralActions';
 export { SocialLinks } from './SocialLinks/SocialLinks';
 export { Version } from './Version/Version';

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2414,6 +2414,14 @@
   },
   "settings": {
     "autoUpdate": "Spektr auto updates",
+    "backendSync": {
+      "title": "Address Book Sync",
+      "notConfigured": "Not configured",
+      "connected": "Connected",
+      "disconnected": "Not connected",
+      "configureButton": "Configure",
+      "addButton": "Add Backend"
+    },
     "currency": {
       "cryptocurrenciesLabel": "Cryptocurrencies",
       "modalTitle": "Currency",


### PR DESCRIPTION
## Description

Add an "Address Book Sync" section to the Settings page showing the current backend connection status with configure/add backend buttons that open the `BackendConfigurationModal`.

## Related Issues

SPEK-164

## Changes Made

- Added `BackendSyncSettings` component to Settings Overview page
- Shows connected/disconnected/not-configured states
- "Configure" and "Add backend" buttons open the configuration modal
- New i18n keys for the settings section

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines