### PR TITLE
fix(contacts): add accessibility attributes to address book (SPEK-159)

### DIFF
--- a/src/renderer/entities/contact/ui/BackendContactRow.tsx
+++ b/src/renderer/entities/contact/ui/BackendContactRow.tsx
@@ -26,9 +26,18 @@ export const BackendContactRow = ({ contact, onSendTo }: Props) => {
             <Address address={contact.address} showIcon iconSize={20} variant="truncate" title={contact.name} />
           </div>
           <div className="ml-auto flex items-center gap-x-1">
-            <IconButton className="shrink-0 text-icon-default" name="sendArrow" onClick={handleSendTo} />
+            <IconButton
+              className="shrink-0 text-icon-default"
+              name="sendArrow"
+              ariaLabel={t('addressBook.a11y.sendTo', { name: contact.name })}
+              onClick={handleSendTo}
+            />
             <Copy value={contact.address} notification={t('general.notifications.addressCopied')}>
-              <IconButton className="shrink-0 text-icon-default" name="copy" />
+              <IconButton
+                className="shrink-0 text-icon-default"
+                name="copy"
+                ariaLabel={t('addressBook.a11y.copyAddress', { name: contact.name })}
+              />
             </Copy>
           </div>
         </div>

--- a/src/renderer/entities/contact/ui/ContactRow.tsx
+++ b/src/renderer/entities/contact/ui/ContactRow.tsx
@@ -43,15 +43,34 @@ export const ContactRow = ({ contact, onSendTo }: Props) => {
           <Address address={contact.address} showIcon iconSize={20} variant="truncate" title={contact.name} />
         </div>
         <div className="ml-auto flex items-center gap-x-1">
-          <IconButton className="shrink-0 text-icon-default" name="sendArrow" onClick={handleSendTo} />
+          <IconButton
+            className="shrink-0 text-icon-default"
+            name="sendArrow"
+            ariaLabel={t('addressBook.a11y.sendTo', { name: contact.name })}
+            onClick={handleSendTo}
+          />
 
           <Copy value={contact.address} notification={t('general.notifications.addressCopied')}>
-            <IconButton className="shrink-0 text-icon-default" name="copy" />
+            <IconButton
+              className="shrink-0 text-icon-default"
+              name="copy"
+              ariaLabel={t('addressBook.a11y.copyAddress', { name: contact.name })}
+            />
           </Copy>
 
-          <IconButton className="shrink-0 text-icon-default" name="edit" onClick={handleEdit} />
+          <IconButton
+            className="shrink-0 text-icon-default"
+            name="edit"
+            ariaLabel={t('addressBook.a11y.edit', { name: contact.name })}
+            onClick={handleEdit}
+          />
 
-          <IconButton className="shrink-0 text-icon-default" name="delete" onClick={handleDelete} />
+          <IconButton
+            className="shrink-0 text-icon-default"
+            name="delete"
+            ariaLabel={t('addressBook.a11y.delete', { name: contact.name })}
+            onClick={handleDelete}
+          />
         </div>
       </Plate>
     </li>

--- a/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
+++ b/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
@@ -205,13 +205,16 @@ export const Contacts = () => {
                     className={cnTw('shrink-0 text-icon-default', isLoading && 'animate-spin')}
                     disabled={isLoading}
                     name="refresh"
+                    ariaLabel={t('addressBook.a11y.syncContacts')}
                     onClick={handleSync}
                   />
                 )}
               </div>
             )}
 
-            {renderViewState(viewState, handleSendTo, handleSync)}
+            <div aria-live="polite" aria-busy={viewState.view === 'loading'}>
+              {renderViewState(viewState, handleSendTo, handleSync)}
+            </div>
           </div>
         </section>
       </div>

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -142,7 +142,14 @@
       "entity": "Entity"
     },
     "title": "Address Book",
-    "undo": "Undo"
+    "undo": "Undo",
+    "a11y": {
+      "sendTo": "Send to {name}",
+      "copyAddress": "Copy address for {name}",
+      "edit": "Edit {name}",
+      "delete": "Delete {name}",
+      "syncContacts": "Sync contacts"
+    }
   },
   "assetBalance": {
     "locked": "Locked",


### PR DESCRIPTION
## Description

Add accessibility attributes to the Address Book contact list: `aria-label` on all `IconButton`s in `ContactRow`, `BackendContactRow`, and `Contacts`, plus an `aria-live` region with `aria-busy` on the contact list to announce content changes to screen readers.

## Related Issues

SPEK-159

## Changes Made

- Added `aria-label` to edit, delete, copy IconButtons in `ContactRow`
- Added `aria-label` to copy IconButton in `BackendContactRow`
- Wrapped contact list in `aria-live="polite"` region with `aria-busy` during loading
- New i18n keys for accessibility labels

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines