### PR TITLE
Fix/spek 157 alert error view

### DIFF
--- a/src/renderer/entities/contact/index.ts
+++ b/src/renderer/entities/contact/index.ts
@@ -1,2 +1,12 @@
-export { BackendContactRow, ContactList, ContactRow, EmptyContactList, EmptyFilteredContacts } from './ui';
+export {
+  BackendContactRow,
+  BackendErrorView,
+  BackendLoadingView,
+  ContactList,
+  ContactRow,
+  ContactSkeleton,
+  EmptyBackendView,
+  EmptyContactList,
+  EmptyFilteredContacts,
+} from './ui';
 export { contactModel } from './model/contact-model';

--- a/src/renderer/entities/contact/ui/BackendErrorView.tsx
+++ b/src/renderer/entities/contact/ui/BackendErrorView.tsx
@@ -1,0 +1,24 @@
+import { useI18n } from '@/shared/i18n';
+import { BodyText, Button, Icon } from '@/shared/ui';
+
+type Props = {
+  error: string;
+  onRetry: () => void;
+};
+
+export const BackendErrorView = ({ error, onRetry }: Props) => {
+  const { t } = useI18n();
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-badge-red-background-default">
+        <Icon name="warnCutout" size={20} className="text-text-negative" />
+      </div>
+      <BodyText className="text-text-tertiary">{t('addressBook.sources.loadError')}</BodyText>
+      <BodyText className="max-w-full text-center text-caption break-all text-text-tertiary">{error}</BodyText>
+      <Button variant="text" className="h-4.5" onClick={onRetry}>
+        {t('addressBook.sources.retry')}
+      </Button>
+    </div>
+  );
+};

--- a/src/renderer/entities/contact/ui/BackendErrorView.tsx
+++ b/src/renderer/entities/contact/ui/BackendErrorView.tsx
@@ -1,22 +1,44 @@
 import { useI18n } from '@/shared/i18n';
-import { BodyText, Button, Icon } from '@/shared/ui';
+import { Alert, Button, CaptionText } from '@/shared/ui';
 
 type Props = {
   error: string;
   onRetry: () => void;
 };
 
+function getErrorMessageKey(error: string): string {
+  const lower = error.toLowerCase();
+
+  if (lower.includes('401') || lower.includes('403') || lower.includes('unauthorized') || lower.includes('forbidden')) {
+    return 'addressBook.sources.errorAuth';
+  }
+
+  if (lower.includes('timeout') || lower.includes('timed out') || lower.includes('aborted')) {
+    return 'addressBook.sources.errorTimeout';
+  }
+
+  if (
+    lower.includes('fetch') ||
+    lower.includes('network') ||
+    lower.includes('econnrefused') ||
+    lower.includes('cors') ||
+    lower.includes('dns')
+  ) {
+    return 'addressBook.sources.errorNetwork';
+  }
+
+  return 'addressBook.sources.errorGeneric';
+}
+
 export const BackendErrorView = ({ error, onRetry }: Props) => {
   const { t } = useI18n();
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-badge-red-background-default">
-        <Icon name="warnCutout" size={20} className="text-text-negative" />
-      </div>
-      <BodyText className="text-text-tertiary">{t('addressBook.sources.loadError')}</BodyText>
-      <BodyText className="max-w-full text-center text-caption break-all text-text-tertiary">{error}</BodyText>
-      <Button variant="text" className="h-4.5" onClick={onRetry}>
+    <div className="flex flex-col gap-y-3 py-4">
+      <Alert title={t(getErrorMessageKey(error))} active variant="error">
+        <CaptionText className="break-all text-text-tertiary">{error}</CaptionText>
+      </Alert>
+      <Button variant="text" className="h-4.5 self-center" onClick={onRetry}>
         {t('addressBook.sources.retry')}
       </Button>
     </div>

--- a/src/renderer/entities/contact/ui/BackendLoadingView.tsx
+++ b/src/renderer/entities/contact/ui/BackendLoadingView.tsx
@@ -1,0 +1,11 @@
+import { ContactSkeleton } from './ContactSkeleton';
+
+export const BackendLoadingView = () => (
+  <ul className="flex flex-col gap-y-2">
+    {Array.from({ length: 5 }).map((_, i) => (
+      <li key={i}>
+        <ContactSkeleton />
+      </li>
+    ))}
+  </ul>
+);

--- a/src/renderer/entities/contact/ui/ContactSkeleton.tsx
+++ b/src/renderer/entities/contact/ui/ContactSkeleton.tsx
@@ -1,0 +1,16 @@
+export const ContactSkeleton = () => (
+  <div className="flex animate-pulse flex-col gap-y-2.5 rounded-md bg-white p-3">
+    <div className="flex items-center gap-x-2">
+      <div className="h-5 w-5 rounded-full bg-shade-12" />
+      <div className="flex flex-col gap-y-1">
+        <div className="h-3.5 w-24 rounded bg-shade-12" />
+        <div className="h-3 w-40 rounded bg-shade-8" />
+      </div>
+    </div>
+    <div className="flex gap-x-1">
+      <div className="h-5 w-14 rounded-2xl bg-shade-8" />
+      <div className="h-5 w-20 rounded-2xl bg-shade-8" />
+      <div className="h-5 w-16 rounded-2xl bg-shade-8" />
+    </div>
+  </div>
+);

--- a/src/renderer/entities/contact/ui/EmptyBackendView.tsx
+++ b/src/renderer/entities/contact/ui/EmptyBackendView.tsx
@@ -1,15 +1,15 @@
 import { useI18n } from '@/shared/i18n';
-import { BodyText, Icon } from '@/shared/ui';
+import { BodyText } from '@/shared/ui';
+import { Graphics } from '@/shared/ui-kit';
 
 export const EmptyBackendView = () => {
   const { t } = useI18n();
 
   return (
-    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-input-background-disabled">
-        <Icon name="globe" size={20} className="text-text-tertiary" />
-      </div>
+    <div className="flex h-full flex-col items-center justify-center gap-y-4">
+      <Graphics name="emptyList" alt={t('addressBook.sources.emptyBackend')} size={178} />
       <BodyText className="text-text-tertiary">{t('addressBook.sources.emptyBackend')}</BodyText>
+      <BodyText className="text-center text-text-tertiary">{t('addressBook.sources.emptyBackendDescription')}</BodyText>
     </div>
   );
 };

--- a/src/renderer/entities/contact/ui/EmptyBackendView.tsx
+++ b/src/renderer/entities/contact/ui/EmptyBackendView.tsx
@@ -1,0 +1,15 @@
+import { useI18n } from '@/shared/i18n';
+import { BodyText, Icon } from '@/shared/ui';
+
+export const EmptyBackendView = () => {
+  const { t } = useI18n();
+
+  return (
+    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
+      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-input-background-disabled">
+        <Icon name="globe" size={20} className="text-text-tertiary" />
+      </div>
+      <BodyText className="text-text-tertiary">{t('addressBook.sources.emptyBackend')}</BodyText>
+    </div>
+  );
+};

--- a/src/renderer/entities/contact/ui/__tests__/BackendErrorView.test.tsx
+++ b/src/renderer/entities/contact/ui/__tests__/BackendErrorView.test.tsx
@@ -11,18 +11,42 @@ vi.mock('@/shared/i18n', () => ({
 }));
 
 describe('entities/contact/ui/BackendErrorView', () => {
-  test('should render error message and retry button', () => {
+  test('should render Alert with error message and retry button', () => {
     const onRetry = vi.fn();
     render(<BackendErrorView error="Network error" onRetry={onRetry} />);
 
-    expect(screen.getByText('addressBook.sources.loadError')).toBeInTheDocument();
+    expect(screen.getByTestId('alert')).toBeInTheDocument();
     expect(screen.getByText('Network error')).toBeInTheDocument();
     expect(screen.getByText('addressBook.sources.retry')).toBeInTheDocument();
   });
 
+  test('should show network error message for fetch errors', () => {
+    render(<BackendErrorView error="Failed to fetch" onRetry={vi.fn()} />);
+
+    expect(screen.getByText('addressBook.sources.errorNetwork')).toBeInTheDocument();
+  });
+
+  test('should show auth error message for 401 errors', () => {
+    render(<BackendErrorView error="401 Unauthorized" onRetry={vi.fn()} />);
+
+    expect(screen.getByText('addressBook.sources.errorAuth')).toBeInTheDocument();
+  });
+
+  test('should show timeout error message for timeout errors', () => {
+    render(<BackendErrorView error="Request timed out" onRetry={vi.fn()} />);
+
+    expect(screen.getByText('addressBook.sources.errorTimeout')).toBeInTheDocument();
+  });
+
+  test('should show generic error for unknown errors', () => {
+    render(<BackendErrorView error="Something unexpected" onRetry={vi.fn()} />);
+
+    expect(screen.getByText('addressBook.sources.errorGeneric')).toBeInTheDocument();
+  });
+
   test('should call onRetry when retry button is clicked', async () => {
     const onRetry = vi.fn();
-    render(<BackendErrorView error="Network error" onRetry={onRetry} />);
+    render(<BackendErrorView error="Error" onRetry={onRetry} />);
 
     await userEvent.click(screen.getByText('addressBook.sources.retry'));
     expect(onRetry).toHaveBeenCalledTimes(1);

--- a/src/renderer/entities/contact/ui/__tests__/BackendErrorView.test.tsx
+++ b/src/renderer/entities/contact/ui/__tests__/BackendErrorView.test.tsx
@@ -1,0 +1,30 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi } from 'vitest';
+
+import { BackendErrorView } from '../BackendErrorView';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: jest.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('entities/contact/ui/BackendErrorView', () => {
+  test('should render error message and retry button', () => {
+    const onRetry = vi.fn();
+    render(<BackendErrorView error="Network error" onRetry={onRetry} />);
+
+    expect(screen.getByText('addressBook.sources.loadError')).toBeInTheDocument();
+    expect(screen.getByText('Network error')).toBeInTheDocument();
+    expect(screen.getByText('addressBook.sources.retry')).toBeInTheDocument();
+  });
+
+  test('should call onRetry when retry button is clicked', async () => {
+    const onRetry = vi.fn();
+    render(<BackendErrorView error="Network error" onRetry={onRetry} />);
+
+    await userEvent.click(screen.getByText('addressBook.sources.retry'));
+    expect(onRetry).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/entities/contact/ui/__tests__/EmptyBackendView.test.tsx
+++ b/src/renderer/entities/contact/ui/__tests__/EmptyBackendView.test.tsx
@@ -1,0 +1,20 @@
+import { render, screen } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { EmptyBackendView } from '../EmptyBackendView';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: jest.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+describe('entities/contact/ui/EmptyBackendView', () => {
+  test('should render empty state with Graphics and description', () => {
+    render(<EmptyBackendView />);
+
+    expect(screen.getByText('addressBook.sources.emptyBackend')).toBeInTheDocument();
+    expect(screen.getByText('addressBook.sources.emptyBackendDescription')).toBeInTheDocument();
+    expect(screen.getByRole('img')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/entities/contact/ui/index.ts
+++ b/src/renderer/entities/contact/ui/index.ts
@@ -1,5 +1,9 @@
 export { BackendContactRow } from './BackendContactRow';
+export { BackendErrorView } from './BackendErrorView';
+export { BackendLoadingView } from './BackendLoadingView';
 export { ContactRow } from './ContactRow';
 export { ContactList } from './ContactList';
+export { ContactSkeleton } from './ContactSkeleton';
+export { EmptyBackendView } from './EmptyBackendView';
 export { EmptyContactList } from './EmptyContactList';
 export { EmptyFilteredContacts } from './EmptyFilteredContacts';

--- a/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
+++ b/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
@@ -4,10 +4,13 @@ import { Outlet } from 'react-router-dom';
 import { type Contact, isBackendContact, isLocalContact } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
-import { BodyText, Button, Header, Icon, IconButton } from '@/shared/ui';
+import { Header, IconButton } from '@/shared/ui';
 import {
   BackendContactRow,
+  BackendErrorView,
+  BackendLoadingView,
   ContactRow,
+  EmptyBackendView,
   EmptyContactList,
   EmptyFilteredContacts,
   contactModel,
@@ -53,69 +56,12 @@ function computeViewState(params: {
   return { view: 'contacts', items: filteredContacts };
 }
 
-const ContactSkeleton = () => (
-  <div className="flex animate-pulse flex-col gap-y-2.5 rounded-md bg-white p-3">
-    <div className="flex items-center gap-x-2">
-      <div className="h-5 w-5 rounded-full bg-shade-12" />
-      <div className="flex flex-col gap-y-1">
-        <div className="h-3.5 w-24 rounded bg-shade-12" />
-        <div className="h-3 w-40 rounded bg-shade-8" />
-      </div>
-    </div>
-    <div className="flex gap-x-1">
-      <div className="h-5 w-14 rounded-2xl bg-shade-8" />
-      <div className="h-5 w-20 rounded-2xl bg-shade-8" />
-      <div className="h-5 w-16 rounded-2xl bg-shade-8" />
-    </div>
-  </div>
-);
-
-const LoadingView = () => (
-  <ul className="flex flex-col gap-y-2">
-    {Array.from({ length: 5 }).map((_, i) => (
-      <li key={i}>
-        <ContactSkeleton />
-      </li>
-    ))}
-  </ul>
-);
-
-const ErrorView = ({ error, onRetry }: { error: string; onRetry: () => void }) => {
-  const { t } = useI18n();
-
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-badge-red-background-default">
-        <Icon name="warnCutout" size={20} className="text-text-negative" />
-      </div>
-      <BodyText className="text-text-tertiary">{t('addressBook.sources.loadError')}</BodyText>
-      <BodyText className="max-w-full text-center text-caption break-all text-text-tertiary">{error}</BodyText>
-      <Button variant="text" className="h-4.5" onClick={onRetry}>
-        {t('addressBook.sources.retry')}
-      </Button>
-    </div>
-  );
-};
-
-const EmptyBackendView = () => {
-  const { t } = useI18n();
-
-  return (
-    <div className="flex h-full flex-col items-center justify-center gap-y-3 py-12">
-      <div className="flex h-10 w-10 items-center justify-center rounded-full bg-input-background-disabled">
-        <Icon name="globe" size={20} className="text-text-tertiary" />
-      </div>
-      <BodyText className="text-text-tertiary">{t('addressBook.sources.emptyBackend')}</BodyText>
-    </div>
-  );
-};
-
 function renderViewState(viewState: ViewState, onSendTo: (contact: Contact) => void, onRetry: () => void) {
   switch (viewState.view) {
     case 'loading':
-      return <LoadingView />;
+      return <BackendLoadingView />;
     case 'error':
-      return <ErrorView error={viewState.message} onRetry={onRetry} />;
+      return <BackendErrorView error={viewState.message} onRetry={onRetry} />;
     case 'emptyBackend':
       return <EmptyBackendView />;
     case 'emptyLocal':

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -121,6 +121,7 @@
       "loading": "Loading contacts...",
       "loadError": "Failed to load contacts from server",
       "emptyBackend": "No contacts found on the server",
+      "emptyBackendDescription": "The connected server has no contacts. Contact your administrator or check the backend configuration.",
       "retry": "Retry"
     },
     "title": "Address Book",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -122,7 +122,11 @@
       "loadError": "Failed to load contacts from server",
       "emptyBackend": "No contacts found on the server",
       "emptyBackendDescription": "The connected server has no contacts. Contact your administrator or check the backend configuration.",
-      "retry": "Retry"
+      "retry": "Retry",
+      "errorNetwork": "Could not connect to the server. Check the URL and try again.",
+      "errorAuth": "Session expired. Please reconnect.",
+      "errorTimeout": "The server took too long to respond. Try again later.",
+      "errorGeneric": "Something went wrong."
     },
     "title": "Address Book",
     "undo": "Undo"

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -26,15 +26,12 @@
   },
   "addressBook": {
     "actions": {
-      "delete": "Delete",
-      "edit": "Edit"
+      "delete": "Delete"
     },
     "contactDeleted": "Contact deleted",
     "contactList": {
-      "emptySearchDescription": "Try to search for another name",
       "emptySearchLabel": "No contact with entered name were found",
       "nameColumnTitle": "Name",
-      "noContactsButton": "Add your first contact",
       "noContactsLabel": "The contact list is empty, you can add a new contact"
     },
     "createContact": {
@@ -89,24 +86,15 @@
       "tooltip": "Import address book from JSON file:",
       "wikiLink": "Wiki guidelines"
     },
-    "removeConfirm": {
-      "cancelButton": "Cancel",
-      "confirmButton": "Delete",
-      "description": "Are you sure you want to remove {name} from contacts?",
-      "title": "Delete contact"
-    },
     "auth": {
       "connectedAccountLabel": "Connected account",
       "connectionSuccess": "Connected successfully",
       "disconnectButton": "Disconnect",
       "errorTitle": "Authentication failed",
       "noExtensionAccounts": "No extension wallet accounts available",
-      "notConnected": "Not signed in",
       "selectAccountLabel": "Select account",
       "selectAccountPlaceholder": "Choose an account",
-      "signOutButton": "Sign out",
-      "signingMessage": "Waiting for signature...",
-      "signInSuccess": "Successfully signed in"
+      "signingMessage": "Waiting for signature..."
     },
     "backendConfiguration": {
       "addTitle": "Add Backend",
@@ -134,12 +122,6 @@
       "loadError": "Failed to load contacts from server",
       "emptyBackend": "No contacts found on the server",
       "retry": "Retry"
-    },
-    "backendContact": {
-      "category": "Category",
-      "contactType": "Type",
-      "chain": "Chain",
-      "entity": "Entity"
     },
     "title": "Address Book",
     "undo": "Undo"

--- a/tasks/SPEK-155-plan.md
+++ b/tasks/SPEK-155-plan.md
@@ -1,0 +1,240 @@
+# SPEK-155 Implementation Plan
+
+## Overview
+12 sub-issues for Address Book UX/UI improvements. Each gets its own branch off `dev`, a code fix, and a UI test (Vitest + React Testing Library) that renders the component to demonstrate the fix for screenshot purposes.
+
+## Execution Order & Dependencies
+
+### Phase 1: SPEK-168 (Cleanup — foundation for other tasks)
+**Branch:** `fix/SPEK-168-cleanup-inline-components`
+
+**Changes:**
+1. Extract from `Contacts.tsx` into separate files:
+   - `entities/contact/ui/ContactSkeleton.tsx` — the skeleton component
+   - `entities/contact/ui/BackendLoadingView.tsx` — renders 5 skeletons
+   - `entities/contact/ui/BackendErrorView.tsx` — error with retry
+   - `entities/contact/ui/EmptyBackendView.tsx` — empty state for backend tab
+2. Remove orphaned i18n keys from `en.json`:
+   - `addressBook.removeConfirm.*` (4 keys)
+   - `addressBook.contactList.emptySearchDescription`
+   - `addressBook.contactList.noContactsButton`
+   - `addressBook.auth.notConnected`, `signOutButton`, `signInSuccess`
+   - `addressBook.backendContact.*` (4 keys)
+   - `addressBook.actions.edit`
+   - Keep: `sources.syncButton`, `sources.loading`, `backendConfiguration.connectingMessage`, `connectionLabel`, `tooltip` (used by later tasks)
+3. Update `Contacts.tsx` to import from new locations
+4. Update `entities/contact` barrel export
+
+**Test:** `entities/contact/ui/__tests__/BackendErrorView.test.tsx` — renders error view, verifies retry button
+
+---
+
+### Phase 2: SPEK-156 (Shared Skeleton)
+**Branch:** `fix/SPEK-156-shared-skeleton`
+
+**Changes:**
+1. Rewrite `ContactSkeleton` using `<Skeleton>` from `@/shared/ui-kit`:
+   - Circle skeleton for avatar (width=5, circle)
+   - Rectangle skeletons for name (width=24, height=3.5)
+   - Rectangle skeletons for address (width=40, height=3)
+   - Label-shaped skeletons (width=14/20/16, height=5, rounded)
+2. Remove `animate-pulse` usage entirely
+
+**Test:** `entities/contact/ui/__tests__/ContactSkeleton.test.tsx` — renders skeleton, verifies `spektr-skeleton` class is used (not `animate-pulse`)
+
+---
+
+### Phase 3: SPEK-157 (Alert Error View)
+**Branch:** `fix/SPEK-157-alert-error-view`
+
+**Changes:**
+1. Rewrite `BackendErrorView` to use `Alert variant="error"`:
+   - Title: user-friendly message based on error type
+   - Secondary text: raw error message for debugging
+   - Retry `Button` below the alert
+2. Add error mapping utility:
+   - Network/fetch errors → "Could not connect to the server. Check the URL and try again."
+   - Auth/401/403 errors → "Session expired. Please reconnect."
+   - Timeout errors → "The server took too long to respond. Try again later."
+   - Default → "Something went wrong."
+3. Add new i18n keys: `addressBook.sources.errorNetwork`, `errorAuth`, `errorTimeout`, `errorGeneric`
+
+**Test:** `entities/contact/ui/__tests__/BackendErrorView.test.tsx` — renders with different error types, verifies Alert component and user-friendly messages
+
+---
+
+### Phase 4: SPEK-158 (Empty Backend View)
+**Branch:** `fix/SPEK-158-empty-backend-view`
+
+**Changes:**
+1. Rewrite `EmptyBackendView` to use `Graphics name="emptyList" size={178}` (matching `EmptyContactList`)
+2. Add contextual guidance text: "The connected server has no contacts. Contact your administrator or check the backend configuration."
+3. Add i18n key: `addressBook.sources.emptyBackendDescription`
+
+**Test:** `entities/contact/ui/__tests__/EmptyBackendView.test.tsx` — renders empty state, verifies Graphics component and description text
+
+---
+
+### Phase 5: SPEK-159 (Accessibility)
+**Branch:** `fix/SPEK-159-accessibility`
+
+**Changes:**
+1. Add `ariaLabel` props to IconButtons:
+   - `ContactRow.tsx`: sendArrow, copy, edit, delete (4 buttons)
+   - `BackendContactRow.tsx`: sendArrow, copy (2 buttons)
+   - `Contacts.tsx`: refresh/sync button (1 button)
+2. Add `aria-label` to `BackendConnectionCard` button element
+3. Wrap dynamic content area in `Contacts.tsx` with `aria-live="polite"`
+4. Add `aria-busy="true"` and sr-only loading text to `BackendLoadingView`
+5. Add i18n keys: `addressBook.a11y.sendTo`, `a11y.editContact`, `a11y.deleteContact`, `a11y.syncContacts`, `a11y.connectionLabel`
+6. Add `general.a11y.copyAddress` key
+
+**Test:** `entities/contact/ui/__tests__/BackendContactRow.test.tsx` — verifies aria-labels on buttons; `pages/AddressBook/__tests__/Contacts.test.tsx` — verifies aria-live region
+
+---
+
+### Phase 6: SPEK-160 (SyncStatusBadge)
+**Branch:** `fix/SPEK-160-sync-status-badge`
+
+**Changes:**
+1. In `backend-contacts-model.ts`:
+   - Add `$lastSyncTime` store (persisted to localStorage via `persist`)
+   - Add `$syncStatus` computed: `'idle' | 'syncing' | 'synced' | 'error'`
+   - Update on `fetchBackendContactsFx` lifecycle events
+2. Create `features/contacts/BackendContacts/ui/SyncStatusBadge.tsx`:
+   - "Synced 2m ago" with relative time (using `Intl.RelativeTimeFormat` or simple helper)
+   - "Syncing..." with spinner icon
+   - "Sync failed" with error indicator + retry click
+3. Replace bare refresh `IconButton` in `Contacts.tsx` with `<SyncStatusBadge />`
+4. Add i18n keys: `addressBook.sync.synced`, `syncing`, `failed`, `syncedAgo`
+
+**Test:** `features/contacts/BackendContacts/ui/__tests__/SyncStatusBadge.test.tsx` — renders all 3 states
+
+---
+
+### Phase 7: SPEK-165 (Read-only Indicator)
+**Branch:** `fix/SPEK-165-readonly-indicator`
+
+**Changes:**
+1. In `BackendContactRow.tsx`:
+   - Add lock icon + "Synced" `Label` in the action area (after copy button)
+   - Add `Tooltip` explaining "This contact is managed by the backend server"
+2. Add i18n keys: `addressBook.backendContact.synced`, `backendContact.managedTooltip`
+
+**Test:** `entities/contact/ui/__tests__/BackendContactRow.test.tsx` — verifies lock icon and "Synced" label presence
+
+---
+
+### Phase 8: SPEK-167 (Disconnected State + Sync Tooltip)
+**Branch:** `fix/SPEK-167-disconnected-state`
+
+**Changes:**
+1. `BackendConnectionCard.tsx`:
+   - When not authenticated: add warning border color, different background
+   - Add small "Reconnect" text or warning dot
+2. `AuthStatus.tsx`:
+   - When not authenticated: show "Not connected" text instead of returning null
+3. Wrap sync button in `Tooltip` with `t('addressBook.sources.syncButton')`
+
+**Test:** `features/contacts/BackendConfiguration/ui/__tests__/BackendConnectionCard.test.tsx` — renders connected vs disconnected states, verifies visual differences
+
+---
+
+### Phase 9: SPEK-162 (Session Expiry)
+**Branch:** `fix/SPEK-162-session-expiry`
+
+**Changes:**
+1. In `auth-model.ts`:
+   - Add `$sessionHealth` store: `'healthy' | 'expired' | 'unknown'`
+   - Add periodic `checkSessionFx` (every 5 minutes via `setInterval` in an init effect)
+   - On session check failure: set `$sessionHealth` to `'expired'` (don't clear auth state immediately)
+2. In `BackendConnectionCard.tsx`:
+   - When session expired: show warning badge/banner "Session expired — Reconnect"
+3. Add `AuthStatus.tsx` update: show expired state
+4. Add i18n keys: `addressBook.auth.sessionExpired`, `auth.reconnect`
+
+**Test:** `features/contacts/BackendConfiguration/ui/__tests__/AuthStatus.test.tsx` — renders healthy vs expired states
+
+---
+
+### Phase 10: SPEK-163 (Test Connection)
+**Branch:** `fix/SPEK-163-test-connection`
+
+**Changes:**
+1. In `backend-configuration-model.ts`:
+   - Add `$urlReachable` store: `null | 'checking' | 'reachable' | 'unreachable'`
+   - Add `checkUrlReachabilityFx` effect (HEAD request to health endpoint)
+   - Debounce URL changes (500ms) → trigger check when URL is syntactically valid
+2. In `BackendConfigurationModal.tsx`:
+   - Show inline indicator next to URL input: green checkmark / red X / spinner
+   - Keep Connect button disabled until URL is both valid and reachable
+3. Add i18n keys: `addressBook.backendConfiguration.checking`, `reachable`, `unreachable`
+
+**Test:** `features/contacts/BackendConfiguration/ui/__tests__/BackendConfigurationModal.test.tsx` — renders URL input with reachability states
+
+---
+
+### Phase 11: SPEK-164 (Settings Page)
+**Branch:** `fix/SPEK-164-settings-backend`
+
+**Changes:**
+1. Create `pages/Settings/Overview/components/BackendSyncSettings.tsx`:
+   - Show current backend URL + connection status (connected/disconnected)
+   - "Configure" button opens `BackendConfigurationModal`
+   - "Not configured" state with "Add Backend" button
+2. Add to `Overview.tsx` between `GeneralActions` and `SocialLinks`
+3. Add i18n keys: `settings.backendSync.title`, `notConfigured`, `connected`, `disconnected`, `configureButton`
+
+**Test:** `pages/Settings/Overview/components/__tests__/BackendSyncSettings.test.tsx` — renders configured vs unconfigured states
+
+---
+
+### Phase 12: SPEK-166 (Cached Contacts on Error)
+**Branch:** `fix/SPEK-166-cached-contacts`
+
+**Changes:**
+1. Update `computeViewState` in `Contacts.tsx`:
+   - New state: `{ view: 'staleContacts'; items: Contact[]; error: string }`
+   - When backend error + cached contacts exist → show contacts with warning banner
+   - When backend error + no cached contacts → show error view
+2. Add `Alert variant="warn"` banner at top of stale contacts list
+3. Add stale indicator when `$lastSyncTime` is > 1 hour old
+4. Add i18n keys: `addressBook.sources.staleWarning`, `lastSynced`
+
+**Test:** Contacts page test showing stale contacts with warning banner
+
+---
+
+## UI Test Strategy
+Each test uses Vitest + React Testing Library to render the component in isolation with mocked Effector stores. Tests verify:
+1. Correct component rendering (visual structure)
+2. Key elements present (for screenshot verification)
+3. Interaction behavior (click handlers, etc.)
+
+Pattern:
+```tsx
+import { render, screen } from '@testing-library/react';
+import { fork, allSettled } from 'effector';
+import { Provider } from 'effector-react';
+
+// Mock i18n
+vi.mock('@/shared/i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// Fork scope with test data
+const scope = fork({ values: [...] });
+
+render(
+  <Provider value={scope}>
+    <Component />
+  </Provider>
+);
+
+expect(screen.getByText(...)).toBeInTheDocument();
+```
+
+## Branch Strategy
+- All branches created from `dev`
+- Each branch is independent (can be reviewed/merged separately)
+- Naming: `fix/SPEK-{number}-{short-description}`

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,82 @@
+# SPEK-155: Address Book UX/UI Improvements
+
+## Sub-issues (12 total, each gets its own branch)
+
+### Phase 1: Foundation & Cleanup (do first — other tasks depend on these)
+- [ ] **SPEK-168** — Cleanup: extract inline components + remove orphaned i18n keys
+  - Branch: `fix/SPEK-168-cleanup-inline-components`
+  - Extract `ContactSkeleton`, `LoadingView`, `ErrorView`, `EmptyBackendView` from Contacts.tsx
+  - Remove unused i18n keys (keep ones needed by other subtasks)
+  - Write UI test for extracted components
+
+- [ ] **SPEK-156** — Replace custom skeletons with shared Skeleton component
+  - Branch: `fix/SPEK-156-shared-skeleton`
+  - Rewrite ContactSkeleton using `<Skeleton>` from `@/shared/ui-kit`
+  - Write UI test showing skeleton loading state
+
+- [ ] **SPEK-157** — Replace custom ErrorView with Alert component
+  - Branch: `fix/SPEK-157-alert-error-view`
+  - Use `Alert variant="error"` + retry Button
+  - Map error types to user-friendly messages
+  - Write UI test showing error state
+
+- [ ] **SPEK-158** — Align EmptyBackendView with shared empty state pattern
+  - Branch: `fix/SPEK-158-empty-backend-view`
+  - Use `Graphics name="emptyList"` or `EmptyMessage` pattern
+  - Add contextual guidance text
+  - Write UI test showing empty backend state
+
+### Phase 2: Accessibility
+- [ ] **SPEK-159** — Add accessibility improvements
+  - Branch: `fix/SPEK-159-accessibility`
+  - Add aria-labels to all IconButtons (ContactRow, BackendContactRow, Contacts)
+  - Add aria-label to BackendConnectionCard button
+  - Add aria-live region for dynamic content
+  - Add aria-busy + sr-only text to loading state
+  - Write UI test verifying aria attributes
+
+### Phase 3: Backend UX Enhancements
+- [ ] **SPEK-160** — Implement SyncStatusBadge with last sync time
+  - Branch: `fix/SPEK-160-sync-status-badge`
+  - Add `$lastSyncTime` and `$syncStatus` stores
+  - Create `SyncStatusBadge` component
+  - Replace bare refresh IconButton
+  - Write UI test showing sync states
+
+- [ ] **SPEK-165** — Add read-only visual indicator on backend contacts
+  - Branch: `fix/SPEK-165-readonly-indicator`
+  - Add lock icon + "Synced" label to BackendContactRow
+  - Add tooltip explaining read-only nature
+  - Write UI test showing the indicator
+
+- [ ] **SPEK-167** — Improve disconnected state visibility + sync tooltip
+  - Branch: `fix/SPEK-167-disconnected-state`
+  - Make BackendConnectionCard disconnected state more prominent
+  - Add tooltip to sync button
+  - Write UI test showing disconnected vs connected states
+
+### Phase 4: Advanced Features
+- [ ] **SPEK-162** — Add session expiry awareness and recovery UX
+  - Branch: `fix/SPEK-162-session-expiry`
+  - Periodic session health check
+  - Non-blocking "Session expired — Reconnect" banner
+  - Update BackendConnectionCard for expired session
+  - Write UI test showing session states
+
+- [ ] **SPEK-163** — Add backend URL reachability check ("Test Connection")
+  - Branch: `fix/SPEK-163-test-connection`
+  - Debounced health check on URL input
+  - Inline green checkmark / red X
+  - Write UI test showing connection check states
+
+- [ ] **SPEK-164** — Add backend configuration section to Settings page
+  - Branch: `fix/SPEK-164-settings-backend`
+  - Add "Address Book Sync" section to Settings Overview
+  - Show current backend status with link to modal
+  - Write UI test showing the settings section
+
+- [ ] **SPEK-166** — Show cached contacts on error + stale data indicator
+  - Branch: `fix/SPEK-166-cached-contacts`
+  - Show cached contacts with warning banner on sync error
+  - Stale data indicator when last sync is old
+  - Write UI test showing stale/cached states


### PR DESCRIPTION
## Description

Two changes stacked together:

1. **SPEK-168** — Extract `ContactSkeleton`, `BackendLoadingView`, `BackendErrorView`, and `EmptyBackendView` from `Contacts.tsx` into individual files under `entities/contact/ui`.
2. **SPEK-157** — Rewrite `BackendErrorView` to use the shared `Alert` component (`variant="error"`) with user-friendly error messages mapped from common error types (network, auth, timeout). The raw error string is shown as secondary text for debugging. Retry button is inside the alert card, left-aligned.

## Related Issues

SPEK-157, SPEK-168

## Changes Made

- Component extraction (same as SPEK-168 base)
- Replaced raw error text with `Alert` component using `variant="error"`
- Added `getErrorMessageKey()` to map error strings to friendly i18n messages
- Retry button moved inside the alert card, aligned with error text

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines