### PR TITLE
Fix/spek 166 cached contacts

### DIFF
--- a/src/renderer/features/contacts/BackendContacts/index.ts
+++ b/src/renderer/features/contacts/BackendContacts/index.ts
@@ -1,1 +1,2 @@
 export { backendContactsModel } from './model/backend-contacts-model';
+export { SyncStatusBadge } from './ui/SyncStatusBadge';

--- a/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
+++ b/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
@@ -5,10 +5,14 @@ import { contactModel } from '@/entities/contact';
 import { authModel, backendConfigurationModel } from '../../BackendConfiguration';
 import { fetchAllContacts } from '../api/backend-contacts-api';
 
+type SyncStatus = 'idle' | 'syncing' | 'done' | 'error';
+
 const syncTriggered = createEvent();
 
 const $isLoading = createStore(false);
 const $error = createStore<string | null>(null);
+const $lastSyncTime = createStore<number | null>(null);
+const $syncStatus = createStore<SyncStatus>('idle');
 
 const fetchBackendContactsFx = createEffect(async (baseUrl: string): Promise<Contact[]> => {
   return fetchAllContacts(baseUrl);
@@ -18,6 +22,10 @@ $isLoading.on(fetchBackendContactsFx, () => true);
 $isLoading.on(fetchBackendContactsFx.finally, () => false);
 $error.on(fetchBackendContactsFx, () => null);
 $error.on(fetchBackendContactsFx.failData, (_, error) => error.message);
+$syncStatus.on(fetchBackendContactsFx, () => 'syncing');
+$syncStatus.on(fetchBackendContactsFx.done, () => 'done');
+$syncStatus.on(fetchBackendContactsFx.fail, () => 'error');
+$lastSyncTime.on(fetchBackendContactsFx.done, () => Date.now());
 
 // Persist fetched backend contacts to Dexie
 sample({
@@ -53,6 +61,8 @@ $error.on(backendConfigurationModel.events.urlCleared, () => null);
 export const backendContactsModel = {
   $isLoading,
   $error,
+  $lastSyncTime,
+  $syncStatus,
 
   events: {
     syncTriggered,

--- a/src/renderer/features/contacts/BackendContacts/ui/SyncStatusBadge.tsx
+++ b/src/renderer/features/contacts/BackendContacts/ui/SyncStatusBadge.tsx
@@ -1,0 +1,72 @@
+import { useUnit } from 'effector-react';
+import { type TFunction } from 'i18next';
+import { useEffect, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { FootnoteText, IconButton } from '@/shared/ui';
+import { Tooltip } from '@/shared/ui-kit';
+import { backendContactsModel } from '../model/backend-contacts-model';
+
+function formatRelativeTime(timestamp: number, t: TFunction): string {
+  const seconds = Math.floor((Date.now() - timestamp) / 1000);
+
+  if (seconds < 60) return t('addressBook.syncStatus.justNow');
+
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return t('addressBook.syncStatus.minutesAgo', { count: minutes });
+
+  const hours = Math.floor(minutes / 60);
+
+  return t('addressBook.syncStatus.hoursAgo', { count: hours });
+}
+
+export const SyncStatusBadge = () => {
+  const { t } = useI18n();
+  const [syncStatus, lastSyncTime, isLoading] = useUnit([
+    backendContactsModel.$syncStatus,
+    backendContactsModel.$lastSyncTime,
+    backendContactsModel.$isLoading,
+  ]);
+
+  const [, setTick] = useState(0);
+
+  useEffect(() => {
+    if (!lastSyncTime) return;
+
+    const interval = setInterval(() => setTick((n) => n + 1), 60_000);
+
+    return () => clearInterval(interval);
+  }, [lastSyncTime]);
+
+  const handleSync = () => {
+    backendContactsModel.events.syncTriggered();
+  };
+
+  const statusText =
+    syncStatus === 'syncing'
+      ? t('addressBook.syncStatus.syncing')
+      : lastSyncTime
+        ? formatRelativeTime(lastSyncTime, t)
+        : null;
+
+  return (
+    <div className="flex items-center gap-x-1">
+      {statusText && (
+        <Tooltip enableHover delay={200}>
+          <Tooltip.Trigger>
+            <FootnoteText className="text-text-tertiary">{statusText}</FootnoteText>
+          </Tooltip.Trigger>
+          <Tooltip.Content>{lastSyncTime ? new Date(lastSyncTime).toLocaleTimeString() : statusText}</Tooltip.Content>
+        </Tooltip>
+      )}
+      <IconButton
+        className={cnTw('shrink-0 text-icon-default', isLoading && 'animate-spin')}
+        disabled={isLoading}
+        name="refresh"
+        ariaLabel={t('addressBook.syncStatus.syncButton')}
+        onClick={handleSync}
+      />
+    </div>
+  );
+};

--- a/src/renderer/features/contacts/index.ts
+++ b/src/renderer/features/contacts/index.ts
@@ -10,4 +10,4 @@ export {
   authModel,
   backendConfigurationModel,
 } from './BackendConfiguration';
-export { backendContactsModel } from './BackendContacts';
+export { SyncStatusBadge, backendContactsModel } from './BackendContacts';

--- a/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
+++ b/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
@@ -3,7 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 import { type Contact, isBackendContact, isLocalContact } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { BodyText, Button, Header, Icon } from '@/shared/ui';
+import { Alert, BodyText, Button, Header, Icon } from '@/shared/ui';
 import {
   BackendContactRow,
   ContactRow,
@@ -30,6 +30,7 @@ import { SendToContactModal, sendToContactModel } from '@/features/send-to-conta
 type ViewState =
   | { view: 'loading' }
   | { view: 'error'; message: string }
+  | { view: 'cachedWithError'; message: string; items: Contact[] }
   | { view: 'emptyLocal' }
   | { view: 'emptyBackend' }
   | { view: 'noResults' }
@@ -45,6 +46,9 @@ function computeViewState(params: {
   const { isBackendTab, isLoading, backendError, localContacts, filteredContacts } = params;
 
   if (isBackendTab && isLoading) return { view: 'loading' };
+  if (isBackendTab && backendError && filteredContacts.length > 0) {
+    return { view: 'cachedWithError', message: backendError, items: filteredContacts };
+  }
   if (isBackendTab && backendError) return { view: 'error', message: backendError };
   if (isBackendTab && filteredContacts.length === 0) return { view: 'emptyBackend' };
   if (!isBackendTab && localContacts.length === 0) return { view: 'emptyLocal' };
@@ -110,12 +114,60 @@ const EmptyBackendView = () => {
   );
 };
 
+const CachedWithErrorView = ({
+  error,
+  items,
+  onSendTo,
+  onRetry,
+}: {
+  error: string;
+  items: Contact[];
+  onSendTo: (contact: Contact) => void;
+  onRetry: () => void;
+}) => {
+  const { t } = useI18n();
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <Alert title={t('addressBook.sources.syncErrorCached')} active variant="warn">
+        <Alert.Item withDot={false}>
+          <div className="flex items-center gap-x-2">
+            <BodyText className="break-all text-text-tertiary">{error}</BodyText>
+            <Button variant="text" className="h-4.5 shrink-0" onClick={onRetry}>
+              {t('addressBook.sources.retry')}
+            </Button>
+          </div>
+        </Alert.Item>
+      </Alert>
+      {renderContactList(items, onSendTo)}
+    </div>
+  );
+};
+
+function renderContactList(items: Contact[], onSendTo: (contact: Contact) => void) {
+  return (
+    <ul className="flex flex-col gap-y-2">
+      {items.map((contact) =>
+        isBackendContact(contact) ? (
+          <BackendContactRow key={contact.id} contact={contact} onSendTo={onSendTo} />
+        ) : isLocalContact(contact) ? (
+          <ContactRow key={contact.id} contact={contact} onSendTo={onSendTo} />
+        ) : null,
+      )}
+    </ul>
+  );
+}
+
 function renderViewState(viewState: ViewState, onSendTo: (contact: Contact) => void, onRetry: () => void) {
   switch (viewState.view) {
     case 'loading':
       return <LoadingView />;
     case 'error':
       return <ErrorView error={viewState.message} onRetry={onRetry} />;
+    case 'cachedWithError':
+      return (
+        <CachedWithErrorView error={viewState.message} items={viewState.items} onSendTo={onSendTo} onRetry={onRetry} />
+      );
     case 'emptyBackend':
       return <EmptyBackendView />;
     case 'emptyLocal':
@@ -123,17 +175,7 @@ function renderViewState(viewState: ViewState, onSendTo: (contact: Contact) => v
     case 'noResults':
       return <EmptyFilteredContacts />;
     case 'contacts':
-      return (
-        <ul className="flex flex-col gap-y-2">
-          {viewState.items.map((contact) =>
-            isBackendContact(contact) ? (
-              <BackendContactRow key={contact.id} contact={contact} onSendTo={onSendTo} />
-            ) : isLocalContact(contact) ? (
-              <ContactRow key={contact.id} contact={contact} onSendTo={onSendTo} />
-            ) : null,
-          )}
-        </ul>
-      );
+      return renderContactList(viewState.items, onSendTo);
   }
 }
 

--- a/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
+++ b/src/renderer/pages/AddressBook/Contacts/Contacts.tsx
@@ -3,8 +3,7 @@ import { Outlet } from 'react-router-dom';
 
 import { type Contact, isBackendContact, isLocalContact } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { cnTw } from '@/shared/lib/utils';
-import { BodyText, Button, Header, Icon, IconButton } from '@/shared/ui';
+import { BodyText, Button, Header, Icon } from '@/shared/ui';
 import {
   BackendContactRow,
   ContactRow,
@@ -20,6 +19,7 @@ import {
   CreateContactNavigation,
   ImportContactsButton,
   SourceTabs,
+  SyncStatusBadge,
   backendConfigurationModel,
   backendContactsModel,
   contactSourceModel,
@@ -200,14 +200,7 @@ export const Contacts = () => {
             {showTabs && (
               <div className="flex items-center gap-x-2">
                 <SourceTabs localCount={localContacts.length} backendCount={backendContacts.length} />
-                {isBackendTab && (
-                  <IconButton
-                    className={cnTw('shrink-0 text-icon-default', isLoading && 'animate-spin')}
-                    disabled={isLoading}
-                    name="refresh"
-                    onClick={handleSync}
-                  />
-                )}
+                {isBackendTab && <SyncStatusBadge />}
               </div>
             )}
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -133,7 +133,8 @@
       "loading": "Loading contacts...",
       "loadError": "Failed to load contacts from server",
       "emptyBackend": "No contacts found on the server",
-      "retry": "Retry"
+      "retry": "Retry",
+      "syncErrorCached": "Sync failed — showing cached contacts"
     },
     "backendContact": {
       "category": "Category",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -142,7 +142,16 @@
       "entity": "Entity"
     },
     "title": "Address Book",
-    "undo": "Undo"
+    "undo": "Undo",
+    "syncStatus": {
+      "syncing": "Syncing...",
+      "justNow": "Synced just now",
+      "minutesAgo_one": "Synced {count}m ago",
+      "minutesAgo_other": "Synced {count}m ago",
+      "hoursAgo_one": "Synced {count}h ago",
+      "hoursAgo_other": "Synced {count}h ago",
+      "syncButton": "Sync contacts"
+    }
   },
   "assetBalance": {
     "locked": "Locked",


### PR DESCRIPTION
## Description

Two changes stacked together:

1. **SPEK-160** — Add `$lastSyncTime` and `$syncStatus` stores to backend-contacts-model. Create `SyncStatusBadge` component showing relative time since last sync (e.g. "Synced just now", "Synced 5 min ago") with a tooltip for the exact timestamp. Replaces the raw refresh `IconButton` in the Contacts page.
2. **SPEK-166** — When a backend sync fails but cached contacts are available, display the cached contacts with a warning alert banner instead of showing a full error screen. Provides a better UX when the server is temporarily unavailable.

## Related Issues

SPEK-160, SPEK-166

## Changes Made

- Added `$lastSyncTime`, `$syncStatus` Effector stores
- Created `SyncStatusBadge` with relative time display + tooltip
- Added `CachedWithErrorView` component showing cached contacts + error banner
- Contacts page now falls back to cached data on sync failure
- New i18n keys for sync status and cached-with-error states

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines