### PR TITLE
Fix/spek 167 disconnected state

### DIFF
--- a/src/renderer/features/contacts/BackendConfiguration/model/auth-model.ts
+++ b/src/renderer/features/contacts/BackendConfiguration/model/auth-model.ts
@@ -1,5 +1,5 @@
 import { combine, createEffect, createEvent, createStore, sample } from 'effector';
-import { once } from 'patronum';
+import { interval, once } from 'patronum';
 
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { walletModel } from '@/entities/wallet';
@@ -187,7 +187,10 @@ sample({
 // Connection result tracking
 $connectionResult
   .on(signAndVerifyFx.done, () => ({ status: 'success' }) as ConnectionResult)
-  .on([connectTriggered, signInClicked, backendConfigurationModel.events.urlCleared], () => ({ status: 'idle' }) as ConnectionResult);
+  .on(
+    [connectTriggered, signInClicked, backendConfigurationModel.events.urlCleared],
+    () => ({ status: 'idle' }) as ConnectionResult,
+  );
 
 sample({
   clock: [requestChallengeFx.failData, signAndVerifyFx.failData],
@@ -256,6 +259,25 @@ sample({
 // On session check failure, clear auth state silently
 $authState.on(checkSessionFx.fail, () => null);
 
+// Session expiry awareness: periodic health check every 5 minutes
+const $isSessionExpired = createStore(false);
+
+const sessionHealthCheck = interval({
+  timeout: 5 * 60 * 1000,
+  start: signAndVerifyFx.done,
+  stop: signOutClicked,
+});
+
+sample({
+  clock: sessionHealthCheck.tick,
+  source: backendConfigurationModel.$backendUrl,
+  filter: (url): url is string => url !== null,
+  target: checkSessionFx,
+});
+
+$isSessionExpired.on(checkSessionFx.fail, () => true);
+$isSessionExpired.on([signAndVerifyFx.done, signOutClicked, backendConfigurationModel.events.urlCleared], () => false);
+
 export const authModel = {
   $authState,
   $authStep,
@@ -263,6 +285,7 @@ export const authModel = {
   $error,
   $connectionResult,
   $isAuthenticated,
+  $isSessionExpired,
   $extensionAccounts,
 
   events: {

--- a/src/renderer/features/contacts/BackendConfiguration/ui/AuthStatus.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/AuthStatus.tsx
@@ -24,7 +24,7 @@ export const AuthStatus = () => {
   }
 
   if (!isAuthenticated || !authState) {
-    return null;
+    return <FootnoteText className="text-text-tertiary">{t('addressBook.auth.disconnected')}</FootnoteText>;
   }
 
   return (

--- a/src/renderer/features/contacts/BackendConfiguration/ui/AuthStatus.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/AuthStatus.tsx
@@ -1,12 +1,27 @@
 import { useUnit } from 'effector-react';
 
+import { useI18n } from '@/shared/i18n';
 import { toAddress } from '@/shared/lib/utils';
-import { FootnoteText } from '@/shared/ui';
+import { FootnoteText, Icon } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
 import { authModel } from '../model/auth-model';
 
 export const AuthStatus = () => {
-  const [isAuthenticated, authState] = useUnit([authModel.$isAuthenticated, authModel.$authState]);
+  const { t } = useI18n();
+  const [isAuthenticated, authState, isSessionExpired] = useUnit([
+    authModel.$isAuthenticated,
+    authModel.$authState,
+    authModel.$isSessionExpired,
+  ]);
+
+  if (isSessionExpired) {
+    return (
+      <div className="flex items-center gap-x-1">
+        <Icon name="warnCutout" size={14} className="text-text-warning" />
+        <FootnoteText className="text-text-warning">{t('addressBook.auth.sessionExpired')}</FootnoteText>
+      </div>
+    );
+  }
 
   if (!isAuthenticated || !authState) {
     return null;

--- a/src/renderer/features/contacts/BackendConfiguration/ui/BackendConnectionCard.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/BackendConnectionCard.tsx
@@ -9,24 +9,33 @@ import { backendConfigurationModel } from '../model/backend-configuration-model'
 import { AuthStatus } from './AuthStatus';
 
 export const BackendConnectionCard = () => {
-  const [hasBackend, backendUrl, isAuthenticated] = useUnit([
+  const [hasBackend, backendUrl, isAuthenticated, isSessionExpired] = useUnit([
     backendConfigurationModel.$hasBackend,
     backendConfigurationModel.$backendUrl,
     authModel.$isAuthenticated,
+    authModel.$isSessionExpired,
   ]);
 
   if (!hasBackend) return null;
 
+  const isDisconnected = !isAuthenticated || isSessionExpired;
+
   return (
     <button
       type="button"
-      className="flex h-full cursor-pointer items-center gap-x-1 rounded-md border border-filter-border bg-input-background px-2.5 hover:bg-hover"
+      className={cnTw(
+        'flex h-full cursor-pointer items-center gap-x-1 rounded-md border bg-input-background px-2.5 hover:bg-hover',
+        isDisconnected ? 'border-text-warning' : 'border-filter-border',
+      )}
       onClick={() => backendConfigurationModel.events.editStarted()}
     >
       <Icon
         name="globe"
         size={16}
-        className={cnTw('shrink-0', isAuthenticated ? 'text-icon-positive' : 'text-icon-accent')}
+        className={cnTw(
+          'shrink-0',
+          isSessionExpired ? 'text-text-warning' : isAuthenticated ? 'text-icon-positive' : 'text-icon-accent',
+        )}
       />
       <Tooltip enableHover delay={200}>
         <Tooltip.Trigger>

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -106,7 +106,8 @@
       "selectAccountPlaceholder": "Choose an account",
       "signOutButton": "Sign out",
       "signingMessage": "Waiting for signature...",
-      "signInSuccess": "Successfully signed in"
+      "signInSuccess": "Successfully signed in",
+      "sessionExpired": "Session expired"
     },
     "backendConfiguration": {
       "addTitle": "Add Backend",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -107,7 +107,8 @@
       "signOutButton": "Sign out",
       "signingMessage": "Waiting for signature...",
       "signInSuccess": "Successfully signed in",
-      "sessionExpired": "Session expired"
+      "sessionExpired": "Session expired",
+      "disconnected": "Disconnected"
     },
     "backendConfiguration": {
       "addTitle": "Add Backend",


### PR DESCRIPTION
## Description

Two changes stacked together:

1. **SPEK-162** — Add `$isSessionExpired` store and a periodic session health check (every 5 minutes via patronum interval). When the session expires, `AuthStatus` shows a warning icon with "Session expired" text instead of the account name.
2. **SPEK-167** — Show a "Disconnected" label when not authenticated (instead of hiding the status entirely). Add a warning border to `BackendConnectionCard` when disconnected or session expired. Globe icon turns warning color on session expiry.

## Related Issues

SPEK-162, SPEK-167

## Changes Made

- Added `$isSessionExpired` Effector store with periodic health check
- `AuthStatus` component shows warning state on session expiry
- `BackendConnectionCard` shows "Disconnected" label instead of hiding status
- Warning border and icon color changes for disconnected/expired states
- New i18n keys for session and connection states

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines