### PR TITLE
fix(accounts-structure): merge multiple connections to one signatory …

### DIFF
--- a/src/renderer/features/accounts-structure/components/AccountsStructure.tsx
+++ b/src/renderer/features/accounts-structure/components/AccountsStructure.tsx
@@ -68,18 +68,24 @@ function createGraphElements(
 ) {
   const nodes: Node<AccountNodeData>[] = [];
   const edges: Edge[] = [];
-  const processedNodes = new Set<string>();
+  const processedAccountIds = new Set<string>();
+  const accountIdToNodeId = new Map<string, string>();
+
+  function resolveNodeId(account: AnyAccount): string {
+    return accountIdToNodeId.get(account.accountId) ?? account.id;
+  }
 
   function processNode(node: AccountNode) {
-    if (processedNodes.has(node.account.id)) return;
-    processedNodes.add(node.account.id);
+    if (processedAccountIds.has(node.account.accountId)) return;
+    processedAccountIds.add(node.account.accountId);
+    accountIdToNodeId.set(node.account.accountId, node.account.id);
 
     nodes.push({
       id: node.account.id,
       type: 'accountNode',
       data: {
         node,
-        isSelected: node.account.id === selectedAccountId,
+        isSelected: node.account.accountId === selectedAccountId,
       },
       position: { x: 0, y: 0 },
       sourcePosition: Position.Left,
@@ -87,12 +93,14 @@ function createGraphElements(
     });
 
     for (const child of node.children) {
+      const childNodeId = resolveNodeId(child.account);
+      const nodeId = node.account.id;
       const connection = accountConnectionTransformer({ source: child.account, target: node.account, t });
 
       edges.push({
-        id: `e${child.account.id}-${node.account.id}`,
-        source: child.account.id,
-        target: node.account.id,
+        id: `e${childNodeId}-${nodeId}`,
+        source: childNodeId,
+        target: nodeId,
         data: {
           source: child.account,
           target: node.account,
@@ -128,7 +136,7 @@ const useGraphLayout = (
   return useCallback(async () => {
     if (!graph || !selectedAccount) return;
 
-    const { nodes, edges } = createGraphElements(graph, selectedAccount.id, t);
+    const { nodes, edges } = createGraphElements(graph, selectedAccount.accountId, t);
 
     const layoutGraph = await elk.layout({
       id: 'root',
@@ -201,10 +209,14 @@ const AccountsStructureInner = () => {
   useEffect(
     () =>
       // eslint-disable-next-line effector/no-watch
-      accountsStructureModel.focusOnSelected.watch(
-        () => selectedAccount && fitView({ nodes: [{ id: selectedAccount.id }], maxZoom: 0.5, duration: 500 }),
-      ),
-    [fitView, selectedAccount],
+      accountsStructureModel.focusOnSelected.watch(() => {
+        if (!selectedAccount) return;
+        const matchingNode = nodes.find((n) => n.data.node.account.accountId === selectedAccount.accountId);
+        if (matchingNode) {
+          fitView({ nodes: [{ id: matchingNode.id }], maxZoom: 0.5, duration: 500 });
+        }
+      }),
+    [fitView, selectedAccount, nodes],
   );
 
   return (

--- a/src/renderer/features/accounts-structure/model/accountsStructureModel.ts
+++ b/src/renderer/features/accounts-structure/model/accountsStructureModel.ts
@@ -137,7 +137,7 @@ function findNodesRelatedToAccount(
   for (const node of graph.values()) {
     accountService.traverseGraph(node, {
       enter(child) {
-        if (child.account === account) {
+        if (child.account.accountId === account.accountId) {
           result.set(node.account, node);
           return false;
         }


### PR DESCRIPTION
## Description

Resolve multiple connections to one synthetic signatory account
Use only one node to represent signatory when it is connected to different multisigs

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

<img width="1010" height="735" alt="image" src="https://github.com/user-attachments/assets/505f0a53-b604-42a0-a3eb-6224b62d280d" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
