### PR TITLE
Spek 173. Referendum detail screen fixes

### DIFF
--- a/src/renderer/domains/collectives/evidence/service.ts
+++ b/src/renderer/domains/collectives/evidence/service.ts
@@ -26,7 +26,7 @@ function getEvidenceFromCid(cid: string): HexString {
 }
 
 function getEvidenceIpfsUrl(evidence: HexString) {
-  return new URL(`/ipfs/${getCidByEvidence(evidence)}`, 'https://subsquare.infura-ipfs.io');
+  return new URL(`/ipfs/${getCidByEvidence(evidence)}`, 'https://ipfs.io');
 }
 
 function getEvidenceUploadIpfsUrl() {

--- a/src/renderer/domains/collectives/referendumMeta/types.ts
+++ b/src/renderer/domains/collectives/referendumMeta/types.ts
@@ -10,7 +10,7 @@ export type ReferendumMeta = {
   chainId: ChainId;
   pallet: CollectivePalletsType;
   title: string;
-  description: string;
+  description: string | null;
   track: number;
   created: number;
   status: string;

--- a/src/renderer/features/fellowship-referendum-details/components/ConnectedGovernanceReferendum.tsx
+++ b/src/renderer/features/fellowship-referendum-details/components/ConnectedGovernanceReferendum.tsx
@@ -148,7 +148,9 @@ export const GovernanceReferendumCard = memo(
     let status: ReferendumStatus | null = null;
     if (governanceReferendumService.isOngoing(governanceReferendum)) {
       track = tracks[governanceReferendum.track] ?? null;
-      endBlock = governanceReferendumService.getReferendumEndTime(governanceReferendum, track!, undecidingTimeout);
+      if (track) {
+        endBlock = governanceReferendumService.getReferendumEndTime(governanceReferendum, track, undecidingTimeout);
+      }
       status = governanceReferendumService.getReferendumStatus(governanceReferendum);
     }
 

--- a/src/renderer/features/fellowship-referendum-details/components/ReferendumDescription.tsx
+++ b/src/renderer/features/fellowship-referendum-details/components/ReferendumDescription.tsx
@@ -27,8 +27,10 @@ export const ReferendumDescription = memo(({ referendum, evidence }: Props) => {
     (trackService.isPromotionTrack(referendumMeta.track) || trackService.isRetentionTrack(referendumMeta.track));
 
   const shouldRenderEvidence = nonNullable(evidenceContent) && !pendingEvidenceContent;
-  const shouldRenderEvidencePending = canHaveEvidence && nullable(evidenceContent) && pendingEvidenceContent;
-  const shouldRenderEvidenceAlert = canHaveEvidence && nullable(evidenceContent) && !pendingEvidenceContent;
+  const shouldRenderEvidencePending =
+    canHaveEvidence && nullable(evidenceContent) && pendingEvidenceContent && nonNullable(evidence);
+  const shouldRenderEvidenceAlert =
+    canHaveEvidence && nullable(evidenceContent) && (!pendingEvidenceContent || nullable(evidence));
 
   return (
     <div className="flex h-full flex-col gap-4">

--- a/src/renderer/features/fellowship-referendum-details/hooks/useDescription.ts
+++ b/src/renderer/features/fellowship-referendum-details/hooks/useDescription.ts
@@ -6,14 +6,15 @@ import { useMetadata } from './useMetadata';
 export const useDescription = (referendum: Referendum | null) => {
   const { data: metadata, pending } = useMetadata(referendum);
 
-  let description;
+  let description = metadata?.description ?? null;
 
-  if (nonNullable(referendum) && referendumService.isOngoing(referendum) && referendum.proposal) {
-    if (referendum.proposal.type === 'Unknown') {
-      description = referendum.proposal.description;
-    }
-  } else {
-    description = metadata?.description ?? null;
+  if (
+    nonNullable(referendum) &&
+    referendumService.isOngoing(referendum) &&
+    referendum.proposal?.type === 'Unknown' &&
+    referendum.proposal.description
+  ) {
+    description = referendum.proposal.description;
   }
 
   return { data: description, pending };

--- a/src/renderer/shared/api/governance/off-chain/service/subsquareService.ts
+++ b/src/renderer/shared/api/governance/off-chain/service/subsquareService.ts
@@ -34,7 +34,7 @@ const getReferendumDetails: GovernanceApi['getReferendumDetails'] = async (chain
   try {
     const details = await subsquareApiService.fetchReferendum({ network, referendumType: 'gov2', referendumId });
 
-    return details.content;
+    return details.content ?? undefined;
   } catch {
     return undefined;
   }

--- a/src/renderer/shared/api/subsquare/lib/types.ts
+++ b/src/renderer/shared/api/subsquare/lib/types.ts
@@ -79,7 +79,7 @@ export type SubsquareSimpleReferendum = {
 };
 
 export type SubsquareFullReferendum = SubsquareSimpleReferendum & {
-  content: string;
+  content: string | null;
 };
 
 type SubsquareReferendumVoteCommonData = {


### PR DESCRIPTION
## Description
Allow null for description and content in referendum metadata and Subsquare types to match API responses and avoid runtime issues
Fix referendum status handling: only call getReferendumEndTime when the track is available
Switch evidence IPFS base URL from subsquare.infura-ipfs.io to ipfs.io
Improve description fallback logic (metadata first, then proposal description when applicable)

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-173

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

https://github.com/user-attachments/assets/edc72b3c-bccc-4635-bd7f-3c25807c16d5



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
