### PR TITLE
Fix/fellowship_crash

### DIFF
--- a/src/renderer/features/fellowship-tasks/hooks/useOngoingReferendumTasks.ts
+++ b/src/renderer/features/fellowship-tasks/hooks/useOngoingReferendumTasks.ts
@@ -144,7 +144,7 @@ export const useOngoingReferendumTasks = () => {
             nonNullable(connectedGovernanceReferendum) && nonNullable(connectedGovernanceReferendum.end)
               ? {
                   ...referendum,
-                  ends: pjsSchema.blockHeight.parse(Math.min(referendum.ends, connectedGovernanceReferendum.end)),
+                  ends: pjsSchema.helpers.toBlockHeight(Math.min(referendum.ends, connectedGovernanceReferendum.end)),
                 }
               : referendum;
 


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->


**Root cause:** useOngoingReferendumTasks.ts:147 called pjsSchema.blockHeight.parse() with a plain number (from Math.min()). The blockHeight schema starts with z.instanceof(u32) which expects a Polkadot codec u32 instance, not a JS number. In the minified build, u32 became hE, hence "Input not instance of hE".                     
                               
**Fix**: Replaced pjsSchema.blockHeight.parse(...) with pjsSchema.helpers.toBlockHeight(...), which is the correct helper for converting plain numbers to the branded BlockHeight type. This helper already exists and is used elsewhere in the codebase (e.g., referendum/resource.ts:141-143).

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

<img width="1624" height="1061" alt="Screenshot 2026-03-06 at 18 57 09" src="https://github.com/user-attachments/assets/219c4113-530c-455f-8cd8-a6378bf6f169" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
