### PR TITLE
feat(sidebar): add collapsible navigation sidebar

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -158,3 +158,8 @@ The renderer follows Feature-Sliced Design methodology:
 - Prioritize code correctness and clarity. Speed and efficiency are secondary priorities unless otherwise specified.
 - Do not write organizational or comments that summarize the code. Comments should only be written in order to explain "why" the code is written in some way in the case there is a reason that is tricky / non-obvious.
 - **Avoid `as` type casts** - Use typeguards with actual runtime checks instead. Prefer `satisfies` for type validation without casting. Type casts hide potential bugs; typeguards catch them.
+
+### UI Animation Patterns
+- **Smooth fold/collapse animations**: Never use conditional DOM branches (`if (folded) return <A>; return <B>`) for animated transitions. Keep identical DOM structure in both states; only change CSS classes (e.g. `max-w-0 opacity-0` ↔ `max-w-[180px] opacity-100`). DOM swaps cause instant jumps that CSS transitions can't smooth over.
+- **Radix UI `asChild` + React Router `NavLink`**: Never put `NavLink` directly inside Radix `Trigger` components (Tooltip.Trigger, etc.) — Radix's `asChild` stringifies NavLink's function `className`. Always wrap NavLink in a `<div>` first.
+- **Radix Tooltip conditional control**: To show tooltip only in certain states, use `open={condition ? undefined : false}` instead of conditionally rendering the Tooltip wrapper.

--- a/src/renderer/features/app-custom-operations/index.tsx
+++ b/src/renderer/features/app-custom-operations/index.tsx
@@ -8,5 +8,5 @@ export { appCustomOperationsFeature };
 
 appCustomOperationsFeature.inject(navigationCustomOperationsSlot, {
   order: 0,
-  render: () => <CustomOperations />,
+  render: ({ folded }) => <CustomOperations folded={folded} />,
 });

--- a/src/renderer/features/app-custom-operations/ui/CustomOperations.tsx
+++ b/src/renderer/features/app-custom-operations/ui/CustomOperations.tsx
@@ -1,19 +1,15 @@
-import { useUnit } from 'effector-react';
-
 import { createSlot, useSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
 import { cnTw } from '@/shared/lib/utils';
 import { BodyText, Icon } from '@/shared/ui';
 import { Dropdown, Tooltip } from '@/shared/ui-kit';
-import { sidebarModel } from '@/features/app-shell';
 
 export const customOperationsSlot = createSlot();
 
-export const CustomOperations = () => {
+export const CustomOperations = ({ folded }: { folded: boolean }) => {
   const { t } = useI18n();
   const [isActionsOpen, toggleIsActionsOpen] = useToggle();
-  const folded = useUnit(sidebarModel.$folded);
 
   const customOperations = useSlot(customOperationsSlot);
 

--- a/src/renderer/features/app-custom-operations/ui/CustomOperations.tsx
+++ b/src/renderer/features/app-custom-operations/ui/CustomOperations.tsx
@@ -1,32 +1,63 @@
+import { useUnit } from 'effector-react';
+
 import { createSlot, useSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { useToggle } from '@/shared/lib/hooks';
-import { Button, Icon } from '@/shared/ui';
-import { Dropdown } from '@/shared/ui-kit';
+import { cnTw } from '@/shared/lib/utils';
+import { BodyText, Icon } from '@/shared/ui';
+import { Dropdown, Tooltip } from '@/shared/ui-kit';
+import { sidebarModel } from '@/features/app-shell';
 
 export const customOperationsSlot = createSlot();
 
 export const CustomOperations = () => {
   const { t } = useI18n();
   const [isActionsOpen, toggleIsActionsOpen] = useToggle();
+  const folded = useUnit(sidebarModel.$folded);
 
   const customOperations = useSlot(customOperationsSlot);
 
   return (
-    <div className="px-3.5">
-      <Dropdown width="trigger" align="center" keepOpen open={isActionsOpen} onToggle={toggleIsActionsOpen}>
-        <Dropdown.Trigger>
-          <Button
-            pallet="secondary"
-            size="sm"
-            className="w-full justify-center"
-            suffixElement={<Icon name={isActionsOpen ? 'up' : 'down'} size={16} className="text-inherit" />}
+    <Tooltip side="right" open={folded && !isActionsOpen ? undefined : false}>
+      <Tooltip.Trigger>
+        <div>
+          <Dropdown
+            width={folded ? 'auto' : 'trigger'}
+            align={folded ? 'start' : 'center'}
+            side={folded ? 'right' : 'bottom'}
+            keepOpen
+            open={isActionsOpen}
+            onToggle={toggleIsActionsOpen}
           >
-            {t('navigation.customOperationLabel')}
-          </Button>
-        </Dropdown.Trigger>
-        <Dropdown.Content>{customOperations}</Dropdown.Content>
-      </Dropdown>
-    </div>
+            <Dropdown.Trigger>
+              <button
+                type="button"
+                className="flex w-full cursor-pointer items-center rounded-md px-3.5 py-2.5 text-tab-icon-inactive outline-offset-reduced transition-all duration-200 select-none hover:bg-tab-background"
+              >
+                <Icon name="magic" size={20} className="shrink-0 text-inherit" />
+                <BodyText
+                  className={cnTw(
+                    'overflow-hidden whitespace-nowrap text-text-secondary transition-all duration-200',
+                    folded ? 'ml-0 max-w-0 opacity-0' : 'ml-3 max-w-[180px] opacity-100',
+                  )}
+                >
+                  {t('navigation.customOperationLabel')}
+                </BodyText>
+                <div
+                  className={cnTw(
+                    'ml-auto overflow-hidden transition-all duration-200',
+                    folded ? 'max-w-0 opacity-0' : 'max-w-[20px] opacity-100',
+                  )}
+                >
+                  <Icon name={isActionsOpen ? 'up' : 'down'} size={16} className="text-inherit" />
+                </div>
+              </button>
+            </Dropdown.Trigger>
+            <Dropdown.Content>{customOperations}</Dropdown.Content>
+          </Dropdown>
+        </div>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{t('navigation.customOperationLabel')}</Tooltip.Content>
+    </Tooltip>
   );
 };

--- a/src/renderer/features/app-shell/components/AppShell.tsx
+++ b/src/renderer/features/app-shell/components/AppShell.tsx
@@ -1,7 +1,10 @@
+import { useUnit } from 'effector-react';
 import { memo } from 'react';
 import { Outlet } from 'react-router-dom';
 
 import { createSlot, useSlot } from '@/shared/di';
+import { cnTw } from '@/shared/lib/utils';
+import { sidebarModel } from '../model/sidebar-model';
 
 import { Favicon } from './Favicon';
 import { Navigation } from './Navigation';
@@ -13,11 +16,17 @@ export const modalsSlot = createSlot();
 export const AppShell = memo(() => {
   const headerNodes = useSlot(navigationHeaderSlot);
   const modals = useSlot(modalsSlot);
+  const folded = useUnit(sidebarModel.$folded);
 
   return (
     <div className="flex h-full animate-in fade-in">
       <Favicon />
-      <aside className="flex w-[240px] shrink-0 flex-col gap-y-6 border-r border-r-container-border bg-left-navigation-menu-background p-4">
+      <aside
+        className={cnTw(
+          'flex shrink-0 flex-col gap-y-6 overflow-hidden border-r border-r-container-border bg-left-navigation-menu-background py-4 transition-all duration-200 ease-in-out',
+          folded ? 'w-16 px-2' : 'w-[240px] px-4',
+        )}
+      >
         {headerNodes}
         <Navigation />
       </aside>

--- a/src/renderer/features/app-shell/components/AppShell.tsx
+++ b/src/renderer/features/app-shell/components/AppShell.tsx
@@ -10,13 +10,13 @@ import { Favicon } from './Favicon';
 import { Navigation } from './Navigation';
 import { NotificationsPortal } from './NotificationsPortal';
 
-export const navigationHeaderSlot = createSlot();
+export const navigationHeaderSlot = createSlot<{ folded: boolean }>();
 export const modalsSlot = createSlot();
 
 export const AppShell = memo(() => {
-  const headerNodes = useSlot(navigationHeaderSlot);
   const modals = useSlot(modalsSlot);
   const folded = useUnit(sidebarModel.$folded);
+  const headerNodes = useSlot(navigationHeaderSlot, { props: { folded } });
 
   return (
     <div className="flex h-full animate-in fade-in">

--- a/src/renderer/features/app-shell/components/NavItem.tsx
+++ b/src/renderer/features/app-shell/components/NavItem.tsx
@@ -1,9 +1,12 @@
+import { useUnit } from 'effector-react';
 import { type ReactNode } from 'react';
 import { NavLink } from 'react-router-dom';
 
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
 import { type IconNames, BodyText, Icon } from '@/shared/ui';
+import { Tooltip } from '@/shared/ui-kit';
+import { sidebarModel } from '../model/sidebar-model';
 
 export type Props = {
   order?: number;
@@ -15,41 +18,69 @@ export type Props = {
 
 export const NavItem = ({ title, link, icon, badge }: Props) => {
   const { t } = useI18n();
+  const folded = useUnit(sidebarModel.$folded);
+
+  const translatedTitle = t(title);
 
   return (
-    <NavLink
-      to={link}
-      className={({ isActive }) =>
-        cnTw(
-          'flex cursor-pointer items-center rounded-md px-3.5 py-2.5 outline-offset-reduced select-none hover:bg-tab-background',
-          isActive && 'bg-tab-background',
-        )
-      }
-    >
-      {({ isActive }) => (
-        <>
-          {typeof icon === 'string' ? (
-            <Icon
-              className={cnTw(isActive ? 'text-tab-icon-active' : 'text-tab-icon-inactive')}
-              name={icon as IconNames}
-              size={20}
-            />
-          ) : (
-            <span
-              className={cnTw(
-                'h-5 w-5 shrink-0 overflow-hidden',
-                isActive ? 'text-tab-icon-active' : 'text-tab-icon-inactive',
-              )}
-            >
-              {icon}
-            </span>
-          )}
-          <BodyText className={cnTw('ml-3', isActive ? 'text-text-primary' : 'text-text-secondary')}>
-            {t(title)}
-          </BodyText>
-          {badge}
-        </>
-      )}
-    </NavLink>
+    <Tooltip side="right" open={folded ? undefined : false}>
+      <Tooltip.Trigger>
+        <div>
+          <NavLink
+            to={link}
+            className={({ isActive }) =>
+              cnTw(
+                'flex cursor-pointer items-center rounded-md px-3.5 py-2.5 outline-offset-reduced transition-all duration-200 select-none hover:bg-tab-background',
+                isActive && 'bg-tab-background',
+              )
+            }
+          >
+            {({ isActive }) => (
+              <>
+                <div className="relative shrink-0">
+                  {typeof icon === 'string' ? (
+                    <Icon
+                      className={cnTw(isActive ? 'text-tab-icon-active' : 'text-tab-icon-inactive')}
+                      name={icon as IconNames}
+                      size={20}
+                    />
+                  ) : (
+                    <span
+                      className={cnTw(
+                        'h-5 w-5 shrink-0 overflow-hidden',
+                        isActive ? 'text-tab-icon-active' : 'text-tab-icon-inactive',
+                      )}
+                    >
+                      {icon}
+                    </span>
+                  )}
+                  {folded && badge && (
+                    <span className="absolute top-0 right-0 h-1.5 w-1.5 rounded-full bg-icon-accent" />
+                  )}
+                </div>
+                <BodyText
+                  className={cnTw(
+                    'overflow-hidden whitespace-nowrap transition-all duration-200',
+                    folded ? 'ml-0 max-w-0 opacity-0' : 'ml-3 max-w-[180px] opacity-100',
+                    isActive ? 'text-text-primary' : 'text-text-secondary',
+                  )}
+                >
+                  {translatedTitle}
+                </BodyText>
+                <div
+                  className={cnTw(
+                    'ml-auto overflow-hidden transition-all duration-200',
+                    folded ? 'max-w-0 opacity-0' : 'max-w-[100px] opacity-100',
+                  )}
+                >
+                  {badge}
+                </div>
+              </>
+            )}
+          </NavLink>
+        </div>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{translatedTitle}</Tooltip.Content>
+    </Tooltip>
   );
 };

--- a/src/renderer/features/app-shell/components/Navigation.tsx
+++ b/src/renderer/features/app-shell/components/Navigation.tsx
@@ -17,13 +17,13 @@ export const navigationTopLinksPipeline = createPipeline<NavItemProps[]>({
   },
 });
 export const navigationBottomLinksSlot = createSlot();
-export const navigationCustomOperationsSlot = createSlot();
+export const navigationCustomOperationsSlot = createSlot<{ folded: boolean }>();
 
 export const Navigation = memo(() => {
   const upperItems = usePipeline(navigationTopLinksPipeline, []);
   const lowerItems = useSlot(navigationBottomLinksSlot);
-  const customOperationItems = useSlot(navigationCustomOperationsSlot);
   const folded = useUnit(sidebarModel.$folded);
+  const customOperationItems = useSlot(navigationCustomOperationsSlot, { props: { folded } });
 
   return (
     <nav className="h-full overflow-x-hidden overflow-y-auto">

--- a/src/renderer/features/app-shell/components/Navigation.tsx
+++ b/src/renderer/features/app-shell/components/Navigation.tsx
@@ -1,6 +1,12 @@
+import { useUnit } from 'effector-react';
 import { memo } from 'react';
 
 import { createPipeline, createSlot, usePipeline, useSlot } from '@/shared/di';
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { BodyText, Icon } from '@/shared/ui';
+import { Tooltip } from '@/shared/ui-kit';
+import { sidebarModel } from '../model/sidebar-model';
 
 import { type Props as NavItemProps, NavItem } from './NavItem';
 
@@ -17,16 +23,49 @@ export const Navigation = memo(() => {
   const upperItems = usePipeline(navigationTopLinksPipeline, []);
   const lowerItems = useSlot(navigationBottomLinksSlot);
   const customOperationItems = useSlot(navigationCustomOperationsSlot);
+  const folded = useUnit(sidebarModel.$folded);
 
   return (
-    <nav className="h-full overflow-y-auto">
+    <nav className="h-full overflow-x-hidden overflow-y-auto">
       <div className="flex h-full flex-col gap-2">
         {upperItems.map(({ icon, title, link, badge }) => (
           <NavItem key={link} icon={icon} title={title} link={link} badge={badge} />
         ))}
         {customOperationItems}
-        <div className="mt-auto flex flex-col gap-2">{lowerItems}</div>
+        <div className="mt-auto flex flex-col gap-2">
+          {lowerItems}
+          <ToggleButton folded={folded} />
+        </div>
       </div>
     </nav>
+  );
+});
+
+const ToggleButton = memo(({ folded }: { folded: boolean }) => {
+  const { t } = useI18n();
+
+  return (
+    <Tooltip side="right" open={folded ? undefined : false}>
+      <Tooltip.Trigger>
+        <div>
+          <button
+            type="button"
+            className="flex w-full cursor-pointer items-center rounded-md px-3.5 py-2.5 text-tab-icon-inactive outline-offset-reduced transition-all duration-200 select-none hover:bg-tab-background"
+            onClick={() => sidebarModel.toggled()}
+          >
+            <Icon name={folded ? 'right' : 'left'} size={20} className="shrink-0 transition-transform duration-200" />
+            <BodyText
+              className={cnTw(
+                'overflow-hidden whitespace-nowrap text-text-secondary transition-all duration-200',
+                folded ? 'ml-0 max-w-0 opacity-0' : 'ml-3 max-w-[180px] opacity-100',
+              )}
+            >
+              {t('navigation.collapseLabel')}
+            </BodyText>
+          </button>
+        </div>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{t('navigation.collapseLabel')}</Tooltip.Content>
+    </Tooltip>
   );
 });

--- a/src/renderer/features/app-shell/index.ts
+++ b/src/renderer/features/app-shell/index.ts
@@ -8,3 +8,4 @@ export {
 export { modalsSlot, navigationHeaderSlot } from './components/AppShell';
 export { Favicon } from './components/Favicon';
 export { faviconModel } from './model/favicon-model';
+export { sidebarModel } from './model/sidebar-model';

--- a/src/renderer/features/app-shell/model/sidebar-model.ts
+++ b/src/renderer/features/app-shell/model/sidebar-model.ts
@@ -1,0 +1,11 @@
+import { createEvent, createStore, sample } from 'effector';
+import { persist } from 'effector-storage/local';
+
+const $folded = createStore(false);
+const toggled = createEvent();
+
+sample({ clock: toggled, source: $folded, fn: (f) => !f, target: $folded });
+
+persist({ key: 'sidebar-folded', store: $folded });
+
+export const sidebarModel = { $folded, toggled };

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -5,10 +5,12 @@ import { TEST_IDS } from '@/shared/constants';
 import { type Wallet } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
 import { BodyText, Icon, SmallTitleText } from '@/shared/ui';
-import { Box, Graphics, Popover, ScrollArea, SearchInput, Skeleton } from '@/shared/ui-kit';
+import { Graphics, Popover, ScrollArea, SearchInput, Skeleton } from '@/shared/ui-kit';
 import { useWalletName } from '@/domains/network';
 import { walletSelect } from '@/aggregates/wallet-select';
+import { sidebarModel } from '@/features/app-shell';
 import { WalletFiatBalance } from '@/features/wallet-fiat-balance';
 import { walletList } from '../model/list';
 
@@ -45,26 +47,30 @@ export const WalletSelect = memo(() => {
 const WalletSelectTrigger = memo(
   ({ wallet, ...rest }: Pick<ComponentProps<'button'>, 'onClick'> & { wallet: Wallet }) => {
     const walletName = useWalletName(wallet);
+    const folded = useUnit(sidebarModel.$folded);
 
     return (
       <button
         type="button"
         data-testid={TEST_IDS.COMMON.WALLET_BUTTON}
-        className="w-full cursor-pointer rounded-md border border-container-border bg-left-navigation-menu-background shadow-card-shadow"
+        className={cnTw(
+          'w-full cursor-pointer rounded-md border py-3 transition-all duration-200',
+          folded
+            ? 'border-transparent px-1'
+            : 'border-container-border bg-left-navigation-menu-background px-3 shadow-card-shadow',
+        )}
         {...rest}
       >
-        <Box direction="row" verticalAlign="center" horizontalAlign="space-between" padding={3}>
-          <div className="flex h-8 w-full min-w-0 items-center gap-x-2">
-            <div className="relative">
-              <Slot id={walletIconSlot} props={{ wallet, size: 32 }} />
-            </div>
-            <div className="flex min-w-0 flex-col">
-              <BodyText className="truncate text-text-primary">{walletName}</BodyText>
-              <WalletFiatBalance wallet={wallet} className="truncate" />
-            </div>
+        <div className="flex h-8 items-center gap-x-2">
+          <div className="relative shrink-0">
+            <Slot id={walletIconSlot} props={{ wallet, size: 32 }} />
+          </div>
+          <div className="flex min-w-0 flex-col overflow-hidden">
+            <BodyText className="whitespace-nowrap text-text-primary">{walletName}</BodyText>
+            <WalletFiatBalance wallet={wallet} className="whitespace-nowrap" />
           </div>
           <Icon name="down" size={16} className="ml-auto shrink-0" />
-        </Box>
+        </div>
       </button>
     );
   },

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -62,7 +62,7 @@ const WalletSelectTrigger = memo(
         {...rest}
       >
         <div className="flex h-8 items-center gap-x-2">
-          <div className="relative shrink-0">
+          <div className={cnTw('relative shrink-0', folded && 'pointer-events-none')}>
             <Slot id={walletIconSlot} props={{ wallet, size: 32 }} />
           </div>
           <div className="flex min-w-0 flex-col overflow-hidden">

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -10,7 +10,6 @@ import { BodyText, Icon, SmallTitleText } from '@/shared/ui';
 import { Graphics, Popover, ScrollArea, SearchInput, Skeleton } from '@/shared/ui-kit';
 import { useWalletName } from '@/domains/network';
 import { walletSelect } from '@/aggregates/wallet-select';
-import { sidebarModel } from '@/features/app-shell';
 import { WalletFiatBalance } from '@/features/wallet-fiat-balance';
 import { walletList } from '../model/list';
 
@@ -21,9 +20,8 @@ export const walletGroupSlot = createSlot<{
 export const walletSelectActionsSlot = createSlot();
 export const walletIconSlot = createSlot<{ wallet: Wallet; size: number }>();
 
-export const WalletSelect = memo(() => {
+export const WalletSelect = memo(({ folded }: { folded: boolean }) => {
   const selectedWallet = useUnit(walletSelect.$selectedWallet);
-  const folded = useUnit(sidebarModel.$folded);
 
   useEffect(() => {
     walletList.fetchWallets();
@@ -36,7 +34,7 @@ export const WalletSelect = memo(() => {
   return (
     <Popover align="start" side={folded ? 'right' : 'bottom'} sideOffset={2}>
       <Popover.Trigger>
-        <WalletSelectTrigger wallet={selectedWallet} />
+        <WalletSelectTrigger wallet={selectedWallet} folded={folded} />
       </Popover.Trigger>
       <Popover.Content>
         <WalletSelectDropdown />
@@ -46,9 +44,8 @@ export const WalletSelect = memo(() => {
 });
 
 const WalletSelectTrigger = memo(
-  ({ wallet, ...rest }: Pick<ComponentProps<'button'>, 'onClick'> & { wallet: Wallet }) => {
+  ({ wallet, folded, ...rest }: Pick<ComponentProps<'button'>, 'onClick'> & { wallet: Wallet; folded: boolean }) => {
     const walletName = useWalletName(wallet);
-    const folded = useUnit(sidebarModel.$folded);
 
     return (
       <button

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -23,6 +23,7 @@ export const walletIconSlot = createSlot<{ wallet: Wallet; size: number }>();
 
 export const WalletSelect = memo(() => {
   const selectedWallet = useUnit(walletSelect.$selectedWallet);
+  const folded = useUnit(sidebarModel.$folded);
 
   useEffect(() => {
     walletList.fetchWallets();
@@ -33,7 +34,7 @@ export const WalletSelect = memo(() => {
   }
 
   return (
-    <Popover align="start" sideOffset={2}>
+    <Popover align="start" side={folded ? 'right' : 'bottom'} sideOffset={2}>
       <Popover.Trigger>
         <WalletSelectTrigger wallet={selectedWallet} />
       </Popover.Trigger>

--- a/src/renderer/features/wallet-select/model/feature.tsx
+++ b/src/renderer/features/wallet-select/model/feature.tsx
@@ -6,6 +6,8 @@ export const walletSelectFeatureStatus = createFeature({
   name: 'wallet/select',
 });
 
-walletSelectFeatureStatus.inject(navigationHeaderSlot, () => {
-  return <WalletSelect />;
+walletSelectFeatureStatus.inject(navigationHeaderSlot, {
+  render({ folded }) {
+    return <WalletSelect folded={folded} />;
+  },
 });

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1812,7 +1812,8 @@
     "transfersLabel": "Transfer",
     "unknownWalletLabel": "Unknown wallet",
     "vestedTransfersLabel": "Vested transfer",
-    "walletsLabel": "Wallets"
+    "walletsLabel": "Wallets",
+    "collapseLabel": "Collapse"
   },
   "notifications": {
     "details": {


### PR DESCRIPTION
## Summary
- Add fold/unfold toggle to navigation sidebar (240px extended, 64px folded) with state persisted to localStorage via Effector
- All sidebar components (NavItem, CustomOperations, WalletSelect, ToggleButton) use identical DOM structure in both states with CSS-only transitions for smooth animation
- Folded state shows icons only with right-side tooltips; badges render as compact dots; wallet selector shows only identicon

## Changes
- **New:** `sidebar-model.ts` — Effector store `$folded` + `toggled` event with localStorage persistence
- **AppShell** — Animated sidebar width transition (`w-[240px]` ↔ `w-16`)
- **NavItem** — Always-present Tooltip + div wrapper (Radix `asChild` compatibility), labels fade via `max-w-0 opacity-0` transition
- **Navigation** — Added collapse toggle button, `overflow-x-hidden` to prevent scrollbar during animation
- **CustomOperations** — Unified DOM structure matching NavItem pattern, dropdown repositions to right when folded
- **WalletSelect** — Single trigger structure with consistent height, text clipped by sidebar overflow
- **CLAUDE.md** — Documented UI animation patterns and Radix gotchas

## Test plan
- [ ] Click collapse toggle: sidebar animates smoothly between 240px and 64px
- [ ] Icons stay in exact same position during animation (no jumping)
- [ ] Folded: tooltips appear on hover for all nav items
- [ ] Folded: notification badge shows as small dot
- [ ] Folded: wallet selector shows identicon only, popover works
- [ ] Folded: custom operations icon opens dropdown to the right
- [ ] State persists across page reload
- [ ] No horizontal scrollbar in folded state

🤖 Generated with [Claude Code](https://claude.com/claude-code)