### PR TITLE
feat(sidebar): add collapsible navigation sidebar

### DIFF
--- a/src/renderer/features/basket-navigation/index.tsx
+++ b/src/renderer/features/basket-navigation/index.tsx
@@ -35,7 +35,11 @@ basketNavigationFeature.inject(navigationBottomLinksSlot, {
         icon="basket"
         title={t('navigation.basketLabel')}
         link={Paths.BASKET}
-        badge={<BodyText className="ml-auto text-text-tertiary">{availableOperations.length || ''}</BodyText>}
+        badge={
+          availableOperations.length > 0 ? (
+            <BodyText className="ml-auto text-text-tertiary">{availableOperations.length}</BodyText>
+          ) : null
+        }
       ></NavItem>
     );
   },

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -22,6 +22,7 @@ export const walletIconSlot = createSlot<{ wallet: Wallet; size: number }>();
 
 export const WalletSelect = memo(({ folded }: { folded: boolean }) => {
   const selectedWallet = useUnit(walletSelect.$selectedWallet);
+  const folded = useUnit(sidebarModel.$folded);
 
   useEffect(() => {
     walletList.fetchWallets();

--- a/src/renderer/features/wallet-select/components/WalletSelect.tsx
+++ b/src/renderer/features/wallet-select/components/WalletSelect.tsx
@@ -22,7 +22,6 @@ export const walletIconSlot = createSlot<{ wallet: Wallet; size: number }>();
 
 export const WalletSelect = memo(({ folded }: { folded: boolean }) => {
   const selectedWallet = useUnit(walletSelect.$selectedWallet);
-  const folded = useUnit(sidebarModel.$folded);
 
   useEffect(() => {
     walletList.fetchWallets();


### PR DESCRIPTION
## Summary
- Add collapsible sidebar with fold/unfold toggle, persisted in local storage
- Smooth CSS transitions for all elements (text fade, width animation, icon stability)
- Wallet select popover opens to the right when sidebar is folded
- Fix basket navigation badge dot showing when empty and sidebar is folded

## Test plan
- [ ] Toggle sidebar collapse/expand via the fold button
- [ ] Verify sidebar state persists across page reloads
- [ ] Verify wallet select popover opens correctly in both states
- [ ] Verify basket icon badge dot only shows when there are actual operations
- [ ] Verify tooltips appear on hover when sidebar is folded
- [ ] Verify navigation links work in both states

🤖 Generated with [Claude Code](https://claude.com/claude-code)