### PR TITLE
fix(dev): prevent HMR crashes during development

### DIFF
--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -78,7 +78,7 @@ const Root = () => {
             onError={(error, errorInfo) => {
               console.error(error.message);
               console.error(errorInfo.componentStack);
-              if (error.message.includes('Failed to fetch dynamically imported module')) {
+              if (error.message.includes('Failed to fetch dynamically imported module') && import.meta.env.PROD) {
                 location.reload();
               }
             }}

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -366,7 +366,7 @@ persist({ store: $cachedOperations, key: 'multisig-operations', done: cachedOper
 // Clear stale cached operations that lack required fields (old format before multisigAccountId was added)
 sample({
   clock: cachedOperationsLoaded,
-  filter: ({ value }) => value.some(op => !op.multisigAccountId),
+  filter: ({ value }) => Array.isArray(value) && value.some(op => !op.multisigAccountId),
   fn: () => [],
   target: $cachedOperations,
 });

--- a/vite.config.renderer.ts
+++ b/vite.config.renderer.ts
@@ -100,7 +100,7 @@ const config: UserConfigFn = async ({ mode, command }) => {
 
       react({
         plugins: isDevServer
-          ? [['@effector/swc-plugin', { hmr: 'es', addNames: true, addLoc: true, factories: ['@/shared/di'] }]]
+          ? [['@effector/swc-plugin', { hmr: 'es', addNames: true, addLoc: false, factories: ['@/shared/di'] }]]
           : [],
       }),
       svgr({


### PR DESCRIPTION
## Summary
- **Disable auto-reload in dev mode**: The error boundary was calling `location.reload()` on transient dynamic import failures during HMR updates, killing the dev session. Now only reloads in production where stale cached chunks are a real issue.
- **Disable `addLoc` in Effector SWC plugin**: This option embeds source file locations into every Effector unit, causing unnecessary module invalidation cascades on every edit. `addNames` is kept for debugging.

## Test plan
- [ ] Run `pnpm start`, edit a component file, verify HMR applies the change without crashing
- [ ] Verify Effector stores still show readable names in devtools (`addNames` still enabled)
- [ ] Verify production build still auto-reloads on stale chunk errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)