### PR TITLE
fix(sidebar): adjust badge position on collapsed nav icons

### DIFF
--- a/src/renderer/features/app-shell/components/NavItem.tsx
+++ b/src/renderer/features/app-shell/components/NavItem.tsx
@@ -55,7 +55,7 @@ export const NavItem = ({ title, link, icon, badge }: Props) => {
                     </span>
                   )}
                   {folded && badge && (
-                    <span className="absolute top-0 right-0 h-1.5 w-1.5 rounded-full bg-icon-accent" />
+                    <span className="absolute -top-0.5 -right-1.5 h-1.5 w-1.5 rounded-full bg-icon-accent" />
                   )}
                 </div>
                 <BodyText


### PR DESCRIPTION
## Summary
- Adjust notification badge dot position on collapsed sidebar icons (`-top-0.5 -right-1.5` instead of `top-0 right-0`) so it aligns properly with the icon

## Test plan
- [ ] Collapse the sidebar and verify badge dots on notification/operations icons are properly positioned
- [ ] Expand sidebar and verify badges still display correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)