### PR TITLE
chore: upgrade to Vite 8 with Rolldown bundler

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -274,7 +274,9 @@ export default tseslint.config(
       parser: tseslint.parser,
       parserOptions: {
         sourceType: 'module',
-        projectService: true,
+        projectService: {
+          allowDefaultProject: ['*.config.ts'],
+        },
         tsconfigRootDir: __dirname,
       },
     },

--- a/package.json
+++ b/package.json
@@ -182,7 +182,7 @@
     "@astrojs/starlight": "0.35.2",
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
-    "@effector/swc-plugin": "0.8.1",
+    "@effector/swc-plugin": "1.0.0",
     "@electron/notarize": "2.5.0",
     "@eslint/js": "9.39.2",
     "@eslint/json": "0.12.0",
@@ -196,7 +196,7 @@
     "@storybook/addon-links": "9.1.12",
     "@storybook/react-vite": "9.1.12",
     "@svgr/plugin-svgo": "8.1.0",
-    "@swc/core": "1.13.5",
+    "@swc/core": "1.15.11",
     "@swc/helpers": "0.5.17",
     "@tailwindcss/language-server": "0.14.26",
     "@tailwindcss/vite": "4.1.12",
@@ -211,12 +211,12 @@
     "@typescript-eslint/eslint-plugin": "8.39.1",
     "@typescript-eslint/parser": "8.39.1",
     "@typescript/native-preview": "7.0.0-dev.20260126.1",
-    "@vitejs/plugin-react-swc": "4.1.0",
-    "@vitest/coverage-v8": "3.2.4",
-    "@vitest/ui": "3.2.4",
+    "@vitejs/plugin-react-swc": "4.3.0",
+    "@vitest/coverage-v8": "4.1.0",
+    "@vitest/ui": "4.1.0",
     "allure-js-commons": "3.2.0",
     "allure-playwright": "3.0.6",
-    "allure-vitest": "3.4.5",
+    "allure-vitest": "3.6.0",
     "astro": "5.13.1",
     "camelcase": "6.3.0",
     "concurrently": "7.6.0",
@@ -269,17 +269,24 @@
     "tslib": "2.8.1",
     "typescript": "5.9.2",
     "typescript-eslint": "8.39.1",
-    "vite": "7.1.11",
+    "vite": "8.0.0",
     "vite-plugin-compression2": "2.2.1",
     "vite-plugin-mkcert": "1.17.8",
     "vite-plugin-node-polyfills": "0.24.0",
     "vite-plugin-svgr": "4.5.0",
     "vite-plugin-target": "0.1.1",
     "vite-tsconfig-paths": "5.1.4",
-    "vitest": "3.2.4"
+    "vitest": "4.1.0"
   },
   "sideEffects": [
     "*.css",
     "*.ts"
-  ]
+  ],
+  "pnpm": {
+    "peerDependencyRules": {
+      "allowedVersions": {
+        "vite": "8"
+      }
+    }
+  }
 }

--- a/package.json
+++ b/package.json
@@ -275,7 +275,6 @@
     "vite-plugin-node-polyfills": "0.24.0",
     "vite-plugin-svgr": "4.5.0",
     "vite-plugin-target": "0.1.1",
-    "vite-tsconfig-paths": "5.1.4",
     "vitest": "4.1.0"
   },
   "sideEffects": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -31,7 +31,7 @@ importers:
         version: 3.0.0
       '@polkadot-api/descriptors':
         specifier: file:.papi/descriptors
-        version: file:.papi/descriptors(polkadot-api@1.20.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1))
+        version: file:.papi/descriptors(polkadot-api@1.20.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1))
       '@polkadot-api/merkleize-metadata':
         specifier: 1.1.26
         version: 1.1.26
@@ -223,7 +223,7 @@ importers:
         version: 2.3.0(effector@23.4.4)
       polkadot-api:
         specifier: 1.20.0
-        version: 1.20.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1)
+        version: 1.20.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1)
       qr-code-styling:
         specifier: 1.9.1
         version: 1.9.1
@@ -290,7 +290,7 @@ importers:
     devDependencies:
       '@astrojs/starlight':
         specifier: 0.35.2
-        version: 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+        version: 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       '@commitlint/cli':
         specifier: 19.8.1
         version: 19.8.1(@types/node@22.17.0)(typescript@5.9.2)
@@ -298,8 +298,8 @@ importers:
         specifier: 19.8.1
         version: 19.8.1
       '@effector/swc-plugin':
-        specifier: 0.8.1
-        version: 0.8.1
+        specifier: 1.0.0
+        version: 1.0.0
       '@electron/notarize':
         specifier: 2.5.0
         version: 2.5.0
@@ -320,28 +320,28 @@ importers:
         version: 2.3.1
       '@peterek/vite-plugin-favicons':
         specifier: 2.1.0
-        version: 2.1.0(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@playwright/test':
         specifier: 1.52.0
         version: 1.52.0
       '@storybook/addon-a11y':
         specifier: 9.1.12
-        version: 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/addon-docs':
         specifier: 9.1.12
-        version: 9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/addon-links':
         specifier: 9.1.12
-        version: 9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/react-vite':
         specifier: 9.1.12
-        version: 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@svgr/plugin-svgo':
         specifier: 8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
       '@swc/core':
-        specifier: 1.13.5
-        version: 1.13.5(@swc/helpers@0.5.17)
+        specifier: 1.15.11
+        version: 1.15.11(@swc/helpers@0.5.17)
       '@swc/helpers':
         specifier: 0.5.17
         version: 0.5.17
@@ -350,7 +350,7 @@ importers:
         version: 0.14.26
       '@tailwindcss/vite':
         specifier: 4.1.12
-        version: 4.1.12(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@testing-library/jest-dom':
         specifier: 6.6.4
         version: 6.6.4
@@ -385,14 +385,14 @@ importers:
         specifier: 7.0.0-dev.20260126.1
         version: 7.0.0-dev.20260126.1
       '@vitejs/plugin-react-swc':
-        specifier: 4.1.0
-        version: 4.1.0(@swc/helpers@0.5.17)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        specifier: 4.3.0
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@vitest/coverage-v8':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0)
       '@vitest/ui':
-        specifier: 3.2.4
-        version: 3.2.4(vitest@3.2.4)
+        specifier: 4.1.0
+        version: 4.1.0(vitest@4.1.0)
       allure-js-commons:
         specifier: 3.2.0
         version: 3.2.0(allure-playwright@3.0.6(@playwright/test@1.52.0))
@@ -400,11 +400,11 @@ importers:
         specifier: 3.0.6
         version: 3.0.6(@playwright/test@1.52.0)
       allure-vitest:
-        specifier: 3.4.5
-        version: 3.4.5(@vitest/runner@3.2.4)(allure-playwright@3.0.6(@playwright/test@1.52.0))(vitest@3.2.4)
+        specifier: 3.6.0
+        version: 3.6.0(@vitest/runner@4.1.0)(allure-playwright@3.0.6(@playwright/test@1.52.0))(vitest@4.1.0)
       astro:
         specifier: 5.13.1
-        version: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+        version: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       camelcase:
         specifier: 6.3.0
         version: 6.3.0
@@ -536,10 +536,10 @@ importers:
         version: 0.5.21
       starlight-typedoc:
         specifier: 0.21.3
-        version: 0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2))
+        version: 0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2))
       storybook:
         specifier: 9.1.12
-        version: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       tailwindcss:
         specifier: 4.1.12
         version: 4.1.12
@@ -548,7 +548,7 @@ importers:
         version: 1.0.7(tailwindcss@4.1.12)
       ts-node:
         specifier: 10.9.2
-        version: 10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.2)
+        version: 10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.2)
       tslib:
         specifier: 2.8.1
         version: 2.8.1
@@ -559,29 +559,29 @@ importers:
         specifier: 8.39.1
         version: 8.39.1(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.2)
       vite:
-        specifier: 7.1.11
-        version: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+        specifier: 8.0.0
+        version: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
       vite-plugin-compression2:
         specifier: 2.2.1
         version: 2.2.1(rollup@4.52.5)
       vite-plugin-mkcert:
         specifier: 1.17.8
-        version: 1.17.8(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-node-polyfills:
         specifier: 0.24.0
-        version: 0.24.0(rollup@4.52.5)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-svgr:
         specifier: 4.5.0
-        version: 4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-target:
         specifier: 0.1.1
         version: 0.1.1
       vite-tsconfig-paths:
         specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 5.1.4(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       vitest:
-        specifier: 3.2.4
-        version: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+        specifier: 4.1.0
+        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
 
 packages:
 
@@ -707,6 +707,10 @@ packages:
     resolution: {integrity: sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==}
     engines: {node: '>=6.9.0'}
 
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
   '@babel/helper-validator-option@7.27.1':
     resolution: {integrity: sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==}
     engines: {node: '>=6.9.0'}
@@ -722,6 +726,11 @@ packages:
 
   '@babel/parser@7.28.3':
     resolution: {integrity: sha512-7+Ey1mAgYqFAx2h0RuoxcQT5+MlG3GTV0TQrgr7/ZliKsm/MNDxVVutlWaziMq7wJNAz8MTqz55XLpWvva6StA==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  '@babel/parser@7.29.0':
+    resolution: {integrity: sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww==}
     engines: {node: '>=6.0.0'}
     hasBin: true
 
@@ -743,6 +752,10 @@ packages:
 
   '@babel/types@7.28.2':
     resolution: {integrity: sha512-ruv7Ae4J5dUYULmeXw1gmb7rYRz57OWCPM57pHojnLq/3Z1CK2lNSLTCVjxVk1F/TZHwOZZrOWi0ur95BbLxNQ==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/types@7.29.0':
+    resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
   '@bcoe/v8-coverage@1.0.2':
@@ -852,8 +865,8 @@ packages:
     peerDependencies:
       effector: ^22.4.0 || ^23.0.0
 
-  '@effector/swc-plugin@0.8.1':
-    resolution: {integrity: sha512-hGoyR73EEdAoL6i8ElWW35KTc9p89xMC4dCW8M4MhCru9mptYgDsq7qKxUFRTJiwCqTVFztIq5j3vP8zdKP1aQ==}
+  '@effector/swc-plugin@1.0.0':
+    resolution: {integrity: sha512-LcT0uZTw62vhYc0ssV/TD5alkyGIYyBtTD4mF7YDPDK0lvh4W0jz5n5gKMisiF5N9/H9otrMG8X/tC/h8rx3Hw==}
 
   '@electron/asar@3.2.18':
     resolution: {integrity: sha512-2XyvMe3N3Nrs8cV39IKELRHTYUWFKrmqqSY1U+GMlc0jvqjIVnoxhNd2H4JolWQncbJi1DCvb5TNxZuI2fEjWg==}
@@ -905,11 +918,20 @@ packages:
   '@emnapi/core@1.4.5':
     resolution: {integrity: sha512-XsLw1dEOpkSX/WucdqUhPWP7hDxSvZiY+fsUC14h+FtQ2Ifni4znbBt8punRX+Uj2JG/uDb8nEHVKvrVlvdZ5Q==}
 
+  '@emnapi/core@1.9.0':
+    resolution: {integrity: sha512-0DQ98G9ZQZOxfUcQn1waV2yS8aWdZ6kJMbYCJB3oUBecjWYO1fqJ+a1DRfPF3O5JEkwqwP1A9QEN/9mYm2Yd0w==}
+
   '@emnapi/runtime@1.4.5':
     resolution: {integrity: sha512-++LApOtY0pEEz1zrd9vy1/zXVaVJJ/EbAF3u0fXIzPJEDtnITsBGbbK0EkM72amhl/R5b+5xx0Y/QhcVOpuulg==}
 
+  '@emnapi/runtime@1.9.0':
+    resolution: {integrity: sha512-QN75eB0IH2ywSpRpNddCRfQIhmJYBCJ1x5Lb3IscKAL8bMnVAKnRg8dCoXbHzVLLH7P38N2Z3mtulB7W0J0FKw==}
+
   '@emnapi/wasi-threads@1.0.4':
     resolution: {integrity: sha512-PJR+bOmMOPH8AtcTGAyYNiuJ3/Fcoj2XN/gBEWzDIKh254XO+mM9XoXHk5GNEhodxeMznbg7BlRojVbKN+gC6g==}
+
+  '@emnapi/wasi-threads@1.2.0':
+    resolution: {integrity: sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==}
 
   '@emotion/is-prop-valid@1.2.2':
     resolution: {integrity: sha512-uNsoYd37AFmaCdXlg6EYD1KaPOaRWRByMCYzbKUX4+hhMfrxdVSelShywL4JVaAeM/eHUOSprYBQls+/neX3pw==}
@@ -1784,10 +1806,6 @@ packages:
     resolution: {integrity: sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w==}
     engines: {node: '>=18.0.0'}
 
-  '@istanbuljs/schema@0.1.3':
-    resolution: {integrity: sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==}
-    engines: {node: '>=8'}
-
   '@jest/expect-utils@29.7.0':
     resolution: {integrity: sha512-GlsNBWiFQFCVi9QVSx7f5AgMeLxe9YCCs5PuP2O2LdjDAA8Jh9eX7lA1Jq/xdXw3Wb3hyvlFNfZIfcRetSzYcA==}
     engines: {node: ^14.15.0 || ^16.10.0 || >=18.0.0}
@@ -1836,9 +1854,6 @@ packages:
   '@jridgewell/trace-mapping@0.3.29':
     resolution: {integrity: sha512-uw6guiW/gcAGPDhLmd77/6lW8QLeiV5RUTsAX46Db6oLhGaVj4lhnPwb184s1bkc8kdVg/+h988dro8GRDpmYQ==}
 
-  '@jridgewell/trace-mapping@0.3.30':
-    resolution: {integrity: sha512-GQ7Nw5G2lTu/BtHTKfXhKHok2WGetd4XYcVKGx00SjAk8GMwgJM3zr6zORiPGuOE+/vkc90KtTosSSvaCjKb2Q==}
-
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
@@ -1871,6 +1886,9 @@ packages:
 
   '@napi-rs/wasm-runtime@1.0.1':
     resolution: {integrity: sha512-KVlQ/jgywZpixGCKMNwxStmmbYEMyokZpCf2YuIChhfJA2uqfAKNEM8INz7zzTo55iEXfBhIIs3VqYyqzDLj8g==}
+
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
   '@noble/ciphers@1.3.0':
     resolution: {integrity: sha512-2I0gnIVPtfnMw9ee9h1dJG7tp81+8Ob3OJb3Mv37rx5L40/b0i7djjCVvGOVqc9AEIQyvyu1i6ypKdFw8R8gQw==}
@@ -1943,6 +1961,13 @@ packages:
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
+
+  '@oxc-project/runtime@0.115.0':
+    resolution: {integrity: sha512-Rg8Wlt5dCbXhQnsXPrkOjL1DTSvXLgb2R/KYfnf1/K+R0k6UMLEmbQXPM+kwrWqSmWA2t0B1EtHy2/3zikQpvQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
+  '@oxc-project/types@0.115.0':
+    resolution: {integrity: sha512-4n91DKnebUS4yjUHl2g3/b2T+IUdCfmoZGhmwsovZCDaJSs+QkVAM+0AqqTxHSsHfeiMuueT75cZaZcT/m0pSw==}
 
   '@oxc-resolver/binding-android-arm-eabi@11.6.0':
     resolution: {integrity: sha512-UJTf5uZs919qavt9Btvbzkr3eaUu4d+FXBri8AB2BtOezriaTTUvArab2K9fdACQ4yFggTD5ews1l19V/6SW2Q==}
@@ -3040,8 +3065,100 @@ packages:
   '@remote-ui/rpc@1.4.7':
     resolution: {integrity: sha512-ORiaKsbVBSEi3Z4YWOj5Ucrp70NrkNktI1hdqqfBW7Z3o0YoxTX9MIqtLmsc6721IbjmExvLrLip5I5Y7uAbng==}
 
-  '@rolldown/pluginutils@1.0.0-beta.35':
-    resolution: {integrity: sha512-slYrCpoxJUqzFDDNlvrOYRazQUNRvWPjXA17dAOISY3rDMxX6k8K4cj2H+hEYMHF81HO3uNd5rHVigAWRM5dSg==}
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-lcJL0bN5hpgJfSIz/8PIf02irmyL43P+j1pTCfbD1DbLkmGRuFIA4DD3B3ZOvGqG0XiVvRznbKtN0COQVaKUTg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-J7Zk3kLYFsLtuH6U+F4pS2sYVzac0qkjcO5QxHS7OS7yZu2LRs+IXo+uvJ/mvpyUljDJ3LROZPoQfgBIpCMhdQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-iwtmmghy8nhfRGeNAIltcNXzD0QMNaaA5U/NyZc1Ia4bxrzFByNMDoppoC+hl7cDiUq5/1CnFthpT9n+UtfFyg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    resolution: {integrity: sha512-DLFYI78SCiZr5VvdEplsVC2Vx53lnA4/Ga5C65iyldMVaErr86aiqCoNBLl92PXPfDtUYjUh+xFFor40ueNs4Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    resolution: {integrity: sha512-CsjTmTwd0Hri6iTw/DRMK7kOZ7FwAkrO4h8YWKoX/kcj833e4coqo2wzIFywtch/8Eb5enQ/lwLM7w6JX1W5RQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-2x9O2JbSPxpxMDhP9Z74mahAStibTlrBMW0520+epJH5sac7/LwZW5Bmg/E6CXuEF53JJFW509uP+lSedaUNxg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-JA1QRW31ogheAIRhIg9tjMfsYbglXXYGNPLdPEYrwFxdbkQCAzvpSCSHCDWNl4hTtrol8WeboCSEpjdZK8qrCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-aOKU9dJheda8Kj8Y3w9gnt9QFOO+qKPAl8SWd7JPHP+Cu0EuDAE5wokQubLzIDQWg2myXq2XhTpOVS07qqvT+w==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-OalO94fqj7IWRn3VdXWty75jC5dk4C197AWEuMhIpvVv2lw9fiPhud0+bW2ctCxb3YoBZor71QHbY+9/WToadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    resolution: {integrity: sha512-cVEl1vZtBsBZna3YMjGXNvnYYrOJ7RzuWvZU0ffvJUexWkukMaDuGhUXn0rjnV0ptzGVkvc+vW9Yqy6h8YX4pg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    resolution: {integrity: sha512-UzYnKCIIc4heAKgI4PZ3dfBGUZefGCJ1TPDuLHoCzgrMYPb5Rv6TLFuYtyM4rWyHM7hymNdsg5ik2C+UD9VDbA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    resolution: {integrity: sha512-+6zoiF+RRyf5cdlFQP7nm58mq7+/2PFaY2DNQeD4B87N36JzfF/l9mdBkkmTvSYcYPE8tMh/o3cRlsx1ldLfog==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    resolution: {integrity: sha512-rgFN6sA/dyebil3YTlL2evvi/M+ivhfnyxec7AccTpRPccno/rPoNlqybEZQBkcbZu8Hy+eqNJCqfBR8P7Pg8g==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-lHVNUG/8nlF1IQk1C0Ci574qKYyty2goMiPlRqkC5R+3LkXDkL5Dhx8ytbxq35m+pkHVIvIxviD+TWLdfeuadA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    resolution: {integrity: sha512-G0oA4+w1iY5AGi5HcDTxWsoxF509hrFIPB2rduV5aDqS9FtDg1CAfa7V34qImbjfhIcA8C+RekocJZA96EarwQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@rolldown/pluginutils@1.0.0-rc.7':
+    resolution: {integrity: sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==}
+
+  '@rolldown/pluginutils@1.0.0-rc.9':
+    resolution: {integrity: sha512-w6oiRWgEBl04QkFZgmW+jnU1EC9b57Oihi2ot3HNWIQRqgHp5PnYDia5iZ5FF7rpa4EQdiqMDXjlqKGXBhsoXw==}
 
   '@rollup/plugin-inject@5.0.5':
     resolution: {integrity: sha512-2+DEJbNBoPROPkgTDNe8/1YXWcqxbN5DTjASVIOx8HS+pITXushyNiBV56RB08zuptzz8gT3YfkqriTBVycepg==}
@@ -3416,68 +3533,68 @@ packages:
     peerDependencies:
       '@svgr/core': '*'
 
-  '@swc/core-darwin-arm64@1.13.5':
-    resolution: {integrity: sha512-lKNv7SujeXvKn16gvQqUQI5DdyY8v7xcoO3k06/FJbHJS90zEwZdQiMNRiqpYw/orU543tPaWgz7cIYWhbopiQ==}
+  '@swc/core-darwin-arm64@1.15.11':
+    resolution: {integrity: sha512-QoIupRWVH8AF1TgxYyeA5nS18dtqMuxNwchjBIwJo3RdwLEFiJq6onOx9JAxHtuPwUkIVuU2Xbp+jCJ7Vzmgtg==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@swc/core-darwin-x64@1.13.5':
-    resolution: {integrity: sha512-ILd38Fg/w23vHb0yVjlWvQBoE37ZJTdlLHa8LRCFDdX4WKfnVBiblsCU9ar4QTMNdeTBEX9iUF4IrbNWhaF1Ng==}
+  '@swc/core-darwin-x64@1.15.11':
+    resolution: {integrity: sha512-S52Gu1QtPSfBYDiejlcfp9GlN+NjTZBRRNsz8PNwBgSE626/FUf2PcllVUix7jqkoMC+t0rS8t+2/aSWlMuQtA==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [darwin]
 
-  '@swc/core-linux-arm-gnueabihf@1.13.5':
-    resolution: {integrity: sha512-Q6eS3Pt8GLkXxqz9TAw+AUk9HpVJt8Uzm54MvPsqp2yuGmY0/sNaPPNVqctCX9fu/Nu8eaWUen0si6iEiCsazQ==}
+  '@swc/core-linux-arm-gnueabihf@1.15.11':
+    resolution: {integrity: sha512-lXJs8oXo6Z4yCpimpQ8vPeCjkgoHu5NoMvmJZ8qxDyU99KVdg6KwU9H79vzrmB+HfH+dCZ7JGMqMF//f8Cfvdg==}
     engines: {node: '>=10'}
     cpu: [arm]
     os: [linux]
 
-  '@swc/core-linux-arm64-gnu@1.13.5':
-    resolution: {integrity: sha512-aNDfeN+9af+y+M2MYfxCzCy/VDq7Z5YIbMqRI739o8Ganz6ST+27kjQFd8Y/57JN/hcnUEa9xqdS3XY7WaVtSw==}
+  '@swc/core-linux-arm64-gnu@1.15.11':
+    resolution: {integrity: sha512-chRsz1K52/vj8Mfq/QOugVphlKPWlMh10V99qfH41hbGvwAU6xSPd681upO4bKiOr9+mRIZZW+EfJqY42ZzRyA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-arm64-musl@1.13.5':
-    resolution: {integrity: sha512-9+ZxFN5GJag4CnYnq6apKTnnezpfJhCumyz0504/JbHLo+Ue+ZtJnf3RhyA9W9TINtLE0bC4hKpWi8ZKoETyOQ==}
+  '@swc/core-linux-arm64-musl@1.15.11':
+    resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
 
-  '@swc/core-linux-x64-gnu@1.13.5':
-    resolution: {integrity: sha512-WD530qvHrki8Ywt/PloKUjaRKgstQqNGvmZl54g06kA+hqtSE2FTG9gngXr3UJxYu/cNAjJYiBifm7+w4nbHbA==}
+  '@swc/core-linux-x64-gnu@1.15.11':
+    resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-linux-x64-musl@1.13.5':
-    resolution: {integrity: sha512-Luj8y4OFYx4DHNQTWjdIuKTq2f5k6uSXICqx+FSabnXptaOBAbJHNbHT/06JZh6NRUouaf0mYXN0mcsqvkhd7Q==}
+  '@swc/core-linux-x64-musl@1.15.11':
+    resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
 
-  '@swc/core-win32-arm64-msvc@1.13.5':
-    resolution: {integrity: sha512-cZ6UpumhF9SDJvv4DA2fo9WIzlNFuKSkZpZmPG1c+4PFSEMy5DFOjBSllCvnqihCabzXzpn6ykCwBmHpy31vQw==}
+  '@swc/core-win32-arm64-msvc@1.15.11':
+    resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [win32]
 
-  '@swc/core-win32-ia32-msvc@1.13.5':
-    resolution: {integrity: sha512-C5Yi/xIikrFUzZcyGj9L3RpKljFvKiDMtyDzPKzlsDrKIw2EYY+bF88gB6oGY5RGmv4DAX8dbnpRAqgFD0FMEw==}
+  '@swc/core-win32-ia32-msvc@1.15.11':
+    resolution: {integrity: sha512-6XnzORkZCQzvTQ6cPrU7iaT9+i145oLwnin8JrfsLG41wl26+5cNQ2XV3zcbrnFEV6esjOceom9YO1w9mGJByw==}
     engines: {node: '>=10'}
     cpu: [ia32]
     os: [win32]
 
-  '@swc/core-win32-x64-msvc@1.13.5':
-    resolution: {integrity: sha512-YrKdMVxbYmlfybCSbRtrilc6UA8GF5aPmGKBdPvjrarvsmf4i7ZHGCEnLtfOMd3Lwbs2WUZq3WdMbozYeLU93Q==}
+  '@swc/core-win32-x64-msvc@1.15.11':
+    resolution: {integrity: sha512-IQ2n6af7XKLL6P1gIeZACskSxK8jWtoKpJWLZmdXTDj1MGzktUy4i+FvpdtxFmJWNavRWH1VmTr6kAubRDHeKw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [win32]
 
-  '@swc/core@1.13.5':
-    resolution: {integrity: sha512-WezcBo8a0Dg2rnR82zhwoR6aRNxeTGfK5QCD6TQ+kg3xx/zNT02s/0o+81h/3zhvFSB24NtqEr8FTw88O5W/JQ==}
+  '@swc/core@1.15.11':
+    resolution: {integrity: sha512-iLmLTodbYxU39HhMPaMUooPwO/zqJWvsqkrXv1ZI38rMb048p6N7qtAtTp37sw9NzSrvH6oli8EdDygo09IZ/w==}
     engines: {node: '>=10'}
     peerDependencies:
       '@swc/helpers': '>=0.5.17'
@@ -3659,6 +3776,9 @@ packages:
 
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -4125,23 +4245,26 @@ packages:
     cpu: [x64]
     os: [win32]
 
-  '@vitejs/plugin-react-swc@4.1.0':
-    resolution: {integrity: sha512-Ff690TUck0Anlh7wdIcnsVMhofeEVgm44Y4OYdeeEEPSKyZHzDI9gfVBvySEhDfXtBp8tLCbfsVKPWEMEjq8/g==}
+  '@vitejs/plugin-react-swc@4.3.0':
+    resolution: {integrity: sha512-mOkXCII839dHyAt/gpoSlm28JIVDwhZ6tnG6wJxUy2bmOx7UaPjvOyIDf3SFv5s7Eo7HVaq6kRcu6YMEzt5Z7w==}
     engines: {node: ^20.19.0 || >=22.12.0}
     peerDependencies:
-      vite: ^4 || ^5 || ^6 || ^7
+      vite: ^4 || ^5 || ^6 || ^7 || ^8
 
-  '@vitest/coverage-v8@3.2.4':
-    resolution: {integrity: sha512-EyF9SXU6kS5Ku/U82E259WSnvg6c8KTjppUncuNdm5QHpe17mwREHnjDzozC8x9MZ0xfBUFSaLkRv4TMA75ALQ==}
+  '@vitest/coverage-v8@4.1.0':
+    resolution: {integrity: sha512-nDWulKeik2bL2Va/Wl4x7DLuTKAXa906iRFooIRPR+huHkcvp9QDkPQ2RJdmjOFrqOqvNfoSQLF68deE3xC3CQ==}
     peerDependencies:
-      '@vitest/browser': 3.2.4
-      vitest: 3.2.4
+      '@vitest/browser': 4.1.0
+      vitest: 4.1.0
     peerDependenciesMeta:
       '@vitest/browser':
         optional: true
 
   '@vitest/expect@3.2.4':
     resolution: {integrity: sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==}
+
+  '@vitest/expect@4.1.0':
+    resolution: {integrity: sha512-EIxG7k4wlWweuCLG9Y5InKFwpMEOyrMb6ZJ1ihYu02LVj/bzUwn2VMU+13PinsjRW75XnITeFrQBMH5+dLvCDA==}
 
   '@vitest/mocker@3.2.4':
     resolution: {integrity: sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==}
@@ -4154,25 +4277,45 @@ packages:
       vite:
         optional: true
 
+  '@vitest/mocker@4.1.0':
+    resolution: {integrity: sha512-evxREh+Hork43+Y4IOhTo+h5lGmVRyjqI739Rz4RlUPqwrkFFDF6EMvOOYjTx4E8Tl6gyCLRL8Mu7Ry12a13Tw==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
   '@vitest/pretty-format@3.2.4':
     resolution: {integrity: sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==}
 
-  '@vitest/runner@3.2.4':
-    resolution: {integrity: sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==}
+  '@vitest/pretty-format@4.1.0':
+    resolution: {integrity: sha512-3RZLZlh88Ib0J7NQTRATfc/3ZPOnSUn2uDBUoGNn5T36+bALixmzphN26OUD3LRXWkJu4H0s5vvUeqBiw+kS0A==}
 
-  '@vitest/snapshot@3.2.4':
-    resolution: {integrity: sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==}
+  '@vitest/runner@4.1.0':
+    resolution: {integrity: sha512-Duvx2OzQ7d6OjchL+trw+aSrb9idh7pnNfxrklo14p3zmNL4qPCDeIJAK+eBKYjkIwG96Bc6vYuxhqDXQOWpoQ==}
+
+  '@vitest/snapshot@4.1.0':
+    resolution: {integrity: sha512-0Vy9euT1kgsnj1CHttwi9i9o+4rRLEaPRSOJ5gyv579GJkNpgJK+B4HSv/rAWixx2wdAFci1X4CEPjiu2bXIMg==}
 
   '@vitest/spy@3.2.4':
     resolution: {integrity: sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==}
 
-  '@vitest/ui@3.2.4':
-    resolution: {integrity: sha512-hGISOaP18plkzbWEcP/QvtRW1xDXF2+96HbEX6byqQhAUbiS5oH6/9JwW+QsQCIYON2bI6QZBF+2PvOmrRZ9wA==}
+  '@vitest/spy@4.1.0':
+    resolution: {integrity: sha512-pz77k+PgNpyMDv2FV6qmk5ZVau6c3R8HC8v342T2xlFxQKTrSeYw9waIJG8KgV9fFwAtTu4ceRzMivPTH6wSxw==}
+
+  '@vitest/ui@4.1.0':
+    resolution: {integrity: sha512-sTSDtVM1GOevRGsCNhp1mBUHKo9Qlc55+HCreFT4fe99AHxl1QQNXSL3uj4Pkjh5yEuWZIx8E2tVC94nnBZECQ==}
     peerDependencies:
-      vitest: 3.2.4
+      vitest: 4.1.0
 
   '@vitest/utils@3.2.4':
     resolution: {integrity: sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==}
+
+  '@vitest/utils@4.1.0':
+    resolution: {integrity: sha512-XfPXT6a8TZY3dcGY8EdwsBulFCIw+BeeX0RZn2x/BtiY/75YGh8FeWGG8QISN/WhaqSrE2OrlDgtF8q5uhOTmw==}
 
   '@walletconnect/core@2.22.3':
     resolution: {integrity: sha512-14qELKSVdLiXHUzFhErhP16DT58JaK7Aw5PM/x94tSKvjrI5Y3ttq8E1aF7c/yoETgJ0VVINav/YfKr2cYH7vQ==}
@@ -4382,10 +4525,10 @@ packages:
       allure-playwright:
         optional: true
 
-  allure-js-commons@3.4.5:
-    resolution: {integrity: sha512-mzAppLFva9PJqWvdI/aXn8jqr+5Am67JITdthMfEk8En6AhsrvRWZAjHZ1yUMDGEbxmivCni3lppvitJGStxFQ==}
+  allure-js-commons@3.6.0:
+    resolution: {integrity: sha512-RquIzMlh2l+ZLtq+Uxt+ZpOptxLzyPvLfPGbwU7dtgXo0QfUvhLFFkCljIR7Gjxo7jZ+WVqoto1yOPpXqU/i4g==}
     peerDependencies:
-      allure-playwright: 3.4.5
+      allure-playwright: 3.6.0
     peerDependenciesMeta:
       allure-playwright:
         optional: true
@@ -4395,8 +4538,8 @@ packages:
     peerDependencies:
       '@playwright/test': '>=1.36.0'
 
-  allure-vitest@3.4.5:
-    resolution: {integrity: sha512-HdimbVVdqCZaMVXd9YDu25cBkj9hbl20JlhuXjzGE8TfCfD1MBVtKrsog6e4YJXQ1ZbX3qVpYhuHWHSDn6x4WQ==}
+  allure-vitest@3.6.0:
+    resolution: {integrity: sha512-ia9YHE6Esidv2lFHMHj5o9khsystHe1iNF9mvLcv6ZB+FWQJYGFmdnnyTwgeIKFQtojVPhY0AcDP47NzzmLIXw==}
     peerDependencies:
       '@vitest/runner': '>=1.3.0'
       vitest: '>=1.3.0'
@@ -4525,8 +4668,8 @@ packages:
     resolution: {integrity: sha512-6t10qk83GOG8p0vKmaCr8eiilZwO171AvbROMtvvNiwrTly62t+7XkA8RdIIVbpMhCASAsxgAzdRSwh6nw/5Dg==}
     engines: {node: '>=4'}
 
-  ast-v8-to-istanbul@0.3.4:
-    resolution: {integrity: sha512-cxrAnZNLBnQwBPByK4CeDaw5sWZtMilJE/Q3iDA0aamgaIVNDF9T6K2/8DfYDZEejZ2jNnDrG9m8MY72HFd0KA==}
+  ast-v8-to-istanbul@1.0.0:
+    resolution: {integrity: sha512-1fSfIwuDICFA4LKkCzRPO7F0hzFf0B7+Xqrl27ynQaa+Rh0e1Es0v6kWHPott3lU10AyAr7oKHa65OppjLn3Rg==}
 
   astral-regex@2.0.0:
     resolution: {integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==}
@@ -4812,6 +4955,10 @@ packages:
 
   chai@5.2.1:
     resolution: {integrity: sha512-5nFxhUrX0PqtyogoYOA8IPswy5sZFTOsBFl/9bNsmDLgsxYTzSZQJDPppDnZPTQbzSEm0hqGjWPzRemQCYbD6A==}
+    engines: {node: '>=18'}
+
+  chai@6.2.2:
+    resolution: {integrity: sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==}
     engines: {node: '>=18'}
 
   chalk@2.4.2:
@@ -5721,6 +5868,9 @@ packages:
   es-module-lexer@1.7.0:
     resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
 
+  es-module-lexer@2.0.0:
+    resolution: {integrity: sha512-5POEcUuZybH7IdmGsD8wlf0AI55wMecM9rVBTI/qEAy2c1kTOm3DjFYjrBdI2K3BaJjJYfYFeRtM0t9ssnRuxw==}
+
   es-object-atoms@1.1.1:
     resolution: {integrity: sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==}
     engines: {node: '>= 0.4'}
@@ -6027,8 +6177,8 @@ packages:
     resolution: {integrity: sha512-jpWzZ1ZhwUmeWRhS7Qv3mhpOhLfwI+uAX4e5fOcXqwMR7EcJ0pj2kV1CVzHVMX/LphnKWD3LObjZCoJ71lKpHw==}
     engines: {node: ^18.19.0 || >=20.5.0}
 
-  expect-type@1.2.2:
-    resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
 
   expect@29.7.0:
@@ -6144,6 +6294,9 @@ packages:
 
   flatted@3.3.3:
     resolution: {integrity: sha512-GX+ysw4PBCz0PzosHDepZGANEuFCMLrnRTiEy9McGjmkCQYwRq4A/X786G/fjM/+OjsWSU1ZrY5qyARZmO/uwg==}
+
+  flatted@3.4.0:
+    resolution: {integrity: sha512-kC6Bb+ooptOIvWj5B63EQWkF0FEnNjV2ZNkLMLZRDDduIiWeFF4iKnslwhiWxjAdbg4NzTNo6h0qLuvFrcx+Sw==}
 
   flattie@1.1.1:
     resolution: {integrity: sha512-9UbaD6XdAL97+k/n+N7JwX46K/M6Zc6KcFYskrYL8wbBV/Uyk0CTAMY0VT+qiK5PM7AIc9aTWYtq65U7T+aCNQ==}
@@ -6959,12 +7112,8 @@ packages:
     resolution: {integrity: sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw==}
     engines: {node: '>=10'}
 
-  istanbul-lib-source-maps@5.0.6:
-    resolution: {integrity: sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A==}
-    engines: {node: '>=10'}
-
-  istanbul-reports@3.1.7:
-    resolution: {integrity: sha512-BewmUXImeuRk2YY0PVbxgKAysvhRPUQE0h5QRM++nVWyubKGV0l8qQ5op8+B2DOmwSe63Jivj0BjkPQVf8fP5g==}
+  istanbul-reports@3.2.0:
+    resolution: {integrity: sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA==}
     engines: {node: '>=8'}
 
   iterator.prototype@1.1.5:
@@ -7022,11 +7171,11 @@ packages:
     resolution: {integrity: sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw==}
     engines: {node: '>=10'}
 
+  js-tokens@10.0.0:
+    resolution: {integrity: sha512-lM/UBzQmfJRo9ABXbPWemivdCW8V2G8FHaHdypQaIy523snUjog0W71ayWXTjiR+ixeMyVHN2XcpnTd/liPg/Q==}
+
   js-tokens@4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
-
-  js-tokens@9.0.1:
-    resolution: {integrity: sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==}
 
   js-yaml@4.1.0:
     resolution: {integrity: sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==}
@@ -7139,8 +7288,20 @@ packages:
   lie@3.3.0:
     resolution: {integrity: sha512-UaiMJzeWRlEujzAuw5LokY1L5ecNQYZKfmyZ9L7wDHb/p5etKaxXhohBcrw0EYby+G/NA52vRSN4N39dxHAIwQ==}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
   lightningcss-darwin-arm64@1.30.1:
     resolution: {integrity: sha512-c8JK7hyE65X1MHMN+Viq9n11RRC7hgin3HhYKhrMyaXflk5GVplZ60IxyoVtzILeKr+xAJwg6zK6sjTBJ0FKYQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [darwin]
@@ -7151,8 +7312,20 @@ packages:
     cpu: [x64]
     os: [darwin]
 
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
   lightningcss-freebsd-x64@1.30.1:
     resolution: {integrity: sha512-kmW6UGCGg2PcyUE59K5r0kWfKPAVy4SltVeut+umLCFoJ53RdCUWxcRDzO1eTaxf/7Q2H7LTquFHPL5R+Gjyig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [freebsd]
@@ -7163,8 +7336,20 @@ packages:
     cpu: [arm]
     os: [linux]
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
   lightningcss-linux-arm64-gnu@1.30.1:
     resolution: {integrity: sha512-gB72maP8rmrKsnKYy8XUuXi/4OctJiuQjcuqWNlJQ6jZiWqtPvqFziskH3hnajfvKB27ynbVCucKSm2rkQp4Bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
@@ -7175,8 +7360,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+
   lightningcss-linux-x64-gnu@1.30.1:
     resolution: {integrity: sha512-piWx3z4wN8J8z3+O5kO74+yr6ze/dKmPnI7vLqfSqI8bccaTGY5xiSGVIJBDd5K5BHlvVLpUB3S2YCfelyJ1bw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
@@ -7187,8 +7384,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+
   lightningcss-win32-arm64-msvc@1.30.1:
     resolution: {integrity: sha512-mSL4rqPi4iXq5YVqzSsJgMVFENoa4nGTT/GjO2c0Yl9OuQfPsIfncvLrEW6RbbB24WtZ3xP/2CCmI3tNkNV4oA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [win32]
@@ -7199,8 +7408,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
   lightningcss@1.30.1:
     resolution: {integrity: sha512-xi6IyHML+c9+Q3W0S4fCQJOym42pyurFiJUHEcEyHS0CeKzia4yZDEsLlqOFykxOdHpNy0NmvVO31vcSqAxJCg==}
+    engines: {node: '>= 12.0.0'}
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
     engines: {node: '>= 12.0.0'}
 
   lilconfig@3.1.3:
@@ -7355,8 +7574,14 @@ packages:
   magic-string@0.30.17:
     resolution: {integrity: sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA==}
 
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
   magicast@0.3.5:
     resolution: {integrity: sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ==}
+
+  magicast@0.5.2:
+    resolution: {integrity: sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ==}
 
   make-dir@4.0.0:
     resolution: {integrity: sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw==}
@@ -7919,6 +8144,9 @@ packages:
     resolution: {integrity: sha512-gXah6aZrcUxjWg2zR2MwouP2eHlCBzdV4pygudehaKXSGW4v2AsRQUK+lwwXhii6KFZcunEnmSUoYp5CXibxtA==}
     engines: {node: '>= 0.4'}
 
+  obug@2.1.1:
+    resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
+
   ofetch@1.4.1:
     resolution: {integrity: sha512-QZj2DfGplQAr2oj9KzceK9Hwz6Whxazmn85yYeVuS3u9XTMOGMRx0kO95MQ+vLsj/S/NwBDMMLU5hpxvI6Tklw==}
 
@@ -8317,6 +8545,10 @@ packages:
 
   postcss@8.5.6:
     resolution: {integrity: sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.8:
+    resolution: {integrity: sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==}
     engines: {node: ^10 || ^12 || >=14}
 
   postject@1.0.0-alpha.6:
@@ -8978,6 +9210,11 @@ packages:
     resolution: {integrity: sha512-CHhPh+UNHD2GTXNYhPWLnU8ONHdI+5DI+4EYIAOaiD63rHeYlZvyh8P+in5999TTSFgUYuKUAjzRI4mdh/p+2A==}
     engines: {node: '>=8.0'}
 
+  rolldown@1.0.0-rc.9:
+    resolution: {integrity: sha512-9EbgWge7ZH+yqb4d2EnELAntgPTWbfL8ajiTW+SyhJEC4qhBbkCKbqFV4Ge4zmu5ziQuVbWxb/XwLZ+RIO7E8Q==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    hasBin: true
+
   rollup@4.52.5:
     resolution: {integrity: sha512-3GuObel8h7Kqdjt0gxkEzaifHTqLVW56Y/bjN7PSQtkKr0w3V/QYSdt6QWYtd7A1xUtYQigtdUfgj1RvWVtorw==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
@@ -9151,8 +9388,8 @@ packages:
     resolution: {integrity: sha512-a2B9Y0KlNXl9u/vsW6sTIu9vGEpfKu2wRV6l1H3XEas/0gUIzGzBoP/IouTcUQbm9JWZLH3COxyn03TYlFax6w==}
     engines: {node: '>=10'}
 
-  sirv@3.0.1:
-    resolution: {integrity: sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==}
+  sirv@3.0.2:
+    resolution: {integrity: sha512-2wcC/oGxHis/BoHkkPwldgiPSYcpZK3JU28WoMVv55yHJgcZ8rlXvuG9iZggz+sU1d4bRgIGASwyWqjxu3FM0g==}
     engines: {node: '>=18'}
 
   sisteransi@1.0.5:
@@ -9300,8 +9537,8 @@ packages:
     resolution: {integrity: sha512-jH9EhtKIjuXZ2cWxmXS8ZP80XyC3iasQxMDV8jzhNJpfDb7VbQLVW4Wvsxz9QZvzV+G4YoSfBUVKDOyxLzi/sg==}
     engines: {node: '>= 6'}
 
-  std-env@3.9.0:
-    resolution: {integrity: sha512-UGvjygr6F6tpH7o2qyqR6QYpwraIjKSdtzyBdyytFOHmPZY917kwdwLG0RbOjWOnKmnm3PeHjaoLLMie7kPLQw==}
+  std-env@4.0.0:
+    resolution: {integrity: sha512-zUMPtQ/HBY3/50VbpkupYHbRroTRZJPRLvreamgErJVys0ceuzMkD44J/QjqhHjOzK42GQ3QZIeFG1OYfOtKqQ==}
 
   stdin-discarder@0.2.2:
     resolution: {integrity: sha512-UhDfHmA92YAlNnCfhmq0VeNL5bDbiZGg7sZ2IvPsXubGkiNa9EC+tUTsjBRsYUAz87btI6/1wf4XoVvQ3uRnmQ==}
@@ -9426,9 +9663,6 @@ packages:
     resolution: {integrity: sha512-4X2FR3UwhNUE9G49aIsJW5hRRR3GXGTBTZRMfv568O60ojM8HcWjV/VxAxCDW3SUND33O6ZY66ZuRcdkj73q2g==}
     engines: {node: '>=14.16'}
 
-  strip-literal@3.0.0:
-    resolution: {integrity: sha512-TcccoMhJOM3OebGhSBEmp3UZ2SfDMZUEBdRA/9ynfLi8yYajyWX3JiXArcJt4Umh4vISpspkQIY8ZZoCqjbviA==}
-
   style-to-js@1.1.17:
     resolution: {integrity: sha512-xQcBGDxJb6jjFCTzvQtfiPn6YvvP2O8U1MDIPNfJQlWMYfktPy+iGsHE7cssjs7y84d9fQaK4UF3RIJaAHSoYA==}
 
@@ -9536,10 +9770,6 @@ packages:
     engines: {node: '>=10'}
     hasBin: true
 
-  test-exclude@7.0.1:
-    resolution: {integrity: sha512-pFYqmTw68LXVjeWJMST4+borgQP2AyMNbg1BpZh9LbyhUeNkeaPF9gzfPGUAnSMV3qPYdWUwDIjjCLiSDOl7vg==}
-    engines: {node: '>=18'}
-
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
 
@@ -9588,6 +9818,10 @@ packages:
   tinyexec@1.0.1:
     resolution: {integrity: sha512-5uC6DDlmeqiOwCPmK9jMSdOuZTh8bU39Ys6yidB+UTt5hfZUPGAypSgFRiEp+jbi9qH40BLDvy85jIU88wKSqw==}
 
+  tinyexec@1.0.2:
+    resolution: {integrity: sha512-W/KYk+NFhkmsYpuHq5JykngiOCnxeVL8v8dFnqxSD8qEEdRfXk1SDM6JzNqcERbcGYj9tMrDQBYV9cjgnunFIg==}
+    engines: {node: '>=18'}
+
   tinyglobby@0.2.14:
     resolution: {integrity: sha512-tX5e7OM1HnYr2+a2C/4V0htOcSQcoSTH9KgJnVvNm5zm/cyEWKJ7j7YutsH9CxMdtOkkLFy2AHrMci9IM8IPZQ==}
     engines: {node: '>=12.0.0'}
@@ -9596,12 +9830,12 @@ packages:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
     engines: {node: '>=12.0.0'}
 
-  tinypool@1.1.1:
-    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
-    engines: {node: ^18.0.0 || >=20.0.0}
-
   tinyrainbow@2.0.0:
     resolution: {integrity: sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==}
+    engines: {node: '>=14.0.0'}
+
+  tinyrainbow@3.1.0:
+    resolution: {integrity: sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==}
     engines: {node: '>=14.0.0'}
 
   tinyspy@4.0.3:
@@ -10106,11 +10340,6 @@ packages:
     resolution: {integrity: sha512-0QwqXteBNXgnLCdWdvPQBX6FXRHtIH3VhJPTd5Lwn28tJXc34YqSCWUmkOvtJHBmB3gGoPtrOKk3Ts8/kEZ9aA==}
     engines: {node: '>=10.13.0'}
 
-  vite-node@3.2.4:
-    resolution: {integrity: sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
-    hasBin: true
-
   vite-plugin-compression2@2.2.1:
     resolution: {integrity: sha512-LMDkgheJaFBmb8cB8ymgUpXHXnd3m4kmjEInvp59fOZMSaT/9oDUtqpO0ihr4ExGsnWfYcRe13/TNN3BEk2t/g==}
 
@@ -10181,15 +10410,16 @@ packages:
       yaml:
         optional: true
 
-  vite@7.1.11:
-    resolution: {integrity: sha512-uzcxnSDVjAopEUjljkWh8EIrg6tlzrjFUfMcR1EVsRDGwf/ccef0qQPRyOrROwhrTDaApueq+ja+KLPlzR/zdg==}
+  vite@8.0.0:
+    resolution: {integrity: sha512-fPGaRNj9Zytaf8LEiBhY7Z6ijnFKdzU/+mL8EFBaKr7Vw1/FWcTBAMW0wLPJAGMPX38ZPVCVgLceWiEqeoqL2Q==}
     engines: {node: ^20.19.0 || >=22.12.0}
     hasBin: true
     peerDependencies:
       '@types/node': ^20.19.0 || >=22.12.0
+      '@vitejs/devtools': ^0.0.0-alpha.31
+      esbuild: ^0.27.0
       jiti: '>=1.21.0'
       less: ^4.0.0
-      lightningcss: ^1.21.0
       sass: ^1.70.0
       sass-embedded: ^1.70.0
       stylus: '>=0.54.8'
@@ -10200,11 +10430,13 @@ packages:
     peerDependenciesMeta:
       '@types/node':
         optional: true
+      '@vitejs/devtools':
+        optional: true
+      esbuild:
+        optional: true
       jiti:
         optional: true
       less:
-        optional: true
-      lightningcss:
         optional: true
       sass:
         optional: true
@@ -10229,26 +10461,33 @@ packages:
       vite:
         optional: true
 
-  vitest@3.2.4:
-    resolution: {integrity: sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==}
-    engines: {node: ^18.0.0 || ^20.0.0 || >=22.0.0}
+  vitest@4.1.0:
+    resolution: {integrity: sha512-YbDrMF9jM2Lqc++2530UourxZHmkKLxrs4+mYhEwqWS97WJ7wOYEkcr+QfRgJ3PW9wz3odRijLZjHEaRLTNbqw==}
+    engines: {node: ^20.0.0 || ^22.0.0 || >=24.0.0}
     hasBin: true
     peerDependencies:
       '@edge-runtime/vm': '*'
-      '@types/debug': ^4.1.12
-      '@types/node': ^18.0.0 || ^20.0.0 || >=22.0.0
-      '@vitest/browser': 3.2.4
-      '@vitest/ui': 3.2.4
+      '@opentelemetry/api': ^1.9.0
+      '@types/node': ^20.0.0 || ^22.0.0 || >=24.0.0
+      '@vitest/browser-playwright': 4.1.0
+      '@vitest/browser-preview': 4.1.0
+      '@vitest/browser-webdriverio': 4.1.0
+      '@vitest/ui': 4.1.0
       happy-dom: '*'
       jsdom: '*'
+      vite: ^6.0.0 || ^7.0.0 || ^8.0.0-0
     peerDependenciesMeta:
       '@edge-runtime/vm':
         optional: true
-      '@types/debug':
+      '@opentelemetry/api':
         optional: true
       '@types/node':
         optional: true
-      '@vitest/browser':
+      '@vitest/browser-playwright':
+        optional: true
+      '@vitest/browser-preview':
+        optional: true
+      '@vitest/browser-webdriverio':
         optional: true
       '@vitest/ui':
         optional: true
@@ -10578,7 +10817,7 @@ snapshots:
   '@ampproject/remapping@2.3.0':
     dependencies:
       '@jridgewell/gen-mapping': 0.3.12
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@apollo/client@3.13.9(@types/react@19.2.2)(graphql@16.11.0)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -10648,12 +10887,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
+  '@astrojs/mdx@4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.5
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       acorn: 8.15.0
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -10677,17 +10916,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
+  '@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.5
-      '@astrojs/mdx': 4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      '@astrojs/mdx': 4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       '@astrojs/sitemap': 3.4.2
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
-      astro-expressive-code: 0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro-expressive-code: 0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -10788,6 +11027,8 @@ snapshots:
 
   '@babel/helper-validator-identifier@7.27.1': {}
 
+  '@babel/helper-validator-identifier@7.28.5': {}
+
   '@babel/helper-validator-option@7.27.1': {}
 
   '@babel/helpers@7.28.2':
@@ -10803,6 +11044,10 @@ snapshots:
     dependencies:
       '@babel/types': 7.28.2
 
+  '@babel/parser@7.29.0':
+    dependencies:
+      '@babel/types': 7.29.0
+
   '@babel/runtime@7.27.0':
     dependencies:
       regenerator-runtime: 0.14.1
@@ -10812,7 +11057,7 @@ snapshots:
   '@babel/template@7.27.2':
     dependencies:
       '@babel/code-frame': 7.27.1
-      '@babel/parser': 7.28.0
+      '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
 
   '@babel/traverse@7.28.0':
@@ -10831,6 +11076,11 @@ snapshots:
     dependencies:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.27.1
+
+  '@babel/types@7.29.0':
+    dependencies:
+      '@babel/helper-string-parser': 7.27.1
+      '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
 
@@ -10986,7 +11236,7 @@ snapshots:
       effector-storage: 7.1.0(effector@23.4.4)
       idb-keyval: 6.2.1
 
-  '@effector/swc-plugin@0.8.1': {}
+  '@effector/swc-plugin@1.0.0': {}
 
   '@electron/asar@3.2.18':
     dependencies:
@@ -11104,12 +11354,28 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/core@1.9.0':
+    dependencies:
+      '@emnapi/wasi-threads': 1.2.0
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/runtime@1.4.5':
     dependencies:
       tslib: 2.8.1
     optional: true
 
+  '@emnapi/runtime@1.9.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
   '@emnapi/wasi-threads@1.0.4':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.2.0':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -11717,8 +11983,6 @@ snapshots:
     dependencies:
       minipass: 7.1.2
 
-  '@istanbuljs/schema@0.1.3': {}
-
   '@jest/expect-utils@29.7.0':
     dependencies:
       jest-get-type: 29.6.3
@@ -11738,12 +12002,12 @@ snapshots:
 
   '@jonasgeiler/tsc-files@2.3.1': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.9.2)
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     optionalDependencies:
       typescript: 5.9.2
 
@@ -11755,7 +12019,7 @@ snapshots:
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
-      '@jridgewell/trace-mapping': 0.3.30
+      '@jridgewell/trace-mapping': 0.3.31
 
   '@jridgewell/remapping@2.3.5':
     dependencies:
@@ -11777,16 +12041,10 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
-  '@jridgewell/trace-mapping@0.3.30':
-    dependencies:
-      '@jridgewell/resolve-uri': 3.1.2
-      '@jridgewell/sourcemap-codec': 1.5.5
-
   '@jridgewell/trace-mapping@0.3.31':
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
-    optional: true
 
   '@jridgewell/trace-mapping@0.3.9':
     dependencies:
@@ -11858,6 +12116,13 @@ snapshots:
       '@tybys/wasm-util': 0.10.0
     optional: true
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.9.0
+      '@emnapi/runtime': 1.9.0
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
   '@noble/ciphers@1.3.0': {}
 
   '@noble/curves@1.2.0':
@@ -11926,6 +12191,10 @@ snapshots:
       rimraf: 3.0.2
 
   '@oslojs/encoding@1.1.0': {}
+
+  '@oxc-project/runtime@0.115.0': {}
+
+  '@oxc-project/types@0.115.0': {}
 
   '@oxc-resolver/binding-android-arm-eabi@11.6.0':
     optional: true
@@ -12050,10 +12319,10 @@ snapshots:
     dependencies:
       zod: 4.2.1
 
-  '@peterek/vite-plugin-favicons@2.1.0(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@peterek/vite-plugin-favicons@2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       favicons: 7.2.0
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
 
   '@pivanov/utils@0.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -12071,7 +12340,7 @@ snapshots:
 
   '@polka/url@1.0.0-next.29': {}
 
-  '@polkadot-api/cli@0.15.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.7.1)':
+  '@polkadot-api/cli@0.15.3(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.7.1)':
     dependencies:
       '@commander-js/extra-typings': 14.0.0(commander@14.0.1)
       '@polkadot-api/codegen': 0.19.2
@@ -12097,7 +12366,7 @@ snapshots:
       read-pkg: 9.0.1
       rxjs: 7.8.2
       tsc-prog: 2.3.0(typescript@5.9.3)
-      tsup: 8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)
+      tsup: 8.5.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1)
       typescript: 5.9.3
       write-package: 7.2.0
     transitivePeerDependencies:
@@ -12119,9 +12388,9 @@ snapshots:
       '@polkadot-api/substrate-bindings': 0.16.4
       '@polkadot-api/utils': 0.2.0
 
-  '@polkadot-api/descriptors@file:.papi/descriptors(polkadot-api@1.20.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1))':
+  '@polkadot-api/descriptors@file:.papi/descriptors(polkadot-api@1.20.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      polkadot-api: 1.20.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1)
+      polkadot-api: 1.20.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1)
 
   '@polkadot-api/ink-contracts@0.4.1':
     dependencies:
@@ -13295,7 +13564,56 @@ snapshots:
 
   '@remote-ui/rpc@1.4.7': {}
 
-  '@rolldown/pluginutils@1.0.0-beta.35': {}
+  '@rolldown/binding-android-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-darwin-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-freebsd-x64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm-gnueabihf@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-arm64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-ppc64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-s390x-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-gnu@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-linux-x64-musl@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-openharmony-arm64@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-wasm32-wasi@1.0.0-rc.9':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@rolldown/binding-win32-arm64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/binding-win32-x64-msvc@1.0.0-rc.9':
+    optional: true
+
+  '@rolldown/pluginutils@1.0.0-rc.7': {}
+
+  '@rolldown/pluginutils@1.0.0-rc.9': {}
 
   '@rollup/plugin-inject@5.0.5(rollup@4.52.5)':
     dependencies:
@@ -13480,42 +13798,42 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-a11y@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
 
-  '@storybook/addon-docs@9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-docs@9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.2)(react@19.2.0)
-      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/icons': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-links@9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-links@9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
     optionalDependencies:
       react: 19.2.0
 
-  '@storybook/builder-vite@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@storybook/builder-vite@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       ts-dedent: 2.2.0
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
 
-  '@storybook/csf-plugin@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/csf-plugin@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -13525,39 +13843,39 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/react-dom-shim@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
 
-  '@storybook/react-vite@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@storybook/react-vite@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.52.5)
-      '@storybook/builder-vite': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
-      '@storybook/react': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)
+      '@storybook/builder-vite': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@storybook/react': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 19.2.0
       react-docgen: 8.0.0
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.10
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       tsconfig-paths: 4.2.0
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)':
+  '@storybook/react@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
     optionalDependencies:
       typescript: 5.9.2
 
@@ -13685,51 +14003,51 @@ snapshots:
     transitivePeerDependencies:
       - typescript
 
-  '@swc/core-darwin-arm64@1.13.5':
+  '@swc/core-darwin-arm64@1.15.11':
     optional: true
 
-  '@swc/core-darwin-x64@1.13.5':
+  '@swc/core-darwin-x64@1.15.11':
     optional: true
 
-  '@swc/core-linux-arm-gnueabihf@1.13.5':
+  '@swc/core-linux-arm-gnueabihf@1.15.11':
     optional: true
 
-  '@swc/core-linux-arm64-gnu@1.13.5':
+  '@swc/core-linux-arm64-gnu@1.15.11':
     optional: true
 
-  '@swc/core-linux-arm64-musl@1.13.5':
+  '@swc/core-linux-arm64-musl@1.15.11':
     optional: true
 
-  '@swc/core-linux-x64-gnu@1.13.5':
+  '@swc/core-linux-x64-gnu@1.15.11':
     optional: true
 
-  '@swc/core-linux-x64-musl@1.13.5':
+  '@swc/core-linux-x64-musl@1.15.11':
     optional: true
 
-  '@swc/core-win32-arm64-msvc@1.13.5':
+  '@swc/core-win32-arm64-msvc@1.15.11':
     optional: true
 
-  '@swc/core-win32-ia32-msvc@1.13.5':
+  '@swc/core-win32-ia32-msvc@1.15.11':
     optional: true
 
-  '@swc/core-win32-x64-msvc@1.13.5':
+  '@swc/core-win32-x64-msvc@1.15.11':
     optional: true
 
-  '@swc/core@1.13.5(@swc/helpers@0.5.17)':
+  '@swc/core@1.15.11(@swc/helpers@0.5.17)':
     dependencies:
       '@swc/counter': 0.1.3
       '@swc/types': 0.1.25
     optionalDependencies:
-      '@swc/core-darwin-arm64': 1.13.5
-      '@swc/core-darwin-x64': 1.13.5
-      '@swc/core-linux-arm-gnueabihf': 1.13.5
-      '@swc/core-linux-arm64-gnu': 1.13.5
-      '@swc/core-linux-arm64-musl': 1.13.5
-      '@swc/core-linux-x64-gnu': 1.13.5
-      '@swc/core-linux-x64-musl': 1.13.5
-      '@swc/core-win32-arm64-msvc': 1.13.5
-      '@swc/core-win32-ia32-msvc': 1.13.5
-      '@swc/core-win32-x64-msvc': 1.13.5
+      '@swc/core-darwin-arm64': 1.15.11
+      '@swc/core-darwin-x64': 1.15.11
+      '@swc/core-linux-arm-gnueabihf': 1.15.11
+      '@swc/core-linux-arm64-gnu': 1.15.11
+      '@swc/core-linux-arm64-musl': 1.15.11
+      '@swc/core-linux-x64-gnu': 1.15.11
+      '@swc/core-linux-x64-musl': 1.15.11
+      '@swc/core-win32-arm64-msvc': 1.15.11
+      '@swc/core-win32-ia32-msvc': 1.15.11
+      '@swc/core-win32-x64-msvc': 1.15.11
       '@swc/helpers': 0.5.17
 
   '@swc/counter@0.1.3': {}
@@ -13812,12 +14130,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.12
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.12
 
-  '@tailwindcss/vite@4.1.12(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@tailwindcss/vite@4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@tailwindcss/node': 4.1.12
       '@tailwindcss/oxide': 4.1.12
       tailwindcss: 4.1.12
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
 
   '@talismn/connect-wallets@1.2.8(@polkadot/api@16.4.8)(@polkadot/extension-inject@0.58.1(@polkadot/api@16.4.8)(@polkadot/util@13.5.6))':
     dependencies:
@@ -13880,6 +14198,11 @@ snapshots:
   '@tsconfig/node16@1.0.4': {}
 
   '@tybys/wasm-util@0.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@tybys/wasm-util@0.10.1':
     dependencies:
       tslib: 2.8.1
     optional: true
@@ -14374,32 +14697,27 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react-swc@4.1.0(@swc/helpers@0.5.17)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@rolldown/pluginutils': 1.0.0-beta.35
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      '@rolldown/pluginutils': 1.0.0-rc.7
+      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
-  '@vitest/coverage-v8@3.2.4(vitest@3.2.4)':
+  '@vitest/coverage-v8@4.1.0(vitest@4.1.0)':
     dependencies:
-      '@ampproject/remapping': 2.3.0
       '@bcoe/v8-coverage': 1.0.2
-      ast-v8-to-istanbul: 0.3.4
-      debug: 4.4.1
+      '@vitest/utils': 4.1.0
+      ast-v8-to-istanbul: 1.0.0
       istanbul-lib-coverage: 3.2.2
       istanbul-lib-report: 3.0.1
-      istanbul-lib-source-maps: 5.0.6
-      istanbul-reports: 3.1.7
-      magic-string: 0.30.17
-      magicast: 0.3.5
-      std-env: 3.9.0
-      test-exclude: 7.0.1
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-    transitivePeerDependencies:
-      - supports-color
+      istanbul-reports: 3.2.0
+      magicast: 0.5.2
+      obug: 2.1.1
+      std-env: 4.0.0
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14409,50 +14727,79 @@ snapshots:
       chai: 5.2.1
       tinyrainbow: 2.0.0
 
-  '@vitest/mocker@3.2.4(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@vitest/expect@4.1.0':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      '@types/chai': 5.2.2
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      chai: 6.2.2
+      tinyrainbow: 3.1.0
+
+  '@vitest/mocker@3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+    dependencies:
+      '@vitest/spy': 4.1.0
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
       tinyrainbow: 2.0.0
 
-  '@vitest/runner@3.2.4':
+  '@vitest/pretty-format@4.1.0':
     dependencies:
-      '@vitest/utils': 3.2.4
-      pathe: 2.0.3
-      strip-literal: 3.0.0
+      tinyrainbow: 3.1.0
 
-  '@vitest/snapshot@3.2.4':
+  '@vitest/runner@4.1.0':
     dependencies:
-      '@vitest/pretty-format': 3.2.4
-      magic-string: 0.30.17
+      '@vitest/utils': 4.1.0
+      pathe: 2.0.3
+
+  '@vitest/snapshot@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/utils': 4.1.0
+      magic-string: 0.30.21
       pathe: 2.0.3
 
   '@vitest/spy@3.2.4':
     dependencies:
       tinyspy: 4.0.3
 
-  '@vitest/ui@3.2.4(vitest@3.2.4)':
+  '@vitest/spy@4.1.0': {}
+
+  '@vitest/ui@4.1.0(vitest@4.1.0)':
     dependencies:
-      '@vitest/utils': 3.2.4
+      '@vitest/utils': 4.1.0
       fflate: 0.8.2
-      flatted: 3.3.3
+      flatted: 3.4.0
       pathe: 2.0.3
-      sirv: 3.0.1
-      tinyglobby: 0.2.14
-      tinyrainbow: 2.0.0
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      sirv: 3.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
       '@vitest/pretty-format': 3.2.4
       loupe: 3.2.0
       tinyrainbow: 2.0.0
+
+  '@vitest/utils@4.1.0':
+    dependencies:
+      '@vitest/pretty-format': 4.1.0
+      convert-source-map: 2.0.0
+      tinyrainbow: 3.1.0
 
   '@walletconnect/core@2.22.3(typescript@5.9.2)(zod@4.0.14)':
     dependencies:
@@ -14849,7 +15196,7 @@ snapshots:
     optionalDependencies:
       allure-playwright: 3.0.6(@playwright/test@1.52.0)
 
-  allure-js-commons@3.4.5(allure-playwright@3.0.6(@playwright/test@1.52.0)):
+  allure-js-commons@3.6.0(allure-playwright@3.0.6(@playwright/test@1.52.0)):
     dependencies:
       md5: 2.3.0
     optionalDependencies:
@@ -14860,11 +15207,11 @@ snapshots:
       '@playwright/test': 1.52.0
       allure-js-commons: 3.0.6(allure-playwright@3.0.6(@playwright/test@1.52.0))
 
-  allure-vitest@3.4.5(@vitest/runner@3.2.4)(allure-playwright@3.0.6(@playwright/test@1.52.0))(vitest@3.2.4):
+  allure-vitest@3.6.0(@vitest/runner@4.1.0)(allure-playwright@3.0.6(@playwright/test@1.52.0))(vitest@4.1.0):
     dependencies:
-      '@vitest/runner': 3.2.4
-      allure-js-commons: 3.4.5(allure-playwright@3.0.6(@playwright/test@1.52.0))
-      vitest: 3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      '@vitest/runner': 4.1.0
+      allure-js-commons: 3.6.0(allure-playwright@3.0.6(@playwright/test@1.52.0))
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
     transitivePeerDependencies:
       - allure-playwright
 
@@ -15044,23 +15391,23 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ast-v8-to-istanbul@0.3.4:
+  ast-v8-to-istanbul@1.0.0:
     dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
+      '@jridgewell/trace-mapping': 0.3.31
       estree-walker: 3.0.3
-      js-tokens: 9.0.1
+      js-tokens: 10.0.0
 
   astral-regex@2.0.0:
     optional: true
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)):
+  astro-expressive-code@0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)):
     dependencies:
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       rehype-expressive-code: 0.41.3
 
-  astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1):
+  astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.7.1
@@ -15116,8 +15463,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.1(idb-keyval@6.2.1)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -15503,6 +15850,8 @@ snapshots:
       deep-eql: 5.0.2
       loupe: 3.2.0
       pathval: 2.0.1
+
+  chai@6.2.2: {}
 
   chalk@2.4.2:
     dependencies:
@@ -16499,6 +16848,8 @@ snapshots:
 
   es-module-lexer@1.7.0: {}
 
+  es-module-lexer@2.0.0: {}
+
   es-object-atoms@1.1.1:
     dependencies:
       es-errors: 1.3.0
@@ -16952,7 +17303,7 @@ snapshots:
       strip-final-newline: 4.0.0
       yoctocolors: 2.1.2
 
-  expect-type@1.2.2: {}
+  expect-type@1.3.0: {}
 
   expect@29.7.0:
     dependencies:
@@ -17080,6 +17431,8 @@ snapshots:
       keyv: 4.5.4
 
   flatted@3.3.3: {}
+
+  flatted@3.4.0: {}
 
   flattie@1.1.1: {}
 
@@ -18103,15 +18456,7 @@ snapshots:
       make-dir: 4.0.0
       supports-color: 7.2.0
 
-  istanbul-lib-source-maps@5.0.6:
-    dependencies:
-      '@jridgewell/trace-mapping': 0.3.29
-      debug: 4.4.1
-      istanbul-lib-coverage: 3.2.2
-    transitivePeerDependencies:
-      - supports-color
-
-  istanbul-reports@3.1.7:
+  istanbul-reports@3.2.0:
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.1
@@ -18196,9 +18541,9 @@ snapshots:
 
   joycon@3.1.1: {}
 
-  js-tokens@4.0.0: {}
+  js-tokens@10.0.0: {}
 
-  js-tokens@9.0.1: {}
+  js-tokens@4.0.0: {}
 
   js-yaml@4.1.0:
     dependencies:
@@ -18333,34 +18678,67 @@ snapshots:
     dependencies:
       immediate: 3.0.6
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
   lightningcss-darwin-arm64@1.30.1:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
     optional: true
 
   lightningcss-darwin-x64@1.30.1:
     optional: true
 
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
   lightningcss-freebsd-x64@1.30.1:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
     optional: true
 
   lightningcss-linux-arm-gnueabihf@1.30.1:
     optional: true
 
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
   lightningcss-linux-arm64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-arm64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
   lightningcss-linux-x64-gnu@1.30.1:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
     optional: true
 
   lightningcss-linux-x64-musl@1.30.1:
     optional: true
 
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
   lightningcss-win32-arm64-msvc@1.30.1:
     optional: true
 
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
   lightningcss-win32-x64-msvc@1.30.1:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
     optional: true
 
   lightningcss@1.30.1:
@@ -18377,6 +18755,22 @@ snapshots:
       lightningcss-linux-x64-musl: 1.30.1
       lightningcss-win32-arm64-msvc: 1.30.1
       lightningcss-win32-x64-msvc: 1.30.1
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.0.4
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
 
   lilconfig@3.1.3: {}
 
@@ -18526,15 +18920,25 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
   magicast@0.3.5:
     dependencies:
       '@babel/parser': 7.28.3
       '@babel/types': 7.28.2
       source-map-js: 1.2.1
 
+  magicast@0.5.2:
+    dependencies:
+      '@babel/parser': 7.29.0
+      '@babel/types': 7.29.0
+      source-map-js: 1.2.1
+
   make-dir@4.0.0:
     dependencies:
-      semver: 7.7.2
+      semver: 7.7.3
 
   make-error@1.3.6: {}
 
@@ -19433,6 +19837,8 @@ snapshots:
       define-properties: 1.2.1
       es-object-atoms: 1.1.1
 
+  obug@2.1.1: {}
+
   ofetch@1.4.1:
     dependencies:
       destr: 2.0.5
@@ -19833,9 +20239,9 @@ snapshots:
 
   pnglib@0.0.1: {}
 
-  polkadot-api@1.20.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1):
+  polkadot-api@1.20.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(rxjs@7.8.2)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:
-      '@polkadot-api/cli': 0.15.3(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.7.1)
+      '@polkadot-api/cli': 0.15.3(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(yaml@2.7.1)
       '@polkadot-api/ink-contracts': 0.4.1
       '@polkadot-api/json-rpc-provider': 0.0.4
       '@polkadot-api/known-chains': 0.9.12
@@ -19904,6 +20310,12 @@ snapshots:
       source-map-js: 1.2.1
 
   postcss@8.5.6:
+    dependencies:
+      nanoid: 3.3.11
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.8:
     dependencies:
       nanoid: 3.3.11
       picocolors: 1.1.1
@@ -20631,6 +21043,27 @@ snapshots:
       sprintf-js: 1.1.3
     optional: true
 
+  rolldown@1.0.0-rc.9:
+    dependencies:
+      '@oxc-project/types': 0.115.0
+      '@rolldown/pluginutils': 1.0.0-rc.9
+    optionalDependencies:
+      '@rolldown/binding-android-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-arm64': 1.0.0-rc.9
+      '@rolldown/binding-darwin-x64': 1.0.0-rc.9
+      '@rolldown/binding-freebsd-x64': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm-gnueabihf': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-arm64-musl': 1.0.0-rc.9
+      '@rolldown/binding-linux-ppc64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-s390x-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-gnu': 1.0.0-rc.9
+      '@rolldown/binding-linux-x64-musl': 1.0.0-rc.9
+      '@rolldown/binding-openharmony-arm64': 1.0.0-rc.9
+      '@rolldown/binding-wasm32-wasi': 1.0.0-rc.9
+      '@rolldown/binding-win32-arm64-msvc': 1.0.0-rc.9
+      '@rolldown/binding-win32-x64-msvc': 1.0.0-rc.9
+
   rollup@4.52.5:
     dependencies:
       '@types/estree': 1.0.8
@@ -20884,7 +21317,7 @@ snapshots:
     dependencies:
       semver: 7.7.2
 
-  sirv@3.0.1:
+  sirv@3.0.2:
     dependencies:
       '@polka/url': 1.0.0-next.29
       mrmime: 2.0.1
@@ -21028,16 +21461,16 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2)):
+  starlight-typedoc@0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2)):
     dependencies:
-      '@astrojs/starlight': 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.30.1)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      '@astrojs/starlight': 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       github-slugger: 2.0.0
       typedoc: 0.27.6(typescript@5.9.2)
       typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6(typescript@5.9.2))
 
   stat-mode@1.0.0: {}
 
-  std-env@3.9.0: {}
+  std-env@4.0.0: {}
 
   stdin-discarder@0.2.2: {}
 
@@ -21048,13 +21481,13 @@ snapshots:
 
   store@2.0.12: {}
 
-  storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.4
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.9
@@ -21214,10 +21647,6 @@ snapshots:
 
   strip-json-comments@5.0.2: {}
 
-  strip-literal@3.0.0:
-    dependencies:
-      js-tokens: 9.0.1
-
   style-to-js@1.1.17:
     dependencies:
       style-to-object: 1.0.9
@@ -21351,12 +21780,6 @@ snapshots:
       source-map-support: 0.5.21
     optional: true
 
-  test-exclude@7.0.1:
-    dependencies:
-      '@istanbuljs/schema': 0.1.3
-      glob: 10.4.5
-      minimatch: 9.0.5
-
   text-decoder@1.2.3:
     dependencies:
       b4a: 1.6.7
@@ -21402,6 +21825,8 @@ snapshots:
 
   tinyexec@1.0.1: {}
 
+  tinyexec@1.0.2: {}
+
   tinyglobby@0.2.14:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.3)
@@ -21412,9 +21837,9 @@ snapshots:
       fdir: 6.5.0(picomatch@4.0.3)
       picomatch: 4.0.3
 
-  tinypool@1.1.1: {}
-
   tinyrainbow@2.0.0: {}
+
+  tinyrainbow@3.1.0: {}
 
   tinyspy@4.0.3: {}
 
@@ -21483,7 +21908,7 @@ snapshots:
     dependencies:
       tslib: 2.8.1
 
-  ts-node@10.9.2(@swc/core@1.13.5(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.2):
+  ts-node@10.9.2(@swc/core@1.15.11(@swc/helpers@0.5.17))(@types/node@22.17.0)(typescript@5.9.2):
     dependencies:
       '@cspotcode/source-map-support': 0.8.1
       '@tsconfig/node10': 1.0.11
@@ -21501,7 +21926,7 @@ snapshots:
       v8-compile-cache-lib: 3.0.1
       yn: 3.1.1
     optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
 
   tsc-prog@2.3.0(typescript@5.9.3):
     dependencies:
@@ -21525,7 +21950,7 @@ snapshots:
 
   tslib@2.8.1: {}
 
-  tsup@8.5.0(@swc/core@1.13.5(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1):
+  tsup@8.5.0(@swc/core@1.15.11(@swc/helpers@0.5.17))(jiti@2.5.1)(postcss@8.5.6)(tsx@4.20.3)(typescript@5.9.3)(yaml@2.7.1):
     dependencies:
       bundle-require: 5.1.0(esbuild@0.25.11)
       cac: 6.7.14
@@ -21545,7 +21970,7 @@ snapshots:
       tinyglobby: 0.2.15
       tree-kill: 1.2.2
     optionalDependencies:
-      '@swc/core': 1.13.5(@swc/helpers@0.5.17)
+      '@swc/core': 1.15.11(@swc/helpers@0.5.17)
       postcss: 8.5.6
       typescript: 5.9.3
     transitivePeerDependencies:
@@ -21979,27 +22404,6 @@ snapshots:
       replace-ext: 2.0.0
       teex: 1.0.1
 
-  vite-node@3.2.4(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
-    dependencies:
-      cac: 6.7.14
-      debug: 4.4.1
-      es-module-lexer: 1.7.0
-      pathe: 2.0.3
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-    transitivePeerDependencies:
-      - '@types/node'
-      - jiti
-      - less
-      - lightningcss
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
-
   vite-plugin-compression2@2.2.1(rollup@4.52.5):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.52.5)
@@ -22007,29 +22411,29 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-mkcert@1.17.8(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-mkcert@1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       axios: 1.11.0(debug@4.4.1)
       debug: 4.4.1
       picocolors: 1.1.1
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-node-polyfills@0.24.0(rollup@4.52.5)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-node-polyfills@0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.52.5)
       node-stdlib-browser: 1.3.1
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-svgr@4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-svgr@4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.52.5)
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -22039,18 +22443,18 @@ snapshots:
     dependencies:
       lib-esm: 0.3.0
 
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       debug: 4.4.1
       globrex: 0.1.2
       tsconfck: 3.1.6(typescript@5.9.2)
     optionalDependencies:
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
       - typescript
 
-  vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
+  vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -22062,76 +22466,61 @@ snapshots:
       '@types/node': 22.17.0
       fsevents: 2.3.3
       jiti: 2.5.1
-      lightningcss: 1.30.1
+      lightningcss: 1.32.0
       terser: 5.37.0
       tsx: 4.20.3
       yaml: 2.7.1
 
-  vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
+  vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:
-      esbuild: 0.25.11
-      fdir: 6.5.0(picomatch@4.0.3)
+      '@oxc-project/runtime': 0.115.0
+      lightningcss: 1.32.0
       picomatch: 4.0.3
-      postcss: 8.5.6
-      rollup: 4.52.5
+      postcss: 8.5.8
+      rolldown: 1.0.0-rc.9
       tinyglobby: 0.2.15
     optionalDependencies:
       '@types/node': 22.17.0
+      esbuild: 0.25.11
       fsevents: 2.3.3
       jiti: 2.5.1
-      lightningcss: 1.30.1
       terser: 5.37.0
       tsx: 4.20.3
       yaml: 2.7.1
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
 
-  vitest@3.2.4(@types/debug@4.1.12)(@types/node@22.17.0)(@vitest/ui@3.2.4)(happy-dom@18.0.1)(jiti@2.5.1)(jsdom@20.0.3)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
+  vitest@4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
-      '@types/chai': 5.2.2
-      '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
-      '@vitest/pretty-format': 3.2.4
-      '@vitest/runner': 3.2.4
-      '@vitest/snapshot': 3.2.4
-      '@vitest/spy': 3.2.4
-      '@vitest/utils': 3.2.4
-      chai: 5.2.1
-      debug: 4.4.1
-      expect-type: 1.2.2
-      magic-string: 0.30.17
+      '@vitest/expect': 4.1.0
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@vitest/pretty-format': 4.1.0
+      '@vitest/runner': 4.1.0
+      '@vitest/snapshot': 4.1.0
+      '@vitest/spy': 4.1.0
+      '@vitest/utils': 4.1.0
+      es-module-lexer: 2.0.0
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      obug: 2.1.1
       pathe: 2.0.3
       picomatch: 4.0.3
-      std-env: 3.9.0
+      std-env: 4.0.0
       tinybench: 2.9.0
-      tinyexec: 0.3.2
-      tinyglobby: 0.2.14
-      tinypool: 1.1.1
-      tinyrainbow: 2.0.0
-      vite: 7.1.11(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-      vite-node: 3.2.4(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.30.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      tinyexec: 1.0.2
+      tinyglobby: 0.2.15
+      tinyrainbow: 3.1.0
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
-      '@types/debug': 4.1.12
       '@types/node': 22.17.0
-      '@vitest/ui': 3.2.4(vitest@3.2.4)
+      '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 18.0.1
       jsdom: 20.0.3
     transitivePeerDependencies:
-      - jiti
-      - less
-      - lightningcss
       - msw
-      - sass
-      - sass-embedded
-      - stylus
-      - sugarss
-      - supports-color
-      - terser
-      - tsx
-      - yaml
 
   vm-browserify@1.1.2: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -576,9 +576,6 @@ importers:
       vite-plugin-target:
         specifier: 0.1.1
         version: 0.1.1
-      vite-tsconfig-paths:
-        specifier: 5.1.4
-        version: 5.1.4(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
       vitest:
         specifier: 4.1.0
         version: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
@@ -6500,9 +6497,6 @@ packages:
     resolution: {integrity: sha512-DpLKbNU4WylpxJykQujfCcwYWiV/Jhm50Goo0wrVILAv5jOr9d+H+UR3PhSCD2rCCEIg0uc+G+muBTwD54JhDQ==}
     engines: {node: '>= 0.4'}
 
-  globrex@0.1.2:
-    resolution: {integrity: sha512-uHJgbwAMwNFf5mLst7IWLNg14x1CkeqglJb/K3doi4dw6q2IvAAmM/Y81kevy83wP+Sst+nutFTYOGg3d1lsxg==}
-
   gopd@1.2.0:
     resolution: {integrity: sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==}
     engines: {node: '>= 0.4'}
@@ -10361,14 +10355,6 @@ packages:
 
   vite-plugin-target@0.1.1:
     resolution: {integrity: sha512-TJn/EHon2bbXmauu3Ledtbi/QB8AflgSwzJJc0Y6LvlmHarRJpLnxAAVxXDycWmLN3+7xFrPOZOIDtcVk2KWnQ==}
-
-  vite-tsconfig-paths@5.1.4:
-    resolution: {integrity: sha512-cYj0LRuLV2c2sMqhqhGpaO3LretdtMn/BVX4cPLanIZuwwrkVl+lK84E/miEXkCHWXuq65rhNN4rXsBcOB3S4w==}
-    peerDependencies:
-      vite: '*'
-    peerDependenciesMeta:
-      vite:
-        optional: true
 
   vite@6.4.1:
     resolution: {integrity: sha512-+Oxm7q9hDoLMyJOYfUYBuHQo+dkAloi33apOPP56pzj+vsdJDzr+j1NISE5pyaAuKL4A3UD34qd0lx5+kfKp2g==}
@@ -17700,8 +17686,6 @@ snapshots:
       define-properties: 1.2.1
       gopd: 1.2.0
 
-  globrex@0.1.2: {}
-
   gopd@1.2.0: {}
 
   got@11.8.6:
@@ -22442,17 +22426,6 @@ snapshots:
   vite-plugin-target@0.1.1:
     dependencies:
       lib-esm: 0.3.0
-
-  vite-tsconfig-paths@5.1.4(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
-    dependencies:
-      debug: 4.4.1
-      globrex: 0.1.2
-      tsconfck: 3.1.6(typescript@5.9.2)
-    optionalDependencies:
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-    transitivePeerDependencies:
-      - supports-color
-      - typescript
 
   vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -1,3 +1,4 @@
+import './polyfills';
 import './index.css';
 import './document.css';
 import './styles/theme/default.css';

--- a/src/renderer/app/polyfills.ts
+++ b/src/renderer/app/polyfills.ts
@@ -1,0 +1,3 @@
+import { Buffer } from 'buffer';
+
+globalThis.Buffer = Buffer;

--- a/tests/integrations/vitest.config.ts
+++ b/tests/integrations/vitest.config.ts
@@ -1,11 +1,11 @@
 import { resolve } from 'node:path';
 
-import { type UserConfigFnPromise, type ViteUserConfig, mergeConfig } from 'vitest/config';
+import { type ViteUserConfig, type ViteUserConfigFnPromise, mergeConfig } from 'vitest/config';
 
 import { folders } from '../../config/index.js';
 import rendererConfig from '../../vite.config.renderer';
 
-const config: UserConfigFnPromise = async (options) => {
+const config: ViteUserConfigFnPromise = async (options) => {
   const base = await rendererConfig(options);
   const testConfig: ViteUserConfig = {
     cacheDir: resolve(folders.root, 'node_modules/.cache/vitest'),

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": ["./tsconfig.base.json", "./tsconfig.paths.json"],
   "include": ["src", ".storybook", "tests", "scripts", "config", "*.ts", "*.js", "*.cjs"],
-  "exclude": ["node_modules"]
+  "exclude": ["node_modules", "*.config.ts", "vite.config.*.ts", "tests/**/vitest.config.ts"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,5 +1,5 @@
 {
   "extends": ["./tsconfig.base.json", "./tsconfig.paths.json"],
-  "include": ["src", ".storybook", "tests", "scripts", "config", ".eslintrc.cjs", "*.ts", "*.js", "*.cjs"],
+  "include": ["src", ".storybook", "tests", "scripts", "config", "*.ts", "*.js", "*.cjs"],
   "exclude": ["node_modules"]
 }

--- a/vite.config.main.ts
+++ b/vite.config.main.ts
@@ -31,10 +31,8 @@ const config: UserConfigFn = async ({ mode }) => {
         fileName: () => 'main.cjs',
         formats: ['cjs'],
       },
-      rollupOptions: {
+      rolldownOptions: {
         output: {
-          // entryFileNames: `[name].js`,
-          // chunkFileNames: `[name].js`,
           globals: {
             process: 'process',
           },

--- a/vite.config.main.ts
+++ b/vite.config.main.ts
@@ -6,7 +6,6 @@ import { folders, title, version } from './config/index.js';
 
 const config: UserConfigFn = async ({ mode }) => {
   const { defineConfig } = await import('vite');
-  const { default: tsconfigPaths } = await import('vite-tsconfig-paths');
   const { default: target } = await import('vite-plugin-target');
 
   const isDev = mode === 'development';
@@ -39,7 +38,10 @@ const config: UserConfigFn = async ({ mode }) => {
         },
       },
     },
-    plugins: [target({ 'electron-main': {} }), tsconfigPaths()],
+    resolve: {
+      tsconfigPaths: true,
+    },
+    plugins: [target({ 'electron-main': {} })],
   });
 };
 

--- a/vite.config.preload.ts
+++ b/vite.config.preload.ts
@@ -6,7 +6,6 @@ import { folders, title, version } from './config/index.js';
 
 const config: UserConfigFn = async ({ mode }) => {
   const { defineConfig } = await import('vite');
-  const { default: tsconfigPaths } = await import('vite-tsconfig-paths');
   const { default: target } = await import('vite-plugin-target');
 
   return defineConfig({
@@ -34,7 +33,10 @@ const config: UserConfigFn = async ({ mode }) => {
         },
       },
     },
-    plugins: [target({ 'electron-preload': {} }), tsconfigPaths()],
+    resolve: {
+      tsconfigPaths: true,
+    },
+    plugins: [target({ 'electron-preload': {} })],
   });
 };
 

--- a/vite.config.preload.ts
+++ b/vite.config.preload.ts
@@ -26,7 +26,7 @@ const config: UserConfigFn = async ({ mode }) => {
         fileName: () => 'preload.cjs',
         formats: ['cjs'],
       },
-      rollupOptions: {
+      rolldownOptions: {
         output: {
           globals: {
             process: 'process',

--- a/vite.config.renderer.ts
+++ b/vite.config.renderer.ts
@@ -28,7 +28,6 @@ const config: UserConfigFn = async ({ mode, command }) => {
   const { default: react } = await import('@vitejs/plugin-react-swc');
   const { default: mkcert } = await import('vite-plugin-mkcert');
   const { compression, defineAlgorithm } = await import('vite-plugin-compression2');
-  const { nodePolyfills } = await import('vite-plugin-node-polyfills');
   const { default: tailwindcss } = await import('@tailwindcss/vite');
 
   const isDevServer = command === 'serve';
@@ -36,18 +35,17 @@ const config: UserConfigFn = async ({ mode, command }) => {
   const isProd = mode === 'production';
   const isStage = mode === 'staging';
 
-  const commonPlugins = [
-    skipSourcemaps(['node_modules']),
-    nodePolyfills({
-      include: ['buffer', 'events', 'crypto', 'stream'],
-    }),
-  ];
+  const commonPlugins = [skipSourcemaps(['node_modules'])];
 
   return defineConfig({
     mode: isStage ? 'production' : mode,
     cacheDir: resolve(folders.cache, 'vite-renderer'),
     resolve: {
       tsconfigPaths: true,
+      alias: {
+        crypto: 'crypto-browserify',
+        stream: 'stream-browserify',
+      },
     },
     base: '',
     root: resolve(folders.rendererRoot, 'app'),
@@ -58,6 +56,7 @@ const config: UserConfigFn = async ({ mode, command }) => {
       'process.env.CHAINS_FILE': JSON.stringify(process.env.CHAINS_FILE ?? 'chains'),
       'process.env.TOKENS_FILE': JSON.stringify(process.env.TOKENS_FILE ?? 'tokens'),
       'process.env.LOGGER': JSON.stringify(process.env.LOGGER),
+      global: 'globalThis',
     },
     worker: {
       format: 'es',

--- a/vite.config.renderer.ts
+++ b/vite.config.renderer.ts
@@ -1,6 +1,5 @@
 /// <reference types="vitest/config" />
 
-import { cpus } from 'node:os';
 import { resolve } from 'node:path';
 
 import { type Plugin, type UserConfigFn } from 'vite';
@@ -31,7 +30,6 @@ const config: UserConfigFn = async ({ mode, command }) => {
   const { default: mkcert } = await import('vite-plugin-mkcert');
   const { compression, defineAlgorithm } = await import('vite-plugin-compression2');
   const { nodePolyfills } = await import('vite-plugin-node-polyfills');
-  // @ts-expect-error unresolved import type
   const { default: tailwindcss } = await import('@tailwindcss/vite');
 
   const isDevServer = command === 'serve';
@@ -70,21 +68,7 @@ const config: UserConfigFn = async ({ mode, command }) => {
       outDir: folders.devBuild,
       emptyOutDir: false,
       target: 'es2021',
-      rollupOptions: {
-        treeshake: 'recommended',
-        maxParallelFileOps: Math.max(1, cpus().length - 1),
-        onLog(level, log, handler) {
-          if (log.cause) {
-            const cause = log.cause as Record<string, string>;
-
-            if (cause.message === `Can't resolve original location of error.`) {
-              return;
-            }
-          }
-
-          handler(level, log);
-        },
-      },
+      rolldownOptions: {},
     },
     assetsInclude: ['**/*.wasm'],
     server: {

--- a/vite.config.renderer.ts
+++ b/vite.config.renderer.ts
@@ -23,7 +23,6 @@ function skipSourcemaps(paths: string[]): Plugin {
 
 const config: UserConfigFn = async ({ mode, command }) => {
   const { defineConfig } = await import('vite');
-  const { default: tsconfigPaths } = await import('vite-tsconfig-paths');
   const { default: svgr } = await import('vite-plugin-svgr');
   const { default: favicons } = await import('@peterek/vite-plugin-favicons');
   const { default: react } = await import('@vitejs/plugin-react-swc');
@@ -39,7 +38,6 @@ const config: UserConfigFn = async ({ mode, command }) => {
 
   const commonPlugins = [
     skipSourcemaps(['node_modules']),
-    tsconfigPaths(),
     nodePolyfills({
       include: ['buffer', 'events', 'crypto', 'stream'],
     }),
@@ -48,6 +46,9 @@ const config: UserConfigFn = async ({ mode, command }) => {
   return defineConfig({
     mode: isStage ? 'production' : mode,
     cacheDir: resolve(folders.cache, 'vite-renderer'),
+    resolve: {
+      tsconfigPaths: true,
+    },
     base: '',
     root: resolve(folders.rendererRoot, 'app'),
     define: {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,6 +1,6 @@
 import { resolve } from 'node:path';
 
-import { type UserConfigFnPromise, type ViteUserConfig, mergeConfig } from 'vitest/config';
+import { type ViteUserConfig, type ViteUserConfigFnPromise, mergeConfig } from 'vitest/config';
 import { type TestSpecification, BaseSequencer } from 'vitest/node';
 
 import { folders } from './config/index.js';
@@ -29,7 +29,7 @@ class Seqencer extends BaseSequencer {
   }
 }
 
-const config: UserConfigFnPromise = async (options) => {
+const config: ViteUserConfigFnPromise = async (options) => {
   const base = await rendererConfig(options);
   const config: ViteUserConfig = {
     cacheDir: resolve(folders.root, 'node_modules/.cache/vitest'),
@@ -50,24 +50,7 @@ const config: UserConfigFnPromise = async (options) => {
         'src/**/*.test.tsx',
       ],
       globals: true,
-      environmentMatchGlobs: [
-        // Integration tests need happy-dom for fake-indexeddb and Dexie
-        ['tests/integrations/**/*.test.ts', 'happy-dom'],
-        ['tests/integrations/**/*.test.tsx', 'happy-dom'],
-        // This list should dissapear over time, simple logic tests shouldn't depend on environment.
-        ['src/renderer/shared/lib/hooks/**/*.ts', 'happy-dom'],
-        ['src/renderer/shared/lib/utils/**/*.ts', 'happy-dom'],
-        ['src/renderer/shared/i18n/**/*.ts', 'happy-dom'],
-        ['src/renderer/shared/api/**/*.ts', 'happy-dom'],
-        ['src/renderer/domains/**/*.ts', 'happy-dom'],
-        ['src/renderer/aggregates/**/*.ts', 'happy-dom'],
-        ['src/renderer/entities/**/*.ts', 'happy-dom'],
-        ['src/renderer/features/**/*.ts', 'happy-dom'],
-        ['src/renderer/widgets/**/*.ts', 'happy-dom'],
-        ['src/renderer/pages/**/*.ts', 'happy-dom'],
-        ['**/*.tsx', 'happy-dom'],
-        ['**/*.ts', 'node'],
-      ],
+      environment: 'happy-dom',
       setupFiles: resolve(folders.root, './vitest.setup.js'),
       reporters: [
         'default',

--- a/vitest.setup.js
+++ b/vitest.setup.js
@@ -5,16 +5,20 @@ import 'fake-indexeddb/auto';
 import { default as crypto } from 'crypto';
 import { TextDecoder, TextEncoder } from 'util';
 
-global.IntersectionObserver = vi.fn().mockImplementation(() => ({
-  observe: vi.fn(),
-  disconnect: vi.fn(),
-}));
+global.IntersectionObserver = vi.fn().mockImplementation(function () {
+  return {
+    observe: vi.fn(),
+    disconnect: vi.fn(),
+  };
+});
 
-global.ResizeObserver = vi.fn().mockImplementation(() => ({
-  disconnect: vi.fn(),
-  observe: vi.fn(),
-  unobserve: vi.fn(),
-}));
+global.ResizeObserver = vi.fn().mockImplementation(function () {
+  return {
+    disconnect: vi.fn(),
+    observe: vi.fn(),
+    unobserve: vi.fn(),
+  };
+});
 
 Object.defineProperty(global, 'crypto', {
   value: {


### PR DESCRIPTION
## Summary
- Upgrade Vite 7 → 8 with Rolldown bundler, plus related dependency bumps (vitest 4.1, @vitejs/plugin-react-swc 4.3, @swc/core 1.15, @effector/swc-plugin 1.0)
- Replace `vite-tsconfig-paths` with Vite 8's built-in `resolve.tsconfigPaths`
- Replace `vite-plugin-node-polyfills` with native Vite config: `resolve.alias` for crypto/stream, `global: 'globalThis'` define, and a minimal `polyfills.ts` for Buffer global
- Remove fragile patch file for vite-plugin-node-polyfills

## Test plan
- [x] `pnpm build:dev` — builds successfully, no deprecation warnings
- [x] `pnpm test` — 1145 tests pass (3 pre-existing timeout failures in transfer-max-ed)
- [x] `pnpm types:go` — passes cleanly
- [x] Dev server starts and app loads without errors
- [ ] Smoke test staking, governance, and transfer flows in Electron

🤖 Generated with [Claude Code](https://claude.com/claude-code)