### PR TITLE
fix: harden renderer security — remove debug globals and restrict IPC surface

### DIFF
--- a/src/renderer/app/debug-globals.test.ts
+++ b/src/renderer/app/debug-globals.test.ts
@@ -1,29 +1,15 @@
-/**
- * Integration tests: debug globals exposure security fix (#19)
- *
- * Verifies that `window.__spektr_config` (feature-flag controls) is only
- * exposed when the app runs in DEV mode and is NOT accessible in production.
- *
- * Security risk: without this fix any user could open DevTools and call
- * window.__spektr_config.enableFeature('dappBrowser') in a production build.
- */
 import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
-
-// ---------------------------------------------------------------------------
-// Mock all heavy / side-effectful dependencies so that importing index.tsx
-// doesn't attempt to render the full React tree or touch real storage.
-// ---------------------------------------------------------------------------
 
 vi.mock('react-dom/client', () => ({
   createRoot: vi.fn(() => ({ render: vi.fn() })),
 }));
 
 vi.mock('react-router-dom', () => ({
-  HashRouter: ({ children }: any) => children,
+  HashRouter: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock('react-error-boundary', () => ({
-  ErrorBoundary: ({ children }: any) => children,
+  ErrorBoundary: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock('@/shared/config/features', () => ({
@@ -35,7 +21,7 @@ vi.mock('@/shared/config/features', () => ({
 }));
 
 vi.mock('@/shared/i18n', () => ({
-  I18Provider: ({ children }: any) => children,
+  I18Provider: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock('@/shared/lib/utils', () => ({
@@ -48,13 +34,13 @@ vi.mock('@/shared/ui', () => ({
 }));
 
 vi.mock('@/shared/ui-kit', () => ({
-  ThemeProvider: ({ children }: any) => children,
-  NotificationProvider: ({ children }: any) => children,
+  ThemeProvider: ({ children }: { children: unknown }) => children,
+  NotificationProvider: ({ children }: { children: unknown }) => children,
 }));
 
 vi.mock('./App', () => ({ App: () => null }));
 vi.mock('./DelayedSuspense', () => ({
-  controlledLazy: (fn: any) => fn,
+  controlledLazy: (fn: unknown) => fn,
   suspenseDelay: vi.fn(() => null),
   LoadingDelay: () => null,
 }));
@@ -65,20 +51,12 @@ vi.mock('./components/WebSplashScreen/WebSplashScreen', () => ({
   WebSplashScreen: () => null,
 }));
 
-// ---------------------------------------------------------------------------
-
-// -------------------------------------------------------------------------
-// DEV mode: controls MUST be exposed
-// -------------------------------------------------------------------------
-describe('App index — debug globals security (#19) — in development mode (import.meta.env.DEV = true)', () => {
+describe('debug globals — development mode', () => {
   beforeAll(async () => {
-    // Provide a minimal DOM so index.tsx doesn't throw "Root container missing"
     document.body.innerHTML = '<div id="app"></div>';
     delete (window as any).__spektr_config;
 
-    // DEV is boolean in vite-env.d.ts; true keeps debug controls accessible
     vi.stubEnv('DEV', true);
-    // Import once for the whole describe block
     await import('./index');
   });
 
@@ -126,15 +104,11 @@ describe('App index — debug globals security (#19) — in development mode (im
   });
 });
 
-// -------------------------------------------------------------------------
-// PRODUCTION mode: controls MUST NOT be exposed
-// -------------------------------------------------------------------------
-describe('App index — debug globals security (#19) — in production mode (import.meta.env.DEV = false)', () => {
+describe('debug globals — production mode', () => {
   beforeAll(async () => {
     document.body.innerHTML = '<div id="app"></div>';
     delete (window as any).__spektr_config;
 
-    // DEV is boolean in vite-env.d.ts; false hides debug controls (production behaviour)
     vi.stubEnv('DEV', false);
     await import('./index');
   });
@@ -145,12 +119,8 @@ describe('App index — debug globals security (#19) — in production mode (imp
     delete (window as any).__spektr_config;
   });
 
-  it('does NOT expose __spektr_config on window', () => {
+  it('does not expose __spektr_config on window', () => {
     expect(window.__spektr_config).toBeUndefined();
-  });
-
-  it('window.__spektr_config is undefined', () => {
-    expect((window as any).__spektr_config).toBeUndefined();
   });
 
   it('window has no enableFeature method', () => {

--- a/src/renderer/app/debug-globals.test.tsx
+++ b/src/renderer/app/debug-globals.test.tsx
@@ -1,0 +1,167 @@
+/**
+ * Integration tests: debug globals exposure security fix (#19)
+ *
+ * Verifies that `window.__spektr_config` (feature-flag controls) is only
+ * exposed when the app runs in DEV mode and is NOT accessible in production.
+ *
+ * Security risk: without this fix any user could open DevTools and call
+ * window.__spektr_config.enableFeature('dappBrowser') in a production build.
+ */
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+
+// ---------------------------------------------------------------------------
+// Mock all heavy / side-effectful dependencies so that importing index.tsx
+// doesn't attempt to render the full React tree or touch real storage.
+// ---------------------------------------------------------------------------
+
+vi.mock('react-dom/client', () => ({
+  createRoot: vi.fn(() => ({ render: vi.fn() })),
+}));
+
+vi.mock('react-router-dom', () => ({
+  HashRouter: ({ children }: any) => children,
+}));
+
+vi.mock('react-error-boundary', () => ({
+  ErrorBoundary: ({ children }: any) => children,
+}));
+
+vi.mock('@/shared/config/features', () => ({
+  updateFeatureStatus: vi.fn(),
+  resetFeatureStatuses: vi.fn(),
+  $features: {},
+  $defaultFeatures: {},
+  $mutatedFeatures: {},
+}));
+
+vi.mock('@/shared/i18n', () => ({
+  I18Provider: ({ children }: any) => children,
+}));
+
+vi.mock('@/shared/lib/utils', () => ({
+  isElectron: vi.fn(() => false),
+  isDev: vi.fn(() => false),
+}));
+
+vi.mock('@/shared/ui', () => ({
+  FallbackScreen: () => null,
+}));
+
+vi.mock('@/shared/ui-kit', () => ({
+  ThemeProvider: ({ children }: any) => children,
+  NotificationProvider: ({ children }: any) => children,
+}));
+
+vi.mock('./App', () => ({ App: () => null }));
+vi.mock('./DelayedSuspense', () => ({
+  controlledLazy: (fn: any) => fn,
+  suspenseDelay: vi.fn(() => null),
+  LoadingDelay: () => null,
+}));
+vi.mock('./components/ElectronSplashScreen/ElectronSplashScreen', () => ({
+  ElectronSplashScreen: () => null,
+}));
+vi.mock('./components/WebSplashScreen/WebSplashScreen', () => ({
+  WebSplashScreen: () => null,
+}));
+
+// ---------------------------------------------------------------------------
+
+// -------------------------------------------------------------------------
+// DEV mode: controls MUST be exposed
+// -------------------------------------------------------------------------
+describe('App index — debug globals security (#19) — in development mode (import.meta.env.DEV = true)', () => {
+  beforeAll(async () => {
+    // Provide a minimal DOM so index.tsx doesn't throw "Root container missing"
+    document.body.innerHTML = '<div id="app"></div>';
+    delete (window as any).__spektr_config;
+
+    // DEV is boolean in vite-env.d.ts; true keeps debug controls accessible
+    vi.stubEnv('DEV', true);
+    // Import once for the whole describe block
+    await import('./index');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    delete (window as any).__spektr_config;
+  });
+
+  it('exposes __spektr_config on window', () => {
+    expect(window.__spektr_config).toBeDefined();
+  });
+
+  it('__spektr_config has enableFeature method', () => {
+    expect(typeof window.__spektr_config?.enableFeature).toBe('function');
+  });
+
+  it('__spektr_config has disableFeature method', () => {
+    expect(typeof window.__spektr_config?.disableFeature).toBe('function');
+  });
+
+  it('__spektr_config has resetFeatureConfig method', () => {
+    expect(typeof window.__spektr_config?.resetFeatureConfig).toBe('function');
+  });
+
+  it('enableFeature delegates to updateFeatureStatus with [name, true]', async () => {
+    const { updateFeatureStatus } = await import('@/shared/config/features');
+
+    window.__spektr_config!.enableFeature('dappBrowser');
+    expect(updateFeatureStatus).toHaveBeenCalledWith(['dappBrowser', true]);
+  });
+
+  it('disableFeature delegates to updateFeatureStatus with [name, false]', async () => {
+    const { updateFeatureStatus } = await import('@/shared/config/features');
+
+    window.__spektr_config!.disableFeature('dappBrowser');
+    expect(updateFeatureStatus).toHaveBeenCalledWith(['dappBrowser', false]);
+  });
+
+  it('resetFeatureConfig delegates to resetFeatureStatuses', async () => {
+    const { resetFeatureStatuses } = await import('@/shared/config/features');
+
+    window.__spektr_config!.resetFeatureConfig();
+    expect(resetFeatureStatuses).toHaveBeenCalled();
+  });
+});
+
+// -------------------------------------------------------------------------
+// PRODUCTION mode: controls MUST NOT be exposed
+// -------------------------------------------------------------------------
+describe('App index — debug globals security (#19) — in production mode (import.meta.env.DEV = false)', () => {
+  beforeAll(async () => {
+    document.body.innerHTML = '<div id="app"></div>';
+    delete (window as any).__spektr_config;
+
+    // DEV is boolean in vite-env.d.ts; false hides debug controls (production behaviour)
+    vi.stubEnv('DEV', false);
+    await import('./index');
+  });
+
+  afterAll(() => {
+    vi.unstubAllEnvs();
+    vi.resetModules();
+    delete (window as any).__spektr_config;
+  });
+
+  it('does NOT expose __spektr_config on window', () => {
+    expect(window.__spektr_config).toBeUndefined();
+  });
+
+  it('window.__spektr_config is undefined', () => {
+    expect((window as any).__spektr_config).toBeUndefined();
+  });
+
+  it('window has no enableFeature method', () => {
+    expect((window as any).__spektr_config?.enableFeature).toBeUndefined();
+  });
+
+  it('window has no disableFeature method', () => {
+    expect((window as any).__spektr_config?.disableFeature).toBeUndefined();
+  });
+
+  it('window has no resetFeatureConfig method', () => {
+    expect((window as any).__spektr_config?.resetFeatureConfig).toBeUndefined();
+  });
+});

--- a/src/renderer/app/index.tsx
+++ b/src/renderer/app/index.tsx
@@ -29,7 +29,7 @@ import { WebSplashScreen } from './components/WebSplashScreen/WebSplashScreen';
 
 declare global {
   interface Window {
-    __spektr_config: {
+    __spektr_config?: {
       enableFeature(name: string): void;
       disableFeature(name: string): void;
       resetFeatureConfig(): void;
@@ -37,11 +37,16 @@ declare global {
   }
 }
 
-window.__spektr_config = {
-  enableFeature: (name) => updateFeatureStatus([name, true]),
-  disableFeature: (name) => updateFeatureStatus([name, false]),
-  resetFeatureConfig: () => resetFeatureStatuses(),
-};
+// Expose feature-flag controls only in non-production builds.
+// In production the window property is not set, preventing console-based
+// toggling of features (walletConnect, multisig, dappBrowser, etc.).
+if (import.meta.env.DEV) {
+  window.__spektr_config = {
+    enableFeature: (name) => updateFeatureStatus([name, true]),
+    disableFeature: (name) => updateFeatureStatus([name, false]),
+    resetFeatureConfig: () => resetFeatureStatuses(),
+  };
+}
 
 const CLEAR_LOADING_TIMEOUT = 700;
 const DIRTY_LOADING_TIMEOUT = 2000;

--- a/src/renderer/shared/config/features/features.test.ts
+++ b/src/renderer/shared/config/features/features.test.ts
@@ -1,16 +1,9 @@
-/**
- * Unit tests for feature flags module (shared/config/features) Tests the
- * enableFeature/disableFeature/resetFeatureConfig logic that is exposed via
- * window.__spektr_config in DEV mode.
- *
- * Issue: #19 — Debug interfaces exposure
- */
 import { allSettled, fork } from 'effector';
 import { describe, expect, it } from 'vitest';
 
 import { $features, $mutatedFeatures, resetFeatureStatuses, updateFeatureStatus } from './index';
 
-describe('shared/config/features — unit tests', () => {
+describe('shared/config/features', () => {
   describe('default feature flags', () => {
     it('should have default features defined', () => {
       const scope = fork();
@@ -40,7 +33,6 @@ describe('shared/config/features — unit tests', () => {
   describe('updateFeatureStatus — enableFeature', () => {
     it('should enable a disabled feature', async () => {
       const scope = fork();
-      // dappBrowser defaults to false
       expect(scope.getState($features).dappBrowser).toBe(false);
 
       await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
@@ -51,7 +43,6 @@ describe('shared/config/features — unit tests', () => {
     it('should record override in mutations store when toggling non-default value', async () => {
       const scope = fork();
 
-      // dappBrowser defaults to false, so enabling it creates a mutation
       await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
 
       expect(scope.getState($mutatedFeatures)).toHaveProperty('dappBrowser', true);
@@ -60,11 +51,9 @@ describe('shared/config/features — unit tests', () => {
     it('should remove mutation when restoring to default value', async () => {
       const scope = fork();
 
-      // dashboard defaults to true — disabling creates mutation
       await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
       expect(scope.getState($mutatedFeatures)).toHaveProperty('dashboard', false);
 
-      // re-enabling (back to default) should remove the mutation
       await allSettled(updateFeatureStatus, { scope, params: ['dashboard', true] });
       expect(scope.getState($mutatedFeatures)).not.toHaveProperty('dashboard');
     });
@@ -145,7 +134,6 @@ describe('shared/config/features — unit tests', () => {
       expect(features.dappBrowser).toBe(true);
       expect(features.dashboard).toBe(false);
       expect(features.staking).toBe(false);
-      // Unrelated features remain at default
       expect(features.assets).toBe(true);
     });
   });

--- a/src/renderer/shared/config/features/features.test.ts
+++ b/src/renderer/shared/config/features/features.test.ts
@@ -1,0 +1,152 @@
+/**
+ * Unit tests for feature flags module (shared/config/features) Tests the
+ * enableFeature/disableFeature/resetFeatureConfig logic that is exposed via
+ * window.__spektr_config in DEV mode.
+ *
+ * Issue: #19 — Debug interfaces exposure
+ */
+import { allSettled, fork } from 'effector';
+import { describe, expect, it } from 'vitest';
+
+import { $features, $mutatedFeatures, resetFeatureStatuses, updateFeatureStatus } from './index';
+
+describe('shared/config/features — unit tests', () => {
+  describe('default feature flags', () => {
+    it('should have default features defined', () => {
+      const scope = fork();
+      const features = scope.getState($features);
+
+      expect(features).toBeDefined();
+      expect(typeof features).toBe('object');
+    });
+
+    it('should have expected core features enabled by default', () => {
+      const scope = fork();
+      const features = scope.getState($features);
+
+      expect(features.dashboard).toBe(true);
+      expect(features.assets).toBe(true);
+      expect(features.staking).toBe(true);
+      expect(features.governance).toBe(true);
+      expect(features.settings).toBe(true);
+    });
+
+    it('should start with empty mutations store', () => {
+      const scope = fork();
+      expect(scope.getState($mutatedFeatures)).toEqual({});
+    });
+  });
+
+  describe('updateFeatureStatus — enableFeature', () => {
+    it('should enable a disabled feature', async () => {
+      const scope = fork();
+      // dappBrowser defaults to false
+      expect(scope.getState($features).dappBrowser).toBe(false);
+
+      await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
+
+      expect(scope.getState($features).dappBrowser).toBe(true);
+    });
+
+    it('should record override in mutations store when toggling non-default value', async () => {
+      const scope = fork();
+
+      // dappBrowser defaults to false, so enabling it creates a mutation
+      await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
+
+      expect(scope.getState($mutatedFeatures)).toHaveProperty('dappBrowser', true);
+    });
+
+    it('should remove mutation when restoring to default value', async () => {
+      const scope = fork();
+
+      // dashboard defaults to true — disabling creates mutation
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
+      expect(scope.getState($mutatedFeatures)).toHaveProperty('dashboard', false);
+
+      // re-enabling (back to default) should remove the mutation
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', true] });
+      expect(scope.getState($mutatedFeatures)).not.toHaveProperty('dashboard');
+    });
+  });
+
+  describe('updateFeatureStatus — disableFeature', () => {
+    it('should disable an enabled feature', async () => {
+      const scope = fork();
+      expect(scope.getState($features).dashboard).toBe(true);
+
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
+
+      expect(scope.getState($features).dashboard).toBe(false);
+    });
+
+    it('should record override when disabling a default-true feature', async () => {
+      const scope = fork();
+
+      await allSettled(updateFeatureStatus, { scope, params: ['staking', false] });
+
+      expect(scope.getState($mutatedFeatures)).toHaveProperty('staking', false);
+    });
+
+    it('should ignore updates for non-existent features', async () => {
+      const scope = fork();
+      const before = scope.getState($mutatedFeatures);
+
+      await allSettled(updateFeatureStatus, { scope, params: ['nonExistentFeature', true] });
+
+      expect(scope.getState($mutatedFeatures)).toEqual(before);
+    });
+  });
+
+  describe('resetFeatureStatuses — resetFeatureConfig', () => {
+    it('should clear all overrides on reset', async () => {
+      const scope = fork();
+
+      await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
+      await allSettled(updateFeatureStatus, { scope, params: ['staking', false] });
+
+      expect(Object.keys(scope.getState($mutatedFeatures)).length).toBeGreaterThan(0);
+
+      await allSettled(resetFeatureStatuses, { scope });
+
+      expect(scope.getState($mutatedFeatures)).toEqual({});
+    });
+
+    it('should restore default values after reset', async () => {
+      const scope = fork();
+
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
+      expect(scope.getState($features).dashboard).toBe(false);
+
+      await allSettled(resetFeatureStatuses, { scope });
+
+      expect(scope.getState($features).dashboard).toBe(true);
+    });
+
+    it('should be idempotent — reset on empty mutations is safe', async () => {
+      const scope = fork();
+
+      await allSettled(resetFeatureStatuses, { scope });
+
+      expect(scope.getState($mutatedFeatures)).toEqual({});
+    });
+  });
+
+  describe('multiple sequential updates', () => {
+    it('should apply multiple feature changes independently', async () => {
+      const scope = fork();
+
+      await allSettled(updateFeatureStatus, { scope, params: ['dappBrowser', true] });
+      await allSettled(updateFeatureStatus, { scope, params: ['dashboard', false] });
+      await allSettled(updateFeatureStatus, { scope, params: ['staking', false] });
+
+      const features = scope.getState($features);
+      expect(features.dappBrowser).toBe(true);
+      expect(features.dashboard).toBe(false);
+      expect(features.staking).toBe(false);
+      // Unrelated features remain at default
+      expect(features.assets).toBe(true);
+    });
+  });
+});

--- a/vite.config.renderer.ts
+++ b/vite.config.renderer.ts
@@ -82,6 +82,10 @@ const config: UserConfigFn = async ({ mode, command }) => {
 
       tailwindcss(),
 
+      // @vitejs/plugin-react-swc automatically disables React Fast Refresh
+      // (and the associated window.$RefreshReg$ / window.$RefreshSig$ globals)
+      // in production builds. The effector SWC plugin with HMR is only applied
+      // during the dev-server to keep those globals out of production bundles.
       react({
         plugins: isDevServer
           ? [['@effector/swc-plugin', { hmr: 'es', addNames: true, addLoc: false, factories: ['@/shared/di'] }]]

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -35,6 +35,10 @@ const config: ViteUserConfigFnPromise = async (options) => {
     cacheDir: resolve(folders.root, 'node_modules/.cache/vitest'),
     resolve: {
       alias: {
+        // Vite 7 native tsconfigPaths does not resolve @/ aliases during Vitest's
+        // transform pass (it works in production Rolldown builds but not test runs).
+        // Explicit alias ensures @/X → src/renderer/X in all environments.
+        '@': resolve(folders.rendererRoot),
         // @polkadot/rpc-provider/mock ESM build uses deprecated `import ... assert { type: 'json' }`
         // which is a SyntaxError in Node 22+. Redirect to the CJS build which uses require() instead.
         '@polkadot/rpc-provider/mock': resolve(folders.root, 'node_modules/@polkadot/rpc-provider/cjs/mock/index.js'),


### PR DESCRIPTION
## Summary

Addresses a security audit finding: the renderer exposed several debug/internal interfaces that amplify XSS attack surface in production builds.

### Changes

**Remove `window.__spektr_config` from production** (`src/renderer/app/index.tsx`)
- Feature-flag controls (`enableFeature`, `disableFeature`, `resetFeatureConfig`) are now only assigned to `window` when `import.meta.env.DEV === true`
- In production a console attacker cannot toggle `walletConnect`, `multisig`, `dappBrowser`, etc.
- `window.__spektr_config` type changed to optional (`?`) to reflect that it may be absent

**Strip `$RefreshReg$` / `$RefreshSig$` globals** (`vite.config.renderer.ts`)
- `@vitejs/plugin-react-swc` already disables React Fast Refresh (and those globals) in production builds; the Effector SWC plugin with HMR is now explicitly restricted to `isDevServer` to keep this guarantee
- Documents why — previously the intent was implicit

**Harden `preload.ts` IPC bridge** (`src/main/preload.ts`, `2bffb52`)
- `ALLOWED_STORE_KEYS` whitelist: `getStoreValue`/`setStoreValue` now reject any key not on the list with a console warning instead of blindly proxying to the main process
- Removed `process.env.USER` (system OS username) from the `contextBridge` API — leaks OS identity to renderer/web content

**Sanitize contact names on import** (`823c8582`)
- Strips control characters and normalises whitespace in imported address-book entries to prevent homograph / invisible-character attacks

### Tests

- `src/renderer/app/debug-globals.test.ts` — verifies `window.__spektr_config` is defined in DEV and `undefined` in production using `vi.stubEnv` + `vi.resetModules` per-scenario
- `src/renderer/shared/config/features/features.test.ts` — unit tests for `updateFeatureStatus` / `resetFeatureStatuses` Effector logic (fork/allSettled pattern)
- `src/main/__tests__/preload.test.ts` — covers whitelist enforcement and username removal
- `vitest.config.ts` — added explicit `@` → `src/renderer` alias; Vite 7 native `tsconfigPaths` does not resolve `@/` during Vitest's transform pass (works only in Rolldown production builds), causing all cross-module tests with `@/` imports to fail

## Test plan

- [ ] `pnpm test src/renderer/app/debug-globals.test.ts` — 11 tests pass
- [ ] `pnpm test src/renderer/shared/config/features/features.test.ts` — 13 tests pass
- [ ] `pnpm test src/main/__tests__/preload.test.ts` — preload whitelist tests pass
- [ ] `pnpm build` — production build contains no `window.__spektr_config` assignment (verify in DevTools after `pnpm preview`)
- [ ] Feature flags UI still works in dev mode (`pnpm start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)