### PR TITLE
feat(dashboard): add 24h price change indicators

### DIFF
--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldings.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldings.ts
@@ -16,6 +16,7 @@ export type Holding = {
   precision: number;
   totalRaw: string;
   fiatValue: string;
+  change: number | null;
 };
 
 export type HoldingsData = {
@@ -48,6 +49,7 @@ export const useHoldings = (accountIds: string[]): HoldingsData => {
         precision: number;
         totalRaw: BigNumber;
         fiatValue: BigNumber;
+        change: number | null;
       }
     >();
 
@@ -79,6 +81,7 @@ export const useHoldings = (accountIds: string[]): HoldingsData => {
           precision: asset.precision,
           totalRaw: new BigNumber(rawBN.toString()),
           fiatValue: new BigNumber(fiat),
+          change: priceItem.change ?? null,
         });
       }
     }
@@ -99,6 +102,7 @@ export const useHoldings = (accountIds: string[]): HoldingsData => {
         precision: group.precision,
         totalRaw: group.totalRaw.toFixed(0),
         fiatValue: group.fiatValue.toString(),
+        change: group.change,
       };
     });
 

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
@@ -12,6 +12,7 @@ import { type BreakdownRow, useHoldingBreakdown } from '../hooks/useHoldingBreak
 import { type Holding } from '../hooks/useHoldings';
 
 import { Price } from './Price';
+import { PriceChangeIndicator } from './PriceChangeIndicator';
 
 type ChartEntry = {
   name: string;
@@ -138,9 +139,12 @@ export const AssetDetailModal = memo(({ holding, accountIds, allEntries, currenc
               {formatted}
               {suffix} {holding.symbol}
             </FootnoteText>
-            <FootnoteText align="right" className="text-text-tertiary tabular-nums">
-              <Price amount={holding.fiatValue} currency={currency} />
-            </FootnoteText>
+            <div className="flex items-center justify-end gap-1">
+              <PriceChangeIndicator change={holding.change} />
+              <FootnoteText align="right" className="text-text-tertiary tabular-nums">
+                <Price amount={holding.fiatValue} currency={currency} />
+              </FootnoteText>
+            </div>
           </div>
         </div>
 

--- a/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
@@ -102,10 +102,10 @@ const PriceChangeIndicator = ({ change }: { change: number | null }) => {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <FootnoteText className={cnTw('tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
+        <span className={cnTw('text-footnote tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
           {isPositive ? '↑' : '↓'}
           {Math.abs(change).toFixed(2)}%
-        </FootnoteText>
+        </span>
       </Tooltip.Trigger>
       <Tooltip.Content>{t('dashboard.portfolioOverview.priceChange24h')}</Tooltip.Content>
     </Tooltip>

--- a/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
@@ -1,7 +1,7 @@
 import { memo, useMemo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { formatBalance } from '@/shared/lib/utils';
+import { cnTw, formatBalance } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
 import { BRAND_COLORS, FALLBACK_COLORS, getColorByPriceId } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
@@ -80,10 +80,28 @@ const HoldingRow = memo(({ holding, color, currency, onSelect }: RowProps) => {
           {formatted}
           {suffix} {holding.symbol}
         </FootnoteText>
-        <FootnoteText align="right" className="text-text-tertiary tabular-nums">
-          <Price amount={holding.fiatValue} currency={currency} />
-        </FootnoteText>
+        <div className="flex items-center justify-end gap-1">
+          <PriceChangeIndicator change={holding.change} />
+          <FootnoteText align="right" className="text-text-tertiary tabular-nums">
+            <Price amount={holding.fiatValue} currency={currency} />
+          </FootnoteText>
+        </div>
       </div>
     </div>
   );
 });
+
+const PriceChangeIndicator = ({ change }: { change: number | null }) => {
+  if (change === null || change === 0 || !Number.isFinite(change)) return null;
+
+  const isPositive = change > 0;
+
+  return (
+    <FootnoteText className={cnTw('tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
+      {/* eslint-disable-next-line i18next/no-literal-string */}
+      {isPositive ? '↑' : '↓'}
+      {isPositive ? '+' : ''}
+      {change.toFixed(2)}%
+    </FootnoteText>
+  );
+};

--- a/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
@@ -5,6 +5,7 @@ import { cnTw, formatBalance } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
 import { BRAND_COLORS, FALLBACK_COLORS, getColorByPriceId } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
+import { Tooltip } from '@/shared/ui-kit';
 import { type CurrencyItem } from '@/domains/price';
 import { type Holding } from '../hooks/useHoldings';
 
@@ -92,16 +93,21 @@ const HoldingRow = memo(({ holding, color, currency, onSelect }: RowProps) => {
 });
 
 const PriceChangeIndicator = ({ change }: { change: number | null }) => {
+  const { t } = useI18n();
+
   if (change === null || change === 0 || !Number.isFinite(change)) return null;
 
   const isPositive = change > 0;
 
   return (
-    <FootnoteText className={cnTw('tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
-      {/* eslint-disable-next-line i18next/no-literal-string */}
-      {isPositive ? '↑' : '↓'}
-      {isPositive ? '+' : ''}
-      {change.toFixed(2)}%
-    </FootnoteText>
+    <Tooltip>
+      <Tooltip.Trigger>
+        <FootnoteText className={cnTw('tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
+          {isPositive ? '↑' : '↓'}
+          {Math.abs(change).toFixed(2)}%
+        </FootnoteText>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{t('dashboard.portfolioOverview.priceChange24h')}</Tooltip.Content>
+    </Tooltip>
   );
 };

--- a/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/HoldingsList.tsx
@@ -1,16 +1,16 @@
 import { memo, useMemo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { cnTw, formatBalance } from '@/shared/lib/utils';
+import { formatBalance } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
 import { BRAND_COLORS, FALLBACK_COLORS, getColorByPriceId } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
-import { Tooltip } from '@/shared/ui-kit';
 import { type CurrencyItem } from '@/domains/price';
 import { type Holding } from '../hooks/useHoldings';
 
 import { AllocationChart } from './AllocationChart';
 import { Price } from './Price';
+import { PriceChangeIndicator } from './PriceChangeIndicator';
 
 type Props = {
   holdings: Holding[];
@@ -91,23 +91,3 @@ const HoldingRow = memo(({ holding, color, currency, onSelect }: RowProps) => {
     </div>
   );
 });
-
-const PriceChangeIndicator = ({ change }: { change: number | null }) => {
-  const { t } = useI18n();
-
-  if (change === null || change === 0 || !Number.isFinite(change)) return null;
-
-  const isPositive = change > 0;
-
-  return (
-    <Tooltip>
-      <Tooltip.Trigger>
-        <span className={cnTw('text-footnote tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
-          {isPositive ? '↑' : '↓'}
-          {Math.abs(change).toFixed(2)}%
-        </span>
-      </Tooltip.Trigger>
-      <Tooltip.Content>{t('dashboard.portfolioOverview.priceChange24h')}</Tooltip.Content>
-    </Tooltip>
-  );
-};

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PriceChangeIndicator.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PriceChangeIndicator.tsx
@@ -1,0 +1,23 @@
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { Tooltip } from '@/shared/ui-kit';
+
+export const PriceChangeIndicator = ({ change }: { change: number | null }) => {
+  const { t } = useI18n();
+
+  if (change === null || change === 0 || !Number.isFinite(change)) return null;
+
+  const isPositive = change > 0;
+
+  return (
+    <Tooltip>
+      <Tooltip.Trigger>
+        <span className={cnTw('text-footnote tabular-nums', isPositive ? 'text-text-positive' : 'text-text-negative')}>
+          {isPositive ? '↑' : '↓'}
+          {Math.abs(change).toFixed(2)}%
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content>{t('dashboard.portfolioOverview.priceChange24h')}</Tooltip.Content>
+    </Tooltip>
+  );
+};

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -522,6 +522,7 @@
         "value": "Value",
         "share": "Share"
       },
+      "priceChange24h": "24h change",
       "assetAllocation": "Asset Allocation",
       "chainDetail": {
         "title": "{chainName} Details",


### PR DESCRIPTION
## Summary
- Thread `PriceItem.change` through the `Holding` type in `useHoldings`
- Add inline `PriceChangeIndicator` component to `HoldingRow` — shows colored arrow + percentage (green ↑ / red ↓) next to the fiat price
- Hidden for `null`, `0`, `NaN`, or non-finite values (e.g. KILT, INTR where CoinGecko doesn't provide 24h change)

## Test plan
- [x] `pnpm types:go` — no type errors
- [x] `pnpm lint` — clean
- [ ] Visual check: green/red arrows visible in "By Asset" view, absent in "By Chain" view
- [ ] Stablecoin rows show near-zero or hidden indicator

🤖 Generated with [Claude Code](https://claude.com/claude-code)