### PR TITLE
refactor(dashboard): compact price tiles SPEK-264

### DIFF
--- a/src/renderer/features/dashboard-price-charts/ui/PriceChange.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceChange.tsx
@@ -1,5 +1,4 @@
 import { cnTw } from '@/shared/lib/utils';
-import { FootnoteText } from '@/shared/ui';
 
 type Props = {
   change: number | undefined;
@@ -12,13 +11,9 @@ export const PriceChange = ({ change }: Props) => {
   const formatted = `${isPositive ? '+' : ''}${change.toFixed(2)}%`;
 
   return (
-    <FootnoteText
-      className={cnTw(
-        'rounded px-1.5 py-0.5',
-        isPositive ? 'bg-[--positive-background] text-text-positive' : 'bg-[--negative-background] text-text-negative',
-      )}
-    >
-      {isPositive ? '\u2191' : '\u2193'} {formatted}
-    </FootnoteText>
+    <span className={cnTw('text-left text-footnote', isPositive ? 'text-text-positive' : 'text-text-negative')}>
+      {isPositive ? '\u2191' : '\u2193'} {}
+      {formatted}
+    </span>
   );
 };

--- a/src/renderer/features/dashboard-price-charts/ui/PriceChartsWidget.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceChartsWidget.tsx
@@ -54,7 +54,7 @@ export const PriceChartsWidget = () => {
       {trackedAssets.length === 0 ? (
         <p className="text-footnote text-text-tertiary">{t('dashboard.priceCharts.emptyState')}</p>
       ) : (
-        <div className="grid grid-cols-3 gap-3">
+        <div className="grid grid-cols-5 gap-2">
           {trackedAssets.map((asset, index) => (
             <PriceTile
               key={asset.priceId}

--- a/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
@@ -1,3 +1,6 @@
+import { useMemo } from 'react';
+
+import { cnTw } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
 import { getColorByPriceId } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
@@ -18,29 +21,43 @@ type Props = {
 export const PriceTile = ({ asset, index, price, currencySymbol, pending, onClick }: Props) => {
   const accentColor = getColorByPriceId(asset.priceId, index);
 
+  const glowStyle = useMemo(
+    () => ({
+      '--accent': accentColor,
+      background: `linear-gradient(135deg, ${accentColor}08 0%, transparent 60%)`,
+    }),
+    [accentColor],
+  );
+
   return (
     <button
       type="button"
-      className="group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border border-token-container-border bg-white shadow-card-shadow transition-all duration-100 hover:-translate-y-0.5 hover:shadow-[0px_4px_6px_rgba(69,69,137,0.06),0px_2px_2px_rgba(69,69,137,0.05),inset_0px_-0.5px_0px_rgba(69,69,137,0.12)]"
+      className={cnTw(
+        'group relative flex cursor-pointer flex-col overflow-hidden rounded-lg border bg-white shadow-card-shadow',
+        'transition-shadow duration-150',
+        'hover:shadow-card-shadow-level2',
+        'border-token-container-border hover:border-[var(--accent)]',
+      )}
+      style={glowStyle}
       onClick={onClick}
     >
-      <div className="absolute inset-y-0 left-0 w-0.5" style={{ backgroundColor: accentColor }} />
+      <div className="absolute inset-y-0 left-0 w-[3px] rounded-l-lg" style={{ backgroundColor: accentColor }} />
 
-      <div className="flex w-full flex-col gap-1.5 py-2 pr-2.5 pl-3">
+      <div className="flex w-full flex-col gap-1.5 p-2.5 pl-3.5">
         <div className="flex items-center gap-1.5">
-          <AssetIcon asset={asset} size={24} />
-          <FootnoteText className="font-semibold text-text-secondary">{asset.symbol}</FootnoteText>
+          <div className="rounded-full shadow-[0_1px_3px_rgba(0,0,0,0.08)]">
+            <AssetIcon asset={asset} size={24} />
+          </div>
+          <FootnoteText className="font-semibold tracking-wide text-text-secondary">{asset.symbol}</FootnoteText>
         </div>
 
         {price ? (
           <div className="flex flex-col gap-0.5">
-            <FootnoteText className="text-left font-semibold text-text-primary tabular-nums">
+            <FootnoteText className="text-left font-semibold text-text-primary">
               {currencySymbol}
               {price.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 })}
             </FootnoteText>
-            <div className="flex">
-              <PriceChange change={price.change} />
-            </div>
+            <PriceChange change={price.change} />
           </div>
         ) : pending ? (
           <div className="flex flex-col gap-0.5">

--- a/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
@@ -21,10 +21,10 @@ type Props = {
 export const PriceTile = ({ asset, index, price, currencySymbol, pending, onClick }: Props) => {
   const accentColor = getColorByPriceId(asset.priceId, index);
 
-  const glowStyle = useMemo(
+  const tileStyle = useMemo(
     () => ({
-      '--accent': accentColor,
-      background: `linear-gradient(135deg, ${accentColor}08 0%, transparent 60%)`,
+      '--accent': `${accentColor}66`,
+      background: `linear-gradient(135deg, ${accentColor}06 0%, transparent 60%)`,
     }),
     [accentColor],
   );
@@ -38,10 +38,13 @@ export const PriceTile = ({ asset, index, price, currencySymbol, pending, onClic
         'hover:shadow-card-shadow-level2',
         'border-token-container-border hover:border-[var(--accent)]',
       )}
-      style={glowStyle}
+      style={tileStyle}
       onClick={onClick}
     >
-      <div className="absolute inset-y-0 left-0 w-[3px] rounded-l-lg" style={{ backgroundColor: accentColor }} />
+      <div
+        className="absolute inset-y-0 left-0 w-[2px] rounded-l-lg opacity-40"
+        style={{ backgroundColor: accentColor }}
+      />
 
       <div className="flex w-full flex-col gap-1.5 p-2.5 pl-3.5">
         <div className="flex items-center gap-1.5">

--- a/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceTile.tsx
@@ -1,4 +1,4 @@
-import { BodyText, FootnoteText } from '@/shared/ui';
+import { FootnoteText } from '@/shared/ui';
 import { getColorByPriceId } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
 import { Skeleton } from '@/shared/ui-kit';
@@ -26,26 +26,26 @@ export const PriceTile = ({ asset, index, price, currencySymbol, pending, onClic
     >
       <div className="absolute inset-y-0 left-0 w-0.5" style={{ backgroundColor: accentColor }} />
 
-      <div className="flex w-full flex-col gap-2.5 py-3 pr-3 pl-3.5">
-        <div className="flex items-center gap-2">
+      <div className="flex w-full flex-col gap-1.5 py-2 pr-2.5 pl-3">
+        <div className="flex items-center gap-1.5">
           <AssetIcon asset={asset} size={24} />
           <FootnoteText className="font-semibold text-text-secondary">{asset.symbol}</FootnoteText>
         </div>
 
         {price ? (
-          <div className="flex flex-col gap-1">
-            <BodyText className="text-left font-semibold text-text-primary tabular-nums">
+          <div className="flex flex-col gap-0.5">
+            <FootnoteText className="text-left font-semibold text-text-primary tabular-nums">
               {currencySymbol}
               {price.price.toLocaleString(undefined, { minimumFractionDigits: 2, maximumFractionDigits: 4 })}
-            </BodyText>
+            </FootnoteText>
             <div className="flex">
               <PriceChange change={price.change} />
             </div>
           </div>
         ) : pending ? (
-          <div className="flex flex-col gap-1">
-            <Skeleton width={20} height={5} />
-            <Skeleton width={12} height={4} />
+          <div className="flex flex-col gap-0.5">
+            <Skeleton width={18} height={4} />
+            <Skeleton width={10} height={3} />
           </div>
         ) : null}
       </div>

--- a/src/renderer/features/dashboard-price-charts/ui/TokenSelectionModal.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/TokenSelectionModal.tsx
@@ -34,7 +34,7 @@ export const TokenSelectionModal = ({ onClose }: Props) => {
   };
 
   return (
-    <Modal size="md" isOpen onToggle={(open) => !open && onClose()}>
+    <Modal size="sm" isOpen onToggle={(open) => !open && onClose()}>
       <Modal.Title close>{t('dashboard.priceCharts.manageTokens')}</Modal.Title>
       <Modal.Content>
         <div className="flex flex-col gap-3 px-5 py-4">


### PR DESCRIPTION
## Summary
- Shrink price tiles: smaller padding, `FootnoteText` for price, 5-column grid with `gap-2`
- Restore asset icon to 24px for readability
- Remove unused `BodyText` import

## Test plan
- [ ] Visual: tiles render in 5-col grid, compact but readable
- [ ] Clicking tiles still opens chart modal

🤖 Generated with [Claude Code](https://claude.com/claude-code)