### PR TITLE
Spek 170. Fix flaky electron start with blank page

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "electron": "electron .",
     "preview": "cross-env RENDERER_SOURCE=localhost pnpm build:staging && concurrently \"pnpm renderer:preview\" \"pnpm electron\"",
     "local:preview": "npm run renderer:dev && npm run renderer:preview",
-    "start": "pnpm r clean:build main:dev preload:dev && concurrently \"pnpm main:dev:watch\" \"pnpm preload:dev:watch\" \"pnpm renderer:dev:watch\" \"pnpm electron\"",
+    "start": "pnpm r clean:build main:dev preload:dev && concurrently \"pnpm main:dev:watch\" \"pnpm preload:dev:watch\" \"pnpm renderer:dev:watch\" \"node scripts/waitForRenderer.mjs && pnpm electron\"",
     "start:renderer": "pnpm renderer:dev:watch",
     "renderer:dev": "cross-env CHAINS_FILE=chains_dev TOKENS_FILE=tokens_dev LOGGER=false vite build --mode development -c vite.config.renderer.ts",
     "renderer:dev:watch": "cross-env CHAINS_FILE=chains_dev TOKENS_FILE=tokens_dev LOGGER=false vite --mode development -c vite.config.renderer.ts",
@@ -286,6 +286,16 @@
       "allowedVersions": {
         "vite": "8"
       }
-    }
+    },
+    "onlyBuiltDependencies": [
+      "@swc/core",
+      "@tailwindcss/oxide",
+      "electron",
+      "electron-winstaller",
+      "esbuild",
+      "oxc-resolver",
+      "sharp",
+      "unrs-resolver"
+    ]
   }
 }

--- a/scripts/waitForRenderer.mjs
+++ b/scripts/waitForRenderer.mjs
@@ -1,0 +1,12 @@
+import https from 'node:https';
+
+const url = process.argv[2] || 'https://localhost:3000';
+const interval = 200;
+
+function probe() {
+  const req = https.get(url, { rejectUnauthorized: false }, () => process.exit(0));
+  req.setTimeout(1000, () => req.destroy());
+  req.on('error', () => setTimeout(probe, interval));
+}
+
+probe();

--- a/src/main/factories/proxy.ts
+++ b/src/main/factories/proxy.ts
@@ -11,11 +11,22 @@ type FetchResult = Pick<Response, 'ok' | 'status' | 'statusText'> & {
 
 export function setupProxy() {
   ipcMain.handle(IPC.PROXY.FETCH, async (_, url: string, init?: FetchInit): Promise<FetchResult> => {
-    const response = await session.fromPartition('persist:auth').fetch(url, {
-      method: init?.method,
-      headers: init?.headers,
-      body: init?.body,
-    });
+    let response: Response;
+    try {
+      response = await session.fromPartition('persist:auth').fetch(url, {
+        method: init?.method,
+        headers: init?.headers,
+        body: init?.body,
+      });
+    } catch (err) {
+      return {
+        ok: false,
+        status: 0,
+        statusText: err instanceof Error ? err.message : String(err),
+        headers: {},
+        body: '{}',
+      };
+    }
 
     const headers: Record<string, string> = {};
     // eslint-disable-next-line no-restricted-syntax -- Headers type lacks iterable support

--- a/src/renderer/features/contacts/BackendConfiguration/lib/backend-auth-api.ts
+++ b/src/renderer/features/contacts/BackendConfiguration/lib/backend-auth-api.ts
@@ -46,13 +46,21 @@ export async function verifySignature(
   return parseResponse(result, verifyResponseSchema);
 }
 
-export async function checkSession(baseUrl: string): Promise<SessionResponse> {
+export async function checkSession(baseUrl: string): Promise<SessionResponse | null> {
   const result = await authFetch(`${baseUrl}/auth/me`, {
     method: 'GET',
     headers: { 'Content-Type': 'application/json' },
   });
 
-  return parseResponse(result, sessionResponseSchema);
+  if (!result.ok) {
+    return null;
+  }
+
+  try {
+    return parseResponse(result, sessionResponseSchema);
+  } catch {
+    return null;
+  }
 }
 
 export async function logout(baseUrl: string): Promise<void> {

--- a/src/renderer/features/contacts/BackendConfiguration/model/auth-model.ts
+++ b/src/renderer/features/contacts/BackendConfiguration/model/auth-model.ts
@@ -3,6 +3,7 @@ import { t } from 'i18next';
 import { interval, once } from 'patronum';
 import { toast } from 'sonner';
 
+import { assert } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount, accountService } from '@/domains/network';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
@@ -291,6 +292,8 @@ sample({
 
 $authState.on(backendConfigurationModel.events.urlCleared, () => null);
 
+const $isSessionExpired = createStore(false);
+
 // Session recovery: when backend URL is available on start, check session
 const sessionRecoveryTriggered = once({
   source: backendConfigurationModel.$backendUrl.updates,
@@ -306,7 +309,9 @@ sample({
 sample({
   clock: checkSessionFx.doneData,
   source: $signableAccounts,
+  filter: (_accounts, sessionData) => sessionData !== null,
   fn: (accounts, sessionData): AuthState => {
+    assert(sessionData);
     const match = accounts.find((a) => a.accountId === sessionData.accountId);
 
     return {
@@ -318,11 +323,22 @@ sample({
   target: $authState,
 });
 
-// On session check failure, clear auth state silently
-$authState.on(checkSessionFx.fail, () => null);
+sample({
+  clock: checkSessionFx.doneData,
+  filter: (session): session is NonNullable<typeof session> => session !== null,
+  fn: () => false,
+  target: $isSessionExpired,
+});
 
-// Session expiry awareness: periodic health check every 5 minutes
-const $isSessionExpired = createStore(false);
+sample({
+  clock: checkSessionFx.done,
+  source: $authState,
+  filter: (auth, { result }) => result === null && auth !== null,
+  fn: () => true,
+  target: $isSessionExpired,
+});
+
+$authState.on(checkSessionFx.fail, () => null);
 
 const sessionHealthCheck = interval({
   timeout: 5 * 60 * 1000,


### PR DESCRIPTION
## Description

- **Wait for Vite dev server before launching Electron:** `pnpm start` now runs a probe script (`waitForRenderer.mjs`) that polls the Vite HTTPS server before launching Electron, preventing the window from loading before the renderer is ready.
- **Fix crash when address-book backend is unreachable:** The `proxy: fetch` IPC handler threw on network errors (e.g. `net::ERR_CONNECTION_REFUSED`), which propagated as an unhandled rejection and triggered the global error/fallback screen. The handler now catches network-level failures and returns a synthetic `{ ok: false, status: 0 }` response so callers can handle them normally.
- **Make session recovery resilient to backend being down:** `checkSession` (`/auth/me`) now returns `null` instead of throwing when the backend is unreachable or returns an error. The auth model wiring was updated so a `null` session result clears auth state silently on first load, and only sets `$isSessionExpired` if the user had a previously active session.

## Related Issues
https://novasama-technologies.atlassian.net/browse/SPEK-170

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

https://github.com/user-attachments/assets/906b3f56-ba5f-46c7-a661-14684584b78c



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
