### PR TITLE
Fix: relax CSP rules to unblock WebSocket connections while preserving security hardening

### DIFF
--- a/src/main/factories/window.test.ts
+++ b/src/main/factories/window.test.ts
@@ -72,7 +72,7 @@ vi.mock('../shared/constants/environment', () => ({
 }));
 
 const EXPECTED_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'";
+  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'";
 
 type HeadersReceivedCallback = (
   details: Record<string, unknown>,

--- a/src/main/factories/window.test.ts
+++ b/src/main/factories/window.test.ts
@@ -72,7 +72,7 @@ vi.mock('../shared/constants/environment', () => ({
 }));
 
 const EXPECTED_CSP =
-  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https:; font-src 'self' data:; object-src 'none'; frame-src 'none'; upgrade-insecure-requests";
+  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'";
 
 type HeadersReceivedCallback = (
   details: Record<string, unknown>,
@@ -92,11 +92,9 @@ async function getHeadersReceivedCallback(): Promise<HeadersReceivedCallback> {
 async function invokeCallback(
   callback: HeadersReceivedCallback,
   existingHeaders: Record<string, string[]> = {},
-): Promise<Record<string, string[]>> {
-  const result: Record<string, unknown> = await new Promise((resolve) =>
-    callback({ responseHeaders: existingHeaders }, resolve),
-  );
-  return result.responseHeaders as Record<string, string[]>;
+  resourceType = 'mainFrame',
+): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => callback({ responseHeaders: existingHeaders, resourceType }, resolve));
 }
 
 describe('window.ts — CSP header via session.webRequest.onHeadersReceived', () => {
@@ -111,15 +109,24 @@ describe('window.ts — CSP header via session.webRequest.onHeadersReceived', ()
     expect(mockOnHeadersReceived).toHaveBeenCalledTimes(1);
   });
 
-  it('should inject Content-Security-Policy into response headers', async () => {
+  it('should inject Content-Security-Policy into document response headers', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers).toHaveProperty('Content-Security-Policy');
+  });
+
+  it('should NOT inject CSP into non-document responses (e.g. websocket, xhr)', async () => {
+    const cb = await getHeadersReceivedCallback();
+    const result = await invokeCallback(cb, { 'X-Custom': ['value'] }, 'websocket');
+    expect(result.cancel).toBe(false);
+    expect(result.responseHeaders).toBeUndefined();
   });
 
   it('CSP header value should be an array with exactly one entry', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     const cspValues = headers['Content-Security-Policy'];
     expect(Array.isArray(cspValues)).toBe(true);
     expect(cspValues).toHaveLength(1);
@@ -127,41 +134,48 @@ describe('window.ts — CSP header via session.webRequest.onHeadersReceived', ()
 
   it("should set directive default-src 'self'", async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers['Content-Security-Policy']?.[0]).toContain("default-src 'self'");
   });
 
-  it("should set directive script-src 'self'", async () => {
+  it("should set directive script-src 'self' 'wasm-unsafe-eval'", async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
-    expect(headers['Content-Security-Policy']?.[0]).toContain("script-src 'self'");
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
+    expect(headers['Content-Security-Policy']?.[0]).toContain("script-src 'self' 'wasm-unsafe-eval'");
   });
 
   it("should set directive object-src 'none' (blocks embedded plugins/Flash)", async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers['Content-Security-Policy']?.[0]).toContain("object-src 'none'");
   });
 
   it("should set directive frame-src 'none' (blocks iframes)", async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers['Content-Security-Policy']?.[0]).toContain("frame-src 'none'");
   });
 
-  it('should set connect-src directive allowing wss: ws: https: (Substrate RPC)', async () => {
+  it('should set connect-src directive allowing wss: ws: https: http: (Substrate RPC)', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     const csp = headers['Content-Security-Policy']?.[0];
     expect(csp).toContain('connect-src');
     expect(csp).toContain('wss:');
     expect(csp).toContain('ws:');
     expect(csp).toContain('https:');
+    expect(csp).toContain('http:');
   });
 
   it('should set img-src directive allowing data: blob: https:', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     const csp = headers['Content-Security-Policy']?.[0];
     expect(csp).toContain('img-src');
     expect(csp).toContain('data:');
@@ -169,18 +183,31 @@ describe('window.ts — CSP header via session.webRequest.onHeadersReceived', ()
     expect(csp).toContain('https:');
   });
 
-  it('should set upgrade-insecure-requests directive', async () => {
+  it("should set worker-src 'self' blob: directive", async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
-    expect(headers['Content-Security-Policy']?.[0]).toContain('upgrade-insecure-requests');
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
+    expect(headers['Content-Security-Policy']?.[0]).toContain("worker-src 'self' blob:");
+  });
+
+  it('should NOT contain upgrade-insecure-requests (unnecessary in Electron file:// context)', async () => {
+    const cb = await getHeadersReceivedCallback();
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
+    expect(headers['Content-Security-Policy']?.[0]).not.toContain('upgrade-insecure-requests');
   });
 
   it('should preserve existing response headers (spread behaviour)', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb, {
-      'Content-Type': ['text/html; charset=utf-8'],
-      'X-Frame-Options': ['DENY'],
-    });
+    const result = await invokeCallback(
+      cb,
+      {
+        'Content-Type': ['text/html; charset=utf-8'],
+        'X-Frame-Options': ['DENY'],
+      },
+      'mainFrame',
+    );
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers['Content-Type']).toEqual(['text/html; charset=utf-8']);
     expect(headers['X-Frame-Options']).toEqual(['DENY']);
     expect(headers['Content-Security-Policy']).toBeDefined();
@@ -188,7 +215,8 @@ describe('window.ts — CSP header via session.webRequest.onHeadersReceived', ()
 
   it('CSP value should match the full expected policy string exactly', async () => {
     const cb = await getHeadersReceivedCallback();
-    const headers = await invokeCallback(cb);
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
     expect(headers['Content-Security-Policy']?.[0]).toBe(EXPECTED_CSP);
   });
 });

--- a/src/main/factories/window.ts
+++ b/src/main/factories/window.ts
@@ -49,14 +49,20 @@ export function createWindow(): BrowserWindow {
   });
 
   session.defaultSession.webRequest.onHeadersReceived((details, callback) => {
-    callback({
-      responseHeaders: {
-        ...details.responseHeaders,
-        'Content-Security-Policy': [
-          "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https:; font-src 'self' data:; object-src 'none'; frame-src 'none'; upgrade-insecure-requests",
-        ],
-      },
-    });
+    // Only attach CSP to document (navigation) responses.
+    // Adding headers to WebSocket upgrade (101) responses breaks the handshake in Electron.
+    if (details.resourceType === 'mainFrame' || details.resourceType === 'subFrame') {
+      callback({
+        responseHeaders: {
+          ...details.responseHeaders,
+          'Content-Security-Policy': [
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'",
+          ],
+        },
+      });
+    } else {
+      callback({ cancel: false });
+    }
   });
 
   // Open urls in the user's browser

--- a/src/main/factories/window.ts
+++ b/src/main/factories/window.ts
@@ -56,7 +56,7 @@ export function createWindow(): BrowserWindow {
         responseHeaders: {
           ...details.responseHeaders,
           'Content-Security-Policy': [
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'",
           ],
         },
       });

--- a/src/renderer/app/csp.test.ts
+++ b/src/renderer/app/csp.test.ts
@@ -37,8 +37,8 @@ describe('src/renderer/app/index.html — Content-Security-Policy meta tag', () 
     expect(cspContent).toContain("default-src 'self'");
   });
 
-  it("should contain directive: script-src 'self'", () => {
-    expect(cspContent).toContain("script-src 'self'");
+  it("should contain directive: script-src 'self' 'wasm-unsafe-eval'", () => {
+    expect(cspContent).toContain("script-src 'self' 'wasm-unsafe-eval'");
   });
 
   it("should contain directive: style-src 'self' 'unsafe-inline'", () => {
@@ -72,12 +72,20 @@ describe('src/renderer/app/index.html — Content-Security-Policy meta tag', () 
     expect(cspContent).toContain("frame-src 'none'");
   });
 
-  it('should contain upgrade-insecure-requests directive', () => {
-    expect(cspContent).toContain('upgrade-insecure-requests');
+  it('should NOT contain upgrade-insecure-requests (unnecessary in Electron file:// context)', () => {
+    expect(cspContent).not.toContain('upgrade-insecure-requests');
+  });
+
+  it("should contain worker-src 'self' blob: for substrate-connect workers", () => {
+    expect(cspContent).toContain("worker-src 'self' blob:");
   });
 
   it('should NOT allow unsafe-eval in script-src (prevents XSS)', () => {
     expect(cspContent).not.toContain("'unsafe-eval'");
+  });
+
+  it("should allow 'wasm-unsafe-eval' for polkadot WASM crypto", () => {
+    expect(cspContent).toContain("'wasm-unsafe-eval'");
   });
 
   it('should NOT use wildcard (*) as default-src', () => {

--- a/src/renderer/app/index.html
+++ b/src/renderer/app/index.html
@@ -8,14 +8,14 @@
       http-equiv="Content-Security-Policy"
       content="
         default-src 'self';
-        script-src 'self';
+        script-src 'self' 'wasm-unsafe-eval';
         style-src 'self' 'unsafe-inline';
         img-src 'self' data: blob: https:;
-        connect-src 'self' wss: ws: https:;
+        connect-src 'self' wss: ws: https: http:;
         font-src 'self' data:;
+        worker-src 'self' blob:;
         object-src 'none';
-        frame-src 'none';
-        upgrade-insecure-requests
+        frame-src 'none'
       "
     />
 

--- a/src/renderer/app/index.html
+++ b/src/renderer/app/index.html
@@ -11,7 +11,7 @@
         script-src 'self' 'wasm-unsafe-eval';
         style-src 'self' 'unsafe-inline';
         img-src 'self' data: blob: https:;
-        connect-src 'self' wss: ws: https: http:;
+        connect-src 'self' data: wss: ws: https: http:;
         font-src 'self' data:;
         worker-src 'self' blob:;
         object-src 'none';


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

https://github.com/novasamatech/nova-spektr/pull/5709

The original CSP changes introduced strict Content-Security-Policy directives but inadvertently broke all network connections (all 35 chains stuck at "Connecting..." status). Root causes:

1. onHeadersReceived intercepted ALL responses including WebSocket upgrade (101 Switching Protocols) — adding CSP headers to the handshake response broke the WebSocket connection lifecycle in Electron. Fixed by filtering to mainFrame/subFrame resource types only, which aligns with the W3C CSP spec (CSP headers on non-document responses are meaningless).

2. script-src 'self' blocked WebAssembly compilation — Chromium requires 'wasm-unsafe-eval' to call WebAssembly.compile()/WebAssembly.instantiate(). Without it, @polkadot/wasm-crypto cannot initialize. Note: 'wasm-unsafe-eval' only permits WASM compilation, NOT eval() — 'unsafe-eval' remains blocked.

3. Missing worker-src directive — @substrate/connect (smoldot light client) creates Web Workers from blob: URLs. Without worker-src 'self' blob:, the fallback to default-src 'self' blocked worker creation.

4. upgrade-insecure-requests is a no-op in Electron — the app loads from file:// protocol where there is no insecure origin to upgrade from. Removed to avoid unexpected side effects.

5. Added http: to connect-src — some RPC endpoints may use plain HTTP. The directive already allowed https:, wss:, and ws:.

All core CSP protections from the original security fix remain intact: default-src 'self', script-src 'self' (no inline scripts, no eval), object-src 'none', frame-src 'none'.



## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

<img width="821" height="603" alt="Screenshot 2026-03-19 at 12 49 27" src="https://github.com/user-attachments/assets/83813415-4346-49c7-8d50-6ee4f534f800" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
