### PR TITLE
fix(ui): resolve button-in-button nesting in CardStack

### DIFF
--- a/src/renderer/shared/ui-kit/CardStack/CardStack.tsx
+++ b/src/renderer/shared/ui-kit/CardStack/CardStack.tsx
@@ -60,24 +60,28 @@ const Trigger = ({ sticky, children }: TriggerProps) => {
         {sticky && open && (
           <div className="card-stack-sticky-gap absolute -top-2 right-0 left-0 -z-10 h-4 w-full bg-top-nav-bar-background" />
         )}
-        <RadixAccordion.Trigger
-          className={cnTw(
-            'card-stack-trigger group flex w-full cursor-pointer items-center gap-x-2 bg-row-background py-1 pr-2 pl-3',
-            'shadow-stack outline-hidden! hover:shadow-stack-hover focus:shadow-stack-hover data-[state=open]:shadow-none',
-            'transition-all duration-300',
-            'data-[state=closed]:rounded-md data-[state=open]:rounded-t-md',
-            'border-b border-transparent data-[state=open]:border-divider',
-          )}
-        >
-          <Icon
+        <RadixAccordion.Trigger asChild>
+          <div
+            role="button"
+            tabIndex={0}
             className={cnTw(
-              'transition-all duration-100 group-data-[state=open]:rotate-90',
-              'shrink-0 text-icon-default group-hover:text-icon-hover group-focus:text-icon-hover',
+              'card-stack-trigger group flex w-full cursor-pointer items-center gap-x-2 bg-row-background py-1 pr-2 pl-3',
+              'shadow-stack outline-hidden! hover:shadow-stack-hover focus:shadow-stack-hover data-[state=open]:shadow-none',
+              'transition-all duration-300',
+              'data-[state=closed]:rounded-md data-[state=open]:rounded-t-md',
+              'border-b border-transparent data-[state=open]:border-divider',
             )}
-            name="shelfRight"
-            size={16}
-          />
-          <div className="flex min-w-0 grow">{children}</div>
+          >
+            <Icon
+              className={cnTw(
+                'transition-all duration-100 group-data-[state=open]:rotate-90',
+                'shrink-0 text-icon-default group-hover:text-icon-hover group-focus:text-icon-hover',
+              )}
+              name="shelfRight"
+              size={16}
+            />
+            <div className="flex min-w-0 grow">{children}</div>
+          </div>
         </RadixAccordion.Trigger>
       </div>
     </RadixAccordion.Header>


### PR DESCRIPTION
## Description

`RadixAccordion.Trigger` renders a native `<button>` element. When interactive elements like `IconButton` (also a `<button>`) are placed inside `CardStack.Trigger` children (e.g., send/receive actions on the Assets page), this creates invalid HTML nesting (`<button>` inside `<button>`), causing React hydration warnings in the console.

## Changes Made

- Used Radix `asChild` pattern on `AccordionTrigger` to delegate rendering to a `<div role="button" tabIndex={0}>` instead of a native `<button>`
- Preserves full accessibility (keyboard navigation, ARIA attributes) via Radix's prop forwarding
- No visual or behavioral changes

## Screenshots/Recordings

**Before:** Console errors on every page load:
```
In HTML, <button> cannot be a descendant of <button>.
This will cause a hydration error.
```

**After:** No button nesting errors in console.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] My code follows the project's coding standards and style guidelines