### PR TITLE
feat(dashboard): drag-and-drop widget reordering

### DIFF
--- a/package.json
+++ b/package.json
@@ -86,6 +86,8 @@
   "dependencies": {
     "@apollo/client": "3.13.9",
     "@ariakit/react": "0.4.17",
+    "@dnd-kit/helpers": "0.3.2",
+    "@dnd-kit/react": "0.3.2",
     "@effector-storage/idb-keyval": "2.0.0",
     "@headlessui/react": "1.7.19",
     "@novasamatech/spektr-dapp-host-container": "0.0.12",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@ariakit/react':
         specifier: 0.4.17
         version: 0.4.17(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
+      '@dnd-kit/helpers':
+        specifier: 0.3.2
+        version: 0.3.2
+      '@dnd-kit/react':
+        specifier: 0.3.2
+        version: 0.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@effector-storage/idb-keyval':
         specifier: 2.0.0
         version: 2.0.0(effector@23.4.4)
@@ -857,6 +863,30 @@ packages:
     resolution: {integrity: sha512-0cp4PsWQ/9avqTVMCtZ+GirikIA36ikvjtHweU4/j8yLtgObI0+JUPhYFScgwlteveGB1rt3Cm8UhN04XayDig==}
     engines: {node: '>= 8.9.0'}
 
+  '@dnd-kit/abstract@0.3.2':
+    resolution: {integrity: sha512-uvPVK+SZYD6Viddn9M0K0JQdXknuVSxA/EbMlFRanve3P/XTc18oLa5zGftKSGjfQGmuzkZ34E26DSbly1zi3Q==}
+
+  '@dnd-kit/collision@0.3.2':
+    resolution: {integrity: sha512-pNmNSLCI8S9fNQ7QJ3fBCDjiT0sqBhUFcKgmyYaGvGCAU+kq0AP8OWlh0JSisc9k5mFyxmRpmFQcnJpILz/RPA==}
+
+  '@dnd-kit/dom@0.3.2':
+    resolution: {integrity: sha512-cIUAVgt2szQyz6JRy7I+0r+xeyOAGH21Y15hb5bIyHoDEaZBvIDH+OOlD9eoLjCbsxDLN9WloU2CBi3OE6LYDg==}
+
+  '@dnd-kit/geometry@0.3.2':
+    resolution: {integrity: sha512-3UBPuIS7E3oGiHxOE8h810QA+0pnrnCtGxl4Os1z3yy5YkC/BEYGY+TxWPTQaY1/OMV7GCX7ZNMlama2QN3n3w==}
+
+  '@dnd-kit/helpers@0.3.2':
+    resolution: {integrity: sha512-pj7pCE6BiysNetpPnzb3BJOrcKiqueUr1LFg6wYoi2fIFYpz66n2Ojd7HTwfwkpv0oyC3QlvA6Dk8cOmi6VavA==}
+
+  '@dnd-kit/react@0.3.2':
+    resolution: {integrity: sha512-1Opg1xw6I75Z95c+rF2NJa0pdGb8rLAENtuopKtJ1J0PudWlz+P6yL137xy/6DV43uaRmNGtsdbMbR0yRYJ72g==}
+    peerDependencies:
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+
+  '@dnd-kit/state@0.3.2':
+    resolution: {integrity: sha512-dLUIkoYrIJhGXfF2wGLTfb46vUokEsO/OoE21TSfmahYrx7ysTmnwbePsznFaHlwgZhQEh6AlLvthLCeY21b1A==}
+
   '@effector-storage/idb-keyval@2.0.0':
     resolution: {integrity: sha512-kHytrEmkjOEjIX0W+zNf7l2Pi60lJe4ibI7Gl1gOuhrdiHVh076SxoPgbHzr1XWcL1PTCHszXaLDA5LslYbbtQ==}
     peerDependencies:
@@ -1608,170 +1638,144 @@ packages:
     resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm64@1.2.0':
     resolution: {integrity: sha512-RXwd0CgG+uPRX5YYrkzKyalt2OJYRiJQ8ED/fi1tq9WQW2jsQIn0tqrlR5l5dr/rjqq6AHAxURhj2DVjyQWSOA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.0.5':
     resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-arm@1.2.0':
     resolution: {integrity: sha512-mWd2uWvDtL/nvIzThLq3fr2nnGfyr/XMXlq8ZJ9WMR6PXijHlC3ksp0IpuhK6bougvQrchUAfzRLnbsen0Cqvw==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-ppc64@1.2.0':
     resolution: {integrity: sha512-Xod/7KaDDHkYu2phxxfeEPXfVXFKx70EAFZ0qyUdOjCcxbjqyJOEUpDe6RIyaunGxT34Anf9ue/wuWOqBW2WcQ==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.0.4':
     resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-s390x@1.2.0':
     resolution: {integrity: sha512-eMKfzDxLGT8mnmPJTNMcjfO33fLiTDsrMlUVcp6b96ETbnJmd4uvZxVJSKPQfS+odwfVaGifhsB07J1LynFehw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.0.4':
     resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linux-x64@1.2.0':
     resolution: {integrity: sha512-ZW3FPWIc7K1sH9E3nxIGB3y3dZkpJlMnkk7z5tu1nSkBoCgw2nSRTFHI5pB/3CQaJM0pdzMF3paf9ckKMSE9Tg==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
     resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-arm64@1.2.0':
     resolution: {integrity: sha512-UG+LqQJbf5VJ8NWJ5Z3tdIe/HXjuIdo4JeVNADXBFuG7z9zjoegpzzGIyV5zQKi4zaJjnAd2+g2nna8TZvuW9Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.0.4':
     resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-libvips-linuxmusl-x64@1.2.0':
     resolution: {integrity: sha512-SRYOLR7CXPgNze8akZwjoGBoN1ThNZoqpOgfnOxmWsklTGVfJiGJoC/Lod7aNMGA1jSsKWM1+HRX43OP6p9+6Q==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linux-arm64@0.33.5':
     resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm64@0.34.3':
     resolution: {integrity: sha512-QdrKe3EvQrqwkDrtuTIjI0bu6YEJHTgEeqdzI3uWJOH6G1O8Nl1iEeVYRGdj1h5I21CqxSvQp1Yv7xeU3ZewbA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.33.5':
     resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-arm@0.34.3':
     resolution: {integrity: sha512-oBK9l+h6KBN0i3dC8rYntLiVfW8D8wH+NPNT3O/WBHeW0OQWCjfWksLUaPidsrDKpJgXp3G3/hkmhptAW0I3+A==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-ppc64@0.34.3':
     resolution: {integrity: sha512-GLtbLQMCNC5nxuImPR2+RgrviwKwVql28FWZIW1zWruy6zLgA5/x2ZXk3mxj58X/tszVF69KK0Is83V8YgWhLA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.33.5':
     resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-s390x@0.34.3':
     resolution: {integrity: sha512-3gahT+A6c4cdc2edhsLHmIOXMb17ltffJlxR0aC2VPZfwKoTGZec6u5GrFgdR7ciJSsHT27BD3TIuGcuRT0KmQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.33.5':
     resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linux-x64@0.34.3':
     resolution: {integrity: sha512-8kYso8d806ypnSq3/Ly0QEw90V5ZoHh10yH0HnrzOCr6DKAPI6QVHvwleqMkVQ0m+fc7EH8ah0BB0QPuWY6zJQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@img/sharp-linuxmusl-arm64@0.33.5':
     resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-arm64@0.34.3':
     resolution: {integrity: sha512-vAjbHDlr4izEiXM1OTggpCcPg9tn4YriK5vAjowJsHwdBIdx0fYRsURkxLG2RLm9gyBq66gwtWI8Gx0/ov+JKQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.33.5':
     resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-linuxmusl-x64@0.34.3':
     resolution: {integrity: sha512-gCWUn9547K5bwvOn9l5XGAEjVTTRji4aPTqLzGXHvIr6bIDZKNTA34seMPgM0WmSf+RYBH411VavCejp3PkOeQ==}
     engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@img/sharp-wasm32@0.33.5':
     resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
@@ -2031,49 +2035,41 @@ packages:
     resolution: {integrity: sha512-EZ/OuxZA9qQoAANBDb9V4krfYXU3MC+LZ9qY+cE0yMYMIxm7NT5AdR0OaRQqfa3tWIbina1VF7FaMR6rpKvmlA==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-arm64-musl@11.6.0':
     resolution: {integrity: sha512-NpF7sID4NnPetpqDk2eOu6TPUt381Qlpos8nGDcSkAluqSsSGFOPfETEB5VbJeqNVQbepEQX9mOxZygFpW0+nA==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-ppc64-gnu@11.6.0':
     resolution: {integrity: sha512-Sqn9Ha4rxCCpjpfkFi9f9y9phsaBnseaKw+JqHgBQoNMToe+/20A1jwIu9OX+484UuLpduM+wLydgngjnoi7Dg==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-gnu@11.6.0':
     resolution: {integrity: sha512-eFoNcPhImp1FLAQf5U3Nlph4WNWEsdWohSThSTtKPrX+jhPZiVsj3iBC9gjaRwq2Ez4QhP1x7/PSL6mtKnS6rw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-riscv64-musl@11.6.0':
     resolution: {integrity: sha512-WQw3CT10aJg7SIc/X1QPrh6lTx2wOLg5IaCu/+Mqlxf1nZBEW3+tV/+y3PzXG0MCRhq7FDTiHaW8MBVAwBineQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-linux-s390x-gnu@11.6.0':
     resolution: {integrity: sha512-p5qcPr/EtGJ2PpeeArL3ifZU/YljWLypeu38+e19z2dyPv8Aoby8tjM+D1VTI8+suMwTkseyove/uu6zIUiqRw==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-gnu@11.6.0':
     resolution: {integrity: sha512-/9M/ieoY5v54k3UjtF9Vw43WQ4bBfed+qRL1uIpFbZcO2qi5aXwVMYnjSd/BoaRtDs5JFV9iOjzHwpw0zdOYZA==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@oxc-resolver/binding-linux-x64-musl@11.6.0':
     resolution: {integrity: sha512-HMtWWHTU7zbwceTFZPAPMMhhWR1nNO2OR60r6i55VprCMvttTWPQl7uLP0AUtAPoU9B/2GqP48rzOuaaKhHnYw==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@oxc-resolver/binding-wasm32-wasi@11.6.0':
     resolution: {integrity: sha512-rDAwr2oqmnG/6LSZJwvO3Bmt/RC3/Q6myyaUmg3P7GhZDyFPrWJONB7NFhPwU2Q4JIpA73ST4LBdhzmGxMTmrw==}
@@ -3243,67 +3239,56 @@ packages:
     resolution: {integrity: sha512-PsNAbcyv9CcecAUagQefwX8fQn9LQ4nZkpDboBOttmyffnInRy8R8dSg6hxxl2Re5QhHBf6FYIDhIj5v982ATQ==}
     cpu: [arm]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.52.5':
     resolution: {integrity: sha512-Fw4tysRutyQc/wwkmcyoqFtJhh0u31K+Q6jYjeicsGJJ7bbEq8LwPWV/w0cnzOqR2m694/Af6hpFayLJZkG2VQ==}
     cpu: [arm]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.52.5':
     resolution: {integrity: sha512-a+3wVnAYdQClOTlyapKmyI6BLPAFYs0JM8HRpgYZQO02rMR09ZcV9LbQB+NL6sljzG38869YqThrRnfPMCDtZg==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.52.5':
     resolution: {integrity: sha512-AvttBOMwO9Pcuuf7m9PkC1PUIKsfaAJ4AYhy944qeTJgQOqJYJ9oVl2nYgY7Rk0mkbsuOpCAYSs6wLYB2Xiw0Q==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-loong64-gnu@4.52.5':
     resolution: {integrity: sha512-DkDk8pmXQV2wVrF6oq5tONK6UHLz/XcEVow4JTTerdeV1uqPeHxwcg7aFsfnSm9L+OO8WJsWotKM2JJPMWrQtA==}
     cpu: [loong64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-ppc64-gnu@4.52.5':
     resolution: {integrity: sha512-W/b9ZN/U9+hPQVvlGwjzi+Wy4xdoH2I8EjaCkMvzpI7wJUs8sWJ03Rq96jRnHkSrcHTpQe8h5Tg3ZzUPGauvAw==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.52.5':
     resolution: {integrity: sha512-sjQLr9BW7R/ZiXnQiWPkErNfLMkkWIoCz7YMn27HldKsADEKa5WYdobaa1hmN6slu9oWQbB6/jFpJ+P2IkVrmw==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.52.5':
     resolution: {integrity: sha512-hq3jU/kGyjXWTvAh2awn8oHroCbrPm8JqM7RUpKjalIRWWXE01CQOf/tUNWNHjmbMHg/hmNCwc/Pz3k1T/j/Lg==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.52.5':
     resolution: {integrity: sha512-gn8kHOrku8D4NGHMK1Y7NA7INQTRdVOntt1OCYypZPRt6skGbddska44K8iocdpxHTMMNui5oH4elPH4QOLrFQ==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.52.5':
     resolution: {integrity: sha512-hXGLYpdhiNElzN770+H2nlx+jRog8TyynpTVzdlc6bndktjKWyZyiCsuDAlpd+j+W+WNqfcyAWz9HxxIGfZm1Q==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.52.5':
     resolution: {integrity: sha512-arCGIcuNKjBoKAXD+y7XomR9gY6Mw7HnFBv5Rw7wQRvwYLR7gBAgV7Mb2QTyjXfTveBNFAtPt46/36vV9STLNg==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@rollup/rollup-openharmony-arm64@4.52.5':
     resolution: {integrity: sha512-QoFqB6+/9Rly/RiPjaomPLmR/13cgkIGfA40LHly9zcH1S0bN2HVFYk3a1eAyHQyjs3ZJYlXvIGtcCs5tko9Cw==}
@@ -3598,28 +3583,24 @@ packages:
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-arm64-musl@1.15.11':
     resolution: {integrity: sha512-PYftgsTaGnfDK4m6/dty9ryK1FbLk+LosDJ/RJR2nkXGc8rd+WenXIlvHjWULiBVnS1RsjHHOXmTS4nDhe0v0w==}
     engines: {node: '>=10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-linux-x64-gnu@1.15.11':
     resolution: {integrity: sha512-DKtnJKIHiZdARyTKiX7zdRjiDS1KihkQWatQiCHMv+zc2sfwb4Glrodx2VLOX4rsa92NLR0Sw8WLcPEMFY1szQ==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@swc/core-linux-x64-musl@1.15.11':
     resolution: {integrity: sha512-mUjjntHj4+8WBaiDe5UwRNHuEzLjIWBTSGTw0JT9+C9/Yyuh4KQqlcEQ3ro6GkHmBGXBFpGIj/o5VMyRWfVfWw==}
     engines: {node: '>=10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@swc/core-win32-arm64-msvc@1.15.11':
     resolution: {integrity: sha512-ZkNNG5zL49YpaFzfl6fskNOSxtcZ5uOYmWBkY4wVAvgbSAQzLRVBp+xArGWh2oXlY/WgL99zQSGTv7RI5E6nzA==}
@@ -3704,28 +3685,24 @@ packages:
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-arm64-musl@4.1.12':
     resolution: {integrity: sha512-V8pAM3s8gsrXcCv6kCHSuwyb/gPsd863iT+v1PGXC4fSL/OJqsKhfK//v8P+w9ThKIoqNbEnsZqNy+WDnwQqCA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-linux-x64-gnu@4.1.12':
     resolution: {integrity: sha512-xYfqYLjvm2UQ3TZggTGrwxjYaLB62b1Wiysw/YE3Yqbh86sOMoTn0feF98PonP7LtjsWOWcXEbGqDL7zv0uW8Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@tailwindcss/oxide-linux-x64-musl@4.1.12':
     resolution: {integrity: sha512-ha0pHPamN+fWZY7GCzz5rKunlv9L5R8kdh+YNvP5awe3LtuXb5nRi/H27GeL2U+TdhDOptU7T6Is7mdwh5Ar3A==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@tailwindcss/oxide-wasm32-wasi@4.1.12':
     resolution: {integrity: sha512-4tSyu3dW+ktzdEpuk6g49KdEangu3eCYoqPhWNsZgUhyegEda3M9rG0/j1GV/JjVVsj+lG7jWAyrTlLzd/WEBg==}
@@ -4239,49 +4216,41 @@ packages:
     resolution: {integrity: sha512-34gw7PjDGB9JgePJEmhEqBhWvCiiWCuXsL9hYphDF7crW7UgI05gyBAi6MF58uGcMOiOqSJ2ybEeCvHcq0BCmQ==}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-arm64-musl@1.11.1':
     resolution: {integrity: sha512-RyMIx6Uf53hhOtJDIamSbTskA99sPHS96wxVE/bJtePJJtpdKGXO1wY90oRdXuYOGOTuqjT8ACccMc4K6QmT3w==}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-ppc64-gnu@1.11.1':
     resolution: {integrity: sha512-D8Vae74A4/a+mZH0FbOkFJL9DSK2R6TFPC9M+jCWYia/q2einCubX10pecpDiTmkJVUH+y8K3BZClycD8nCShA==}
     cpu: [ppc64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-gnu@1.11.1':
     resolution: {integrity: sha512-frxL4OrzOWVVsOc96+V3aqTIQl1O2TjgExV4EKgRY09AJ9leZpEg8Ak9phadbuX0BA4k8U5qtvMSQQGGmaJqcQ==}
     cpu: [riscv64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-riscv64-musl@1.11.1':
     resolution: {integrity: sha512-mJ5vuDaIZ+l/acv01sHoXfpnyrNKOk/3aDoEdLO/Xtn9HuZlDD6jKxHlkN8ZhWyLJsRBxfv9GYM2utQ1SChKew==}
     cpu: [riscv64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-linux-s390x-gnu@1.11.1':
     resolution: {integrity: sha512-kELo8ebBVtb9sA7rMe1Cph4QHreByhaZ2QEADd9NzIQsYNQpt9UkM9iqr2lhGr5afh885d/cB5QeTXSbZHTYPg==}
     cpu: [s390x]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-gnu@1.11.1':
     resolution: {integrity: sha512-C3ZAHugKgovV5YvAMsxhq0gtXuwESUKc5MhEtjBpLoHPLYM+iuwSj3lflFwK3DPm68660rZ7G8BMcwSro7hD5w==}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   '@unrs/resolver-binding-linux-x64-musl@1.11.1':
     resolution: {integrity: sha512-rV0YSoyhK2nZ4vEswT/QwqzqQXw5I6CjoaYMOX0TqBlWhojUf8P94mvI7nuJTeaCkkds3QE4+zS8Ko+GdXuZtA==}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   '@unrs/resolver-binding-wasm32-wasi@1.11.1':
     resolution: {integrity: sha512-5u4RkfxJm+Ng7IWgkzi3qrFOvLvQYnPBmjmZQ8+szTK/b31fQCnleNl1GgEt7nIsZRIf5PLhPwT0WM+q45x/UQ==}
@@ -7402,7 +7371,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-arm64-gnu@1.32.0:
     resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
@@ -7415,7 +7383,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [arm64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-arm64-musl@1.32.0:
     resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
@@ -7428,7 +7395,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [glibc]
 
   lightningcss-linux-x64-gnu@1.32.0:
     resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
@@ -7441,7 +7407,6 @@ packages:
     engines: {node: '>= 12.0.0'}
     cpu: [x64]
     os: [linux]
-    libc: [musl]
 
   lightningcss-linux-x64-musl@1.32.0:
     resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
@@ -11280,6 +11245,50 @@ snapshots:
     dependencies:
       ajv: 6.12.6
       ajv-keywords: 3.5.2(ajv@6.12.6)
+
+  '@dnd-kit/abstract@0.3.2':
+    dependencies:
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/collision@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/dom@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/collision': 0.3.2
+      '@dnd-kit/geometry': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/geometry@0.3.2':
+    dependencies:
+      '@dnd-kit/state': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/helpers@0.3.2':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      tslib: 2.8.1
+
+  '@dnd-kit/react@0.3.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@dnd-kit/abstract': 0.3.2
+      '@dnd-kit/dom': 0.3.2
+      '@dnd-kit/state': 0.3.2
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
+      tslib: 2.8.1
+
+  '@dnd-kit/state@0.3.2':
+    dependencies:
+      '@preact/signals-core': 1.11.0
+      tslib: 2.8.1
 
   '@effector-storage/idb-keyval@2.0.0(effector@23.4.4)':
     dependencies:

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
@@ -4,6 +4,7 @@ import { type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { useBalanceAllocation } from '../hooks/useBalanceAllocation';
 import { useChainHoldings } from '../hooks/useChainHoldings';
 import { useHoldings } from '../hooks/useHoldings';
@@ -23,8 +24,6 @@ type Props = {
   accountIds: string[];
   allEntries: EntryLike[];
 };
-
-const containerClass = 'w-[560px] rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
 
 const toggleButtonClass = 'flex-1 rounded px-3 py-1 text-footnote font-semibold transition-colors';
 const activeToggleClass = 'bg-white text-text-primary shadow-sm';
@@ -46,20 +45,20 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
 
   if (accountIds.length === 0) {
     return (
-      <div className={containerClass}>
+      <DashboardWidget>
         <FootnoteText className="text-text-tertiary">{t('dashboard.portfolioOverview.title')}</FootnoteText>
         <div className="flex flex-col items-center gap-y-1 py-6">
           <SmallTitleText className="text-text-tertiary">{t('dashboard.noSelection.title')}</SmallTitleText>
           <BodyText className="text-text-tertiary">{t('dashboard.noSelection.description')}</BodyText>
         </div>
-      </div>
+      </DashboardWidget>
     );
   }
 
   const hasData = (viewMode === 'asset' ? holdings.length > 0 : chainHoldings.length > 0) && totalFiat !== null;
 
   return (
-    <div className={containerClass}>
+    <DashboardWidget>
       <div className="flex items-start justify-between gap-4">
         <div>
           <FootnoteText className="text-text-tertiary">{t('dashboard.portfolioOverview.title')}</FootnoteText>
@@ -125,6 +124,6 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
           onClose={() => setSelectedChainId(null)}
         />
       )}
-    </div>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/features/dashboard-price-charts/ui/PriceChartsWidget.tsx
+++ b/src/renderer/features/dashboard-price-charts/ui/PriceChartsWidget.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { IconButton, TitleText } from '@/shared/ui';
 import { useAssetsPrices } from '@/domains/price';
 import { currencySelect } from '@/aggregates/currency-select';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { type TrackedAssetInfo } from '../hooks/useAvailableAssets';
 import { useTrackedAssets } from '../hooks/useTrackedAssets';
 
@@ -45,7 +46,7 @@ export const PriceChartsWidget = () => {
   const currencySymbol = currency.symbol ?? currency.code;
 
   return (
-    <div className="flex w-[560px] flex-col gap-3">
+    <DashboardWidget card={false} className="flex flex-col gap-3">
       <div className="flex items-center gap-2">
         <TitleText>{t('dashboard.priceCharts.title')}</TitleText>
         <IconButton name="settingsLite" size={16} onClick={() => setShowTokenSelector(true)} />
@@ -79,6 +80,6 @@ export const PriceChartsWidget = () => {
       )}
 
       {showTokenSelector && <TokenSelectionModal onClose={() => setShowTokenSelector(false)} />}
-    </div>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/features/dashboard-staking/ui/MonthlyRewardsWidget.tsx
+++ b/src/renderer/features/dashboard-staking/ui/MonthlyRewardsWidget.tsx
@@ -8,6 +8,7 @@ import { formatFiatBalance, toAccountId } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, SmallTitleText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
 import { useAccountName } from '@/domains/network';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { type ChainMode, type MonthlyBarData, useMonthlyRewardsChart } from '../hooks/useMonthlyRewardsChart';
 import { type EntryLike } from '../hooks/useStakingBreakdown';
 
@@ -20,9 +21,6 @@ const pillContainerClass = 'flex rounded-md bg-tab-background p-0.5';
 const pillButtonClass = 'rounded px-3 py-1 text-footnote font-semibold transition-colors cursor-pointer';
 const pillActiveClass = 'shadow-sm text-white';
 const pillInactiveClass = 'text-text-tertiary hover:text-text-secondary';
-
-const containerClass =
-  'relative w-full rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
 
 const DualLabel = (props: LabelProps & { data?: MonthlyBarData[] }) => {
   const x = typeof props.x === 'number' ? props.x : 0;
@@ -168,13 +166,13 @@ export const MonthlyRewardsWidget = ({ accountIds, allEntries }: Props) => {
 
   if (accountIds.length === 0) {
     return (
-      <div className={containerClass}>
+      <DashboardWidget colSpan={4} className="relative">
         <FootnoteText className="text-text-tertiary">{t('dashboard.monthlyRewards.title')}</FootnoteText>
         <div className="flex flex-col items-center gap-y-1 py-6">
           <SmallTitleText className="text-text-tertiary">{t('dashboard.noSelection.title')}</SmallTitleText>
           <BodyText className="text-text-tertiary">{t('dashboard.noSelection.description')}</BodyText>
         </div>
-      </div>
+      </DashboardWidget>
     );
   }
 
@@ -183,7 +181,7 @@ export const MonthlyRewardsWidget = ({ accountIds, allEntries }: Props) => {
     : formatFiatBalance(total.fiat).formatted;
 
   return (
-    <div className={containerClass}>
+    <DashboardWidget colSpan={4} className="relative">
       <div className="flex items-start justify-between">
         <div>
           <FootnoteText className="text-text-tertiary">{t('dashboard.monthlyRewards.title')}</FootnoteText>
@@ -267,6 +265,6 @@ export const MonthlyRewardsWidget = ({ accountIds, allEntries }: Props) => {
           </div>
         )}
       </div>
-    </div>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/features/dashboard-staking/ui/StakingOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-staking/ui/StakingOverviewWidget.tsx
@@ -6,6 +6,7 @@ import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { useStakingOverview } from '../hooks/useStakingOverview';
 
 import { ChainAllocationChart } from './ChainAllocationChart';
@@ -17,8 +18,6 @@ type Props = {
   allEntries: { accountId: string; name: string; address: string }[];
 };
 
-const containerClass = 'w-[560px] rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
-
 export const StakingOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const { t } = useI18n();
   const { chains, stakingDataByChain, totalFiat, totalActiveValidators, pending, fiatFlag, currency } =
@@ -29,20 +28,20 @@ export const StakingOverviewWidget = ({ accountIds, allEntries }: Props) => {
 
   if (accountIds.length === 0) {
     return (
-      <div className={containerClass}>
+      <DashboardWidget>
         <FootnoteText className="text-text-tertiary">{t('dashboard.stakingOverview.title')}</FootnoteText>
         <div className="flex flex-col items-center gap-y-1 py-6">
           <SmallTitleText className="text-text-tertiary">{t('dashboard.noSelection.title')}</SmallTitleText>
           <BodyText className="text-text-tertiary">{t('dashboard.noSelection.description')}</BodyText>
         </div>
-      </div>
+      </DashboardWidget>
     );
   }
 
   const selectedChain = selectedChainId ? chains.find((c) => c.chainId === selectedChainId) : null;
 
   return (
-    <div className={containerClass}>
+    <DashboardWidget>
       <FootnoteText className="text-text-tertiary">{t('dashboard.stakingOverview.title')}</FootnoteText>
       <TitleText className="mt-1">
         {pending ? <Skeleton width={30} height={7} /> : <Price amount={totalFiat ?? '0'} currency={currency} />}
@@ -152,6 +151,6 @@ export const StakingOverviewWidget = ({ accountIds, allEntries }: Props) => {
           onClose={() => setSelectedChainId(null)}
         />
       )}
-    </div>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/features/dashboard-staking/ui/StakingSummaryWidget.tsx
+++ b/src/renderer/features/dashboard-staking/ui/StakingSummaryWidget.tsx
@@ -3,6 +3,7 @@ import { useMemo } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { BodyText, FootnoteText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { useStakingOverview } from '../hooks/useStakingOverview';
 
 import { Price } from './Price';
@@ -11,8 +12,6 @@ type Props = {
   accountIds: string[];
   allEntries: { accountId: string; name: string; address: string }[];
 };
-
-const containerClass = 'w-fit rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
 
 export const StakingSummaryWidget = ({ accountIds }: Props) => {
   const { t } = useI18n();
@@ -45,7 +44,7 @@ export const StakingSummaryWidget = ({ accountIds }: Props) => {
   const hasStaking = chains.length > 0;
 
   return (
-    <div className={containerClass}>
+    <DashboardWidget colSpan={1}>
       <FootnoteText className="text-text-tertiary">{t('dashboard.stakingSummary.title')}</FootnoteText>
 
       {pending && !hasStaking && (
@@ -86,6 +85,6 @@ export const StakingSummaryWidget = ({ accountIds }: Props) => {
           </div>
         </div>
       )}
-    </div>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/features/dashboard-staking/ui/TotalRewardsWidget.tsx
+++ b/src/renderer/features/dashboard-staking/ui/TotalRewardsWidget.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
 import { Skeleton } from '@/shared/ui-kit';
+import { DashboardWidget } from '@/pages/Dashboard';
 import { type EntryLike } from '../hooks/useStakingBreakdown';
 import { useTotalRewards } from '../hooks/useTotalRewards';
 
@@ -28,7 +29,6 @@ const SINCE_OFFSETS: Record<Exclude<RewardsTimeRange, 'all'>, number> = {
   '1y': 365 * 24 * 3600,
 };
 
-const containerClass = 'w-[560px] rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
 const toggleButtonClass = 'flex-1 rounded px-3 py-1 text-footnote font-semibold transition-colors';
 const activeClass = 'bg-white text-text-primary shadow-sm';
 const inactiveClass = 'text-text-tertiary hover:text-text-secondary';
@@ -55,13 +55,13 @@ export const TotalRewardsWidget = ({ accountIds, allEntries }: Props) => {
 
   if (accountIds.length === 0) {
     return (
-      <div className={containerClass}>
+      <DashboardWidget>
         <FootnoteText className="text-text-tertiary">{t('dashboard.totalRewards.title')}</FootnoteText>
         <div className="flex flex-col items-center gap-y-1 py-6">
           <SmallTitleText className="text-text-tertiary">{t('dashboard.noSelection.title')}</SmallTitleText>
           <BodyText className="text-text-tertiary">{t('dashboard.noSelection.description')}</BodyText>
         </div>
-      </div>
+      </DashboardWidget>
     );
   }
 
@@ -74,87 +74,85 @@ export const TotalRewardsWidget = ({ accountIds, allEntries }: Props) => {
   };
 
   return (
-    <>
-      <div className={containerClass}>
-        <div className="flex items-center justify-between">
-          <FootnoteText className="text-text-tertiary">{t('dashboard.totalRewards.title')}</FootnoteText>
-          <div className="flex w-fit rounded-md bg-tab-background p-0.5">
-            {RANGES.map((range) => (
-              <button
-                key={range}
-                type="button"
-                className={`${toggleButtonClass} ${timeRange === range ? activeClass : inactiveClass}`}
-                onClick={() => setTimeRange(range)}
-              >
-                {rangeLabels[range]}
-              </button>
-            ))}
-          </div>
+    <DashboardWidget>
+      <div className="flex items-center justify-between">
+        <FootnoteText className="text-text-tertiary">{t('dashboard.totalRewards.title')}</FootnoteText>
+        <div className="flex w-fit rounded-md bg-tab-background p-0.5">
+          {RANGES.map((range) => (
+            <button
+              key={range}
+              type="button"
+              className={`${toggleButtonClass} ${timeRange === range ? activeClass : inactiveClass}`}
+              onClick={() => setTimeRange(range)}
+            >
+              {rangeLabels[range]}
+            </button>
+          ))}
         </div>
-        <div className="flex items-center gap-4">
-          <div className="flex-1">
-            <TitleText className="mt-1">
-              {pending ? <Skeleton width={30} height={7} /> : <Price amount={totalFiat ?? '0'} currency={currency} />}
-            </TitleText>
-          </div>
-        </div>
-
-        {chains.length > 0 && (
-          <>
-            <div className="my-4 border-t border-divider" />
-            <div className="flex gap-3">
-              <ChainAllocationChart chains={chains} />
-              <div className="flex flex-1 flex-col gap-3">
-                {chains.map((chain) => {
-                  const { formatted, suffix } = formatBalance(chain.totalRewards, chain.precision);
-
-                  return (
-                    <button
-                      key={chain.chainId}
-                      type="button"
-                      className="flex cursor-pointer items-center justify-between rounded-md px-2 py-1 hover:bg-hover"
-                      onClick={() => setSelectedChainId(chain.chainId)}
-                    >
-                      <div className="flex items-center gap-2">
-                        <img src={chain.icon.colored} alt={chain.chainName} className="h-6 w-6" />
-                        <div>
-                          <FootnoteText className="text-text-primary">{chain.chainName}</FootnoteText>
-                          <FootnoteText className="text-text-tertiary">
-                            {formatted}
-                            {suffix ? ` ${suffix}` : ''} {chain.symbol}
-                          </FootnoteText>
-                        </div>
-                      </div>
-                      <FootnoteText className="text-text-secondary">
-                        <Price amount={chain.fiatValue} currency={currency} />
-                      </FootnoteText>
-                    </button>
-                  );
-                })}
-              </div>
-            </div>
-          </>
-        )}
-
-        {!pending && chains.length === 0 && (
-          <div className="flex flex-col items-center gap-y-1 py-6">
-            <BodyText className="text-text-tertiary">{t('dashboard.totalRewards.noRewards')}</BodyText>
-          </div>
-        )}
-
-        {pending && chains.length === 0 && (
-          <>
-            <div className="my-4 border-t border-divider" />
-            <div className="flex gap-3">
-              <Skeleton circle width={40} />
-              <div className="flex flex-1 flex-col gap-3">
-                <Skeleton width="100%" height={10} />
-                <Skeleton width="100%" height={10} />
-              </div>
-            </div>
-          </>
-        )}
       </div>
+      <div className="flex items-center gap-4">
+        <div className="flex-1">
+          <TitleText className="mt-1">
+            {pending ? <Skeleton width={30} height={7} /> : <Price amount={totalFiat ?? '0'} currency={currency} />}
+          </TitleText>
+        </div>
+      </div>
+
+      {chains.length > 0 && (
+        <>
+          <div className="my-4 border-t border-divider" />
+          <div className="flex gap-3">
+            <ChainAllocationChart chains={chains} />
+            <div className="flex flex-1 flex-col gap-3">
+              {chains.map((chain) => {
+                const { formatted, suffix } = formatBalance(chain.totalRewards, chain.precision);
+
+                return (
+                  <button
+                    key={chain.chainId}
+                    type="button"
+                    className="flex cursor-pointer items-center justify-between rounded-md px-2 py-1 hover:bg-hover"
+                    onClick={() => setSelectedChainId(chain.chainId)}
+                  >
+                    <div className="flex items-center gap-2">
+                      <img src={chain.icon.colored} alt={chain.chainName} className="h-6 w-6" />
+                      <div>
+                        <FootnoteText className="text-text-primary">{chain.chainName}</FootnoteText>
+                        <FootnoteText className="text-text-tertiary">
+                          {formatted}
+                          {suffix ? ` ${suffix}` : ''} {chain.symbol}
+                        </FootnoteText>
+                      </div>
+                    </div>
+                    <FootnoteText className="text-text-secondary">
+                      <Price amount={chain.fiatValue} currency={currency} />
+                    </FootnoteText>
+                  </button>
+                );
+              })}
+            </div>
+          </div>
+        </>
+      )}
+
+      {!pending && chains.length === 0 && (
+        <div className="flex flex-col items-center gap-y-1 py-6">
+          <BodyText className="text-text-tertiary">{t('dashboard.totalRewards.noRewards')}</BodyText>
+        </div>
+      )}
+
+      {pending && chains.length === 0 && (
+        <>
+          <div className="my-4 border-t border-divider" />
+          <div className="flex gap-3">
+            <Skeleton circle width={40} />
+            <div className="flex flex-1 flex-col gap-3">
+              <Skeleton width="100%" height={10} />
+              <Skeleton width="100%" height={10} />
+            </div>
+          </div>
+        </>
+      )}
 
       {selectedChain && (
         <RewardsDetailModal
@@ -166,6 +164,6 @@ export const TotalRewardsWidget = ({ accountIds, allEntries }: Props) => {
           onClose={() => setSelectedChainId(null)}
         />
       )}
-    </>
+    </DashboardWidget>
   );
 };

--- a/src/renderer/pages/Dashboard/index.ts
+++ b/src/renderer/pages/Dashboard/index.ts
@@ -1,1 +1,2 @@
 export { Dashboard, dashboardStakingSlot, dashboardWidgetsSlot } from './ui/Dashboard';
+export { DashboardWidget } from './ui/DashboardWidget';

--- a/src/renderer/pages/Dashboard/model/dashboard-model.ts
+++ b/src/renderer/pages/Dashboard/model/dashboard-model.ts
@@ -20,8 +20,16 @@ const selectionChanged = createEvent<string[]>();
 const selectAll = createEvent();
 const deselectAll = createEvent();
 const tabChanged = createEvent<string>();
+const widgetOrderChanged = createEvent<{ tab: string; order: string[] }>();
+const editModeToggled = createEvent();
 
 const $activeTab = createStore('overview');
+const $editMode = createStore(false);
+$editMode.on(editModeToggled, (state) => !state);
+
+const $widgetOrder = createStore<Record<string, string[]>>({});
+persist({ store: $widgetOrder, key: 'dashboard-widget-order', sync: true });
+$widgetOrder.on(widgetOrderChanged, (state, { tab, order }) => ({ ...state, [tab]: order }));
 
 $activeTab.on(tabChanged, (_, tab) => tab);
 
@@ -155,11 +163,15 @@ export const dashboardModel = {
   $selectedAccounts,
   $selectedContactAccountIds,
   $activeTab,
+  $widgetOrder,
+  $editMode,
 
   selectionChanged,
   selectAll,
   deselectAll,
   tabChanged,
+  widgetOrderChanged,
+  editModeToggled,
 };
 
 export type { DashboardEntry };

--- a/src/renderer/pages/Dashboard/ui/Dashboard.tsx
+++ b/src/renderer/pages/Dashboard/ui/Dashboard.tsx
@@ -1,13 +1,14 @@
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { Slot, createSlot } from '@/shared/di';
+import { createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { BodyText, Header, SmallTitleText } from '@/shared/ui';
+import { BodyText, Header, IconButton, SmallTitleText } from '@/shared/ui';
 import { Tabs } from '@/shared/ui-kit';
 import { dashboardModel } from '../model/dashboard-model';
 
 import { DashboardAccountSelector } from './DashboardAccountSelector';
+import { DashboardGrid } from './DashboardGrid';
 
 export const dashboardWidgetsSlot = createSlot<{
   accountIds: string[];
@@ -26,7 +27,9 @@ export const Dashboard = () => {
   const allEntries = useUnit(dashboardModel.$allEntries);
   const selectedIds = useUnit(dashboardModel.$selectedIds);
   const activeTab = useUnit(dashboardModel.$activeTab);
+  const editMode = useUnit(dashboardModel.$editMode);
   const tabChanged = useUnit(dashboardModel.tabChanged);
+  const editModeToggled = useUnit(dashboardModel.editModeToggled);
 
   const accountIds = useMemo(() => {
     const selectedIdSet = new Set(selectedIds);
@@ -43,7 +46,12 @@ export const Dashboard = () => {
   return (
     <section className="flex h-full flex-col">
       <Header title={t('dashboard.title')} titleClass="py-[3px]" headerClass="pt-4 pb-[15px]">
-        {allEntries.length > 0 && <DashboardAccountSelector />}
+        {allEntries.length > 0 && (
+          <div className="flex items-center gap-x-2">
+            <IconButton className={editMode ? 'text-icon-accent' : ''} name="edit" onClick={editModeToggled} />
+            <DashboardAccountSelector />
+          </div>
+        )}
       </Header>
 
       <div className="flex min-h-0 flex-1 flex-col px-4">
@@ -67,9 +75,12 @@ export const Dashboard = () => {
                 </div>
               </div>
             ) : (
-              <div className="flex h-full w-full flex-wrap content-start items-start gap-4 overflow-y-auto py-4">
-                <Slot id={dashboardWidgetsSlot} props={{ accountIds, allEntries }} />
-              </div>
+              <DashboardGrid
+                slot={dashboardWidgetsSlot}
+                tab="overview"
+                editMode={editMode}
+                props={{ accountIds, allEntries }}
+              />
             )}
           </Tabs.Content>
 
@@ -82,9 +93,12 @@ export const Dashboard = () => {
                 </div>
               </div>
             ) : (
-              <div className="flex h-full w-full flex-wrap content-start items-start gap-4 overflow-y-auto py-4">
-                <Slot id={dashboardStakingSlot} props={{ accountIds, allEntries }} />
-              </div>
+              <DashboardGrid
+                slot={dashboardStakingSlot}
+                tab="staking"
+                editMode={editMode}
+                props={{ accountIds, allEntries }}
+              />
             )}
           </Tabs.Content>
 

--- a/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
+++ b/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
@@ -1,0 +1,110 @@
+import { move } from '@dnd-kit/helpers';
+import { DragDropProvider } from '@dnd-kit/react';
+import { useUnit } from 'effector-react';
+import { useCallback, useMemo, useRef, useState } from 'react';
+
+import { type SlotIdentifier, type SlotProps } from '@/shared/di/createSlot';
+import { dashboardModel } from '../model/dashboard-model';
+
+import { WidgetSortableProvider } from './WidgetSortableContext';
+
+const EMPTY_PROPS: Record<string, unknown> = {};
+
+type Props<P extends SlotProps> = {
+  slot: SlotIdentifier<P>;
+  tab: string;
+  props: P;
+  editMode: boolean;
+};
+
+export const DashboardGrid = <P extends SlotProps>({ slot, tab, props, editMode }: Props<P>) => {
+  const handlers = useUnit(slot.$handlers);
+  const widgetOrder = useUnit(dashboardModel.$widgetOrder);
+  const onOrderChanged = useUnit(dashboardModel.widgetOrderChanged);
+
+  const availableHandlers = useMemo(() => {
+    return handlers.filter((h) => {
+      try {
+        return h.available();
+      } catch {
+        return false;
+      }
+    });
+  }, [handlers]);
+
+  const { orderedHandlers, handlersByKey } = useMemo(() => {
+    const byKey = new Map(availableHandlers.map((h) => [h.key, h]));
+
+    const savedOrder = widgetOrder[tab];
+    if (!savedOrder || savedOrder.length === 0) {
+      const sorted = [...availableHandlers].sort((a, b) => (a.body.order ?? 0) - (b.body.order ?? 0));
+
+      return { orderedHandlers: sorted, handlersByKey: byKey };
+    }
+
+    const ordered = savedOrder.filter((key) => byKey.has(key)).map((key) => byKey.get(key)!);
+
+    const orderedKeySet = new Set(savedOrder);
+    const newHandlers = availableHandlers
+      .filter((h) => h.key && !orderedKeySet.has(h.key))
+      .sort((a, b) => (a.body.order ?? 0) - (b.body.order ?? 0));
+
+    return { orderedHandlers: [...ordered, ...newHandlers], handlersByKey: byKey };
+  }, [availableHandlers, widgetOrder, tab]);
+
+  const storeKeys = useMemo(
+    () => orderedHandlers.map((h) => h.key).filter((key): key is string => key != null),
+    [orderedHandlers],
+  );
+
+  const [dragKeys, setDragKeys] = useState<string[] | null>(null);
+  const dragKeysRef = useRef<string[] | null>(null);
+  dragKeysRef.current = dragKeys;
+
+  const displayKeys = dragKeys ?? storeKeys;
+
+  const handleDragStart = useCallback(() => {
+    setDragKeys(storeKeys);
+  }, [storeKeys]);
+
+  const handleDragOver: React.ComponentProps<typeof DragDropProvider>['onDragOver'] = useCallback(
+    (event: Parameters<NonNullable<React.ComponentProps<typeof DragDropProvider>['onDragOver']>>[0]) => {
+      setDragKeys((prev) => {
+        if (!prev) return prev;
+        const next = move(prev, event);
+
+        return next.join(',') === prev.join(',') ? prev : next;
+      });
+    },
+    [],
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (dragKeysRef.current) {
+      onOrderChanged({ tab, order: dragKeysRef.current });
+    }
+    setDragKeys(null);
+  }, [tab, onOrderChanged]);
+
+  const componentProps = (props ?? EMPTY_PROPS) satisfies Record<string, unknown>;
+
+  return (
+    <DragDropProvider onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
+      <div className="grid h-full w-full grid-cols-4 items-start gap-4 overflow-y-auto p-4">
+        {displayKeys.map((key, index) => {
+          const handler = handlersByKey.get(key);
+          if (!handler) return null;
+
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          const Component = handler.body.render as React.ComponentType<any>;
+
+          return (
+            <WidgetSortableProvider key={key} id={key} index={index} editMode={editMode}>
+              <Component {...componentProps} />
+            </WidgetSortableProvider>
+          );
+        })}
+      </div>
+    </DragDropProvider>
+  );
+};

--- a/src/renderer/pages/Dashboard/ui/DashboardWidget.tsx
+++ b/src/renderer/pages/Dashboard/ui/DashboardWidget.tsx
@@ -1,0 +1,58 @@
+import { type ReactNode } from 'react';
+
+import { cnTw } from '@/shared/lib/utils';
+
+import { useWidgetSortable } from './WidgetSortableContext';
+
+type Props = {
+  colSpan?: 1 | 2 | 3 | 4;
+  children: ReactNode;
+  className?: string;
+  card?: boolean;
+};
+
+const COL_SPAN_CLASS: Record<number, string> = {
+  1: 'col-span-1',
+  2: 'col-span-2',
+  3: 'col-span-3',
+  4: 'col-span-4',
+};
+
+const CARD_CLASS = 'rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
+
+export const DashboardWidget = ({ colSpan = 2, children, className, card = true }: Props) => {
+  const ctx = useWidgetSortable();
+
+  return (
+    <div
+      ref={ctx?.sortableRef}
+      className={cnTw(
+        COL_SPAN_CLASS[colSpan],
+        card && CARD_CLASS,
+        ctx && 'relative transition-shadow duration-200',
+        ctx?.editMode && 'ring-2 ring-primary-button-background-default/30',
+        ctx?.isDragging && 'z-10 opacity-60',
+        className,
+      )}
+    >
+      {ctx?.editMode && (
+        <button
+          ref={ctx.handleRef}
+          type="button"
+          className="absolute -top-2.5 -left-2.5 z-10 flex h-6 w-6 cursor-grab items-center justify-center rounded-full bg-primary-button-background-default text-white shadow-card-shadow active:cursor-grabbing"
+          aria-label="Drag to reorder"
+        >
+          <svg width="12" height="12" viewBox="0 0 16 16" fill="currentColor">
+            <circle cx="5" cy="3" r="1.5" />
+            <circle cx="11" cy="3" r="1.5" />
+            <circle cx="5" cy="8" r="1.5" />
+            <circle cx="11" cy="8" r="1.5" />
+            <circle cx="5" cy="13" r="1.5" />
+            <circle cx="11" cy="13" r="1.5" />
+          </svg>
+        </button>
+      )}
+      {children}
+    </div>
+  );
+};

--- a/src/renderer/pages/Dashboard/ui/WidgetSortableContext.tsx
+++ b/src/renderer/pages/Dashboard/ui/WidgetSortableContext.tsx
@@ -1,0 +1,37 @@
+import { useSortable } from '@dnd-kit/react/sortable';
+import { type ReactNode, createContext, useContext, useMemo, useRef } from 'react';
+
+type WidgetSortableContextValue = {
+  sortableRef: (element: Element | null) => void;
+  handleRef: React.RefObject<HTMLButtonElement | null>;
+  editMode: boolean;
+  isDragging: boolean;
+};
+
+const WidgetSortableContext = createContext<WidgetSortableContextValue | null>(null);
+
+export const useWidgetSortable = () => useContext(WidgetSortableContext);
+
+type ProviderProps = {
+  id: string;
+  index: number;
+  editMode: boolean;
+  children: ReactNode;
+};
+
+export const WidgetSortableProvider = ({ id, index, editMode, children }: ProviderProps) => {
+  const handleRef = useRef<HTMLButtonElement>(null);
+  const { ref, isDragging } = useSortable({
+    id,
+    index,
+    handle: handleRef,
+    disabled: !editMode,
+  });
+
+  const value = useMemo(
+    () => ({ sortableRef: ref, handleRef, editMode, isDragging }),
+    [ref, handleRef, editMode, isDragging],
+  );
+
+  return <WidgetSortableContext.Provider value={value}>{children}</WidgetSortableContext.Provider>;
+};


### PR DESCRIPTION
## Summary

- Add drag-and-drop reordering for dashboard widgets using `@dnd-kit/react`
- Edit mode toggle button (pencil icon) in the dashboard header — drag handles only appear when active
- Widget order persisted per tab to localStorage via `effector-storage/local`
- Each widget controls its own grid span via `<DashboardWidget colSpan={N}>` — no DI system pollution
- Context-based architecture: `WidgetSortableProvider` passes sortable ref/state to `DashboardWidget` via React context, so `DashboardWidget` is the direct CSS Grid child (no wrapper div)

## Test plan

- [ ] Open dashboard, verify widgets render in default order with correct column spans
- [ ] Click pencil icon — verify ring outlines and drag handles appear on all widgets
- [ ] Drag a widget by its handle — verify other widgets reflow and new order sticks
- [ ] Refresh page — verify persisted order is restored
- [ ] Switch between Overview and Staking tabs — verify each tab has independent order
- [ ] Toggle edit mode off — verify handles disappear, no layout shift
- [ ] Verify interactive widget content (charts, buttons, links) works normally in both modes

🤖 Generated with [Claude Code](https://claude.com/claude-code)