### PR TITLE
fix: prevent tree-shaking of app-custom-operations nav item

### DIFF
--- a/src/renderer/app/bootstrap/index.ts
+++ b/src/renderer/app/bootstrap/index.ts
@@ -9,7 +9,6 @@ import { notificationModel } from '@/entities/notification';
 import { proxyModel } from '@/entities/proxy';
 import { walletModel } from '@/entities/wallet';
 import { governanceMetaProvider } from '@/aggregates/governance-meta-provider';
-import { appCustomOperationsFeature } from '@/features/app-custom-operations';
 import { assetsSettingsModel, portfolioModel } from '@/features/assets';
 import { assetsNavigationFeature } from '@/features/assets-navigation';
 import { basketNavigationFeature } from '@/features/basket-navigation';
@@ -84,7 +83,7 @@ export const bootstrap = () => {
     governanceNavigationFeature,
     vestedTransferFeature,
     multiTransferFeature,
-    appCustomOperationsFeature,
+    import('@/features/app-custom-operations').then(({ appCustomOperationsFeature }) => appCustomOperationsFeature),
 
     import('@/features/wallet-select').then(({ walletSelectFeature }) => walletSelectFeature.feature),
     import('@/features/wallet-details').then(({ walletDetailsFeature }) => walletDetailsFeature),

--- a/src/renderer/features/app-custom-operations/feature.tsx
+++ b/src/renderer/features/app-custom-operations/feature.tsx
@@ -1,0 +1,17 @@
+import { $features } from '@/shared/config/features';
+import { createFeature } from '@/shared/feature';
+import { navigationCustomOperationsSlot } from '@/features/app-shell';
+
+import { CustomOperations } from './ui/CustomOperations';
+
+const appCustomOperationsFeature = createFeature({
+  name: 'app/custom-operations',
+  enable: $features.map(({ appCustomOperations }) => appCustomOperations),
+});
+
+appCustomOperationsFeature.inject(navigationCustomOperationsSlot, {
+  order: 0,
+  render: ({ folded }) => <CustomOperations folded={folded} />,
+});
+
+export { appCustomOperationsFeature };

--- a/src/renderer/features/app-custom-operations/index.tsx
+++ b/src/renderer/features/app-custom-operations/index.tsx
@@ -1,12 +1,5 @@
-import { navigationCustomOperationsSlot } from '@/features/app-shell';
-
-import { appCustomOperationsFeature } from './model/feature';
+import { appCustomOperationsFeature } from './feature';
 import { CustomOperations } from './ui/CustomOperations';
 
+export { CustomOperations, appCustomOperationsFeature };
 export { customOperationsSlot } from './ui/CustomOperations';
-export { appCustomOperationsFeature };
-
-appCustomOperationsFeature.inject(navigationCustomOperationsSlot, {
-  order: 0,
-  render: ({ folded }) => <CustomOperations folded={folded} />,
-});

--- a/src/renderer/features/app-custom-operations/model/feature.ts
+++ b/src/renderer/features/app-custom-operations/model/feature.ts
@@ -1,7 +1,0 @@
-import { $features } from '@/shared/config/features';
-import { createFeature } from '@/shared/feature';
-
-export const appCustomOperationsFeature = createFeature({
-  name: 'app/custom-operations',
-  enable: $features.map(({ appCustomOperations }) => appCustomOperations),
-});


### PR DESCRIPTION
## Summary
- The `sideEffects` field in `package.json` lists `*.css` and `*.ts` but not `*.tsx`, so the top-level `inject()` call in `app-custom-operations/index.tsx` was dropped by the bundler in production builds
- Switched to dynamic import (matching the pattern used by ~40 other features in bootstrap) to ensure the side effect is preserved

## Test plan
- [ ] Verify custom operations nav item renders in production build (`pnpm prod:sequence` or `pnpm staging:sequence`)
- [ ] Verify it still works in dev mode (`pnpm start`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)