### PR TITLE
fix: resolve merge conflict in app-custom-operations

### DIFF
--- a/src/renderer/app/bootstrap/index.ts
+++ b/src/renderer/app/bootstrap/index.ts
@@ -9,7 +9,6 @@ import { notificationModel } from '@/entities/notification';
 import { proxyModel } from '@/entities/proxy';
 import { walletModel } from '@/entities/wallet';
 import { governanceMetaProvider } from '@/aggregates/governance-meta-provider';
-import { appCustomOperationsFeature } from '@/features/app-custom-operations';
 import { assetsSettingsModel, portfolioModel } from '@/features/assets';
 import { assetsNavigationFeature } from '@/features/assets-navigation';
 import { basketNavigationFeature } from '@/features/basket-navigation';
@@ -75,7 +74,7 @@ export const bootstrap = () => {
     governanceNavigationFeature,
     vestedTransferFeature,
     multiTransferFeature,
-    appCustomOperationsFeature,
+    import('@/features/app-custom-operations').then(({ appCustomOperationsFeature }) => appCustomOperationsFeature),
 
     import('@/features/wallet-select').then(({ walletSelectFeature }) => walletSelectFeature.feature),
     import('@/features/wallet-details').then(({ walletDetailsFeature }) => walletDetailsFeature),

--- a/src/renderer/features/app-custom-operations/feature.tsx
+++ b/src/renderer/features/app-custom-operations/feature.tsx
@@ -1,0 +1,17 @@
+import { $features } from '@/shared/config/features';
+import { createFeature } from '@/shared/feature';
+import { navigationCustomOperationsSlot } from '@/features/app-shell';
+
+import { CustomOperations } from './ui/CustomOperations';
+
+const appCustomOperationsFeature = createFeature({
+  name: 'app/custom-operations',
+  enable: $features.map(({ appCustomOperations }) => appCustomOperations),
+});
+
+appCustomOperationsFeature.inject(navigationCustomOperationsSlot, {
+  order: 0,
+  render: () => <CustomOperations />,
+});
+
+export { appCustomOperationsFeature };

--- a/src/renderer/features/app-custom-operations/index.tsx
+++ b/src/renderer/features/app-custom-operations/index.tsx
@@ -1,12 +1,5 @@
-import { navigationCustomOperationsSlot } from '@/features/app-shell';
-
-import { appCustomOperationsFeature } from './model/feature';
+import { appCustomOperationsFeature } from './feature';
 import { CustomOperations } from './ui/CustomOperations';
 
+export { CustomOperations, appCustomOperationsFeature };
 export { customOperationsSlot } from './ui/CustomOperations';
-export { appCustomOperationsFeature };
-
-appCustomOperationsFeature.inject(navigationCustomOperationsSlot, {
-  order: 0,
-  render: () => <CustomOperations />,
-});

--- a/src/renderer/features/app-custom-operations/model/feature.ts
+++ b/src/renderer/features/app-custom-operations/model/feature.ts
@@ -1,7 +1,0 @@
-import { $features } from '@/shared/config/features';
-import { createFeature } from '@/shared/feature';
-
-export const appCustomOperationsFeature = createFeature({
-  name: 'app/custom-operations',
-  enable: $features.map(({ appCustomOperations }) => appCustomOperations),
-});


### PR DESCRIPTION
## Summary
- Resolved merge conflict between tree-shaking fix (#5738) and feature.tsx refactor
- Moved `inject` call and feature creation into `feature.tsx`, keeping `index.tsx` as clean re-exports
- Fixed type error: removed invalid `folded` prop (component takes no props, slot has no type parameter)

## Test plan
- [x] Type checking passes (`pnpm types:files`)
- [x] Lint and formatting pass
- [ ] Verify custom operations nav item renders correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)