### PR TITLE
refactor(address-book): multisig name override

### DIFF
--- a/src/renderer/entities/wallet/model/wallet-model.ts
+++ b/src/renderer/entities/wallet/model/wallet-model.ts
@@ -103,7 +103,7 @@ const createWalletsFx = createEffect(async (drafts: WalletCreateParams[]): Promi
       accountsToCreate.push({
         ...account,
         walletId: wallet.id,
-        nameType: account.nameType ?? AccountNameType.GENERATED,
+        nameType: account.nameType ?? AccountNameType.CUSTOM,
       } as AnyAccountDraft);
     }
   }

--- a/src/renderer/features/account-sync/model/sync.multisig.test.ts
+++ b/src/renderer/features/account-sync/model/sync.multisig.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck - Test file with mock data that doesn't match strict types
 import { describe, expect, test } from 'vitest';
 
+import { AccountNameType } from '@/shared/core';
+
 import {
   allAccounts,
   allWallets,
@@ -31,6 +33,7 @@ describe('syncMultisigAccounts', () => {
               accountType: multisigAccount1.accountType,
               cryptoType: multisigAccount1.cryptoType,
               name: '13HZ3...deSPH',
+              nameType: AccountNameType.CUSTOM,
               signatories: multisigAccount1.signatories,
               signingType: multisigAccount1.signingType,
               threshold: multisigAccount1.threshold,
@@ -47,6 +50,7 @@ describe('syncMultisigAccounts', () => {
               accountType: multisigAccount2.accountType,
               cryptoType: multisigAccount2.cryptoType,
               name: '13oKT...bKKxZ',
+              nameType: AccountNameType.CUSTOM,
               signatories: multisigAccount2.signatories,
               signingType: multisigAccount2.signingType,
               threshold: multisigAccount2.threshold,
@@ -63,6 +67,7 @@ describe('syncMultisigAccounts', () => {
               accountType: multisigAccount3.accountType,
               cryptoType: multisigAccount3.cryptoType,
               name: '149AX...N4idM',
+              nameType: AccountNameType.CUSTOM,
               signatories: multisigAccount3.signatories,
               signingType: multisigAccount3.signingType,
               threshold: multisigAccount3.threshold,

--- a/src/renderer/features/account-sync/model/sync.ts
+++ b/src/renderer/features/account-sync/model/sync.ts
@@ -19,6 +19,7 @@ import {
   type ProxyAccount,
   type ProxyType,
   type Wallet,
+  AccountNameType,
   AccountType,
   CryptoType,
   NotificationType,
@@ -456,6 +457,7 @@ export const syncMultisigAccounts = ({ allAccounts, allWallets, syncResult, iden
         accounts: [
           {
             name,
+            nameType: AccountNameType.CUSTOM,
             type: 'universal',
             accountType: AccountType.MULTISIG,
             accountId: syncedAccount.accountId,
@@ -573,6 +575,7 @@ export const syncFlexibleMultisigs = ({
           type: 'chain',
           chainId: matchedSyncedProxy.chainId,
           name: proxiedName,
+          nameType: AccountNameType.CUSTOM,
           accountId: matchedSyncedProxy.accountId,
 
           multisigAccountId: syncedMultisig.accountId,

--- a/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
+++ b/src/renderer/features/multisig-wallet-create/multisig-wallet/model/flow-model.ts
@@ -10,6 +10,7 @@ import {
   type MultisigAccount,
   type NoID,
   type Wallet,
+  AccountNameType,
   AccountType,
   CryptoType,
   SigningType,
@@ -389,6 +390,7 @@ sample({
     const account: Omit<NoID<MultisigAccount>, 'walletId'> = {
       signatories: sortedSignatories,
       name: name.trim(),
+      nameType: AccountNameType.CUSTOM,
       accountId: accountId,
       threshold: threshold,
       cryptoType,

--- a/src/renderer/shared/api/storage/migration/__tests__/migration-19.test.ts
+++ b/src/renderer/shared/api/storage/migration/__tests__/migration-19.test.ts
@@ -1,0 +1,78 @@
+import { type Transaction } from 'dexie';
+
+import { migrateMultisigAccountNameType } from '@/shared/api/storage/migration';
+import { AccountNameType, AccountType } from '@/shared/core';
+
+type RawAccount = { id: string; nameType?: AccountNameType; accountType?: AccountType; [key: string]: unknown };
+
+describe('Migration 19 - Backfill nameType: CUSTOM for multisig accounts', () => {
+  const db = {
+    accounts2: [] as RawAccount[],
+  };
+
+  const transactionMock = {
+    table: vi.fn().mockImplementation((tableName: 'accounts2') => {
+      return {
+        toArray: vi.fn(() => db[tableName]),
+        bulkPut: vi.fn().mockImplementation((records: RawAccount[]) => {
+          const updated = new Map(records.map((r) => [r.id, r]));
+          db[tableName] = db[tableName].map((r) => updated.get(r.id) ?? r);
+        }),
+      };
+    }),
+  } as unknown as Transaction;
+
+  beforeEach(() => {
+    db.accounts2 = [];
+  });
+
+  it('should migrate multisig accounts with GENERATED nameType to CUSTOM', async () => {
+    db.accounts2 = [
+      { id: '1', accountType: AccountType.MULTISIG, nameType: AccountNameType.GENERATED, name: 'MS Wallet' },
+      { id: '2', accountType: AccountType.MULTISIG, nameType: AccountNameType.GENERATED, name: 'MS Wallet 2' },
+    ];
+
+    await migrateMultisigAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]!.nameType).toBe(AccountNameType.CUSTOM);
+    expect(db.accounts2[1]!.nameType).toBe(AccountNameType.CUSTOM);
+  });
+
+  it('should migrate flex_multisig accounts with GENERATED nameType to CUSTOM', async () => {
+    db.accounts2 = [
+      { id: '1', accountType: AccountType.FLEX_MULTISIG, nameType: AccountNameType.GENERATED, name: 'Flex MS' },
+    ];
+
+    await migrateMultisigAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]!.nameType).toBe(AccountNameType.CUSTOM);
+  });
+
+  it('should not change non-multisig accounts with GENERATED nameType', async () => {
+    db.accounts2 = [
+      { id: '1', accountType: AccountType.BASE, nameType: AccountNameType.GENERATED, name: 'Base Account' },
+      { id: '2', accountType: AccountType.CHAIN, nameType: AccountNameType.GENERATED, name: 'Chain Account' },
+    ];
+
+    await migrateMultisigAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]!.nameType).toBe(AccountNameType.GENERATED);
+    expect(db.accounts2[1]!.nameType).toBe(AccountNameType.GENERATED);
+  });
+
+  it('should not change multisig accounts already with CUSTOM nameType', async () => {
+    db.accounts2 = [
+      { id: '1', accountType: AccountType.MULTISIG, nameType: AccountNameType.CUSTOM, name: 'Already Custom' },
+    ];
+
+    await migrateMultisigAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]!.nameType).toBe(AccountNameType.CUSTOM);
+  });
+
+  it('should handle empty accounts array', async () => {
+    db.accounts2 = [];
+    await migrateMultisigAccountNameType(transactionMock);
+    expect(db.accounts2).toEqual([]);
+  });
+});

--- a/src/renderer/shared/api/storage/migration/index.ts
+++ b/src/renderer/shared/api/storage/migration/index.ts
@@ -16,3 +16,4 @@ export { migrateNotificationStructure } from './migration-15';
 export { addFlexibleMultisigProxyType } from './migration-16';
 export { addAccountCreatedAt } from './migration-17';
 export { backupContactsBeforePKChange, migrateContactsToStringIds, restoreContactsAfterPKChange } from './migration-18';
+export { migrateMultisigAccountNameType } from './migration-19';

--- a/src/renderer/shared/api/storage/migration/migration-19.ts
+++ b/src/renderer/shared/api/storage/migration/migration-19.ts
@@ -1,0 +1,30 @@
+import { type Transaction } from 'dexie';
+
+import { AccountNameType, AccountType } from '@/shared/core';
+
+type RawAccount = { id: string; nameType?: AccountNameType; accountType?: AccountType; [key: string]: unknown };
+
+/**
+ * Multisig accounts created via account-sync received nameType: GENERATED
+ * (wrong fallback in createWalletsFx), which allowed backend contacts to
+ * override the wallet name. Backfill them to CUSTOM so wallet names take
+ * priority over address-book contacts.
+ */
+export async function migrateMultisigAccountNameType(t: Transaction): Promise<void> {
+  const allAccounts = await t.table<RawAccount>('accounts2').toArray();
+
+  const toUpdate = allAccounts.filter(
+    (account) =>
+      account.nameType === AccountNameType.GENERATED &&
+      (account.accountType === AccountType.MULTISIG || account.accountType === AccountType.FLEX_MULTISIG),
+  );
+
+  if (toUpdate.length === 0) return;
+
+  const updated = toUpdate.map((account) => ({
+    ...account,
+    nameType: AccountNameType.CUSTOM,
+  }));
+
+  await t.table('accounts2').bulkPut(updated);
+}

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -26,6 +26,7 @@ import {
   migrateEVMAccountsCryptoType,
   migrateEvents,
   migrateMultishardAccounts,
+  migrateMultisigAccountNameType,
   migrateMultisigAccounts,
   migrateNotificationStructure,
   migratePVAccounts,
@@ -165,6 +166,8 @@ class DexieStorage extends Dexie {
     this.version(47).stores({ contacts: 'id,source' }).upgrade(restoreContactsAfterPKChange);
     this.version(48).stores({ _contactsBackup: null });
 
+    this.version(49).upgrade(migrateMultisigAccountNameType);
+
     this.connections = this.table('connections');
     this.balances2 = this.table('balances2');
     this.wallets = this.table('wallets');
@@ -198,6 +201,7 @@ export const importDb = async (blob: Blob) => {
     await addFlexibleMultisigProxyType(t);
     await addAccountCreatedAt(t);
     await migrateContactsToStringIds(t);
+    await migrateMultisigAccountNameType(t);
   });
 };
 


### PR DESCRIPTION
## Description
Multisig wallet names were being overridden by matching entries in the external address book. The name resolution priority chain (custom name → local contact → backend contact → identity) was established in #5736, but multisig accounts were never assigned nameType: CUSTOM, so the check failed and execution fell through to the contact lookup.

The fix assigns nameType: CUSTOM at all multisig creation points and adds a DB migration to backfill existing records.

## Related Issues
SPEK-305

## Changes Made

- Fixed wrong fallback in createWalletsFx (GENERATED → CUSTOM) — affected all bulk-created wallets including sync-discovered multisigs
- Added nameType: AccountNameType.CUSTOM explicitly to syncMultisigAccounts and syncFlexibleMultisigs in sync.ts
- Added DB migration (version 49) to backfill existing multisig/flex-multisig accounts that already have nameType: GENERATED in IndexedDB
- Updated sync.multisig.test.ts to include nameType in expected output
- Added migration-19.test.ts with 5 test cases covering the migration logic

## Screenshots/Recordings

https://github.com/user-attachments/assets/674af144-6025-4ec9-839d-5ccbb58dd112


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
