### PR TITLE
feat(dashboard): governance detail modals with account & track breakdown

### DIFF
--- a/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
@@ -3,7 +3,7 @@ import { useUnit } from 'effector-react';
 import { useMemo, useRef } from 'react';
 
 import { type Chunks, UnlockChunkType } from '@/shared/api/governance';
-import { type ChainId, type VotingMap } from '@/shared/core';
+import { type ChainId, type TrackInfo, type VotingMap } from '@/shared/core';
 import { useThrottledSnapshot } from '@/shared/lib/hooks';
 import { entries, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
@@ -40,12 +40,15 @@ export type ChainGovernanceData = {
   icon: { monochrome: string; colored: string };
   priceId: string;
   pending: boolean;
+  votingMap: VotingMap;
+  tracks: Record<string, TrackInfo>;
 };
 
 function computeGovernanceStats(votingMap: VotingMap) {
   let activeVotingAccounts = 0;
   let totalLocked = new BN(0);
-  const multipliers: number[] = [];
+  let totalWeight = new BN(0);
+  let weightedConvictionSum = 0;
 
   for (const [, trackVoting] of Object.entries(votingMap)) {
     let accountMaxLock = new BN(0);
@@ -64,7 +67,11 @@ function computeGovernanceStats(votingMap: VotingMap) {
             accountMaxLock = amount;
           }
           const conviction = votingService.getAccountVoteConviction(vote);
-          multipliers.push(votingService.getConvictionMultiplier(conviction));
+          const multiplier = votingService.getConvictionMultiplier(conviction);
+          // Use amount as float weight for weighted average
+          const weight = parseFloat(amount.toString());
+          totalWeight = totalWeight.add(amount);
+          weightedConvictionSum += weight * multiplier;
         }
 
         if (voting.prior && voting.prior.amount && !voting.prior.amount.isZero()) {
@@ -81,7 +88,10 @@ function computeGovernanceStats(votingMap: VotingMap) {
         if (voting.prior && voting.prior.amount && voting.prior.amount.gt(accountMaxLock)) {
           accountMaxLock = voting.prior.amount;
         }
-        multipliers.push(votingService.getConvictionMultiplier(voting.conviction));
+        const multiplier = votingService.getConvictionMultiplier(voting.conviction);
+        const weight = parseFloat(voting.balance.toString());
+        totalWeight = totalWeight.add(voting.balance);
+        weightedConvictionSum += weight * multiplier;
       }
     }
 
@@ -91,7 +101,8 @@ function computeGovernanceStats(votingMap: VotingMap) {
     totalLocked = totalLocked.add(accountMaxLock);
   }
 
-  const averageConviction = multipliers.length > 0 ? multipliers.reduce((a, b) => a + b, 0) / multipliers.length : 0;
+  const totalWeightFloat = parseFloat(totalWeight.toString());
+  const averageConviction = totalWeightFloat > 0 ? weightedConvictionSum / totalWeightFloat : 0;
 
   return { activeVotingAccounts, totalLocked, averageConviction };
 }
@@ -245,5 +256,7 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
     icon: asset.icon,
     priceId: asset.priceId,
     pending,
+    votingMap,
+    tracks,
   } satisfies ChainGovernanceData;
 };

--- a/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
@@ -1,4 +1,5 @@
 import { BN, BN_ZERO } from '@polkadot/util';
+import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo, useRef } from 'react';
 
@@ -47,8 +48,8 @@ export type ChainGovernanceData = {
 function computeGovernanceStats(votingMap: VotingMap) {
   let activeVotingAccounts = 0;
   let totalLocked = new BN(0);
-  let totalWeight = new BN(0);
-  let weightedConvictionSum = 0;
+  let totalWeight = new BigNumber(0);
+  let weightedConvictionSum = new BigNumber(0);
 
   for (const [, trackVoting] of Object.entries(votingMap)) {
     let accountMaxLock = new BN(0);
@@ -68,10 +69,9 @@ function computeGovernanceStats(votingMap: VotingMap) {
           }
           const conviction = votingService.getAccountVoteConviction(vote);
           const multiplier = votingService.getConvictionMultiplier(conviction);
-          // Use amount as float weight for weighted average
-          const weight = parseFloat(amount.toString());
-          totalWeight = totalWeight.add(amount);
-          weightedConvictionSum += weight * multiplier;
+          const weight = new BigNumber(amount.toString());
+          totalWeight = totalWeight.plus(weight);
+          weightedConvictionSum = weightedConvictionSum.plus(weight.times(multiplier));
         }
 
         if (voting.prior && voting.prior.amount && !voting.prior.amount.isZero()) {
@@ -89,9 +89,9 @@ function computeGovernanceStats(votingMap: VotingMap) {
           accountMaxLock = voting.prior.amount;
         }
         const multiplier = votingService.getConvictionMultiplier(voting.conviction);
-        const weight = parseFloat(voting.balance.toString());
-        totalWeight = totalWeight.add(voting.balance);
-        weightedConvictionSum += weight * multiplier;
+        const weight = new BigNumber(voting.balance.toString());
+        totalWeight = totalWeight.plus(weight);
+        weightedConvictionSum = weightedConvictionSum.plus(weight.times(multiplier));
       }
     }
 
@@ -101,8 +101,7 @@ function computeGovernanceStats(votingMap: VotingMap) {
     totalLocked = totalLocked.add(accountMaxLock);
   }
 
-  const totalWeightFloat = parseFloat(totalWeight.toString());
-  const averageConviction = totalWeightFloat > 0 ? weightedConvictionSum / totalWeightFloat : 0;
+  const averageConviction = totalWeight.gt(0) ? weightedConvictionSum.div(totalWeight).toNumber() : 0;
 
   return { activeVotingAccounts, totalLocked, averageConviction };
 }

--- a/src/renderer/features/dashboard-governance/hooks/useGovernanceBreakdown.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useGovernanceBreakdown.ts
@@ -57,7 +57,6 @@ export const useGovernanceBreakdown = ({ votingMap, chainSummary, accountIds, al
     for (const [accountId, trackVoting] of Object.entries(votingMap)) {
       if (!accountIdSet.has(accountId)) continue;
 
-      // Compute max lock and weighted average conviction across all tracks for this account
       let maxLock = BN_ZERO;
       let totalWeight = new BigNumber(0);
       let weightedConvictionSum = new BigNumber(0);

--- a/src/renderer/features/dashboard-governance/hooks/useGovernanceBreakdown.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useGovernanceBreakdown.ts
@@ -1,0 +1,134 @@
+import { BN_ZERO } from '@polkadot/util';
+import { default as BigNumber } from 'bignumber.js';
+import { useUnit } from 'effector-react';
+import { useMemo } from 'react';
+
+import { type VotingMap } from '@/shared/core';
+import { getRoundedValue } from '@/shared/lib/utils';
+import { useAssetsPrices } from '@/domains/price';
+import { votingService } from '@/entities/governance';
+import { currencySelect } from '@/aggregates/currency-select';
+
+import { type ChainGovernanceSummary } from './useGovernanceOverview';
+
+export type GovernanceBreakdownRow = {
+  accountId: string;
+  name: string;
+  address: string;
+  rawAmount: string;
+  rawAmountNum: number;
+  fiatValue: string;
+  fiatValueNum: number;
+  sharePercent: number;
+  averageConviction: number;
+  precision: number;
+  symbol: string;
+  colorIndex: number;
+};
+
+export type EntryLike = { accountId: string; name: string; address: string };
+
+type Params = {
+  votingMap: VotingMap;
+  chainSummary: ChainGovernanceSummary;
+  accountIds: string[];
+  allEntries: EntryLike[];
+};
+
+export const useGovernanceBreakdown = ({ votingMap, chainSummary, accountIds, allEntries }: Params) => {
+  const currency = useUnit(currencySelect.$activeCurrency);
+  const pricesParams = useUnit(currencySelect.$currentPricesParams);
+  const { data: prices } = useAssetsPrices(pricesParams);
+
+  return useMemo(() => {
+    if (!prices || !currency) return { rows: [] };
+
+    const entryMap = new Map<string, { name: string; address: string }>();
+    for (const entry of allEntries) {
+      entryMap.set(entry.accountId, { name: entry.name, address: entry.address });
+    }
+
+    const priceItem = prices[chainSummary.priceId]?.[currency.coingeckoId];
+    const accountIdSet = new Set(accountIds);
+
+    const rawRows: GovernanceBreakdownRow[] = [];
+    let totalFiat = new BigNumber(0);
+
+    for (const [accountId, trackVoting] of Object.entries(votingMap)) {
+      if (!accountIdSet.has(accountId)) continue;
+
+      // Compute max lock and weighted average conviction across all tracks for this account
+      let maxLock = BN_ZERO;
+      let totalWeight = new BigNumber(0);
+      let weightedConvictionSum = new BigNumber(0);
+
+      for (const voting of Object.values(trackVoting)) {
+        if (votingService.isCasting(voting)) {
+          for (const vote of Object.values(voting.votes)) {
+            const amount = votingService.calculateAccountVoteAmount(vote);
+            if (amount.gt(maxLock)) {
+              maxLock = amount;
+            }
+            const conviction = votingService.getAccountVoteConviction(vote);
+            const multiplier = votingService.getConvictionMultiplier(conviction);
+            const weight = new BigNumber(amount.toString());
+            totalWeight = totalWeight.plus(weight);
+            weightedConvictionSum = weightedConvictionSum.plus(weight.times(multiplier));
+          }
+          if (voting.prior?.amount && voting.prior.amount.gt(maxLock)) {
+            maxLock = voting.prior.amount;
+          }
+        } else if (votingService.isDelegating(voting)) {
+          if (voting.balance.gt(maxLock)) {
+            maxLock = voting.balance;
+          }
+          const multiplier = votingService.getConvictionMultiplier(voting.conviction);
+          const weight = new BigNumber(voting.balance.toString());
+          totalWeight = totalWeight.plus(weight);
+          weightedConvictionSum = weightedConvictionSum.plus(weight.times(multiplier));
+          if (voting.prior?.amount && voting.prior.amount.gt(maxLock)) {
+            maxLock = voting.prior.amount;
+          }
+        }
+      }
+
+      if (maxLock.isZero()) continue;
+
+      const averageConviction = totalWeight.gt(0) ? weightedConvictionSum.div(totalWeight).toNumber() : 0;
+
+      const fiat = priceItem
+        ? new BigNumber(getRoundedValue(maxLock.toString(), priceItem.price, chainSummary.precision))
+        : new BigNumber(0);
+
+      totalFiat = totalFiat.plus(fiat);
+
+      const entry = entryMap.get(accountId);
+      rawRows.push({
+        accountId,
+        name: entry?.name ?? '',
+        address: entry?.address ?? '',
+        rawAmount: maxLock.toString(),
+        rawAmountNum: new BigNumber(maxLock.toString()).toNumber(),
+        fiatValue: fiat.toString(),
+        fiatValueNum: fiat.toNumber(),
+        sharePercent: 0,
+        averageConviction,
+        precision: chainSummary.precision,
+        symbol: chainSummary.symbol,
+        colorIndex: 0,
+      });
+    }
+
+    rawRows.sort((a, b) => b.fiatValueNum - a.fiatValueNum);
+
+    for (let i = 0; i < rawRows.length; i++) {
+      const row = rawRows[i]!;
+      row.colorIndex = i;
+      row.sharePercent = totalFiat.gt(0)
+        ? Math.round(new BigNumber(row.fiatValue).div(totalFiat).times(1000).toNumber()) / 10
+        : 0;
+    }
+
+    return { rows: rawRows };
+  }, [votingMap, chainSummary, accountIds, allEntries, prices, currency]);
+};

--- a/src/renderer/features/dashboard-governance/hooks/useGovernanceOverview.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useGovernanceOverview.ts
@@ -2,7 +2,7 @@ import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { type ChainId, type TrackInfo, type VotingMap } from '@/shared/core';
+import { type ChainId, type VotingMap } from '@/shared/core';
 import { getRoundedValue } from '@/shared/lib/utils';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
 import { currencySelect } from '@/aggregates/currency-select';
@@ -19,7 +19,6 @@ export type ChainGovernanceSummary = ChainGovernanceData & {
 export type GovernanceOverviewResult = {
   chains: ChainGovernanceSummary[];
   votingMapByChain: Record<ChainId, VotingMap>;
-  tracksByChain: Record<ChainId, Record<string, TrackInfo>>;
   totalFiat: string | null;
   pending: boolean;
   fiatFlag: boolean | null;
@@ -76,18 +75,9 @@ export const useGovernanceOverview = (accountIds: string[]): GovernanceOverviewR
     return map;
   }, [polkadotData, kusamaData]);
 
-  const tracksByChain = useMemo(() => {
-    const map: Record<ChainId, Record<string, TrackInfo>> = {};
-    if (polkadotData) map[POLKADOT_AH_CHAIN_ID] = polkadotData.tracks;
-    if (kusamaData) map[KUSAMA_AH_CHAIN_ID] = kusamaData.tracks;
-
-    return map;
-  }, [polkadotData, kusamaData]);
-
   return {
     ...result,
     votingMapByChain,
-    tracksByChain,
     pending:
       accountIds.length > 0 &&
       ((polkadotData === null && kusamaData === null) ||

--- a/src/renderer/features/dashboard-governance/hooks/useGovernanceOverview.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useGovernanceOverview.ts
@@ -2,7 +2,7 @@ import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { type ChainId } from '@/shared/core';
+import { type ChainId, type TrackInfo, type VotingMap } from '@/shared/core';
 import { getRoundedValue } from '@/shared/lib/utils';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
 import { currencySelect } from '@/aggregates/currency-select';
@@ -18,6 +18,8 @@ export type ChainGovernanceSummary = ChainGovernanceData & {
 
 export type GovernanceOverviewResult = {
   chains: ChainGovernanceSummary[];
+  votingMapByChain: Record<ChainId, VotingMap>;
+  tracksByChain: Record<ChainId, Record<string, TrackInfo>>;
   totalFiat: string | null;
   pending: boolean;
   fiatFlag: boolean | null;
@@ -66,8 +68,26 @@ export const useGovernanceOverview = (accountIds: string[]): GovernanceOverviewR
     return { chains: summaries, totalFiat: grandTotal.toString() };
   }, [polkadotData, kusamaData, prices, currency]);
 
+  const votingMapByChain = useMemo(() => {
+    const map: Record<ChainId, VotingMap> = {};
+    if (polkadotData) map[POLKADOT_AH_CHAIN_ID] = polkadotData.votingMap;
+    if (kusamaData) map[KUSAMA_AH_CHAIN_ID] = kusamaData.votingMap;
+
+    return map;
+  }, [polkadotData, kusamaData]);
+
+  const tracksByChain = useMemo(() => {
+    const map: Record<ChainId, Record<string, TrackInfo>> = {};
+    if (polkadotData) map[POLKADOT_AH_CHAIN_ID] = polkadotData.tracks;
+    if (kusamaData) map[KUSAMA_AH_CHAIN_ID] = kusamaData.tracks;
+
+    return map;
+  }, [polkadotData, kusamaData]);
+
   return {
     ...result,
+    votingMapByChain,
+    tracksByChain,
     pending:
       accountIds.length > 0 &&
       ((polkadotData === null && kusamaData === null) ||

--- a/src/renderer/features/dashboard-governance/ui/AccountTracksModal.tsx
+++ b/src/renderer/features/dashboard-governance/ui/AccountTracksModal.tsx
@@ -1,0 +1,265 @@
+import { BN_ZERO } from '@polkadot/util';
+import { default as BigNumber } from 'bignumber.js';
+import { useUnit } from 'effector-react';
+import { memo, useMemo } from 'react';
+import { Pie, PieChart, Tooltip } from 'recharts';
+
+import { type TrackId, type VotingMap } from '@/shared/core';
+import { useI18n } from '@/shared/i18n';
+import { formatBalance, getRoundedValue, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { FootnoteText } from '@/shared/ui';
+import { FALLBACK_COLORS } from '@/shared/ui/chart-constants';
+import { Identicon, getTrackMeta } from '@/shared/ui-entities';
+import { type Column, Modal, Table } from '@/shared/ui-kit';
+import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
+import { votingService } from '@/entities/governance';
+import { currencySelect } from '@/aggregates/currency-select';
+import { type ChainGovernanceSummary } from '../hooks/useGovernanceOverview';
+
+import { ChartTooltip } from './ChartTooltip';
+import { Price } from './Price';
+
+type TrackBreakdownRow = {
+  trackId: TrackId;
+  trackName: string;
+  rawAmount: string;
+  rawAmountNum: number;
+  conviction: string;
+  fiatValue: string;
+  fiatValueNum: number;
+  sharePercent: number;
+  precision: number;
+  symbol: string;
+  colorIndex: number;
+};
+
+type Props = {
+  accountId: string;
+  accountName: string;
+  accountAddress: string;
+  votingMap: VotingMap;
+  chainSummary: ChainGovernanceSummary;
+  currency: CurrencyItem | null;
+  onClose: () => void;
+};
+
+export const AccountTracksModal = memo(
+  ({ accountId, accountName, accountAddress, votingMap, chainSummary, currency, onClose }: Props) => {
+    const { t } = useI18n();
+    const activeCurrency = useUnit(currencySelect.$activeCurrency);
+    const pricesParams = useUnit(currencySelect.$currentPricesParams);
+    const { data: prices } = useAssetsPrices(pricesParams);
+
+    const rows = useMemo(() => {
+      const trackVoting = votingMap[accountId as keyof typeof votingMap];
+      if (!trackVoting) return [];
+
+      const cur = activeCurrency ?? currency;
+      const priceItem = cur && prices ? prices[chainSummary.priceId]?.[cur.coingeckoId] : null;
+
+      const rawRows: TrackBreakdownRow[] = [];
+      let totalFiat = new BigNumber(0);
+
+      for (const [trackId, voting] of Object.entries(trackVoting)) {
+        let lockAmount = BN_ZERO;
+        let conviction = 'None';
+
+        if (votingService.isCasting(voting)) {
+          for (const vote of Object.values(voting.votes)) {
+            const amount = votingService.calculateAccountVoteAmount(vote);
+            if (amount.gt(lockAmount)) {
+              lockAmount = amount;
+              conviction = votingService.getAccountVoteConviction(vote);
+            }
+          }
+          if (voting.prior?.amount && voting.prior.amount.gt(lockAmount)) {
+            lockAmount = voting.prior.amount;
+          }
+        } else if (votingService.isDelegating(voting)) {
+          lockAmount = voting.balance;
+          conviction = voting.conviction;
+          if (voting.prior?.amount && voting.prior.amount.gt(lockAmount)) {
+            lockAmount = voting.prior.amount;
+          }
+        }
+
+        if (lockAmount.isZero()) continue;
+
+        const fiat = priceItem
+          ? new BigNumber(getRoundedValue(lockAmount.toString(), priceItem.price, chainSummary.precision))
+          : new BigNumber(0);
+
+        totalFiat = totalFiat.plus(fiat);
+
+        const multiplier = votingService.getConvictionMultiplier(
+          conviction as Parameters<typeof votingService.getConvictionMultiplier>[0],
+        );
+        const convictionDisplay = conviction === 'None' ? 'None' : `${multiplier}x`;
+
+        const trackMeta = getTrackMeta(trackId);
+
+        rawRows.push({
+          trackId,
+          trackName: t(trackMeta.title),
+          rawAmount: lockAmount.toString(),
+          rawAmountNum: new BigNumber(lockAmount.toString()).toNumber(),
+          conviction: convictionDisplay,
+          fiatValue: fiat.toString(),
+          fiatValueNum: fiat.toNumber(),
+          sharePercent: 0,
+          precision: chainSummary.precision,
+          symbol: chainSummary.symbol,
+          colorIndex: 0,
+        });
+      }
+
+      rawRows.sort((a, b) => b.fiatValueNum - a.fiatValueNum);
+
+      for (let i = 0; i < rawRows.length; i++) {
+        const row = rawRows[i]!;
+        row.colorIndex = i;
+        row.sharePercent = totalFiat.gt(0)
+          ? Math.round(new BigNumber(row.fiatValue).div(totalFiat).times(1000).toNumber()) / 10
+          : 0;
+      }
+
+      return rawRows;
+    }, [accountId, votingMap, chainSummary, prices, activeCurrency, currency, t]);
+
+    const chartData = useMemo(() => {
+      const totalFiat = rows.reduce((sum, r) => sum + r.fiatValueNum, 0);
+
+      return rows
+        .map((row, i) => ({
+          name: row.trackName,
+          value: row.fiatValueNum,
+          percent: totalFiat > 0 ? (row.fiatValueNum / totalFiat) * 100 : 0,
+          index: i,
+          fill: FALLBACK_COLORS[i % FALLBACK_COLORS.length],
+        }))
+        .filter((d) => d.value > 0);
+    }, [rows]);
+
+    const displayName = accountName || toShortAddress(accountAddress);
+
+    const totalLocked = useMemo(() => {
+      return rows.reduce((max, row) => {
+        const rowBN = new BigNumber(row.rawAmount);
+
+        return rowBN.gt(max) ? rowBN : max;
+      }, new BigNumber(0));
+    }, [rows]);
+
+    const { formatted, suffix } = formatBalance(totalLocked.toString(), chainSummary.precision);
+
+    const columns: Column<TrackBreakdownRow>[] = useMemo(
+      () => [
+        {
+          key: 'trackName',
+          title: t('dashboard.governanceOverview.trackDetail.track'),
+          width: '40%',
+          render: (_, item) => (
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: FALLBACK_COLORS[item.colorIndex % FALLBACK_COLORS.length] }}
+              />
+              <FootnoteText className="truncate font-semibold">{item.trackName}</FootnoteText>
+            </div>
+          ),
+        },
+        {
+          key: 'rawAmountNum',
+          title: t('dashboard.governanceOverview.trackDetail.locked'),
+          sortable: true,
+          width: '20%',
+          render: (_, item) => {
+            const bal = formatBalance(item.rawAmount, item.precision);
+
+            return (
+              <FootnoteText className="tabular-nums">
+                {bal.formatted}
+                {bal.suffix} {item.symbol}
+              </FootnoteText>
+            );
+          },
+        },
+        {
+          key: 'conviction',
+          title: t('dashboard.governanceOverview.trackDetail.conviction'),
+          width: '12%',
+          render: (_, item) => <FootnoteText className="tabular-nums">{item.conviction}</FootnoteText>,
+        },
+        {
+          key: 'fiatValueNum',
+          title: t('dashboard.governanceOverview.trackDetail.value'),
+          sortable: true,
+          width: '16%',
+          render: (_, item) => (
+            <FootnoteText className="tabular-nums">
+              <Price amount={item.fiatValue} currency={currency} />
+            </FootnoteText>
+          ),
+        },
+        {
+          key: 'sharePercent',
+          title: t('dashboard.governanceOverview.trackDetail.share'),
+          sortable: true,
+          width: '12%',
+          render: (_, item) => (
+            <FootnoteText className="tabular-nums">
+              {}
+              {item.sharePercent.toFixed(1)}%
+            </FootnoteText>
+          ),
+        },
+      ],
+      [t, currency],
+    );
+
+    const showChart = chartData.length > 0;
+
+    return (
+      <Modal isOpen size="lg" onToggle={(open) => !open && onClose()}>
+        <Modal.Title close>{t('dashboard.governanceOverview.trackDetail.title', { account: displayName })}</Modal.Title>
+        <Modal.Content disableScroll>
+          <div className="flex items-center gap-3 px-5 py-3">
+            <Identicon address={toAddress(accountAddress)} size={32} />
+            <div className="min-w-0 flex-1">
+              <FootnoteText className="font-bold">{displayName}</FootnoteText>
+              <FootnoteText className="text-text-tertiary">{toShortAddress(accountAddress)}</FootnoteText>
+            </div>
+            <div className="shrink-0">
+              <FootnoteText align="right" className="font-bold tabular-nums">
+                {formatted}
+                {suffix ? ` ${suffix}` : ''} {chainSummary.symbol}
+              </FootnoteText>
+            </div>
+          </div>
+
+          <div className="border-t border-divider" />
+
+          {showChart && (
+            <div className="flex justify-center px-5 py-3">
+              <PieChart width={180} height={180}>
+                <Pie
+                  data={chartData}
+                  innerRadius={55}
+                  outerRadius={85}
+                  dataKey="value"
+                  stroke="none"
+                  animationDuration={400}
+                />
+                <Tooltip content={<ChartTooltip />} />
+              </PieChart>
+            </div>
+          )}
+
+          <div className="overflow-y-auto px-5 pb-4" style={{ maxHeight: 440 }}>
+            <Table columns={columns} data={rows} />
+          </div>
+        </Modal.Content>
+      </Modal>
+    );
+  },
+);

--- a/src/renderer/features/dashboard-governance/ui/AccountTracksModal.tsx
+++ b/src/renderer/features/dashboard-governance/ui/AccountTracksModal.tsx
@@ -4,7 +4,7 @@ import { useUnit } from 'effector-react';
 import { memo, useMemo } from 'react';
 import { Pie, PieChart, Tooltip } from 'recharts';
 
-import { type TrackId, type VotingMap } from '@/shared/core';
+import { type Conviction, type TrackId, type VotingMap } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance, getRoundedValue, toAddress, toShortAddress } from '@/shared/lib/utils';
 import { FootnoteText } from '@/shared/ui';
@@ -46,23 +46,22 @@ type Props = {
 export const AccountTracksModal = memo(
   ({ accountId, accountName, accountAddress, votingMap, chainSummary, currency, onClose }: Props) => {
     const { t } = useI18n();
-    const activeCurrency = useUnit(currencySelect.$activeCurrency);
     const pricesParams = useUnit(currencySelect.$currentPricesParams);
     const { data: prices } = useAssetsPrices(pricesParams);
 
     const rows = useMemo(() => {
-      const trackVoting = votingMap[accountId as keyof typeof votingMap];
+      const typedAccountId = accountId as keyof VotingMap;
+      const trackVoting = votingMap[typedAccountId];
       if (!trackVoting) return [];
 
-      const cur = activeCurrency ?? currency;
-      const priceItem = cur && prices ? prices[chainSummary.priceId]?.[cur.coingeckoId] : null;
+      const priceItem = currency && prices ? prices[chainSummary.priceId]?.[currency.coingeckoId] : null;
 
       const rawRows: TrackBreakdownRow[] = [];
       let totalFiat = new BigNumber(0);
 
       for (const [trackId, voting] of Object.entries(trackVoting)) {
         let lockAmount = BN_ZERO;
-        let conviction = 'None';
+        let conviction: Conviction = 'None';
 
         if (votingService.isCasting(voting)) {
           for (const vote of Object.values(voting.votes)) {
@@ -91,9 +90,7 @@ export const AccountTracksModal = memo(
 
         totalFiat = totalFiat.plus(fiat);
 
-        const multiplier = votingService.getConvictionMultiplier(
-          conviction as Parameters<typeof votingService.getConvictionMultiplier>[0],
-        );
+        const multiplier = votingService.getConvictionMultiplier(conviction);
         const convictionDisplay = conviction === 'None' ? 'None' : `${multiplier}x`;
 
         const trackMeta = getTrackMeta(trackId);
@@ -124,7 +121,7 @@ export const AccountTracksModal = memo(
       }
 
       return rawRows;
-    }, [accountId, votingMap, chainSummary, prices, activeCurrency, currency, t]);
+    }, [accountId, votingMap, chainSummary, prices, currency, t]);
 
     const chartData = useMemo(() => {
       const totalFiat = rows.reduce((sum, r) => sum + r.fiatValueNum, 0);
@@ -208,7 +205,7 @@ export const AccountTracksModal = memo(
           width: '12%',
           render: (_, item) => (
             <FootnoteText className="tabular-nums">
-              {}
+              {/* eslint-disable-next-line i18next/no-literal-string */}
               {item.sharePercent.toFixed(1)}%
             </FootnoteText>
           ),

--- a/src/renderer/features/dashboard-governance/ui/ChartTooltip.tsx
+++ b/src/renderer/features/dashboard-governance/ui/ChartTooltip.tsx
@@ -1,0 +1,32 @@
+import { memo } from 'react';
+
+import { CHART_TOOLTIP_STYLE } from '@/shared/ui/chart-constants';
+
+type TooltipEntry = {
+  name: string;
+  percent: number;
+};
+
+type TooltipPayloadItem = {
+  payload: TooltipEntry;
+};
+
+type Props = {
+  active?: boolean;
+  payload?: TooltipPayloadItem[];
+};
+
+export const ChartTooltip = memo(({ active, payload }: Props) => {
+  if (!active || !payload?.length) return null;
+
+  const item = payload[0];
+  if (!item) return null;
+
+  return (
+    <div style={CHART_TOOLTIP_STYLE}>
+      <div style={{ fontWeight: 600 }}>{item.payload.name}</div>
+      {/* eslint-disable-next-line i18next/no-literal-string */}
+      <div>{item.payload.percent.toFixed(1)}%</div>
+    </div>
+  );
+});

--- a/src/renderer/features/dashboard-governance/ui/GovernanceDetailModal.tsx
+++ b/src/renderer/features/dashboard-governance/ui/GovernanceDetailModal.tsx
@@ -1,0 +1,202 @@
+import { memo, useCallback, useMemo, useState } from 'react';
+import { Pie, PieChart, Tooltip } from 'recharts';
+
+import { type VotingMap } from '@/shared/core';
+import { useI18n } from '@/shared/i18n';
+import { formatBalance, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { FootnoteText, Icon } from '@/shared/ui';
+import { FALLBACK_COLORS } from '@/shared/ui/chart-constants';
+import { Identicon } from '@/shared/ui-entities';
+import { type Column, Modal, Table } from '@/shared/ui-kit';
+import { type CurrencyItem } from '@/domains/price';
+import { type EntryLike, type GovernanceBreakdownRow, useGovernanceBreakdown } from '../hooks/useGovernanceBreakdown';
+import { type ChainGovernanceSummary } from '../hooks/useGovernanceOverview';
+
+import { AccountTracksModal } from './AccountTracksModal';
+import { ChartTooltip } from './ChartTooltip';
+import { Price } from './Price';
+
+type Props = {
+  chainSummary: ChainGovernanceSummary;
+  votingMap: VotingMap;
+  accountIds: string[];
+  allEntries: EntryLike[];
+  currency: CurrencyItem | null;
+  onClose: () => void;
+};
+
+export const GovernanceDetailModal = memo(
+  ({ chainSummary, votingMap, accountIds, allEntries, currency, onClose }: Props) => {
+    const { t } = useI18n();
+    const { rows } = useGovernanceBreakdown({ votingMap, chainSummary, accountIds, allEntries });
+    const { formatted, suffix } = formatBalance(chainSummary.totalLocked, chainSummary.precision);
+    const [selectedAccountId, setSelectedAccountId] = useState<string | null>(null);
+
+    const chartData = useMemo(() => {
+      const totalFiat = rows.reduce((sum, r) => sum + r.fiatValueNum, 0);
+
+      return rows
+        .map((row, i) => ({
+          name: row.name || toShortAddress(row.address),
+          value: row.fiatValueNum,
+          percent: totalFiat > 0 ? (row.fiatValueNum / totalFiat) * 100 : 0,
+          index: i,
+          fill: FALLBACK_COLORS[i % FALLBACK_COLORS.length],
+        }))
+        .filter((d) => d.value > 0);
+    }, [rows]);
+
+    const columns: Column<GovernanceBreakdownRow>[] = useMemo(
+      () => [
+        {
+          key: 'name',
+          title: t('dashboard.governanceOverview.governanceDetail.account'),
+          width: '30%',
+          render: (_, item) => (
+            <div className="flex items-center gap-2">
+              <span
+                className="h-2 w-2 shrink-0 rounded-full"
+                style={{ backgroundColor: FALLBACK_COLORS[item.colorIndex % FALLBACK_COLORS.length] }}
+              />
+              <Identicon address={toAddress(item.address)} />
+              <div className="min-w-0">
+                <FootnoteText className="truncate font-semibold">{item.name}</FootnoteText>
+                <FootnoteText className="text-text-tertiary">{toShortAddress(item.address)}</FootnoteText>
+              </div>
+            </div>
+          ),
+        },
+        {
+          key: 'rawAmountNum',
+          title: t('dashboard.governanceOverview.governanceDetail.locked'),
+          sortable: true,
+          width: '20%',
+          render: (_, item) => {
+            const bal = formatBalance(item.rawAmount, item.precision);
+
+            return (
+              <FootnoteText className="tabular-nums">
+                {bal.formatted}
+                {bal.suffix} {item.symbol}
+              </FootnoteText>
+            );
+          },
+        },
+        {
+          key: 'averageConviction',
+          title: t('dashboard.governanceOverview.governanceDetail.conviction'),
+          sortable: true,
+          width: '12%',
+          render: (_, item) => (
+            <FootnoteText className="tabular-nums">
+              {t('dashboard.governanceOverview.convictionDisplay', {
+                value: item.averageConviction.toFixed(1),
+              })}
+            </FootnoteText>
+          ),
+        },
+        {
+          key: 'fiatValueNum',
+          title: t('dashboard.governanceOverview.governanceDetail.value'),
+          sortable: true,
+          width: '16%',
+          render: (_, item) => (
+            <FootnoteText className="tabular-nums">
+              <Price amount={item.fiatValue} currency={currency} />
+            </FootnoteText>
+          ),
+        },
+        {
+          key: 'sharePercent',
+          title: t('dashboard.governanceOverview.governanceDetail.share'),
+          sortable: true,
+          width: '14%',
+          render: (_, item) => (
+            <FootnoteText className="tabular-nums">
+              {/* eslint-disable-next-line i18next/no-literal-string */}
+              {item.sharePercent.toFixed(1)}%
+            </FootnoteText>
+          ),
+        },
+        {
+          key: 'accountId',
+          title: '',
+          width: '8%',
+          render: () => <Icon name="right" size={16} className="text-text-tertiary" />,
+        },
+      ],
+      [t, currency],
+    );
+
+    const handleRowClick = useCallback((row: GovernanceBreakdownRow) => setSelectedAccountId(row.accountId), []);
+    const handleClearSelection = useCallback(() => setSelectedAccountId(null), []);
+
+    const showChart = chartData.length > 0;
+
+    const selectedRow = selectedAccountId ? rows.find((r) => r.accountId === selectedAccountId) : null;
+
+    return (
+      <>
+        <Modal isOpen size="lg" onToggle={(open) => !open && onClose()}>
+          <Modal.Title close>
+            {t('dashboard.governanceOverview.governanceDetail.title', { chain: chainSummary.chainName })}
+          </Modal.Title>
+          <Modal.Content disableScroll>
+            <div className="flex items-center gap-3 px-5 py-3">
+              <img src={chainSummary.icon.colored} alt={chainSummary.chainName} className="h-8 w-8" />
+              <div className="min-w-0 flex-1">
+                <FootnoteText className="font-bold">{chainSummary.chainName}</FootnoteText>
+                <FootnoteText className="text-text-tertiary">
+                  {t('dashboard.governanceOverview.governanceDetail.accountCount', { count: rows.length })}
+                </FootnoteText>
+              </div>
+              <div className="shrink-0">
+                <FootnoteText align="right" className="font-bold tabular-nums">
+                  {formatted}
+                  {suffix ? ` ${suffix}` : ''} {chainSummary.symbol}
+                </FootnoteText>
+                <FootnoteText align="right" className="text-text-tertiary tabular-nums">
+                  <Price amount={chainSummary.totalLockedFiat} currency={currency} />
+                </FootnoteText>
+              </div>
+            </div>
+
+            <div className="border-t border-divider" />
+
+            {showChart && (
+              <div className="flex justify-center px-5 py-3">
+                <PieChart width={180} height={180}>
+                  <Pie
+                    data={chartData}
+                    innerRadius={55}
+                    outerRadius={85}
+                    dataKey="value"
+                    stroke="none"
+                    animationDuration={400}
+                  />
+                  <Tooltip content={<ChartTooltip />} />
+                </PieChart>
+              </div>
+            )}
+
+            <div className="overflow-y-auto px-5 pb-4" style={{ maxHeight: 440 }}>
+              <Table columns={columns} data={rows} onRowClick={handleRowClick} />
+            </div>
+          </Modal.Content>
+        </Modal>
+
+        {selectedRow && (
+          <AccountTracksModal
+            accountId={selectedRow.accountId}
+            accountName={selectedRow.name}
+            accountAddress={selectedRow.address}
+            votingMap={votingMap}
+            chainSummary={chainSummary}
+            currency={currency}
+            onClose={handleClearSelection}
+          />
+        )}
+      </>
+    );
+  },
+);

--- a/src/renderer/features/dashboard-governance/ui/GovernanceOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-governance/ui/GovernanceOverviewWidget.tsx
@@ -1,6 +1,7 @@
-import { memo, useDeferredValue } from 'react';
+import { memo, useCallback, useDeferredValue, useState } from 'react';
 import { Pie, PieChart, Tooltip } from 'recharts';
 
+import { type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
@@ -9,6 +10,7 @@ import { Skeleton } from '@/shared/ui-kit';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { type ChainGovernanceSummary, useGovernanceOverview } from '../hooks/useGovernanceOverview';
 
+import { GovernanceDetailModal } from './GovernanceDetailModal';
 import { Price } from './Price';
 
 type Props = {
@@ -16,10 +18,14 @@ type Props = {
   allEntries: { accountId: string; name: string; address: string }[];
 };
 
-export const GovernanceOverviewWidget = ({ accountIds }: Props) => {
+export const GovernanceOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const { t } = useI18n();
   const deferredAccountIds = useDeferredValue(accountIds);
-  const { chains, totalFiat, pending, fiatFlag, currency } = useGovernanceOverview(deferredAccountIds);
+  const { chains, votingMapByChain, totalFiat, pending, fiatFlag, currency } =
+    useGovernanceOverview(deferredAccountIds);
+  const [selectedChainId, setSelectedChainId] = useState<ChainId | null>(null);
+
+  const handleCloseDetail = useCallback(() => setSelectedChainId(null), []);
 
   if (!fiatFlag) return null;
 
@@ -35,6 +41,8 @@ export const GovernanceOverviewWidget = ({ accountIds }: Props) => {
     );
   }
 
+  const selectedChain = selectedChainId ? chains.find((c) => c.chainId === selectedChainId) : null;
+
   return (
     <DashboardWidget colSpan={2}>
       <FootnoteText className="text-text-tertiary">{t('dashboard.governanceOverview.title')}</FootnoteText>
@@ -49,7 +57,13 @@ export const GovernanceOverviewWidget = ({ accountIds }: Props) => {
             <LockAllocationChart chains={chains} />
             <div className="flex flex-1 flex-col gap-3">
               {chains.map((chain) => (
-                <ChainRow key={chain.chainId} chain={chain} currency={currency} t={t} />
+                <ChainRow
+                  key={chain.chainId}
+                  chain={chain}
+                  currency={currency}
+                  t={t}
+                  onClick={() => setSelectedChainId(chain.chainId)}
+                />
               ))}
             </div>
           </div>
@@ -68,6 +82,17 @@ export const GovernanceOverviewWidget = ({ accountIds }: Props) => {
           <Skeleton width="100%" height={10} />
         </div>
       )}
+
+      {selectedChain && (
+        <GovernanceDetailModal
+          chainSummary={selectedChain}
+          votingMap={votingMapByChain[selectedChain.chainId] ?? {}}
+          accountIds={accountIds}
+          allEntries={allEntries}
+          currency={currency}
+          onClose={handleCloseDetail}
+        />
+      )}
     </DashboardWidget>
   );
 };
@@ -76,16 +101,20 @@ type ChainRowProps = {
   chain: ChainGovernanceSummary;
   currency: ReturnType<typeof useGovernanceOverview>['currency'];
   t: ReturnType<typeof useI18n>['t'];
+  onClick: () => void;
 };
 
-const ChainRow = memo(({ chain, currency, t }: ChainRowProps) => {
+const ChainRow = memo(({ chain, currency, t, onClick }: ChainRowProps) => {
   const { formatted, suffix } = formatBalance(chain.totalLocked, chain.precision);
   const { formatted: claimFormatted, suffix: claimSuffix } = formatBalance(chain.claimableAmount, chain.precision);
   const hasClaimable = chain.claimableAmount !== '0';
 
   return (
     <div>
-      <div className="flex items-center justify-between rounded-md px-2 py-1">
+      <div
+        className="flex cursor-pointer items-center justify-between rounded-md px-2 py-1 hover:bg-hover"
+        onClick={onClick}
+      >
         <div className="flex items-center gap-2">
           <img src={chain.icon.colored} alt={chain.chainName} className="h-6 w-6" />
           <div>

--- a/src/renderer/features/dashboard-governance/ui/GovernanceOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-governance/ui/GovernanceOverviewWidget.tsx
@@ -5,11 +5,12 @@ import { type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
-import { CHART_TOOLTIP_STYLE, getColorByPriceId } from '@/shared/ui/chart-constants';
+import { getColorByPriceId } from '@/shared/ui/chart-constants';
 import { Skeleton } from '@/shared/ui-kit';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { type ChainGovernanceSummary, useGovernanceOverview } from '../hooks/useGovernanceOverview';
 
+import { ChartTooltip } from './ChartTooltip';
 import { GovernanceDetailModal } from './GovernanceDetailModal';
 import { Price } from './Price';
 
@@ -146,25 +147,6 @@ const ChainRow = memo(({ chain, currency, t, onClick }: ChainRowProps) => {
           </FootnoteText>
         </div>
       )}
-    </div>
-  );
-});
-
-type ChartTooltipProps = {
-  active?: boolean;
-  payload?: { payload: { name: string; percent: number } }[];
-};
-
-const ChartTooltip = memo(({ active, payload }: ChartTooltipProps) => {
-  if (!active || !payload?.length) return null;
-  const item = payload[0];
-  if (!item) return null;
-
-  return (
-    <div style={CHART_TOOLTIP_STYLE}>
-      <div style={{ fontWeight: 600 }}>{item.payload.name}</div>
-      {/* eslint-disable-next-line i18next/no-literal-string */}
-      <div>{item.payload.percent.toFixed(1)}%</div>
     </div>
   );
 });

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -631,7 +631,25 @@
       "unlockable": "Claimable",
       "averageConviction": "Avg. conviction",
       "noGovernance": "No governance activity found",
-      "convictionDisplay": "{value}x"
+      "convictionDisplay": "{value}x",
+      "governanceDetail": {
+        "title": "Governance \u2014 {chain}",
+        "account": "Account",
+        "locked": "Locked",
+        "conviction": "Avg. conviction",
+        "value": "Value",
+        "share": "Share",
+        "accountCount_one": "{count} voting account",
+        "accountCount_other": "{count} voting accounts"
+      },
+      "trackDetail": {
+        "title": "Tracks \u2014 {account}",
+        "track": "Track",
+        "locked": "Locked",
+        "conviction": "Conviction",
+        "value": "Value",
+        "share": "Share"
+      }
     },
     "referendums": {
       "activeTab": "Active",


### PR DESCRIPTION
## Summary
- Clicking a chain row in Governance Overview opens a detail modal with per-account lock distribution (pie chart + sortable table)
- Clicking an account row drills into a second modal showing per-track breakdown with conviction and lock amounts
- Conviction averages are weighted by vote balance (both in overview and detail modals)
- Pie charts render even with a single item

## Test plan
- [ ] Open Dashboard with accounts that have governance activity on Polkadot/Kusama
- [ ] Click a chain row in Governance Overview → verify detail modal opens with correct account breakdown
- [ ] Verify pie chart, locked amounts, fiat values, share percentages, and weighted avg conviction per account
- [ ] Click an account row → verify tracks modal opens with per-track breakdown
- [ ] Verify track names, locked amounts, conviction display, and pie chart
- [ ] Close modals via X button and clicking outside
- [ ] Verify single-account and single-track scenarios still show pie chart

🤖 Generated with [Claude Code](https://claude.com/claude-code)