### PR TITLE
fix(dashboard): prevent claimable tokens flicker during referendum pagination

### DIFF
--- a/src/renderer/domains/governance/index.ts
+++ b/src/renderer/domains/governance/index.ts
@@ -3,7 +3,7 @@ export { type ReferendumSummary, referendumSummaryResource } from './referendum-
 export { useReferendumSummary } from './referendum-summary/hooks';
 export type { ReferendumSummaryRequestParams } from './referendum-summary/resource';
 
-export { subscriptionResource as referendumSubscriptionResource } from './referendum/resource';
+export { $referendumsFullyLoaded, subscriptionResource as referendumSubscriptionResource } from './referendum/resource';
 export { useReferendums } from './referendum/hooks';
 export type { ReferendumSubscriptionParams } from './referendum/resource';
 

--- a/src/renderer/domains/governance/referendum/resource.ts
+++ b/src/renderer/domains/governance/referendum/resource.ts
@@ -1,5 +1,5 @@
 import { type ApiPromise } from '@polkadot/api';
-import { createStore } from 'effector';
+import { createEvent, createStore, scopeBind } from 'effector';
 
 import { type ChainId, type Referendum } from '@/shared/core';
 import { merge } from '@/shared/lib/utils';
@@ -10,15 +10,28 @@ export type ReferendumSubscriptionParams = {
   api: ApiPromise;
 };
 
+const referendumsFullyLoaded = createEvent<string>();
+
+export const $referendumsFullyLoaded = createStore<Record<string, boolean>>({}).on(
+  referendumsFullyLoaded,
+  (state, key) => (state[key] ? state : { ...state, [key]: true }),
+);
+
 const $sharedReferendumsCache = createStore<Record<ChainId, Referendum[]>>({});
 
 export const subscriptionResource = createSubscriptionResource<ReferendumSubscriptionParams>({
   key: ({ api }) => [api.genesisHash.toHex()],
 })
   .subscribe<Referendum[]>(({ api }, callback) => {
+    const genesisHash = api.genesisHash.toHex();
+    const boundFullyLoaded = scopeBind(referendumsFullyLoaded, { safe: true });
+
     return governanceSubscribeService.subscribeReferendums(api, result => {
       if (result.value) {
         callback(result.value);
+      }
+      if (result.done) {
+        boundFullyLoaded(genesisHash);
       }
     });
   })

--- a/src/renderer/features/dashboard-governance/hooks/claimScheduleCache.ts
+++ b/src/renderer/features/dashboard-governance/hooks/claimScheduleCache.ts
@@ -5,6 +5,7 @@ type CacheEntry = {
   block: number;
   votingRef: object;
   trackLocksRef: object;
+  referendumsRef: object;
   result: Chunks[];
 };
 
@@ -20,6 +21,7 @@ export function cachedEstimateClaimSchedule(
   params: Parameters<typeof claimScheduleService.estimateClaimSchedule>[0],
   votingRef: object,
   trackLocksRef: object,
+  referendumsRef: object,
 ): Chunks[] {
   const entry = cache.get(accountId);
 
@@ -27,13 +29,14 @@ export function cachedEstimateClaimSchedule(
     entry &&
     entry.block === params.currentBlockNumber &&
     entry.votingRef === votingRef &&
-    entry.trackLocksRef === trackLocksRef
+    entry.trackLocksRef === trackLocksRef &&
+    entry.referendumsRef === referendumsRef
   ) {
     return entry.result;
   }
 
   const result = claimScheduleService.estimateClaimSchedule(params);
-  cache.set(accountId, { block: params.currentBlockNumber, votingRef, trackLocksRef, result });
+  cache.set(accountId, { block: params.currentBlockNumber, votingRef, trackLocksRef, referendumsRef, result });
 
   return result;
 }

--- a/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useChainGovernanceData.ts
@@ -1,6 +1,6 @@
 import { BN, BN_ZERO } from '@polkadot/util';
 import { default as BigNumber } from 'bignumber.js';
-import { useUnit } from 'effector-react';
+import { useStoreMap, useUnit } from 'effector-react';
 import { useMemo, useRef } from 'react';
 
 import { type Chunks, UnlockChunkType } from '@/shared/api/governance';
@@ -8,7 +8,14 @@ import { type ChainId, type TrackInfo, type VotingMap } from '@/shared/core';
 import { useThrottledSnapshot } from '@/shared/lib/hooks';
 import { entries, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { useReferendums, useTrackLocks, useTracks, useUndecidingTimeout, useVoting } from '@/domains/governance';
+import {
+  $referendumsFullyLoaded,
+  useReferendums,
+  useTrackLocks,
+  useTracks,
+  useUndecidingTimeout,
+  useVoting,
+} from '@/domains/governance';
 import { useBlock, useBlockTime } from '@/domains/network';
 import { locksService, votingService } from '@/entities/governance';
 import { networkModel, useApi } from '@/entities/network';
@@ -160,6 +167,12 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
   }, [rawVotingMap, typedAccountIds]);
 
   const { data: referendums } = useReferendums({ api });
+  const genesisHash = api?.genesisHash.toHex() ?? null;
+  const referendumsFullyLoaded = useStoreMap({
+    store: $referendumsFullyLoaded,
+    keys: [genesisHash],
+    fn: (state, [key]) => (key ? (state[key] ?? false) : false),
+  });
   const { data: undecidingTimeout } = useUndecidingTimeout({ api });
 
   const { data: trackLocks } = useTrackLocks({
@@ -177,7 +190,8 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
       typedAccountIds.length === 0 ||
       Object.keys(votingMap).length === 0 ||
       referendums.length === 0 ||
-      Object.keys(tracks).length === 0
+      Object.keys(tracks).length === 0 ||
+      !referendumsFullyLoaded
     ) {
       return EMPTY_CLAIM;
     }
@@ -206,6 +220,7 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
         },
         votingByTrack,
         accountTrackLocks,
+        referendums,
       );
 
       collectChunks(schedule, accountId, allChunks);
@@ -220,7 +235,17 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
     }
 
     return { claimable: totalClaimable, unlockChunks: allChunks, delegated: totalDelegated };
-  }, [api, currentBlock, typedAccountIds, votingMap, referendums, tracks, trackLocks, undecidingTimeout]);
+  }, [
+    api,
+    currentBlock,
+    typedAccountIds,
+    votingMap,
+    referendums,
+    tracks,
+    trackLocks,
+    undecidingTimeout,
+    referendumsFullyLoaded,
+  ]);
 
   const stats = useMemo(() => computeGovernanceStats(votingMap), [votingMap]);
 
@@ -228,7 +253,7 @@ export const useChainGovernanceData = (chainId: ChainId, accountIds: string[]) =
   // Flip when pending states resolve (not when data appears), so accounts with
   // no governance activity don't get stuck in skeleton.
   const hasEverLoaded = useRef(false);
-  if (api && !tracksPending && !votingPending && currentBlock !== null) {
+  if (api && !tracksPending && !votingPending && currentBlock !== null && referendumsFullyLoaded) {
     hasEverLoaded.current = true;
   }
 

--- a/src/renderer/features/dashboard-governance/hooks/useEndedReferendums.ts
+++ b/src/renderer/features/dashboard-governance/hooks/useEndedReferendums.ts
@@ -168,6 +168,7 @@ function useChainEndedReferendums(
         },
         trackVoting,
         accountTrackLocks,
+        referendums,
       );
 
       for (const chunk of schedule) {


### PR DESCRIPTION
## Summary
- Fix race condition where claimable governance tokens briefly appear then disappear during paginated referendum loading
- Track referendum loading completion via `$referendumsFullyLoaded` Effector store — skeleton shown until all pages arrive
- Fix `claimScheduleCache` to invalidate when the referendum array reference changes

## Root Cause
Referendums load page-by-page (500/page). The claim schedule was calculated after the first page, and `maxConvictionEndOf()` treated not-yet-loaded referendums as cancelled (immediately claimable via `currentBlockNumber` fallback). When remaining pages arrived with the actual referendum data, the correct conviction end time was calculated and the claimable amount vanished.

## Test plan
- [ ] `pnpm types:go` passes
- [ ] `pnpm test` passes (1189 tests)
- [ ] `pnpm lint` passes (0 errors)
- [ ] Manual: open dashboard with governance accounts, verify skeleton shows until all referendum pages load, then correct claimable amount appears without flickering
- [ ] Manual: verify no regression for accounts with no governance activity

🤖 Generated with [Claude Code](https://claude.com/claude-code)