### PR TITLE
feat(SPEK-270): add address with correct prefix

### DIFF
--- a/src/renderer/pages/Dashboard/model/__tests__/apply-preset-filter.test.ts
+++ b/src/renderer/pages/Dashboard/model/__tests__/apply-preset-filter.test.ts
@@ -1,12 +1,13 @@
 import { describe, expect, it } from 'vitest';
 
+import { type Address } from '@/shared/core';
 import { type PresetFilterCriteria } from '@/aggregates/dashboard-presets';
 import { type DashboardEntry, applyPresetFilter } from '../dashboard-model';
 
 const wallet: DashboardEntry = {
   id: 'w1',
   name: 'Main Wallet',
-  address: '0x1',
+  address: '0x1' as Address,
   accountId: '0x1',
   source: 'wallet',
 };
@@ -14,7 +15,7 @@ const wallet: DashboardEntry = {
 const localContact: DashboardEntry = {
   id: 'lc1',
   name: 'Alice Local',
-  address: '0x2',
+  address: '0x2' as Address,
   accountId: '0x2',
   source: 'local-contact',
 };
@@ -22,7 +23,7 @@ const localContact: DashboardEntry = {
 const backendContact: DashboardEntry = {
   id: 'bc1',
   name: 'Bob Backend',
-  address: '0x3',
+  address: '0x3' as Address,
   accountId: '0x3',
   source: 'backend-contact',
   entityNames: ['Parity', 'W3F'],
@@ -33,7 +34,7 @@ const backendContact: DashboardEntry = {
 const backendContact2: DashboardEntry = {
   id: 'bc2',
   name: 'Charlie Backend',
-  address: '0x4',
+  address: '0x4' as Address,
   accountId: '0x4',
   source: 'backend-contact',
   entityNames: ['W3F'],

--- a/src/renderer/pages/Dashboard/model/dashboard-model.ts
+++ b/src/renderer/pages/Dashboard/model/dashboard-model.ts
@@ -1,17 +1,18 @@
 import { combine, createEvent, createStore } from 'effector';
 import { persist } from 'effector-storage/local';
 
-import { type ID, type WalletType } from '@/shared/core';
+import { type Address, type ID, type WalletType } from '@/shared/core';
 import { type ContactTag } from '@/shared/core/types/contact';
 import { toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
+import { networkModel } from '@/entities/network';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { type PresetFilterCriteria, dashboardPresetsModel } from '@/aggregates/dashboard-presets';
 
 type DashboardEntry = {
   id: string;
   name: string;
-  address: string;
+  address: Address;
   accountId: string;
   source: 'wallet' | 'local-contact' | 'backend-contact';
   walletId?: ID;
@@ -62,8 +63,9 @@ const $allEntries = combine(
     accountsWithWallets: $accountsWithWallets,
     localContacts: contactModel.$localContacts,
     backendContacts: contactModel.$backendContacts,
+    chains: networkModel.$chains,
   },
-  ({ accountsWithWallets: { accounts, wallets }, localContacts, backendContacts }): DashboardEntry[] => {
+  ({ accountsWithWallets: { accounts, wallets }, localContacts, backendContacts, chains }): DashboardEntry[] => {
     const walletNameById = new Map(wallets.map((w) => [w.id, w.name]));
     const walletTypeById = new Map(wallets.map((w) => [w.id, w.type]));
     const entries: DashboardEntry[] = [];
@@ -71,10 +73,12 @@ const $allEntries = combine(
     for (const account of accounts) {
       if (accountUtils.isMultisigSignatoryAccount(account)) continue;
 
+      const addressPrefix = account.type === 'chain' ? chains[account.chainId]?.addressPrefix : undefined;
+
       entries.push({
         id: account.id,
         name: account.name,
-        address: toAddress(account.accountId),
+        address: toAddress(account.accountId, { prefix: addressPrefix }),
         accountId: account.accountId,
         source: 'wallet',
         walletId: account.walletId,

--- a/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
@@ -1,8 +1,8 @@
 import { type ReactNode, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { cnTw, includes, toAddress } from '@/shared/lib/utils';
-import { FootnoteText } from '@/shared/ui';
+import { cnTw, includes, toShortAddress } from '@/shared/lib/utils';
+import { CaptionText, FootnoteText } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
 import { Checkbox, Input, SearchInput } from '@/shared/ui-kit';
 import { type DashboardEntry } from '@/pages/Dashboard/model/dashboard-model';
@@ -103,11 +103,12 @@ export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameCha
             onClick={() => toggleEntry(entry.id)}
           >
             <Checkbox checked={selectedSet.has(entry.id)} onChange={() => toggleEntry(entry.id)} />
-            <div className="pointer-events-none shrink-0">
-              <Identicon address={toAddress(entry.address)} size={24} canCopy={false} />
+            <div className="shrink-0">
+              <Identicon address={entry.address} size={24} canCopy />
             </div>
             <div className="min-w-0 flex-1">
               <FootnoteText className="truncate text-text-primary">{entry.name}</FootnoteText>
+              <CaptionText className="text-text-tertiary">{toShortAddress(entry.address, 6)}</CaptionText>
             </div>
             <div className="flex shrink-0 items-center gap-x-1">
               {entry.entityNames && entry.entityNames.length > 0 && (

--- a/src/renderer/widgets/PresetManagementModal/ui/MatchedAccountsPreview.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/MatchedAccountsPreview.tsx
@@ -1,7 +1,7 @@
 import { type ReactNode, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { cnTw, includes, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { cnTw, includes, toShortAddress } from '@/shared/lib/utils';
 import { CaptionText, FootnoteText } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
 import { SearchInput } from '@/shared/ui-kit';
@@ -68,8 +68,8 @@ export const MatchedAccountsPreview = ({ allEntries, filters }: Props) => {
         <div className="max-h-40 overflow-y-auto rounded-sm">
           {visible.map((entry) => (
             <div key={entry.id} className="flex items-center gap-x-2 rounded px-2 py-1.5">
-              <div className="pointer-events-none shrink-0">
-                <Identicon address={toAddress(entry.address)} size={24} canCopy={false} />
+              <div className="shrink-0">
+                <Identicon address={entry.address} size={24} canCopy />
               </div>
               <div className="min-w-0 flex-1">
                 <FootnoteText className="truncate text-text-primary">{entry.name}</FootnoteText>


### PR DESCRIPTION
## Description
The dashboard preset selector was showing all addresses in Polkadot format regardless of the actual chain. Chain-specific accounts (proxies, flexible multisigs) now encode addresses using their chain's SS58 prefix. DashboardEntry.address is typed as Address to prevent silent re-encoding downstream.

Additionally, the custom selection tab now shows short addresses below account names (matching the smart filter tab), and identicons in both tabs support click-to-copy.

## Related Issues
Relates to SPEK-270

## Changes Made

- Encode chain-specific account addresses with the correct SS58 prefix by joining networkModel.$chains into $allEntries
- Type DashboardEntry.address as Address branded type instead of string
- Show short address in the custom selection tab (consistent with smart filter tab)
- Enable click-to-copy on identicons in both tabs

## Screenshots/Recordings
<img width="1438" height="673" alt="Снимок экрана 2026-03-31 в 19 32 45" src="https://github.com/user-attachments/assets/c8bec037-fcd1-47da-8c83-06e6a703b8c1" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
