### PR TITLE
fix(dashboard): polish governance dates, referenda rename & UX tweaks

### DIFF
--- a/src/renderer/features/dashboard-governance/ui/EndedReferendumDetailModal.tsx
+++ b/src/renderer/features/dashboard-governance/ui/EndedReferendumDetailModal.tsx
@@ -14,12 +14,8 @@ type Props = {
   onClose: () => void;
 };
 
-function formatUnlockDate(ms: number): string {
-  return new Date(ms).toLocaleDateString('en', { month: 'short', day: 'numeric', year: 'numeric' });
-}
-
 export const EndedReferendumDetailModal = memo(({ referendum, onClose }: Props) => {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
 
   const { formatted: lockedFormatted } = formatBalance(referendum.totalLockedAmount, referendum.precision);
   const outcomeLabel = t(`dashboard.referendums.${OUTCOME_I18N_KEY[referendum.outcome]}`);
@@ -98,7 +94,7 @@ export const EndedReferendumDetailModal = memo(({ referendum, onClose }: Props) 
           if (item.unlockAtMs) {
             return (
               <FootnoteText className="text-text-warning">
-                {t('dashboard.referendums.lockedUntil', { date: formatUnlockDate(item.unlockAtMs) })}
+                {t('dashboard.referendums.lockedUntil', { date: formatDate(item.unlockAtMs, 'MMM d, yyyy') })}
               </FootnoteText>
             );
           }
@@ -137,7 +133,7 @@ export const EndedReferendumDetailModal = memo(({ referendum, onClose }: Props) 
         {/* End date + locked amount */}
         <div className="flex items-center justify-between px-5 py-2">
           <FootnoteText className="text-text-tertiary">
-            {t('dashboard.referendums.detail.endedDate', { date: formatEndDate(referendum.endedAtMs, t) })}
+            {t('dashboard.referendums.detail.endedDate', { date: formatEndDate(referendum.endedAtMs, t, formatDate) })}
           </FootnoteText>
           <FootnoteText className="font-bold tabular-nums">
             {lockedFormatted} {referendum.symbol}

--- a/src/renderer/features/dashboard-governance/ui/ReferendumsWidget.tsx
+++ b/src/renderer/features/dashboard-governance/ui/ReferendumsWidget.tsx
@@ -467,7 +467,7 @@ type EndedTabContentProps = {
 };
 
 const EndedTabContent = ({ accountIds, allEntries, chainFilter, searchQuery, onCountChange }: EndedTabContentProps) => {
-  const { t } = useI18n();
+  const { t, formatDate } = useI18n();
   const { referendums: endedRefs, pending: endedPending } = useEndedReferendums(accountIds, allEntries);
   const [selectedEnded, setSelectedEnded] = useState<EndedReferendum | null>(null);
 
@@ -518,7 +518,7 @@ const EndedTabContent = ({ accountIds, allEntries, chainFilter, searchQuery, onC
         sortable: true,
         width: '90px',
         render: (_v, row) => (
-          <FootnoteText className="text-text-tertiary">{formatEndDate(row.endedAtMs, t)}</FootnoteText>
+          <FootnoteText className="text-text-tertiary">{formatEndDate(row.endedAtMs, t, formatDate)}</FootnoteText>
         ),
       },
       {

--- a/src/renderer/features/dashboard-governance/ui/referendum-helpers.ts
+++ b/src/renderer/features/dashboard-governance/ui/referendum-helpers.ts
@@ -2,6 +2,8 @@ import { type TFunction } from 'i18next';
 
 import { type EndedReferendum } from '../hooks/useEndedReferendums';
 
+type FormatDate = (date: Date | number, format: string) => string;
+
 const DAY = 86_400_000;
 
 export const OUTCOME_STYLES: Record<EndedReferendum['outcome'], string> = {
@@ -20,11 +22,11 @@ export const OUTCOME_I18N_KEY: Record<EndedReferendum['outcome'], string> = {
   Killed: 'killed',
 };
 
-export function formatEndDate(ms: number, t: TFunction): string {
+export function formatEndDate(ms: number, t: TFunction, formatDate: FormatDate): string {
   const daysAgo = Math.floor((Date.now() - ms) / DAY);
   if (daysAgo === 0) return t('dashboard.referendums.time.today');
   if (daysAgo === 1) return t('dashboard.referendums.time.daysAgo', { count: 1 });
   if (daysAgo < 30) return t('dashboard.referendums.time.daysAgo', { count: daysAgo });
 
-  return new Date(ms).toLocaleDateString(undefined, { month: 'short', day: 'numeric' });
+  return formatDate(ms, 'MMM d, yyyy');
 }

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBar.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBar.tsx
@@ -26,17 +26,19 @@ export const AllocationBar = memo(({ allocation }: Props) => {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <div className="bg-input-border-disabled flex h-1.5 w-full overflow-hidden rounded-full">
-          {SEGMENTS.map(
-            (seg) =>
-              allocation[seg.key] > 0 && (
-                <div
-                  key={seg.key}
-                  className="h-full"
-                  style={{ width: `${allocation[seg.key]}%`, backgroundColor: seg.color }}
-                />
-              ),
-          )}
+        <div className="relative before:absolute before:inset-x-0 before:-inset-y-2 before:content-['']">
+          <div className="bg-input-border-disabled flex h-1.5 w-full overflow-hidden rounded-full">
+            {SEGMENTS.map(
+              (seg) =>
+                allocation[seg.key] > 0 && (
+                  <div
+                    key={seg.key}
+                    className="h-full"
+                    style={{ width: `${allocation[seg.key]}%`, backgroundColor: seg.color }}
+                  />
+                ),
+            )}
+          </div>
         </div>
       </Tooltip.Trigger>
       <Tooltip.Content>

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
@@ -25,7 +25,7 @@ type Props = {
   allEntries: EntryLike[];
 };
 
-const toggleButtonClass = 'flex-1 rounded px-3 py-1 text-footnote font-semibold transition-colors';
+const toggleButtonClass = 'flex-1 cursor-pointer rounded px-3 py-1 text-footnote font-semibold transition-colors';
 const activeToggleClass = 'bg-white text-text-primary shadow-sm';
 const inactiveToggleClass = 'text-text-tertiary hover:text-text-secondary';
 

--- a/src/renderer/features/dashboard-staking/ui/TotalRewardsWidget.tsx
+++ b/src/renderer/features/dashboard-staking/ui/TotalRewardsWidget.tsx
@@ -29,7 +29,7 @@ const SINCE_OFFSETS: Record<Exclude<RewardsTimeRange, 'all'>, number> = {
   '1y': 365 * 24 * 3600,
 };
 
-const toggleButtonClass = 'flex-1 rounded px-3 py-1 text-footnote font-semibold transition-colors';
+const toggleButtonClass = 'flex-1 cursor-pointer rounded px-3 py-1 text-footnote font-semibold transition-colors';
 const activeClass = 'bg-white text-text-primary shadow-sm';
 const inactiveClass = 'text-text-tertiary hover:text-text-secondary';
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -688,7 +688,7 @@
       "accountCount": "{count} accounts"
     },
     "activeReferendums": {
-      "title": "Referendums",
+      "title": "Referenda",
       "noReferendums": "No active referendums found",
       "aye": "Aye",
       "nay": "Nay",


### PR DESCRIPTION
## Summary
- **Governance dates**: ended referendum dates now include year and always render in English via `formatDate` from date-fns (replaces raw `toLocaleDateString`)
- **Referenda rename**: widget title changed from "Referendums" to "Referenda"
- **Cursor pointer**: added missing `cursor-pointer` to portfolio "By Asset/By Chain" and staking time-range toggle buttons
- **AllocationBar hover**: expanded tooltip hover area using a pseudo-element so users don't have to land exactly on the 6px bar

## Test plan
- [ ] Open Governance → Ended tab, verify dates show year (e.g. "Jan 15, 2026") and are always in English regardless of system locale
- [ ] Open ended referendum detail modal, verify ended date and unlock date include year
- [ ] Verify widget title reads "Referenda" not "Referendums"
- [ ] Hover portfolio "By Asset" / "By Chain" toggles — cursor should be pointer
- [ ] Hover staking "7D / 1M / 6M / 1Y / Max" toggles — cursor should be pointer
- [ ] Hover AllocationBar in asset/chain detail modals — tooltip should appear easily

🤖 Generated with [Claude Code](https://claude.com/claude-code)