### PR TITLE
fix(dashboard): filter contact-chain pairs by address scheme

### DIFF
--- a/src/renderer/features/dashboard-portfolio-overview/index.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/index.ts
@@ -2,6 +2,7 @@ import { combine, createStore, sample } from 'effector';
 
 import { $features } from '@/shared/config/features';
 import { createFeature } from '@/shared/feature';
+import { accountService } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { balanceSubModel } from '@/features/assets-balances';
 import { dashboardWidgetsSlot } from '@/pages/Dashboard';
@@ -24,7 +25,12 @@ sample({
 sample({
   clock: combine(dashboardModel.$selectedContactAccountIds, networkModel.$chainsList),
   filter: ([accountIds]) => accountIds.length > 0,
-  fn: ([accountIds, chains]) => chains.flatMap((chain) => accountIds.map((accountId) => ({ accountId, chain }))),
+  fn: ([accountIds, chains]) =>
+    chains.flatMap((chain) =>
+      accountIds
+        .filter((accountId) => accountService.isAccountSchemeMatchChain(accountId, chain))
+        .map((accountId) => ({ accountId, chain })),
+    ),
   target: balanceSubModel.fetchAccountIds,
 });
 


### PR DESCRIPTION
## Summary
- Ethereum-style contacts (20-byte addresses, e.g. Moonbeam/Astar EVM) were paired with all chains — including Substrate chains expecting 32-byte AccountIds — causing `Invalid AccountId provided, expected 32 bytes, found 20` RPC errors
- Added `accountService.isAccountSchemeMatchChain` filter so contacts only fetch balances on scheme-compatible chains
- Uses the same compatibility check already used by `balanceSubModel.fetchAccounts` for wallet accounts

## Test plan
- [ ] Add a contact with an Ethereum-compatible address (e.g. Moonbeam)
- [ ] Select that contact on the Dashboard
- [ ] Verify no `createType(Vec<StorageKey>)` console errors
- [ ] Verify balances load correctly on EVM-compatible chains
- [ ] Add a Substrate contact and verify balances still load on Substrate chains

🤖 Generated with [Claude Code](https://claude.com/claude-code)