### PR TITLE
fix(contacts): delete stale backend contacts from IndexedDB during sync

### DIFF
--- a/src/renderer/entities/contact/model/contact-model.ts
+++ b/src/renderer/entities/contact/model/contact-model.ts
@@ -73,6 +73,14 @@ const deleteContactFx = createEffect(async (contactId: string): Promise<string> 
 });
 
 const syncBackendContactsFx = createEffect(async (contacts: Contact[]): Promise<Contact[]> => {
+  const all = await storageService.contacts.readAll();
+  const oldBackendIds = all.filter((c) => c.source === 'backend').map((c) => c.id);
+  const newIds = new Set(contacts.map((c) => c.id));
+  const staleIds = oldBackendIds.filter((id) => !newIds.has(id));
+
+  if (staleIds.length > 0) {
+    await storageService.contacts.deleteAll(staleIds);
+  }
   await storageService.contacts.insertAll(contacts);
 
   return contacts;


### PR DESCRIPTION
## Summary
- Fix removed backend contacts reappearing after app restart
- `syncBackendContactsFx` now deletes stale backend contacts from IndexedDB before upserting the new set
- The in-memory Effector store was already correct; only the IndexedDB persistence layer was missing deletions

## Root Cause
`syncBackendContactsFx` called `insertAll` (upsert) but never removed contacts that were deleted from the backend. On restart, `populateContactsFx` read all contacts from IndexedDB — including stale ones — causing them to reappear.

## Test plan
- [ ] Connect to backend with contacts, verify they appear on dashboard
- [ ] Remove contacts from the external address book, trigger sync
- [ ] Verify removed contacts disappear from dashboard
- [ ] Restart the app — verify removed contacts do not reappear
- [ ] Verify local contacts are unaffected by the sync

🤖 Generated with [Claude Code](https://claude.com/claude-code)