### PR TITLE
feat: add cursor pointer and expand hover area

### DIFF
--- a/src/renderer/features/dashboard-governance/ui/ReferendumsWidget.tsx
+++ b/src/renderer/features/dashboard-governance/ui/ReferendumsWidget.tsx
@@ -301,7 +301,7 @@ const TabButton = memo(
     <button
       type="button"
       className={cnTw(
-        'flex items-center gap-2 rounded-md px-3 py-1.5 text-footnote font-semibold transition-colors',
+        'flex cursor-pointer items-center gap-2 rounded-md px-3 py-1.5 text-footnote font-semibold transition-colors',
         active ? 'bg-selected-background text-text-primary' : 'text-text-tertiary hover:text-text-secondary',
       )}
       onClick={onClick}

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBar.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBar.tsx
@@ -26,7 +26,7 @@ export const AllocationBar = memo(({ allocation }: Props) => {
   return (
     <Tooltip>
       <Tooltip.Trigger>
-        <div className="relative before:absolute before:inset-x-0 before:-inset-y-2 before:content-['']">
+        <div className="relative w-full before:absolute before:inset-x-0 before:-inset-y-2 before:content-['']">
           <div className="bg-input-border-disabled flex h-1.5 w-full overflow-hidden rounded-full">
             {SEGMENTS.map(
               (seg) =>


### PR DESCRIPTION
## Description
Two small cursor/hover fixes on the Dashboard:

1. The Active/Ended tab buttons in the Referenda widget showed an arrow cursor on hover instead of a pointer, because <button> elements get cursor: default from Tailwind's preflight reset and no override was applied.
2. The Asset Allocation bar in the Portfolio Overview modals (Asset Detail / Chain Detail) was rendering narrower than its table cell because the Radix asChild trigger wrapper lacked an explicit w-full, causing both the visible bar and the before: hover-area pseudo-element to size to content rather than filling the column.

## Screenshots/Recordings

https://github.com/user-attachments/assets/a8f0a077-4a67-4ad2-b6c4-b6d0d50d7f56

## Changes made

- Added cursor-pointer to the TabButton component in ReferendumsWidget so the Active/Ended tabs show the correct pointer cursor on hover
- Added w-full to the outer wrapper div in AllocationBar so the bar and its extended hover area fill the full table column width in AssetDetailModal and ChainDetailModal

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
