### PR TITLE
feat(dashboard): fix share rounding

### DIFF
--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
@@ -107,7 +107,7 @@ export const useChainBreakdown = (chainId: ChainId, accountIds: string[]): Chain
           rawAmountNum: group.totalRaw.toNumber(),
           fiatValue: group.fiatValue.toString(),
           fiatValueNum: fiatNum,
-          sharePercent: Math.round(share * 10) / 10,
+          sharePercent: share,
           colorIndex: 0,
         };
       })

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
@@ -104,7 +104,7 @@ export const useHoldingBreakdown = (priceId: string, accountIds: string[], allEn
           rawAmountNum: group.totalRaw.toNumber(),
           fiatValue: group.fiatValue.toString(),
           fiatValueNum: fiatNum,
-          sharePercent: Math.round(share * 10) / 10,
+          sharePercent: share,
           precision: group.precision,
           symbol: group.symbol,
           colorIndex: 0,

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
@@ -1,3 +1,4 @@
+import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { memo, useMemo } from 'react';
 import { Cell, Pie, PieChart, Tooltip } from 'recharts';
@@ -44,7 +45,7 @@ const ChartTooltip = memo(({ active, payload }: { active?: boolean; payload?: To
   return (
     <div style={CHART_TOOLTIP_STYLE}>
       <div style={{ fontWeight: 600 }}>{row.name || toShortAddress(row.address)}</div>
-      <div>{row.sharePercent.toFixed(1)}%</div>
+      <div>{new BigNumber(row.sharePercent).decimalPlaces(1, BigNumber.ROUND_DOWN).toFixed(1)}%</div>
     </div>
   );
 });
@@ -141,7 +142,11 @@ export const AssetDetailModal = memo(({ holding, accountIds, allEntries, currenc
         title: t('dashboard.portfolioOverview.assetDetail.share'),
         sortable: true,
         width: '15%',
-        render: (_, item) => <FootnoteText className="tabular-nums">{item.sharePercent.toFixed(1)}%</FootnoteText>,
+        render: (_, item) => (
+          <FootnoteText className="tabular-nums">
+            {new BigNumber(item.sharePercent).decimalPlaces(1, BigNumber.ROUND_DOWN).toFixed(1)}%
+          </FootnoteText>
+        ),
       },
       {
         key: 'allocation',

--- a/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
@@ -1,3 +1,4 @@
+import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { memo, useMemo } from 'react';
 import { Pie, PieChart, Tooltip } from 'recharts';
@@ -49,7 +50,7 @@ const ChartTooltip = memo(({ active, payload }: { active?: boolean; payload?: To
         {formatted}
         {suffix} {row.symbol}
       </div>
-      <div>{row.sharePercent.toFixed(1)}%</div>
+      <div>{new BigNumber(row.sharePercent).decimalPlaces(1, BigNumber.ROUND_DOWN).toFixed(1)}%</div>
     </div>
   );
 });
@@ -139,7 +140,11 @@ export const ChainDetailModal = memo(({ chainHolding, accountIds, currency, onCl
         title: t('dashboard.portfolioOverview.chainDetail.share'),
         sortable: true,
         width: '15%',
-        render: (_, item) => <FootnoteText className="tabular-nums">{item.sharePercent.toFixed(1)}%</FootnoteText>,
+        render: (_, item) => (
+          <FootnoteText className="tabular-nums">
+            {new BigNumber(item.sharePercent).decimalPlaces(1, BigNumber.ROUND_DOWN).toFixed(1)}%
+          </FootnoteText>
+        ),
       },
       {
         key: 'allocation',


### PR DESCRIPTION
## Description
In the Dashboard Portfolio Overview, the Share column in Asset Detail and Chain Detail modals was incorrectly displaying 100.0% for holdings with a dominant but non-100% share (e.g. 99.95%). This happened due to double rounding: the hooks pre-rounded share values with Math.round(share * 10) / 10 (rounding 99.95 → 100.0), and the display then applied .toFixed(1) on top. The same issue affected both the table cell and the pie chart tooltip.

The fix removes pre-rounding from the model layer (share is now stored as a raw number) and applies BigNumber.ROUND_DOWN at display time — consistent with the app-wide truncation convention used in formatBalance, formatFiatBalance, and getRoundedValue. A 99.95% share now correctly displays as 99.9%.

## Related Issues
SPEK-347

## Changes Made

- Removed Math.round(share * 10) / 10 pre-rounding in useHoldingBreakdown.ts and useChainBreakdown.ts — share percentage is now stored as a raw value
- Updated AssetDetailModal.tsx and ChainDetailModal.tsx to format share using new BigNumber(share).decimalPlaces(1, BigNumber.ROUND_DOWN).toFixed(1) in both the table column and the pie chart tooltip

## Screenshots/Recordings
#### Before:
<img width="659" height="631" alt="Снимок экрана 2026-04-03 в 09 40 13" src="https://github.com/user-attachments/assets/052bc4ff-7d79-44be-a178-55604f56c0be" />

#### After:
<img width="615" height="579" alt="Снимок экрана 2026-04-03 в 17 05 16" src="https://github.com/user-attachments/assets/4342104c-cf6d-4a1c-b483-88d3e958506c" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
