### PR TITLE
feat: fix self-notification

### DIFF
--- a/src/renderer/features/multisig-operations/model/notifications.ts
+++ b/src/renderer/features/multisig-operations/model/notifications.ts
@@ -293,20 +293,23 @@ const operationChanges = pairwise(multisigOperation.$list)
       newOperations.length > 0 || statusChanges.length > 0 || removedKeys.length > 0 || newEvents.length > 0,
   });
 
+const $allAccounts = accounts.$list;
+
 sample({
   clock: operationChanges,
   source: {
     populated: multisigOperation.$populated,
     anyMultisigAccounts: $anyMultisigAccounts,
+    allAccounts: $allAccounts,
     chains: networkModel.$chains,
   },
   filter: ({ populated }) => populated,
-  fn: ({ anyMultisigAccounts, chains }, { newOperations, statusChanges, removedKeys, newEvents }) => {
+  fn: ({ anyMultisigAccounts, allAccounts, chains }, { newOperations, statusChanges, removedKeys, newEvents }) => {
     // Filter new operations - apply timestamp filter to exclude operations created before account was connected
     const newOperationNotifications = newOperations
       .filter(operation => {
-        // Don't notify the operation creator
-        if (operation.status === 'pending' && anyMultisigAccounts.some(a => a.accountId === operation.depositor)) {
+        // Don't notify the operation creator (depositor is a signatory account, not a multisig account)
+        if (operation.status === 'pending' && allAccounts.some(a => a.accountId === operation.depositor)) {
           return false;
         }
 


### PR DESCRIPTION
## Description
When a user creates a multisig operation, they were incorrectly receiving a "Multisig operation created" notification about their own action. Only the other signatories should be notified.

The root cause was a type mismatch in the creator-suppression check: operation.depositor is the signatory's AccountId (a regular wallet account), but the check compared it against anyMultisigAccounts — which contains multisig account IDs. Since these are different account types, the check never matched and the creator was always notified.

The fix expands the source to include all accounts (accounts.$list) and checks the depositor against those instead.

## Related Issues
SPEK-346

## Changes Made

- Fixed creator notification suppression in features/multisig-operations/model/notifications.ts — compare operation.depositor against all wallet accounts (accounts.$list) instead of multisig accounts only

## Screenshots/Recordings

https://github.com/user-attachments/assets/f7d4ea9f-b382-4cad-91c4-786bad258591



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
