### PR TITLE
feat: show regular multisig operations properly

### DIFF
--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -142,7 +142,8 @@ const $operationsWithAccounts = combine(
         const key = `${op.proxiedAccountId}:${op.multisigAccountId}`;
         return byAccountId.get(key)?.find(a => accountUtils.isFlexibleMultisigAccount(a));
       }
-      return byMultisigAccountId.get(op.multisigAccountId)?.[0];
+      const candidates = byMultisigAccountId.get(op.multisigAccountId);
+      return candidates?.find(a => accountUtils.isMultisigAccount(a)) ?? candidates?.[0];
     };
 
     const result: OperationWithAccount[] = [];
@@ -164,14 +165,7 @@ const $filteredOperations = combine(
     multisigWallets: $multisigWallets,
     chains: networkModel.$chains,
   },
-  ({
-    operationsWithAccounts,
-    filter,
-    tab,
-    hiddenIds,
-    multisigWallets,
-    chains,
-  }): OperationWithAccount[] => {
+  ({ operationsWithAccounts, filter, tab, hiddenIds, multisigWallets, chains }): OperationWithAccount[] => {
     return operationsWithAccounts.filter(({ operation, account }) =>
       filterOperation(operation, account, {
         filters: filter,


### PR DESCRIPTION
## Description
When a user submits an operation from a regular multisig wallet, it was incorrectly displayed as a flex multisig operation on the Operations page.

The root cause was in findAccount inside $operationsWithAccounts. The byMultisigAccountId map stores both MultisigAccount and FlexibleMultisigAccount entries under the same key when a flex multisig and a regular multisig share the same underlying multisig address (which is the normal setup — a flex multisig IS a proxy over a regular multisig). The fallback ?.[0] returned whichever account was inserted first, often the flex one, causing regular operations to render with the wrong UI.

The fix adds an explicit preference for AccountType.MULTISIG when resolving non-proxied operations, only falling back to [0] if no regular account exists in the candidates.

## Related Issues
Related to [SPEK-345](https://novasama-technologies.atlassian.net/browse/SPEK-345)

## Changes Made

- Fixed findAccount in features/multisig-operations/model/context.ts to prefer MultisigAccount over FlexibleMultisigAccount when resolving operations with no proxiedAccountId

## Screenshots/Recordings
<img width="883" height="610" alt="Снимок экрана 2026-04-03 в 16 37 35" src="https://github.com/user-attachments/assets/d5e4202f-249a-4f8d-9a06-1f72020db630" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines


[SPEK-345]: https://novasama-technologies.atlassian.net/browse/SPEK-345?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ