### PR TITLE
fix: deduplicate account preset entries by accountId

### DIFF
--- a/src/renderer/aggregates/account-presets/model.ts
+++ b/src/renderer/aggregates/account-presets/model.ts
@@ -1,5 +1,6 @@
 import { combine, createEvent, createStore, sample } from 'effector';
 import { persist } from 'effector-storage/local';
+import { uniqBy } from 'lodash';
 
 import { toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
@@ -196,7 +197,7 @@ const $allEntries = combine(
       });
     }
 
-    return entries;
+    return uniqBy(entries, 'accountId');
   },
 );
 


### PR DESCRIPTION
## Summary
- Fix duplicate entries in account presets when the same `accountId` exists in both local and backend contact sources
- Use `lodash.uniqBy` to deduplicate `$allEntries` by `accountId`

## Test plan
- [ ] Verify contacts with overlapping accountIds across local/backend sources appear only once in preset lists
- [ ] Verify existing preset functionality works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)