### PR TITLE
chore: improve CLAUDE.md, fix docs, clean up stale tasks

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,13 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 Nova Spektr is a Polkadot & Kusama ecosystem Enterprise Desktop application built with Electron, React, and TypeScript. It's a multi-wallet application supporting hardware wallets (Polkadot Vault), multisig accounts, staking, and cross-chain transfers.
 
+<!-- SYNC MAP: Sections below mirror content from docs/. When editing either side, update the other.
+  - "Development Commands" ↔ docs/content/docs/onboarding/getting-started.mdx
+  - "Frontend Architecture" + "Domain Structure" ↔ docs/content/docs/onboarding/project-structure.mdx
+  - "Code Style Requirements" (naming parts) ↔ docs/content/docs/code/style/naming.md
+  - "Key Architectural Patterns" (Effector) ↔ docs/content/docs/code/style/effector.md
+-->
+
 ## Development Commands
 
 ### Development

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,42 +58,79 @@ Nova Spektr is a Polkadot & Kusama ecosystem Enterprise Desktop application buil
 
 ## Development Commands
 
-For full command reference, see [docs/onboarding/getting-started.mdx](docs/content/docs/onboarding/getting-started.mdx).
+### Development
+- `pnpm start` - Start Electron app in dev mode (also accessible via browser)
+- `pnpm start:renderer` - Start only renderer without Electron (not recommended)
+- `pnpm preview` - Start Electron in staging mode with browser access
 
-Key commands not in docs:
+### Build
+- `pnpm build` - Build app in production mode
+- `pnpm build:dev` - Build app in development mode
+- `pnpm build:staging` - Build app in staging mode
+- `pnpm staging:sequence` - Full staging build sequence (clean, build, postbuild, dist)
+- `pnpm prod:sequence` - Full production build sequence (clean, build, postbuild, dist)
+
+### Testing
+- `pnpm test` - Run unit tests (Vitest)
 - `pnpm test:watch` - Run tests in watch mode
+- `pnpm test:ui` - Run tests with UI
+- `pnpm test:coverage` - Run tests with coverage report
+- `pnpm test:system` - Run end-to-end tests (Playwright)
 - `pnpm test tests/integrations` - Run integration tests
-- `pnpm types:go` - TypeScript type checking with tsgo (~6x faster, preferred)
-- `pnpm fmt:check` - Check formatting without auto-fixing
-- `pnpm fmt:fix` - Auto-fix formatting
-- `pnpm build:dev` / `pnpm build:staging` - Non-production builds
 
-### Integration Tests
-Integration tests live in `tests/integrations/` and test feature model logic (Effector stores/events), storage persistence (IndexedDB), state management workflows, validation rules, and transaction building.
+#### Integration Tests
+Integration tests live in `tests/integrations/` and test feature model logic (Effector stores/events), storage persistence (IndexedDB), state management workflows, validation rules, and transaction building. They use a custom FeatureTestBuilder/FeatureTestEnvironment framework with fake IndexedDB and isolated Effector scopes.
 
 **When to use**: Multi-step business logic spanning stores, events, and storage. Not for UI rendering (component tests), pure functions (unit tests), or full user flows (E2E/Playwright).
 
 See [`tests/integrations/CLAUDE.md`](tests/integrations/CLAUDE.md) for the complete framework reference.
 
+### Code Quality
+- `pnpm lint` - Run ESLint on source code
+- `pnpm lint:fix` - Run linter and auto-fix issues
+- `pnpm types` - Run TypeScript type checking (tsc)
+- `pnpm types:go` - Run TypeScript type checking with tsgo (~6x faster, preferred)
+- `pnpm fmt:check` - Check code formatting with Prettier
+- `pnpm fmt:fix` - Auto-fix code formatting
+
 ## Architecture
 
-For project structure, folder layout, domain/aggregate/feature patterns, and store/service conventions, see [docs/onboarding/project-structure.mdx](docs/content/docs/onboarding/project-structure.mdx).
+Detailed folder layouts, domain/aggregate/feature conventions, and store/service patterns: [docs/onboarding/project-structure.mdx](docs/content/docs/onboarding/project-structure.mdx).
+Naming conventions: [docs/code/style/naming.md](docs/content/docs/code/style/naming.md).
+Effector patterns (sample minimization, effects vs events, attach): [docs/code/style/effector.md](docs/content/docs/code/style/effector.md).
 
-For naming conventions, see [docs/code/style/naming.md](docs/content/docs/code/style/naming.md).
+### Main Application Structure
+- **Electron Main Process** (`src/main/`) - Application lifecycle, window management, system integration
+- **Electron Preload** (`src/main/preload.ts`) - Secure bridge between main and renderer processes
+- **Renderer Process** (`src/renderer/`) - React-based UI application
 
-For Effector patterns (sample minimization, effects vs events, attach), see [docs/code/style/effector.md](docs/content/docs/code/style/effector.md).
+### Frontend Architecture (Feature-Sliced Design)
+The renderer follows a modified Feature-Sliced Design methodology:
 
-### Patterns Not Covered in Docs
+- **`app/`** - Application initialization, routing, and global providers
+- **`pages/`** - Route-level components (Assets, Governance, Staking, etc.)
+- **`widgets/`** - UI components that access data via hooks (useUnit, useStoreMap, etc.), not whole features — just hook-consuming UI
+- **`features/`** - Business logic units (wallet management, transactions, governance)
+- **`sdk/`** - Simple way to integrate features and domains
+- **`entities/`** - **DEPRECATED.** Never create new modules here. When touching existing entity code, migrate: models/services → `domains/`, hook-consuming UI → `widgets/`
+- **`shared/`** - Reusable code across layers
 
-**Dependency Injection** (`shared/di/`):
-- **Slots**: Page creates `createSlot<Props>({ name })`, renders `<Slot id={slot} props={...} />`. Features inject via `feature.inject(slot, { order, render: Component })`.
-- **Pipelines**: Data transformation chains (`createPipeline<Value>`). Features inject via `feature.inject(pipeline, (value) => transform(value))`.
+### Key Architectural Patterns
+- **Effector** - State management with stores, events, and effects
+- **Dependency Injection** - Custom DI system in `shared/di/`
+  - **Slots**: Page creates `createSlot<Props>({ name })`, renders `<Slot id={slot} props={...} />`. Features inject via `feature.inject(slot, { order, render: Component })`.
+  - **Pipelines**: Data transformation chains (`createPipeline<Value>`). Features inject via `feature.inject(pipeline, (value) => transform(value))`.
+- **Feature file layout**: `ui/` contains React components only. Hooks (custom React hooks) live in a dedicated `hooks/` subfolder within the feature, not in `ui/`. Shared chart/visual constants belong in `shared/ui/chart-constants.ts`.
+- **Resource Management** - Data fetching abstractions in `shared/resource/`
+- **Query Resources** - Standard data-fetching pattern using `createQueryResource` + `useResource` from `shared/query/`. Reference implementations: `domains/governance/tracks/resource.ts` and `hooks.ts`. Prefer this over hand-rolled Effector effects with manual cache stores.
+- **Feature Flags** - Dynamic feature toggling system in `shared/config/features/`
 
-**Feature file layout**: `ui/` contains React components only. Hooks (custom React hooks) live in a dedicated `hooks/` subfolder within the feature, not in `ui/`. Shared chart/visual constants belong in `shared/ui/chart-constants.ts`.
-
-**Query Resources**: Standard data-fetching pattern using `createQueryResource` + `useResource` from `shared/query/`. Reference implementations: `domains/governance/tracks/resource.ts` and `hooks.ts`. Prefer this over hand-rolled Effector effects with manual cache stores.
-
-**Feature Flags**: Dynamic feature toggling system in `shared/config/features/`.
+### Domain Structure
+- **`domains/`** - Pure business logic: Effector models, services, types, constants, resources. No `effector-react` imports allowed.
+  - **`domains/network/`** - Blockchain network interactions (accounts, transactions, multisig operations)
+  - **`domains/collectives/`** - Polkadot Fellowship and governance-related logic
+  - **Naming**: Service exports must be named `somethingService` (e.g. `stakingService`), not `somethingUtils`.
+- **`aggregates/`** - User-preference stores and orchestration logic that combine multiple domains. Domains stay pure for data-fetching; if a model needs a user preference or cross-domain combine, it belongs in an aggregate.
 
 ### Balance Subscription System
 - `balanceSubModel.fetchAccounts` (`features/assets-balances`) accepts `AnyAccount[]` — wallet account objects only. It uses `accountService.isAccountAvailableOnChain` to filter chains per account.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,10 +16,9 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - One task per subagent for focused execution
 
 ### 3. Self-Improvement Loop
-- After ANY correction from the user: update 'tasks/lessons.md' with the pattern
+- After ANY correction from the user: save the pattern to Claude Code memory
 - Write rules for yourself that prevent the same mistake
 - Ruthlessly iterate on these lessons until mistake rate drops
-- Review lessons at session start for relevant project
 
 ### 4. Verification Before Done
 - Never mark a task complete without proving it works
@@ -40,12 +39,10 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Go fix failing CI tests without being told how
 
 ## Task Management
-1. Plan First: Write plan to 'tasks/todo.md' with checkable items
+1. Plan First: Use plan mode or TaskCreate for checkable items
 2. Verify Plan: Check in before starting implementation
 3. Track Progress: Mark items complete as you go
 4. Explain Changes: High-level summary at each step
-5. Document Results: Add review to 'tasks/todo.md'
-6. Capture Lessons: Update 'tasks/lessons.md' after corrections
 
 ## Core Principles
 - Simplicity First: Make every change as simple as possible. Impact minimal code.
@@ -173,6 +170,12 @@ The renderer follows a modified Feature-Sliced Design methodology:
   ```tsx
   {/* eslint-disable-next-line i18next/no-literal-string */}
   ```
+
+### Custom ESLint Rules
+- **`enforce-di-naming-convention`** — DI identifiers must match their creator: `createSlot` → `*Slot`, `createPipeline` → `*Pipeline`, `createAsyncPipeline` → `*AsyncPipeline`, `createAnyOf` → `*AnyOf`, `createCombine` → `*Combine`, `createTransformer` → `*Transformer`.
+- **`no-self-import`** — Can't import your own package through aliases or index files; use relative paths.
+- **`no-relative-import-from-root`** — Can't use relative imports that escape package boundaries.
+- **`boundaries/entry-point`** — Most layers only export through `index.ts` barrel files. Exceptions: `shared/` and `pages/` allow all imports; `features/operations`, `features/governance`, `features/wallets` allow deep imports.
 
 ### Code Style Requirements
 - **Import boundaries**: Features must import from domain barrel files (`@/domains/network`), never deep paths (`@/domains/network/price-history/resource`). The `boundaries/entry-point` lint rule enforces this.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -58,70 +58,42 @@ Nova Spektr is a Polkadot & Kusama ecosystem Enterprise Desktop application buil
 
 ## Development Commands
 
-### Development
-- `pnpm start` - Start Electron app in dev mode (also accessible via browser)
-- `pnpm start:renderer` - Start only renderer without Electron (not recommended)
-- `pnpm preview` - Start Electron in staging mode with browser access
+For full command reference, see [docs/onboarding/getting-started.mdx](docs/content/docs/onboarding/getting-started.mdx).
 
-### Build
-- `pnpm build` - Build app in production mode
-- `pnpm build:dev` - Build app in development mode
-- `pnpm build:staging` - Build app in staging mode
-- `pnpm staging:sequence` - Full staging build sequence (clean, build, postbuild, dist)
-- `pnpm prod:sequence` - Full production build sequence (clean, build, postbuild, dist)
-
-### Testing
-- `pnpm test` - Run unit tests (Vitest)
+Key commands not in docs:
 - `pnpm test:watch` - Run tests in watch mode
-- `pnpm test:ui` - Run tests with UI
-- `pnpm test:coverage` - Run tests with coverage report
-- `pnpm test:system` - Run end-to-end tests (Playwright)
 - `pnpm test tests/integrations` - Run integration tests
+- `pnpm types:go` - TypeScript type checking with tsgo (~6x faster, preferred)
+- `pnpm fmt:check` - Check formatting without auto-fixing
+- `pnpm fmt:fix` - Auto-fix formatting
+- `pnpm build:dev` / `pnpm build:staging` - Non-production builds
 
-#### Integration Tests
-Integration tests live in `tests/integrations/` and test feature model logic (Effector stores/events), storage persistence (IndexedDB), state management workflows, validation rules, and transaction building. They use a custom FeatureTestBuilder/FeatureTestEnvironment framework with fake IndexedDB and isolated Effector scopes.
+### Integration Tests
+Integration tests live in `tests/integrations/` and test feature model logic (Effector stores/events), storage persistence (IndexedDB), state management workflows, validation rules, and transaction building.
 
 **When to use**: Multi-step business logic spanning stores, events, and storage. Not for UI rendering (component tests), pure functions (unit tests), or full user flows (E2E/Playwright).
 
 See [`tests/integrations/CLAUDE.md`](tests/integrations/CLAUDE.md) for the complete framework reference.
 
-### Code Quality
-- `pnpm lint` - Run ESLint on source code
-- `pnpm lint:fix` - Run linter and auto-fix issues
-- `pnpm types` - Run TypeScript type checking (tsc)
-- `pnpm types:go` - Run TypeScript type checking with tsgo (~6x faster, preferred)
-- `pnpm fmt:check` - Check code formatting with Prettier
-- `pnpm fmt:fix` - Auto-fix code formatting
-
-
 ## Architecture
 
-### Main Application Structure
-- **Electron Main Process** (`src/main/`) - Controls application lifecycle, window management, and system integration
-- **Electron Preload** (`src/main/preload.ts`) - Secure bridge between main and renderer processes
-- **Renderer Process** (`src/renderer/`) - React-based UI application
+For project structure, folder layout, domain/aggregate/feature patterns, and store/service conventions, see [docs/onboarding/project-structure.mdx](docs/content/docs/onboarding/project-structure.mdx).
 
-### Frontend Architecture (Feature-Sliced Design)
-The renderer follows a modified Feature-Sliced Design methodology:
+For naming conventions, see [docs/code/style/naming.md](docs/content/docs/code/style/naming.md).
 
-- **`app/`** - Application initialization, routing, and global providers
-- **`pages/`** - Route-level components (Assets, Governance, Staking, etc.)
-- **`widgets/`** - UI components that access data via hooks (useUnit, useStoreMap, etc.), not whole features — just hook-consuming UI
-- **`features/`** - Business logic units (wallet management, transactions, governance)
-- **`sdk/`** - Simple way to integrate features and domains
-- **`entities/`** - **DEPRECATED.** Never create new modules here. When touching existing entity code, migrate: models/services → `domains/`, hook-consuming UI → `widgets/`
-- **`shared/`** - Reusable code across layers
+For Effector patterns (sample minimization, effects vs events, attach), see [docs/code/style/effector.md](docs/content/docs/code/style/effector.md).
 
-### Key Architectural Patterns
-- **Effector** - State management with stores, events, and effects
-- **Dependency Injection** - Custom DI system in `shared/di/`
-  - **Slots**: Page creates `createSlot<Props>({ name })`, renders `<Slot id={slot} props={...} />`. Features inject via `feature.inject(slot, { order, render: Component })`.
-  - **Pipelines**: Data transformation chains (`createPipeline<Value>`). Features inject via `feature.inject(pipeline, (value) => transform(value))`.
-- **Feature file layout**: `ui/` contains React components only. Hooks (custom React hooks) live in a dedicated `hooks/` subfolder within the feature, not in `ui/`. Shared chart/visual constants belong in `shared/ui/chart-constants.ts`.
-- **Resource Management** - Data fetching abstractions in `shared/resource/`
-- **Query Resources** - Standard data-fetching pattern using `createQueryResource` + `useResource` from `shared/query/`. Reference implementations: `domains/governance/tracks/resource.ts` and `hooks.ts`. Prefer this over hand-rolled Effector effects with manual cache stores.
-- **Feature Flags** - Dynamic feature toggling system
-- **Form Management** - Custom form utilities with validation
+### Patterns Not Covered in Docs
+
+**Dependency Injection** (`shared/di/`):
+- **Slots**: Page creates `createSlot<Props>({ name })`, renders `<Slot id={slot} props={...} />`. Features inject via `feature.inject(slot, { order, render: Component })`.
+- **Pipelines**: Data transformation chains (`createPipeline<Value>`). Features inject via `feature.inject(pipeline, (value) => transform(value))`.
+
+**Feature file layout**: `ui/` contains React components only. Hooks (custom React hooks) live in a dedicated `hooks/` subfolder within the feature, not in `ui/`. Shared chart/visual constants belong in `shared/ui/chart-constants.ts`.
+
+**Query Resources**: Standard data-fetching pattern using `createQueryResource` + `useResource` from `shared/query/`. Reference implementations: `domains/governance/tracks/resource.ts` and `hooks.ts`. Prefer this over hand-rolled Effector effects with manual cache stores.
+
+**Feature Flags**: Dynamic feature toggling system in `shared/config/features/`.
 
 ### Balance Subscription System
 - `balanceSubModel.fetchAccounts` (`features/assets-balances`) accepts `AnyAccount[]` — wallet account objects only. It uses `accountService.isAccountAvailableOnChain` to filter chains per account.
@@ -136,13 +108,6 @@ The renderer follows a modified Feature-Sliced Design methodology:
 - **`localStorageService` is deprecated** — use `persist` from `effector-storage/local` instead.
 - Pattern: initialize store with default value, call `persist({ key, store, sync: true })`. No manual `init` event needed — `persist` auto-hydrates at module load.
 - Reference: `aggregates/staking-network/model.ts`, `shared/config/features/index.ts`
-
-### Domain Structure
-- **`domains/`** - Pure business logic: Effector models, services, types, constants, resources. No `effector-react` imports allowed.
-  - **`domains/network/`** - Blockchain network interactions (accounts, transactions, multisig operations)
-  - **`domains/collectives/`** - Polkadot Fellowship and governance-related logic
-  - **Naming**: Service exports must be named `somethingService` (e.g. `stakingService`), not `somethingUtils`.
-- **`aggregates/`** - User-preference stores and orchestration logic that combine multiple domains. Domains stay pure for data-fetching; if a model needs a user preference or cross-domain combine, it belongs in an aggregate.
 
 ### Key Technologies
 - **React 19** with TypeScript and SWC compilation

--- a/docs/content/docs/onboarding/project-structure.mdx
+++ b/docs/content/docs/onboarding/project-structure.mdx
@@ -34,7 +34,7 @@ Source code is separated into 3 build targets:
   - domains/ core business logic
   - aggregates/ shared state and logic
   - features/ user flows implemented as separated modules
-  - sdk/ simple way to integate features and domains
+  - sdk/ simple way to integrate features and domains
   - pages/ combination of features
   - shared/ helpers, utils, integrations
   - entities/ **deprecated** logic and ui for given entity (e.g. wallet, chain, etc.)

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,7 +1,0 @@
-# Lessons
-
-## Resources belong in domains/, not features/
-When creating `createQueryResource` resources, they must live in `domains/` (e.g., `domains/governance/track-locks/resource.ts`) with a corresponding `hooks.ts` wrapping `useResource`. Features consume domain hooks via barrel imports — never create resources inside `features/`.
-
-## Check for existing hooks before creating new resources
-Before creating a new resource, search for existing hooks (e.g., `useBlock` already existed in `@/domains/network`). Don't duplicate infrastructure that already exists in the codebase.


### PR DESCRIPTION
## Summary
- **CLAUDE.md improvements**: Add docs links as supplementary references (sync map in HTML comment), document custom ESLint rules (`enforce-di-naming-convention`, `no-self-import`, `no-relative-import-from-root`, `boundaries/entry-point` exceptions), keep all inline content for instant AI context
- **Task management modernized**: Replace stale `tasks/todo.md` / `tasks/lessons.md` references with plan mode, TaskCreate, and Claude Code memory. Delete stale `tasks/lessons.md`
- **Docs fix**: Fix "integate" → "integrate" typo in `project-structure.mdx`

## Test plan
- [ ] Verify CLAUDE.md links resolve correctly from repo root
- [ ] Verify custom ESLint rule names match actual rule files in `eslint/rules/`
- [ ] Confirm no content was lost that isn't covered by linked docs

🤖 Generated with [Claude Code](https://claude.com/claude-code)