### PR TITLE
fix: friendly error on forbidden description save

### DIFF
--- a/src/renderer/domains/backend/operations/service.ts
+++ b/src/renderer/domains/backend/operations/service.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
-import { authFetch, parseResponse } from '@/shared/api/backend-fetch';
+import { authFetch } from '@/shared/api/backend-fetch';
+import { HttpError } from '../contacts/service';
 
 const backendOperationSchema = z.object({
   id: z.string(),
@@ -27,7 +28,7 @@ async function createDescription(
   });
 
   if (!result.ok) {
-    parseResponse(result, z.never());
+    throw new HttpError(result.status, result.body);
   }
 }
 

--- a/src/renderer/features/multisig-operations/model/approve-model.ts
+++ b/src/renderer/features/multisig-operations/model/approve-model.ts
@@ -15,7 +15,7 @@ import {
   createTxValidator,
   getActionRequiredAmount,
 } from '@/shared/transactions';
-import { operationDescriptionsResource, operationsService } from '@/domains/backend';
+import { HttpError, operationDescriptionsResource, operationsService } from '@/domains/backend';
 import {
   type AnyAccount,
   type MultisigOperation,
@@ -285,7 +285,9 @@ sample({
 });
 
 const showDescriptionErrorFx = createEffect((error: Error) => {
-  toast.error(t('operation.descriptionSaveError'), { description: error.message });
+  const description =
+    error instanceof HttpError && error.status === 403 ? t('addressBook.sources.errorForbidden') : error.message;
+  toast.error(t('operation.descriptionSaveError'), { description });
 });
 
 sample({

--- a/src/renderer/features/transfer/model/transfer-model.ts
+++ b/src/renderer/features/transfer/model/transfer-model.ts
@@ -5,7 +5,7 @@ import { toast } from 'sonner';
 
 import { type Transaction } from '@/shared/core';
 import { isStep, nonNullable, nullable, validateAddress } from '@/shared/lib/utils';
-import { operationDescriptionsResource, operationsService } from '@/domains/backend';
+import { HttpError, operationDescriptionsResource, operationsService } from '@/domains/backend';
 import { multisigOperationService } from '@/domains/network';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { authModel, backendConfigurationModel } from '@/aggregates/backend';
@@ -276,7 +276,9 @@ sample({
 });
 
 const showDescriptionErrorFx = createEffect((error: Error) => {
-  toast.error(t('operation.descriptionSaveError'), { description: error.message });
+  const description =
+    error instanceof HttpError && error.status === 403 ? t('addressBook.sources.errorForbidden') : error.message;
+  toast.error(t('operation.descriptionSaveError'), { description });
 });
 
 sample({


### PR DESCRIPTION
## Description
When a user without the required access tries to store an operation description, the toast was showing the raw backend string "Forbidden" instead of a user-friendly message. This PR maps HTTP 403 responses to the existing `errorForbidden` i18n string ("Access denied. Please contact your administrator.") while keeping the toast title unchanged.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-431

## Changes Made
- `domains/backend/operations/service.ts` — throw `HttpError` (with status code) instead of a plain `Error` from `parseResponse`, so callers can inspect the HTTP status
- `features/transfer/model/transfer-model.ts` — map 403 to `addressBook.sources.errorForbidden` in `showDescriptionErrorFx`
- `features/multisig-operations/model/approve-model.ts` — same

## Screenshots/Recordings
<img width="312" height="98" alt="Снимок экрана 2026-04-16 в 18 07 52" src="https://github.com/user-attachments/assets/d4ec2f87-51a1-4cea-91d3-4db1eefd0f20" />


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines