### PR TITLE
fix(drafts): friendly error on forbidden draft creation

### DIFF
--- a/src/renderer/domains/backend/drafts/service.ts
+++ b/src/renderer/domains/backend/drafts/service.ts
@@ -1,6 +1,7 @@
 import { z } from 'zod';
 
 import { authFetch, parseResponse } from '@/shared/api/backend-fetch';
+import { HttpError } from '../contacts/service';
 
 const backendDraftSchema = z.object({
   id: z.string(),
@@ -12,7 +13,6 @@ const backendDraftSchema = z.object({
   createdBy: z.string(),
   createdAt: z.string(),
   updatedAt: z.string(),
-
 });
 
 export type Draft = z.infer<typeof backendDraftSchema>;
@@ -38,6 +38,10 @@ async function createDraft(
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(params),
   });
+
+  if (!result.ok) {
+    throw new HttpError(result.status, result.body);
+  }
 
   return parseResponse(result, backendDraftSchema);
 }

--- a/src/renderer/features/drafts/components/DraftsSection.tsx
+++ b/src/renderer/features/drafts/components/DraftsSection.tsx
@@ -62,6 +62,7 @@ import {
 import { Json } from '@/shared/ui-kit/Json/Json';
 import {
   type Draft,
+  HttpError,
   PERMISSIONS,
   draftsResource,
   draftsService,
@@ -629,8 +630,13 @@ export const DraftsSection = () => {
       setIsModalOpen(false);
       resetCreateState();
     } catch (e) {
-      const message = e instanceof Error ? e.message : t('operations.drafts.createError');
-      toast.error(t('operations.drafts.createError'), { description: message });
+      const description =
+        e instanceof HttpError && e.status === 403
+          ? t('addressBook.sources.errorForbidden')
+          : e instanceof Error
+            ? e.message
+            : t('operations.drafts.createError');
+      toast.error(t('operations.drafts.createError'), { description });
     } finally {
       setIsSubmitting(false);
     }


### PR DESCRIPTION
## Description
When creating a draft operation with an expired address book session, the error toast was showing the raw backend string `"Forbidden"` (HTTP 403) instead of a human-readable message.

## Related Issues
Closes SPEK-441
Related to #5787 (same fix for operation description save)

## Changes Made
- `domains/backend/drafts/service.ts` — `createDraft` now throws `HttpError` (carrying HTTP status code) instead of a plain `Error` via `parseResponse`, consistent with how `operations/service.ts` works
- `features/drafts/components/DraftsSection.tsx` — catch block in `handleCreateDraft` maps `HttpError` with status 403 to `t('addressBook.sources.errorForbidden')` ("Access denied. Please contact your administrator.")

## Screenshots/Recordings
<img width="902" height="547" alt="Снимок экрана 2026-04-17 в 12 12 28" src="https://github.com/user-attachments/assets/fd475634-3ee4-4185-9cb1-9e94403d84fd" />


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)