### PR TITLE
fix(contacts): allow null field in contactFieldOptions Zod schema

### DIFF
--- a/src/renderer/domains/backend/contacts/service.ts
+++ b/src/renderer/domains/backend/contacts/service.ts
@@ -26,7 +26,7 @@ const backendContactSchema = z.object({
     .array(
       z.object({
         fieldOption: z.object({ value: z.string() }),
-        field: z.object({ name: z.string() }),
+        field: z.object({ name: z.string() }).nullish(),
       }),
     )
     .optional()
@@ -62,7 +62,7 @@ function groupTagOptions(raw: RawBackendContact): ContactTag[] {
 }
 
 function extractFieldValues(raw: RawBackendContact, fieldName: string): string[] {
-  return raw.contactFieldOptions.filter(cfo => cfo.field.name === fieldName).map(cfo => cfo.fieldOption.value);
+  return raw.contactFieldOptions.filter(cfo => cfo.field?.name === fieldName).map(cfo => cfo.fieldOption.value);
 }
 
 function mapToContact(raw: RawBackendContact): BackendContact {

--- a/src/renderer/domains/backend/contacts/service.ts
+++ b/src/renderer/domains/backend/contacts/service.ts
@@ -99,8 +99,8 @@ function extractContacts(body: unknown): { raw: unknown[]; total: number } {
   if (typeof body === 'object' && body !== null) {
     const obj = body as Record<string, unknown>;
 
-    const items = obj.data ?? obj.items ?? obj.contacts ?? obj.results;
-    const total = obj.total ?? obj.count ?? obj.totalCount;
+    const items = obj['data'] ?? obj['items'] ?? obj['contacts'] ?? obj['results'];
+    const total = obj['total'] ?? obj['count'] ?? obj['totalCount'];
 
     if (Array.isArray(items)) {
       return { raw: items, total: typeof total === 'number' ? total : items.length };


### PR DESCRIPTION
## Description
The backend API can return `null` for `contactFieldOptions[].field`, causing the strict `z.object()` Zod schema to reject the entire contact. This results in all contacts being silently filtered out in the address book.

## Related Issues
Closes SPEK-443

## Changes Made
- Made `field` nullable (`z.object({ name: z.string() }).nullish()`) in `backendContactSchema`
- Added optional chaining in `extractFieldValues` (`cfo.field?.name`) to skip null field entries gracefully

## Screenshots/Recordings
N/A — console error `[BackendContacts] Skipping invalid contact` no longer appears and contacts load correctly.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)