### PR TITLE
fix(multisig): skip EVM accounts when fetching multisig keys

### DIFF
--- a/src/renderer/domains/network/multisig-operation/resource.ts
+++ b/src/renderer/domains/network/multisig-operation/resource.ts
@@ -13,6 +13,7 @@ import {
   entries,
   getCreatedDateFromApi,
   getNativeAssetId,
+  isSubstrateAccountId,
   nonNullable,
   nullable,
   toAccountId,
@@ -303,10 +304,12 @@ export const initialOnChainFetch = createQueryResource<OnChainRequestParams>({
     const callHashesByAccount: Record<AccountId, HexString[]> = {};
     const onChainData: Record<AccountId, Record<HexString, MultisigOperation>> = {};
 
+    const substrateAccountIds = accountIds.filter(isSubstrateAccountId);
+
     // Phase 1: Fetch all keys for all accounts in parallel (N parallel RPC calls)
     // Using keys() instead of entries() - we'll batch the value fetches in phase 2
     const keysResults = await Promise.allSettled(
-      accountIds.map(async accountId => {
+      substrateAccountIds.map(async accountId => {
         const keys = await api.query.multisig.multisigs.keys(accountId);
         return { accountId, keys };
       }),


### PR DESCRIPTION
## Description
EVM accounts (20-byte H160 addresses) were being passed to `api.query.multisig.multisigs.keys()`, which only accepts 32-byte Substrate AccountIds. This caused a hard error for any wallet containing EVM accounts, preventing multisig operations from loading.

## Related Issues
Closes [SPEK-444](https://novasama-technologies.atlassian.net/browse/SPEK-444)

## Changes Made
- Added `isSubstrateAccountId` filter on `accountIds` before the multisig keys query in `initialOnChainFetch` (`src/renderer/domains/network/multisig-operation/resource.ts`)
- EVM accounts are silently skipped — they cannot participate in Substrate multisig operations

## Screenshots/Recordings
N/A — console error `Failed to fetch keys for account on chain ...: Invalid AccountId provided, expected 32 bytes, found 20` no longer appears.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SPEK-444]: https://novasama-technologies.atlassian.net/browse/SPEK-444?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ