### PR TITLE
fix(extrinsic-builder): deduplicate accounts in MultiAddress dropdown

### DIFF
--- a/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
@@ -1,5 +1,6 @@
 import { type ApiPromise } from '@polkadot/api';
 import { useUnit } from 'effector-react';
+import { uniqBy } from 'lodash';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
@@ -32,7 +33,8 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
     return { prefix: prefix ?? undefined };
   }, [api]);
 
-  const resolvedAccounts = useAccountsNames(accountsList, null);
+  const uniqueAccountsList = useMemo(() => uniqBy(accountsList, 'accountId'), [accountsList]);
+  const resolvedAccounts = useAccountsNames(uniqueAccountsList, null);
 
   // Collect all known addresses for selection detection
   const knownAddresses = useMemo(() => {


### PR DESCRIPTION
## Description

When editing a draft operation and selecting Transfer, the `dest: MultiAddress (Account)` dropdown showed duplicate entries — the same wallet name and address repeated once per chain the wallet was active on.

## Related Issues

[SPEK-448](https://novasama-technologies.atlassian.net/browse/SPEK-448)

## Changes Made

- `AccountParamInput.tsx`: deduplicate `$availableAccounts` by `accountId` before passing to `useAccountsNames`, using `uniqBy` from lodash — the same pattern already used in `TransferForm.tsx` and the `account-presets` aggregate.

## Root Cause

`walletModel.$availableAccounts` returns one account object per (wallet × chain) combination. Since the dropdown only needs unique addresses, identical `accountId`s were rendering as multiple rows.

## Screenshots
<img width="368" height="624" alt="Снимок экрана 2026-04-20 в 18 56 25" src="https://github.com/user-attachments/assets/1078f1ab-7ba8-40ce-b9e8-d24701af0304" />



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SPEK-448]: https://novasama-technologies.atlassian.net/browse/SPEK-448?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ