### PR TITLE
fix(operations): always render styled FROM DRAFT badge

### DIFF
--- a/src/renderer/features/multisig-operations/components/Operation.tsx
+++ b/src/renderer/features/multisig-operations/components/Operation.tsx
@@ -184,23 +184,18 @@ export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = fal
 
               <div className="flex shrink-0 items-center gap-x-2">
                 <div className="w-[100px]">
-                  {isDraftLinked &&
-                    (description ? (
-                      <Tooltip>
-                        <Tooltip.Trigger>
-                          <div className="inline-flex items-center rounded-[20px] border border-icon-accent/30 bg-icon-accent/8 px-2.5 py-1">
-                            <CaptionText className="text-icon-accent uppercase">
-                              {t('operations.drafts.operationBadge')}
-                            </CaptionText>
-                          </div>
-                        </Tooltip.Trigger>
-                        <Tooltip.Content>{description}</Tooltip.Content>
-                      </Tooltip>
-                    ) : (
-                      <CaptionText className="text-icon-accent uppercase">
-                        {t('operations.drafts.operationBadge')}
-                      </CaptionText>
-                    ))}
+                  {isDraftLinked && (
+                    <Tooltip open={description ? undefined : false}>
+                      <Tooltip.Trigger>
+                        <div className="inline-flex items-center rounded-[20px] border border-icon-accent/30 bg-icon-accent/8 px-2.5 py-1">
+                          <CaptionText className="text-icon-accent uppercase">
+                            {t('operations.drafts.operationBadge')}
+                          </CaptionText>
+                        </div>
+                      </Tooltip.Trigger>
+                      <Tooltip.Content>{description}</Tooltip.Content>
+                    </Tooltip>
+                  )}
                 </div>
                 <OperationTitleStatus operation={operation} account={multisigAccount} />
               </div>


### PR DESCRIPTION
## Description

In the multisig operations list, the "FROM DRAFT" badge rendered inconsistently — operations with a draft description showed a styled badge (rounded border + accent background), while operations without a description showed plain unstyled text.

## Related Issues

Fixes [SPEK-449](https://novasama-technologies.atlassian.net/browse/SPEK-449)

## Changes Made

- [Operation.tsx](src/renderer/features/multisig-operations/components/Operation.tsx): Always render the styled badge wrapper. Use `open={description ? undefined : false}` on `Tooltip` to suppress it when there's no description, per the Radix Tooltip conditional control pattern.

## Screenshots
<img width="935" height="300" alt="Снимок экрана 2026-04-20 в 19 20 45" src="https://github.com/user-attachments/assets/e2108ec4-bc2e-477c-ac4e-fa88465f9c18" />


## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

🤖 Generated with [Claude Code](https://claude.ai/claude-code)

[SPEK-449]: https://novasama-technologies.atlassian.net/browse/SPEK-449?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ