### PR TITLE
fix(drafts): make description required, fix placeholder color and 422 error message

### DIFF
--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -251,8 +251,8 @@ export const CreateDraftModal = () => {
       const errorDescription =
         e instanceof HttpError && e.status === 403
           ? t('addressBook.sources.errorForbidden')
-          : e instanceof Error
-            ? e.message
+          : e instanceof HttpError && e.status === 422
+            ? t('operations.drafts.descriptionRequired')
             : t('operations.drafts.createError');
       toast.error(t('operations.drafts.createError'), { description: errorDescription });
     } finally {
@@ -455,7 +455,13 @@ export const CreateDraftModal = () => {
 
           {activeStep === 'confirm' && (
             <div className="flex flex-col gap-4 p-4">
-              <Field text={t('operations.drafts.descriptionLabel')}>
+              <Field
+                text={
+                  <>
+                    {t('operations.drafts.descriptionLabel')} <span className="text-text-negative">*</span>
+                  </>
+                }
+              >
                 <TextArea
                   placeholder={t('operations.drafts.descriptionPlaceholder')}
                   value={description}

--- a/src/renderer/features/drafts/model/create-draft-model.ts
+++ b/src/renderer/features/drafts/model/create-draft-model.ts
@@ -148,12 +148,13 @@ const $canContinue = combine(
     account: $selectedAccount,
     proxyMultisig: $selectedMultisigForProxy,
     isProxy: $isProxySelected,
+    description: $description,
   },
-  ({ step, chain, callData, errorKey, account, proxyMultisig, isProxy }) => {
+  ({ step, chain, callData, errorKey, account, proxyMultisig, isProxy, description }) => {
     if (step === 'call-data') return !!chain && callData.length > 0 && errorKey === null;
     if (step === 'select-multisig') return !!account && (!isProxy || !!proxyMultisig);
 
-    return step === 'confirm';
+    return step === 'confirm' && description.trim().length > 0;
   },
 );
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2514,7 +2514,7 @@
       "callDataPlaceholder": "0x...",
       "callDataErrorHex": "Call data must be valid hex starting with 0x",
       "descriptionLabel": "Description",
-      "descriptionPlaceholder": "Note for signatories (optional)",
+      "descriptionPlaceholder": "Note for signatories (max 500 characters)",
       "descriptionRequired": "Description is required",
       "summaryTitle": "Summary",
       "summaryMultisig": "Multisig",

--- a/src/renderer/shared/ui-kit/TextArea/TextArea.tsx
+++ b/src/renderer/shared/ui-kit/TextArea/TextArea.tsx
@@ -29,7 +29,7 @@ export const TextArea = forwardRef<HTMLTextAreaElement, Props>(
         className={cnTw(
           'w-full rounded-sm px-3 py-2',
           'resize-none text-footnote text-text-primary',
-          'bg-input-background outline-1 outline-filter-border outline-solid placeholder:text-text-secondary',
+          'bg-input-background outline-1 outline-filter-border outline-solid placeholder:text-text-tertiary',
           {
             'outline-filter-border-negative': invalid,
             'focus-within:outline-active-container-border hover:shadow-card-shadow focus:outline-1': !disabled,


### PR DESCRIPTION
## Description

Fixes UX issues in the draft creation flow around the Description field.

## Related Issues

[SPEK-454](https://novasama-technologies.atlassian.net/browse/SPEK-454)

## Changes Made

- **Description field marked as required** — asterisk (`*`) added next to the label in red
- **Create button gated on description** — `$canContinue` in `create-draft-model.ts` now requires `description.trim().length > 0` on the confirm step
- **Human-readable 422 error** — instead of the raw HTTP error string, a 422 response now shows the localized "Description is required" message in the toast
- **TextArea placeholder color fixed** — changed from `text-text-secondary` (darker than the label) to `text-text-tertiary` (matches label tone)
- **Placeholder text updated** — removed "(optional)" suffix since the field is now required

## Screenshots

<img width="368" height="530" alt="Снимок экрана 2026-04-21 в 20 12 14" src="https://github.com/user-attachments/assets/359cedac-5812-44f1-b6d8-841b837695f1" />


## Checklist

- [x] Code follows project conventions
- [x] Localization keys used (no hardcoded strings)
- [x] Pre-commit hooks pass (lint, format, types)
- [x] No unrelated files changed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SPEK-454]: https://novasama-technologies.atlassian.net/browse/SPEK-454?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ