### PR TITLE
fix(drafts): group account selector by type and rename proxy multisig label

### DIFF
--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -396,24 +396,50 @@ export const CreateDraftModal = () => {
                     value={selectedAccount?.accountId ?? null}
                     onChange={handleAccountChange}
                   >
-                    {draftAccountOptions.map((opt) => (
-                      <Select.Item key={opt.accountId} value={opt.accountId}>
-                        <span className="flex w-full min-w-0 items-center gap-x-2 overflow-hidden">
-                          <WalletAccountIcon
-                            address={opt.address}
-                            type={opt.walletType ?? ('Multisig' as WalletType)}
-                            size={24}
-                            iconSize={12}
-                          />
-                          <span className="flex w-full flex-col overflow-hidden">
-                            <span className="w-fit max-w-full truncate">{opt.name}</span>
-                            <span className="w-full text-help-text text-text-tertiary">
-                              <Hash value={opt.address} variant="truncate" />
+                    <Select.Group title={t('operations.drafts.multisigsGroup')}>
+                      {draftAccountOptions
+                        .filter((o) => !o.isProxy)
+                        .map((opt) => (
+                          <Select.Item key={opt.accountId} value={opt.accountId}>
+                            <span className="flex w-full min-w-0 items-center gap-x-2 overflow-hidden">
+                              <WalletAccountIcon
+                                address={opt.address}
+                                type={opt.walletType ?? ('Multisig' as WalletType)}
+                                size={24}
+                                iconSize={12}
+                              />
+                              <span className="flex w-full flex-col overflow-hidden">
+                                <span className="w-fit max-w-full truncate">{opt.name}</span>
+                                <span className="w-full text-help-text text-text-tertiary">
+                                  <Hash value={opt.address} variant="truncate" />
+                                </span>
+                              </span>
                             </span>
-                          </span>
-                        </span>
-                      </Select.Item>
-                    ))}
+                          </Select.Item>
+                        ))}
+                    </Select.Group>
+                    <Select.Group title={t('operations.drafts.proxiedAccountsGroup')}>
+                      {draftAccountOptions
+                        .filter((o) => o.isProxy)
+                        .map((opt) => (
+                          <Select.Item key={opt.accountId} value={opt.accountId}>
+                            <span className="flex w-full min-w-0 items-center gap-x-2 overflow-hidden">
+                              <WalletAccountIcon
+                                address={opt.address}
+                                type={opt.walletType ?? ('Multisig' as WalletType)}
+                                size={24}
+                                iconSize={12}
+                              />
+                              <span className="flex w-full flex-col overflow-hidden">
+                                <span className="w-fit max-w-full truncate">{opt.name}</span>
+                                <span className="w-full text-help-text text-text-tertiary">
+                                  <Hash value={opt.address} variant="truncate" />
+                                </span>
+                              </span>
+                            </span>
+                          </Select.Item>
+                        ))}
+                    </Select.Group>
                   </Select>
                 </Field>
               )}

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2507,7 +2507,7 @@
     "drafts": {
       "title": "Drafts",
       "createNew": "New draft",
-      "selectMultisig": "Multisig account",
+      "selectMultisig": "Select account",
       "selectNetwork": "Network",
       "backButton": "Back",
       "callDataLabel": "Call data",
@@ -2569,7 +2569,9 @@
       "summaryNoCallData": "No call data - you'll add it when submitting this operation.",
       "linkCopied": "Draft link copied!",
       "shareDraftTooltip": "Share draft link with signatories",
-      "selectMultisigForProxy": "Multisig for proxy",
+      "selectMultisigForProxy": "Proxy multisig",
+      "multisigsGroup": "Multisigs",
+      "proxiedAccountsGroup": "Proxied accounts",
       "proxyLabel": "Proxy",
       "viewDraft": "View draft",
       "notifications": {


### PR DESCRIPTION
## Description

Improves the account selector UX in the draft creation modal.

## Related Issues

Fixes [SPEK-456](https://novasama-technologies.atlassian.net/browse/SPEK-456)

## Changes Made

- Split the flat account list in the "Select account" dropdown into two labeled groups: **Multisigs** and **Proxied accounts** using `Select.Group`
- Renamed the secondary field label from "Multisig for proxy" → **"Proxy multisig"** (the multisig that holds proxy rights over the selected proxied account)
- Added i18n keys: `multisigsGroup`, `proxiedAccountsGroup`, updated `selectMultisigForProxy`

## Screenshots
<img width="376" height="425" alt="Снимок экрана 2026-04-21 в 21 19 40" src="https://github.com/user-attachments/assets/14c405ea-dc99-485f-804f-968c012c0e5b" />
<img width="376" height="313" alt="Снимок экрана 2026-04-21 в 21 19 55" src="https://github.com/user-attachments/assets/1f90954d-a39a-438a-a0e7-0773fbb36afd" />



## Checklist

 I have performed 

- [x] a self-review of my own code
- [x]  I have tested the changes and verified the happy path works as expected
- [x]  I have provided screenshot of the working feature (if applicable)
- [x]  I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ]  I have added tests that cover the base logic (if applicable)
- [x]  My code follows the project's coding standards and style guidelines

[SPEK-456]: https://novasama-technologies.atlassian.net/browse/SPEK-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ