### PR TITLE
feat: update ChangeSignatories flow to support trust/verified paths

### DIFF
--- a/src/renderer/features/flexible-change-signatories/index.ts
+++ b/src/renderer/features/flexible-change-signatories/index.ts
@@ -1,1 +1,1 @@
-export { ChangeSignatories } from './ui/ChangeSignatories';
+export { ChangeSignatoriesFlow as ChangeSignatories } from './ui/ChangeSignatoriesFlow';

--- a/src/renderer/features/flexible-change-signatories/ui/ChangeSignatories.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/ChangeSignatories.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { type ComponentProps, type PropsWithChildren, useMemo, useState } from 'react';
+import { type ComponentProps, type PropsWithChildren, useEffect, useMemo, useRef, useState } from 'react';
 
 import { type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -33,12 +33,23 @@ const MODAL_SIZE: Record<string, Pick<ComponentProps<typeof Modal>, 'size' | 'he
 type Props = PropsWithChildren<{
   wallet: Wallet;
   onClose?: () => void;
+  launchOpen?: boolean;
+  hideTrigger?: boolean;
 }>;
 
-export const ChangeSignatories = ({ wallet, onClose, children }: Props) => {
+export const ChangeSignatories = ({ wallet, onClose, children, launchOpen, hideTrigger }: Props) => {
   const { t } = useI18n();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const walletRef = useRef(wallet);
+  walletRef.current = wallet;
+
+  useEffect(() => {
+    if (!launchOpen) return;
+
+    setIsModalOpen(true);
+    changeSignatoriesModel.flow.open({ wallet: walletRef.current });
+  }, [launchOpen, wallet.id]);
 
   const step = useUnit(changeSignatoriesModel.$step);
   const canSubmit = useUnit(changeSignatoriesModel.$canSubmit);
@@ -106,7 +117,7 @@ export const ChangeSignatories = ({ wallet, onClose, children }: Props) => {
 
   return (
     <Modal isOpen={isModalOpen} size={MODAL_SIZE[step]!.size} height={MODAL_SIZE[step]!.height} onToggle={onToggle}>
-      <Modal.Trigger>{children}</Modal.Trigger>
+      {!hideTrigger && <Modal.Trigger>{children}</Modal.Trigger>}
 
       <Modal.Title close>
         {chain && <OperationTitle title={t('flexibleMultisig.editTitleOn')} chainId={chain.chainId} />}

--- a/src/renderer/features/flexible-change-signatories/ui/ChangeSignatoriesFlow.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/ChangeSignatoriesFlow.tsx
@@ -1,0 +1,184 @@
+import { type PropsWithChildren, useEffect, useState } from 'react';
+import { Trans } from 'react-i18next';
+
+import { type Wallet } from '@/shared/core';
+import { useI18n } from '@/shared/i18n';
+import { BodyText, Button, FootnoteText, HeaderTitleText, Icon, SmallTitleText } from '@/shared/ui';
+import { Modal, RadioGroup } from '@/shared/ui-kit';
+import { AddProxy } from '@/features/proxy-add';
+
+import { ChangeSignatories } from './ChangeSignatories';
+
+type ChangeSignatoriesMode = 'trust' | 'verified';
+
+type Props = PropsWithChildren<{
+  wallet: Wallet;
+  onClose?: () => void;
+  canUseVerifiedPath?: boolean;
+}>;
+
+export const ChangeSignatoriesFlow = ({ wallet, onClose, children, canUseVerifiedPath = true }: Props) => {
+  const { t } = useI18n();
+
+  const [pickerOpen, setPickerOpen] = useState(false);
+  const [selectedMode, setSelectedMode] = useState<ChangeSignatoriesMode | undefined>();
+  const [pendingFlow, setPendingFlow] = useState<ChangeSignatoriesMode | null>(null);
+  const [activeFlow, setActiveFlow] = useState<ChangeSignatoriesMode | null>(null);
+  const [trustFlowKey, setTrustFlowKey] = useState(0);
+  const [verifiedFlowKey, setVerifiedFlowKey] = useState(0);
+
+  const trustOption = {
+    id: 'trust',
+    value: 'trust' as const,
+    title: t('flexibleMultisig.changeSignatoriesMode.trustTitle'),
+    tagline: t('flexibleMultisig.changeSignatoriesMode.trustTagline'),
+  };
+
+  const verifiedOption = {
+    id: 'verified',
+    value: 'verified' as const,
+    title: t('flexibleMultisig.changeSignatoriesMode.verifiedTitle'),
+    tagline: t('flexibleMultisig.changeSignatoriesMode.verifiedTagline'),
+  };
+
+  const handlePickerToggle = (open: boolean) => {
+    if (open) {
+      setSelectedMode(undefined);
+      setActiveFlow(null);
+      setPendingFlow(null);
+    }
+    setPickerOpen(open);
+  };
+
+  useEffect(() => {
+    if (pickerOpen || pendingFlow === null) return;
+
+    const openDeferredFlow = () => {
+      setActiveFlow(pendingFlow);
+      setPendingFlow(null);
+      if (pendingFlow === 'trust') {
+        setTrustFlowKey((key) => key + 1);
+      } else {
+        setVerifiedFlowKey((key) => key + 1);
+      }
+    };
+
+    const timeoutId = window.setTimeout(openDeferredFlow, 0);
+
+    return () => window.clearTimeout(timeoutId);
+  }, [pickerOpen, pendingFlow]);
+
+  const handleContinue = () => {
+    if (!selectedMode) return;
+    if (selectedMode === 'verified' && !canUseVerifiedPath) return;
+    setPendingFlow(selectedMode);
+    setPickerOpen(false);
+  };
+
+  const handleTrustFlowClose = () => {
+    setActiveFlow(null);
+    onClose?.();
+  };
+
+  const handleVerifiedFlowClose = () => {
+    setActiveFlow(null);
+    onClose?.();
+  };
+
+  const continueDisabled = !selectedMode || (selectedMode === 'verified' && !canUseVerifiedPath);
+
+  return (
+    <>
+      <Modal size="mdlg" height="fit" isOpen={pickerOpen} onToggle={handlePickerToggle}>
+        <Modal.Trigger>{children}</Modal.Trigger>
+        <Modal.Title close>{t('flexibleMultisig.changeSignatoriesMode.pickerTitle')}</Modal.Title>
+        <Modal.Content>
+          <SmallTitleText className="mx-5 mt-4">
+            {t('flexibleMultisig.changeSignatoriesMode.pickerSubtitle')}
+          </SmallTitleText>
+          <div className="mx-5 my-4 flex min-w-0 flex-row gap-x-6">
+            <RadioGroup
+              className={canUseVerifiedPath ? 'flex min-w-0 flex-1 flex-row gap-x-6' : 'w-full min-w-0 flex-1 flex-col'}
+              value={selectedMode}
+              onChange={(value: ChangeSignatoriesMode) => setSelectedMode(value)}
+            >
+              <div className={canUseVerifiedPath ? 'min-w-0 flex-1' : 'w-full'}>
+                <RadioGroup.CardOption option={trustOption}>
+                  <div className="flex min-h-[200px] flex-col">
+                    <div className="mb-4 flex items-start justify-between gap-3">
+                      <div className="flex min-w-0 flex-col gap-1">
+                        <HeaderTitleText as="p" className="text-tab-text-accent">
+                          {trustOption.title}
+                        </HeaderTitleText>
+                        <FootnoteText className="text-text-secondary">{trustOption.tagline}</FootnoteText>
+                      </div>
+                      <RadioGroup.RadioButton />
+                    </div>
+                    <BodyText className="text-text-secondary">
+                      <Trans i18nKey="flexibleMultisig.changeSignatoriesMode.trustDescription" t={t} />
+                    </BodyText>
+                  </div>
+                </RadioGroup.CardOption>
+              </div>
+              {canUseVerifiedPath ? (
+                <div className="min-w-0 flex-1">
+                  <RadioGroup.CardOption option={verifiedOption}>
+                    <div className="flex min-h-[200px] flex-col">
+                      <div className="mb-4 flex items-start justify-between gap-3">
+                        <div className="flex min-w-0 flex-col gap-1">
+                          <HeaderTitleText as="p" className="text-tab-text-accent">
+                            {verifiedOption.title}
+                          </HeaderTitleText>
+                          <FootnoteText className="text-text-secondary">{verifiedOption.tagline}</FootnoteText>
+                        </div>
+                        <RadioGroup.RadioButton />
+                      </div>
+                      <BodyText className="text-text-secondary">
+                        <Trans i18nKey="flexibleMultisig.changeSignatoriesMode.verifiedDescription" t={t} />
+                      </BodyText>
+                    </div>
+                  </RadioGroup.CardOption>
+                </div>
+              ) : null}
+            </RadioGroup>
+            {!canUseVerifiedPath ? (
+              <div className="min-w-0 flex-1">
+                <div className="rounded-sm border border-filter-border p-6 opacity-60">
+                  <div className="mb-4 flex items-start gap-x-3">
+                    <Icon name="delegate" className="mt-0.5 shrink-0" size={24} />
+                    <div className="flex min-w-0 flex-col gap-1">
+                      <HeaderTitleText as="p" className="text-tab-text-accent">
+                        {verifiedOption.title}
+                      </HeaderTitleText>
+                      <FootnoteText className="text-text-secondary">{verifiedOption.tagline}</FootnoteText>
+                    </div>
+                  </div>
+                  <FootnoteText className="text-text-secondary">
+                    {t('flexibleMultisig.changeSignatoriesMode.verifiedUnavailable')}
+                  </FootnoteText>
+                </div>
+              </div>
+            ) : null}
+          </div>
+        </Modal.Content>
+        <Modal.Footer>
+          <Button disabled={continueDisabled} onClick={handleContinue}>
+            {t('signing.continueButton')}
+          </Button>
+        </Modal.Footer>
+      </Modal>
+
+      {activeFlow === 'trust' && (
+        <ChangeSignatories key={trustFlowKey} wallet={wallet} hideTrigger launchOpen onClose={handleTrustFlowClose}>
+          {null}
+        </ChangeSignatories>
+      )}
+
+      {activeFlow === 'verified' && (
+        <AddProxy key={verifiedFlowKey} wallet={wallet} hideTrigger launchOpen onClose={handleVerifiedFlowClose}>
+          {null}
+        </AddProxy>
+      )}
+    </>
+  );
+};

--- a/src/renderer/features/proxy-add/ui/AddProxy.tsx
+++ b/src/renderer/features/proxy-add/ui/AddProxy.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { type PropsWithChildren, useEffect, useState } from 'react';
+import { type PropsWithChildren, useEffect, useRef, useState } from 'react';
 
 import { type Chain, type Wallet } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
@@ -20,12 +20,27 @@ import { AddProxyForm } from './AddProxyForm';
 type Props = PropsWithChildren<{
   wallet: Wallet;
   onClose?: () => void;
+  launchOpen?: boolean;
+  hideTrigger?: boolean;
 }>;
 
-export const AddProxy = ({ wallet, onClose, children }: Props) => {
+export const AddProxy = ({ wallet, onClose, children, launchOpen, hideTrigger }: Props) => {
   const { t } = useI18n();
 
   const [isModalOpen, setIsModalOpen] = useState(false);
+  const walletRef = useRef(wallet);
+  walletRef.current = wallet;
+
+  const hasStartedRef = useRef(false);
+  const hasClosedRef = useRef(false);
+
+  useEffect(() => {
+    if (!launchOpen) return;
+
+    hasClosedRef.current = false;
+    setIsModalOpen(true);
+    addProxyModel.events.flowStarted(walletRef.current);
+  }, [launchOpen, wallet.id]);
 
   const step = useUnit(addProxyModel.$step);
   const chain = useUnit(addProxyModel.$chain);
@@ -37,19 +52,33 @@ export const AddProxy = ({ wallet, onClose, children }: Props) => {
   );
 
   const closeModal = () => {
+    if (hasClosedRef.current) return;
+    hasClosedRef.current = true;
+    hasStartedRef.current = false;
     setIsModalOpen(false);
     addProxyModel.output.flowClosed();
     onClose?.();
   };
 
   useEffect(() => {
-    if (step === Step.NONE) {
-      setIsModalOpen(false);
+    if (step !== Step.NONE) {
+      hasStartedRef.current = true;
+      return;
+    }
+
+    if (!hasStartedRef.current) return;
+
+    hasStartedRef.current = false;
+    setIsModalOpen(false);
+    if (launchOpen && !hasClosedRef.current) {
+      hasClosedRef.current = true;
+      onClose?.();
     }
   }, [step]);
 
   const onToggle = (isOpen: boolean) => {
     if (isOpen) {
+      hasClosedRef.current = false;
       setIsModalOpen(true);
       addProxyModel.events.flowStarted(wallet);
       return;
@@ -84,7 +113,7 @@ export const AddProxy = ({ wallet, onClose, children }: Props) => {
 
   return (
     <Modal size="md" height="fit" isOpen={isModalOpen} onToggle={onToggle}>
-      <Modal.Trigger>{children}</Modal.Trigger>
+      {!hideTrigger && <Modal.Trigger>{children}</Modal.Trigger>}
       <Modal.Title close>{getModalTitle(step, chain)}</Modal.Title>
       <Modal.Content>
         {addProxyUtils.isInitStep(step) && <AddProxyForm />}

--- a/src/renderer/features/wallet-details/index.tsx
+++ b/src/renderer/features/wallet-details/index.tsx
@@ -1,4 +1,4 @@
-import { useGate } from 'effector-react';
+import { useGate, useUnit } from 'effector-react';
 import { type ReactNode, useState } from 'react';
 
 import { TEST_IDS } from '@/shared/constants';
@@ -8,7 +8,8 @@ import { createFeature } from '@/shared/feature';
 import { useI18n } from '@/shared/i18n';
 import { type IconNames, Icon, IconButton } from '@/shared/ui';
 import { Dropdown } from '@/shared/ui-kit';
-import { permissionUtils, walletUtils } from '@/entities/wallet';
+import { networkModel, networkUtils } from '@/entities/network';
+import { accountUtils, permissionUtils, walletUtils } from '@/entities/wallet';
 import { walletActionsSlot as extensionActionsSlot } from '@/features/extension-wallet';
 import { ChangeSignatories } from '@/features/flexible-change-signatories';
 import { walletActionsSlot as multisigActionsSlot } from '@/features/multisig-wallet';
@@ -88,7 +89,14 @@ walletDetailsFeature.inject(walletActionSlot, ({ wallet }) => {
   const [isWalletDetailsOpen, setIsWalletDetailsOpen] = useState(false);
   const [isDropdownOpen, setIsDropdownOpen] = useState(false);
 
+  const chains = useUnit(networkModel.$chains);
   const { t } = useI18n();
+
+  const flexibleMultisigAccount = wallet.accounts.find(accountUtils.isFlexibleMultisigAccount);
+  const chain = flexibleMultisigAccount ? chains[flexibleMultisigAccount.chainId] : undefined;
+  const canUseVerifiedPath =
+    (permissionUtils.canCreateAnyProxy(wallet) || permissionUtils.canCreateNonAnyProxy(wallet)) &&
+    networkUtils.isProxySupported(chain?.options);
 
   const createModalCloseHandler = (modalCloseFn?: () => void) => () => {
     modalCloseFn?.();
@@ -151,7 +159,7 @@ walletDetailsFeature.inject(walletActionSlot, ({ wallet }) => {
   if (walletUtils.isFlexibleMultisig(wallet)) {
     items.push({
       component: (
-        <ChangeSignatories wallet={wallet} onClose={createModalCloseHandler()}>
+        <ChangeSignatories wallet={wallet} canUseVerifiedPath={canUseVerifiedPath} onClose={createModalCloseHandler()}>
           <Dropdown.Item>
             <div className="flex items-center gap-2">
               <Icon name="changeSignatories" size={20} className="text-icon-accent" />

--- a/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
+++ b/src/renderer/features/wallet-details/ui/wallets/FlexibleWalletDetails.tsx
@@ -101,7 +101,7 @@ export const FlexibleWalletDetails = ({ wallet, onClose }: Props) => {
   const actions: WalletAction[] = [
     {
       component: (
-        <ChangeSignatories wallet={wallet}>
+        <ChangeSignatories wallet={wallet} canUseVerifiedPath={canCreateProxy}>
           <Action title={t('walletDetails.multisig.changeSignatories')} icon="changeSignatories" />
         </ChangeSignatories>
       ),

--- a/src/renderer/shared/api/proxy/service/proxyService.ts
+++ b/src/renderer/shared/api/proxy/service/proxyService.ts
@@ -39,20 +39,29 @@ async function getProxiesForAccount(api: ApiPromise, account: AccountId): Promis
   return { accounts, deposit: firstRecord.deposit.toString() };
 }
 
-/**
- * Calculate deposit delta for new proxy connection based on existing proxied
- */
-function getProxyDepositDelta(api: ApiPromise, existingDeposit: string, proxyNumber: number) {
-  const { proxyDepositFactor, proxyDepositBase } = api.consts.proxy;
-  const proxyDeposit = proxyDepositFactor.muln(proxyNumber).add(proxyDepositBase);
+function proxyDepositRequired(api: ApiPromise, numProxies: number): BN {
+  const proxyCount = Math.max(0, Math.floor(Number(numProxies)));
 
-  return proxyDeposit.sub(new BN(existingDeposit));
+  if (proxyCount === 0) {
+    return new BN(0);
+  }
+
+  const { proxyDepositFactor, proxyDepositBase } = api.consts.proxy;
+
+  return new BN(proxyDepositFactor.toString()).muln(proxyCount).add(new BN(proxyDepositBase.toString()));
+}
+
+function getProxyDepositDelta(api: ApiPromise, existingDeposit: string, newProxyCount: number) {
+  const required = proxyDepositRequired(api, newProxyCount);
+  const existing = new BN(existingDeposit || '0', 10);
+  const delta = required.sub(existing);
+
+  return delta.isNeg() ? new BN(0) : delta;
 }
 
 /**
  * Calculate pure proxy deposit, that will be locked on spawner
  */
 function getPureProxyDeposit(api: ApiPromise) {
-  const { proxyDepositFactor, proxyDepositBase } = api.consts.proxy;
-  return proxyDepositFactor.add(proxyDepositBase);
+  return proxyDepositRequired(api, 1);
 }

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1549,6 +1549,17 @@
     }
   },
   "flexibleMultisig": {
+    "changeSignatoriesMode": {
+      "pickerSubtitle": "Choose how you want to update signatories.",
+      "pickerTitle": "Change signatories",
+      "trustDescription": "Submit one batch transaction that adds the new multisig proxy and removes the old one. Fastest path. The tradeoff is that signers are approving the whole change at once, with no intermediate ‘test then remove’ step.",
+      "trustTagline": "Single step",
+      "trustTitle": "Trust-based",
+      "verifiedDescription": "Add a new multisig as a delegated authority (proxy), verify it from the Proxies tab (via system remark), then remove the old proxy when you are ready. Safer because you add and verify the new proxy before removing the old one.",
+      "verifiedTagline": "Multi-step",
+      "verifiedTitle": "With verification",
+      "verifiedUnavailable": "Adding a proxy is not available for this wallet or network, so the verified path cannot be used."
+    },
     "editSubtitle": "Change the signatories and set the signatory threshold for your flexible multisig.",
     "editTitleOn": "Edit flexible multisig on",
     "thresholdDescription": "Minimum signatories needed to approve."


### PR DESCRIPTION
## Description
Flexible multisig “change signatories” previously pushed users down a single path. Users who want a safer, proxy-first workflow (add and verify a new multisig proxy before removing the old one) need an explicit choice, while others may prefer the faster trust-based batch update. This PR adds a mode picker (trust vs verified), wires the verified path to the existing Add proxy flow, and disables or explains the verified option when the wallet or chain cannot create proxies—so we do not advertise a path that cannot be completed.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-424

## Changes Made
- Introduce ChangeSignatoriesFlow (still exported as ChangeSignatories from @/features/flexible-change-signatories) with a modal to choose trust-based (existing change-signatories multisig edit) vs with verification (delegate via proxy).
- Pass canUseVerifiedPath from wallet details using proxy-creation permissions and networkUtils.isProxySupported for the flexible multisig’s chain.
- Support programmatic opening of nested flows: launchOpen / hideTrigger on the existing ChangeSignatories and AddProxy modals so the picker can open either flow without a duplicate trigger.
- Add flexibleMultisig.changeSignatoriesMode.* copy in en.json (picker titles, mode descriptions, unavailable message).

## Screenshots/Recordings

https://github.com/user-attachments/assets/75d2f536-bc1f-4107-a033-8ec25ae39ac3



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
