### PR TITLE
fix: hide proxy verification for non-multisig rows

### DIFF
--- a/src/renderer/features/wallet-details/model/__tests__/proxies-model.test.ts
+++ b/src/renderer/features/wallet-details/model/__tests__/proxies-model.test.ts
@@ -8,12 +8,13 @@ import {
   type MultisigWallet,
   type ProxiedWallet,
   AccountType,
+  CryptoType,
   ProxyTypes,
   ProxyVariant,
   WalletType,
 } from '@/shared/core';
 import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
-import { type MultisigOperation, accounts, multisigOperation } from '@/domains/network';
+import { type MultisigOperation, accounts, contactMultisigsModel, multisigOperation } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { walletModel } from '@/entities/wallet';
 import { type WalletProxy, isProxyVerifiable, proxiesModel } from '../proxies-model';
@@ -546,6 +547,48 @@ describe('features/wallet-details/model/proxies-model', () => {
       expect(proxies).toHaveLength(2);
       const m2Row = proxies.find(p => p.proxyAccountId === M2);
       expect(m2Row?.pendingVerificationOperation?.operationId).toBe('op-verify-m2');
+    });
+
+    test('Proxied wallet view treats address-book-only multisig proxy as multisig', async () => {
+      const M2 = ('0x' + 'cc'.repeat(32)) as AccountId;
+      const walletProxiesWithExternal = {
+        [verifyChainId]: {
+          proxies: [
+            { accountId: M2, proxiedAccountId: F, chainId: verifyChainId, proxyType: ProxyTypes.ANY, delay: 0 },
+          ],
+          deposit: null,
+        },
+      };
+
+      const scope = fork({
+        values: new Map<any, any>([
+          [walletModel.__test.$rawWallets, [pwWallet]],
+          [accounts.__test.$list, [pwAccount]],
+          [
+            contactMultisigsModel.$contactMultisigs,
+            [
+              {
+                accountId: M2,
+                name: 'External multisig',
+                signatories: ['0xsig3' as AccountId, '0xsig4' as AccountId],
+                threshold: 2,
+                cryptoType: CryptoType.SR25519,
+                contactIds: ['contact-1'],
+              },
+            ],
+          ],
+          [networkModel.$chains, { [verifyChainId]: chain }],
+          [walletProxiesModel.$walletProxies, walletProxiesWithExternal],
+          [multisigOperation.__test.$cachedOperations, []],
+        ]),
+      });
+      await allSettled(walletProxiesModel.flow.open, { scope, params: { wallet: pwWallet } });
+      const proxies = scope.getState(proxiesModel.$proxies);
+
+      expect(proxies).toHaveLength(1);
+      expect(proxies[0]?.proxyMultisigAccountId).toBe(M2);
+      expect(proxies[0]?.status).toBe('not_verified_no_wallet');
+      expect(proxies[0]?.verifiable).toBe(false);
     });
   });
 });

--- a/src/renderer/features/wallet-details/model/proxies-model.ts
+++ b/src/renderer/features/wallet-details/model/proxies-model.ts
@@ -6,8 +6,10 @@ import { nullable, toAccountId } from '@/shared/lib/utils';
 import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
 import {
   type AnyAccount,
+  type ContactMultisig,
   type MultisigOperation,
   accounts,
+  contactMultisigsModel,
   multisigOperation,
   multisigOperationService,
 } from '@/domains/network';
@@ -131,9 +133,15 @@ type ProxyResolution = {
   account: AnyAccount | null;
   multisigAccountId: AccountId | null;
   isMultisig: boolean;
+  contactMultisig: ContactMultisig | null;
 };
 
-function resolveProxy(wallets: Wallet[], proxyAccountId: AccountId, chainId: ChainId): ProxyResolution {
+function resolveProxy(
+  wallets: Wallet[],
+  contactMultisigs: ContactMultisig[],
+  proxyAccountId: AccountId,
+  chainId: ChainId,
+): ProxyResolution {
   const matched = walletUtils.getWalletFilteredAccounts(wallets, {
     walletFn: w => !walletUtils.isWatchOnly(w),
     accountFn: account => {
@@ -145,13 +153,25 @@ function resolveProxy(wallets: Wallet[], proxyAccountId: AccountId, chainId: Cha
     },
   });
 
+  const contactMultisig = contactMultisigs.find(cm => cm.accountId === proxyAccountId) ?? null;
+
   if (!matched) {
-    return { wallet: null, account: null, multisigAccountId: null, isMultisig: false };
+    if (contactMultisig) {
+      return {
+        wallet: null,
+        account: contactMultisigsModel.toSyntheticMultisigAccount(contactMultisig),
+        multisigAccountId: contactMultisig.accountId,
+        isMultisig: true,
+        contactMultisig,
+      };
+    }
+
+    return { wallet: null, account: null, multisigAccountId: null, isMultisig: false, contactMultisig: null };
   }
 
   const account = matched.accounts[0] ?? null;
   if (!account) {
-    return { wallet: matched, account: null, multisigAccountId: null, isMultisig: false };
+    return { wallet: matched, account: null, multisigAccountId: null, isMultisig: false, contactMultisig };
   }
 
   if (accountUtils.isAnyMultisigAccount(account)) {
@@ -160,10 +180,11 @@ function resolveProxy(wallets: Wallet[], proxyAccountId: AccountId, chainId: Cha
       account,
       multisigAccountId: multisigService.getMultisigAccountId(account),
       isMultisig: true,
+      contactMultisig,
     };
   }
 
-  return { wallet: matched, account, multisigAccountId: null, isMultisig: false };
+  return { wallet: matched, account, multisigAccountId: null, isMultisig: false, contactMultisig };
 }
 
 function findLatestExecutedOperation(
@@ -224,8 +245,9 @@ const $proxies = combine(
     wallets: walletModel.$wallets,
     operations: multisigOperation.$list,
     allAccounts: accounts.$list,
+    contactMultisigs: contactMultisigsModel.$contactMultisigs,
   },
-  ({ wallet, walletProxies, wallets, operations, allAccounts }): WalletProxy[] => {
+  ({ wallet, walletProxies, wallets, operations, allAccounts, contactMultisigs }): WalletProxy[] => {
     if (!wallet) return [];
 
     const onChainProxies: WalletProxy[] = [];
@@ -237,15 +259,13 @@ const $proxies = combine(
         if (seenKeys.has(key)) continue;
         seenKeys.add(key);
 
-        const resolved = resolveProxy(wallets, proxy.accountId, proxy.chainId);
+        const resolved = resolveProxy(wallets, contactMultisigs, proxy.accountId, proxy.chainId);
 
         let status: WalletProxyStatus;
         let lastOperation: WalletProxyLastOperation | null = null;
         let verifiable = false;
 
-        if (!resolved.wallet) {
-          status = 'not_verified_no_wallet';
-        } else if (resolved.isMultisig && resolved.multisigAccountId) {
+        if (resolved.isMultisig && resolved.multisigAccountId) {
           const executed = findLatestExecutedOperation(
             operations,
             proxy.chainId,
@@ -265,10 +285,12 @@ const $proxies = combine(
               transaction: executed.transaction,
             };
           } else {
-            status = 'not_verified';
+            status = resolved.wallet ? 'not_verified' : 'not_verified_no_wallet';
           }
 
-          verifiable = VERIFIABLE_PROXY_TYPES.has(proxy.proxyType) && proxy.delay === 0;
+          verifiable = resolved.wallet !== null && VERIFIABLE_PROXY_TYPES.has(proxy.proxyType) && proxy.delay === 0;
+        } else if (!resolved.wallet) {
+          status = 'not_verified_no_wallet';
         } else {
           status = 'not_verified';
         }
@@ -347,7 +369,7 @@ const $proxies = combine(
           if (seenKeys.has(key)) continue;
           seenKeys.add(key);
 
-          const resolved = resolveProxy(wallets, addProxyArgs.proxy, op.chainId);
+          const resolved = resolveProxy(wallets, contactMultisigs, addProxyArgs.proxy, op.chainId);
           const account = allAccounts.find(a => a.accountId === addProxyArgs.proxy) ?? resolved.account;
 
           pendingProxies.push({

--- a/src/renderer/features/wallet-details/ui/components/proxies/ProxyRow.tsx
+++ b/src/renderer/features/wallet-details/ui/components/proxies/ProxyRow.tsx
@@ -21,34 +21,49 @@ type Props = {
 export const ProxyRow = ({ proxy, verifyAction, onRemove, onCloseWalletDetails }: Props) => {
   const chains = useUnit(networkModel.$chains);
   const chain = chains[proxy.chainId] ?? null;
+  const isMultisigProxy = proxy.proxyMultisigAccountId !== null;
+
+  const rowContent = (
+    <div className="flex w-full items-center normal-case">
+      <div className="min-w-0 flex-1">
+        <Box direction="row" gap={2} verticalAlign="center" horizontalAlign="space-between" fitContainer>
+          <div className="min-w-0 flex-1">
+            <NamedAccount accountId={proxy.proxyAccountId} chain={chain ?? undefined} variant="truncate" />
+          </div>
+          <div className="shrink-0">
+            {chain ? (
+              <ChainTitle chain={chain} iconSize={12} fontClass="text-text-tertiary" />
+            ) : (
+              <FootnoteText className="text-text-tertiary">{proxy.chainId}</FootnoteText>
+            )}
+          </div>
+          <div className="shrink-0">
+            <Label variant="gray">{proxy.proxyType}</Label>
+          </div>
+          {isMultisigProxy && (
+            <div className="shrink-0">
+              <ProxyStatusBadge status={proxy.status} />
+            </div>
+          )}
+        </Box>
+      </div>
+    </div>
+  );
+
+  if (!isMultisigProxy) {
+    return (
+      <li className="border-b border-divider px-2 py-1.5 last:border-b-0">
+        <div className="flex w-full items-center gap-2 rounded-md px-2 py-1.5 text-caption text-text-secondary uppercase">
+          <div className="flex min-w-0 grow items-center gap-2 truncate text-start">{rowContent}</div>
+        </div>
+      </li>
+    );
+  }
 
   return (
     <li className="border-b border-divider px-2 py-1.5 last:border-b-0">
       <Accordion initialOpen={false}>
-        <Accordion.Trigger>
-          <div className="flex w-full items-center normal-case">
-            <div className="min-w-0 flex-1">
-              <Box direction="row" gap={2} verticalAlign="center" horizontalAlign="space-between" fitContainer>
-                <div className="min-w-0 flex-1">
-                  <NamedAccount accountId={proxy.proxyAccountId} chain={chain ?? undefined} variant="truncate" />
-                </div>
-                <div className="shrink-0">
-                  {chain ? (
-                    <ChainTitle chain={chain} iconSize={12} fontClass="text-text-tertiary" />
-                  ) : (
-                    <FootnoteText className="text-text-tertiary">{proxy.chainId}</FootnoteText>
-                  )}
-                </div>
-                <div className="shrink-0">
-                  <Label variant="gray">{proxy.proxyType}</Label>
-                </div>
-                <div className="shrink-0">
-                  <ProxyStatusBadge status={proxy.status} />
-                </div>
-              </Box>
-            </div>
-          </div>
-        </Accordion.Trigger>
+        <Accordion.Trigger>{rowContent}</Accordion.Trigger>
         <Accordion.Content>
           <ProxyDetails
             proxy={proxy}

--- a/src/renderer/features/wallet-details/ui/components/proxies/ProxyRow.tsx
+++ b/src/renderer/features/wallet-details/ui/components/proxies/ProxyRow.tsx
@@ -2,7 +2,8 @@ import { useUnit } from 'effector-react';
 import { type ReactNode } from 'react';
 
 import { FootnoteText } from '@/shared/ui';
-import { Accordion, Box, Label } from '@/shared/ui-kit';
+import { Accordion, Label } from '@/shared/ui-kit';
+import { useWalletName } from '@/domains/network';
 import { ChainTitle } from '@/entities/chain';
 import { networkModel } from '@/entities/network';
 import { NamedAccount } from '@/widgets/NameResolver';
@@ -22,31 +23,34 @@ export const ProxyRow = ({ proxy, verifyAction, onRemove, onCloseWalletDetails }
   const chains = useUnit(networkModel.$chains);
   const chain = chains[proxy.chainId] ?? null;
   const isMultisigProxy = proxy.proxyMultisigAccountId !== null;
+  const proxyWalletName = useWalletName(proxy.proxyWallet);
 
   const rowContent = (
-    <div className="flex w-full items-center normal-case">
-      <div className="min-w-0 flex-1">
-        <Box direction="row" gap={2} verticalAlign="center" horizontalAlign="space-between" fitContainer>
-          <div className="min-w-0 flex-1">
-            <NamedAccount accountId={proxy.proxyAccountId} chain={chain ?? undefined} variant="truncate" />
-          </div>
-          <div className="shrink-0">
-            {chain ? (
-              <ChainTitle chain={chain} iconSize={12} fontClass="text-text-tertiary" />
-            ) : (
-              <FootnoteText className="text-text-tertiary">{proxy.chainId}</FootnoteText>
-            )}
-          </div>
-          <div className="shrink-0">
-            <Label variant="gray">{proxy.proxyType}</Label>
-          </div>
-          {isMultisigProxy && (
-            <div className="shrink-0">
-              <ProxyStatusBadge status={proxy.status} />
-            </div>
-          )}
-        </Box>
+    <div className="grid w-full grid-cols-[minmax(0,1fr)_160px_96px_144px] items-center gap-3 normal-case">
+      <div className="min-w-0">
+        <NamedAccount
+          accountId={proxy.proxyAccountId}
+          chain={chain ?? undefined}
+          title={proxyWalletName ?? undefined}
+          variant="truncate"
+          iconSize={28}
+        />
       </div>
+      <div className="min-w-0">
+        {chain ? (
+          <ChainTitle chain={chain} iconSize={16} className="min-w-0" fontClass="truncate text-text-tertiary" />
+        ) : (
+          <FootnoteText className="truncate text-text-tertiary">{proxy.chainId}</FootnoteText>
+        )}
+      </div>
+      <div className="flex min-w-0 justify-start">
+        <Label variant="gray">{proxy.proxyType}</Label>
+      </div>
+      {isMultisigProxy && (
+        <div className="flex min-w-0 justify-start">
+          <ProxyStatusBadge status={proxy.status} />
+        </div>
+      )}
     </div>
   );
 
@@ -61,7 +65,7 @@ export const ProxyRow = ({ proxy, verifyAction, onRemove, onCloseWalletDetails }
   }
 
   return (
-    <li className="border-b border-divider px-2 py-1.5 last:border-b-0">
+    <li className="border-b border-divider px-3 py-3 last:border-b-0">
       <Accordion initialOpen={false}>
         <Accordion.Trigger>{rowContent}</Accordion.Trigger>
         <Accordion.Content>


### PR DESCRIPTION
## Description
Fixes the Proxied Wallet Details → Proxies tab: non-multisig proxy rows no longer show a verification status badge or expand into verification details, since those concepts only apply to multisig delegates. Extends multisig detection to cover address-book contacts so that a multisig known only via the address book (no local wallet) is still treated as a multisig row. Also refactors the row layout to a CSS grid so all columns align consistently across rows.

## Related Issues
Closes SPEK-507

## Changes Made
- Hide verification status badge and accordion expansion for non-multisig proxy rows
- Detect address-book-only multisigs as multisig proxies (`contactMultisigsModel.$contactMultisigs` consulted in `resolveProxy`); such rows get `not_verified_no_wallet` status and `verifiable: false`
- Replace flex/space-between row layout with a CSS grid (`minmax(0,1fr) 160px 96px 144px`) so account, chain, type, and status columns align across all rows
- Show wallet display name (via `useWalletName`) and larger account icon (`iconSize=28`) in the account column
- Add test coverage for address-book multisig proxy detection

## Screenshots/Recordings
<img width="605" height="566" alt="Снимок экрана 2026-04-28 в 14 34 39" src="https://github.com/user-attachments/assets/1fedc4c9-3ac3-4c49-bf0f-1f5db7afdc75" />

<img width="604" height="570" alt="Снимок экрана 2026-04-28 в 14 35 34" src="https://github.com/user-attachments/assets/828b50cc-9385-4fbe-91fb-0c13a08b39b9" />

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines