### PR TITLE
fix(SPEK-524): correct duplicate proxy check to compare by accountId

### DIFF
--- a/src/renderer/features/proxy-add/model/form-model.ts
+++ b/src/renderer/features/proxy-add/model/form-model.ts
@@ -5,7 +5,7 @@ import { and, not } from 'patronum';
 
 import { chainsService } from '@/shared/api/network';
 import { proxyService } from '@/shared/api/proxy';
-import { type Address, type Chain, type ProxyType, type Transaction, type Wallet, ProxyTypes } from '@/shared/core';
+import { type Chain, type ProxyType, type Transaction, type Wallet, ProxyTypes } from '@/shared/core';
 import { createStoreFromEffect } from '@/shared/effector';
 import { type Form, createForm } from '@/shared/forms';
 import {
@@ -39,7 +39,7 @@ import { proxiesUtils } from '@/features/proxies';
 
 type ProxyAccounts = {
   accounts: {
-    address: Address;
+    accountId: AccountId;
     proxyType: ProxyType;
   }[];
   deposit: string;
@@ -200,7 +200,7 @@ const form: Form<FormParams> = createForm<FormParams>({
             }
 
             const sameProxyExist = activeProxies.some((proxy) => {
-              return proxy.proxyType === form.proxyType && proxy.address === delegate;
+              return proxy.proxyType === form.proxyType && proxy.accountId === toAccountId(delegate);
             });
             if (sameProxyExist) {
               return { message: 'proxy.addProxy.proxyTypeExistError' };


### PR DESCRIPTION
## Description

Fixes duplicate proxy validation that was silently broken for all account types (regular and multisig).

In `proxy-add/model/form-model.ts`, the local `ProxyAccounts` type declared `address: Address` on each proxy entry, but `proxyService.getProxiesForAccount` has always returned `accountId: AccountId`. The comparison `proxy.address === delegate` was always `undefined === string` at runtime — the guard never triggered, allowing users to submit a transaction that fails on-chain with a `duplicate` error.

## Related Issues

[SPEK-524](https://novasama-technologies.atlassian.net/browse/SPEK-524)

## Changes Made

- Corrected `ProxyAccounts.accounts` type: `address: Address` → `accountId: AccountId`
- Updated comparison: `proxy.address === delegate` → `proxy.accountId === toAccountId(delegate)`
- Removed now-unused `Address` import

## Screenshots/Recordings

N/A — validation logic fix, no UI change.

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines

[SPEK-524]: https://novasama-technologies.atlassian.net/browse/SPEK-524?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ