### PR TITLE
fix(SPEK-526): human-readable error on address book session expiry + rename toast

### DIFF
--- a/src/renderer/entities/contact/ui/BackendErrorView.tsx
+++ b/src/renderer/entities/contact/ui/BackendErrorView.tsx
@@ -2,11 +2,11 @@ import { useI18n } from '@/shared/i18n';
 import { Alert, Button, CaptionText } from '@/shared/ui';
 
 export type BackendErrorCategory = 'auth' | 'forbidden' | 'timeout' | 'network' | 'generic';
-export type BackendError = { category: BackendErrorCategory; message: string };
+export type BackendError = { category: BackendErrorCategory; message?: string };
 
 type Props = {
   category: BackendErrorCategory;
-  message: string;
+  message?: string;
   onRetry: () => void;
 };
 
@@ -24,7 +24,7 @@ export const BackendErrorView = ({ category, message, onRetry }: Props) => {
   return (
     <div className="py-4">
       <Alert title={t(i18nKeyByCategory[category])} active variant="error">
-        <CaptionText className="break-all text-text-tertiary">{message}</CaptionText>
+        {message && <CaptionText className="break-all text-text-tertiary">{message}</CaptionText>}
         <Button variant="text" className="h-4.5 self-start p-0" onClick={onRetry}>
           {t('addressBook.sources.retry')}
         </Button>

--- a/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
+++ b/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
@@ -9,8 +9,10 @@ import { authModel, backendConfigurationModel } from '@/aggregates/backend';
 function categorizeError(error: Error): BackendError {
   if (error instanceof HttpError) {
     const category = error.status === 401 ? 'auth' : error.status === 403 ? 'forbidden' : 'generic';
+    // auth/forbidden titles are self-contained — don't expose raw HTTP response body
+    const message = category === 'generic' ? error.message : undefined;
 
-    return { category, message: error.message };
+    return { category, message };
   }
 
   if (error.name === 'AbortError') return { category: 'timeout', message: error.message };

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -51,7 +51,7 @@
       "selectAccountLabel": "Select account",
       "selectAccountPlaceholder": "Choose an account",
       "sessionExpired": "Session expired",
-      "sessionExpiredToast": "Session expired",
+      "sessionExpiredToast": "Address Book session expired",
       "signingMessage": "Waiting for signature...",
       "signInSuccess": "Successfully signed in",
       "signOutButton": "Sign out"


### PR DESCRIPTION
## Description

Fixes two UX issues when the backend address book session expires and the user attempts to re-sync.

## Related Issues

SPEK-526

## Changes Made

- **`BackendErrorView.tsx`** — make `message` optional; skip rendering the caption when absent
- **`backend-contacts-model.ts`** — omit `message` for `auth` / `forbidden` error categories so the raw HTTP response body (`Request failed with status 401: {"message":"Unauthorized",...}`) never surfaces to the user; the localised title is self-contained for both cases
- **`en.json`** — rename session-expired toast from `"Session expired"` to `"Address Book session expired"` to clarify scope (unrelated wallet sessions exist)

## Screenshots

<img width="282" height="62" alt="Снимок экрана 2026-04-30 в 12 52 36" src="https://github.com/user-attachments/assets/b898314f-f5bd-4317-8f98-1f88019faed2" />
<img width="763" height="257" alt="Снимок экрана 2026-04-30 в 12 51 49" src="https://github.com/user-attachments/assets/51c4b251-79b1-4089-b9a9-120649ad71dc" />


## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have tested my changes locally
- [ ] I have added tests (if applicable)
- [ ] I have updated the documentation (if applicable)