### PR TITLE
fix(SPEK-527): add Save as Draft and fix Add to Basket in Remove Proxy confirmation

### DIFF
--- a/src/renderer/features/drafts/components/DraftsSection.tsx
+++ b/src/renderer/features/drafts/components/DraftsSection.tsx
@@ -20,6 +20,7 @@ import { networkModel, useApi } from '@/entities/network';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { authModel, backendConfigurationModel } from '@/aggregates/backend';
 import { tryDecodeCallData } from '../lib/decode-call-data';
+import { useCanCreateDraft } from '../lib/useCanCreateDraft';
 import { DESCRIPTION_MAX_LENGTH, createDraftModel } from '../model/create-draft-model';
 import { draftDeepLinkModel } from '../model/draft-deep-link';
 import '../model/drafts-model'; // side-effect: orchestration wiring
@@ -38,7 +39,7 @@ export const DraftsSection = () => {
   const focusedDraftId = useUnit(draftDeepLinkModel.$focusedDraftId);
 
   const canRead = isAuthenticated && (authState?.permissions.includes(PERMISSIONS.OPERATION_DRAFT_READ) ?? false);
-  const canWrite = isAuthenticated && (authState?.permissions.includes(PERMISSIONS.OPERATION_DRAFT_WRITE) ?? false);
+  const canWrite = useCanCreateDraft();
   const canDelete = isAuthenticated && (authState?.permissions.includes(PERMISSIONS.OPERATION_DRAFT_DELETE) ?? false);
 
   const { data: drafts } = useDrafts(canRead ? backendUrl : null);

--- a/src/renderer/features/drafts/components/InitiateDraftButton.tsx
+++ b/src/renderer/features/drafts/components/InitiateDraftButton.tsx
@@ -1,12 +1,10 @@
-import { useUnit } from 'effector-react';
 import { useEffect, useRef } from 'react';
 
 import { type ChainId } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { Button } from '@/shared/ui';
 import { Tooltip } from '@/shared/ui-kit';
-import { PERMISSIONS } from '@/domains/backend';
-import { authModel } from '@/aggregates/backend';
+import { useCanCreateDraft } from '../lib/useCanCreateDraft';
 import { createDraftModel } from '../model/create-draft-model';
 
 type Props = {
@@ -51,8 +49,7 @@ export const InitiateDraftButton = ({
   onDraftCreated,
 }: Props) => {
   const { t } = useI18n();
-  const isAuthenticated = useUnit(authModel.$isAuthenticated);
-  const authState = useUnit(authModel.$authState);
+  const canWrite = useCanCreateDraft();
 
   // Tracks whether this button instance started the currently-open draft flow.
   // Only the initiator should fire onDraftCreated — prevents unrelated draft
@@ -77,8 +74,6 @@ export const InitiateDraftButton = ({
       unsubClosed();
     };
   }, [onDraftCreated]);
-
-  const canWrite = isAuthenticated && (authState?.permissions.includes(PERMISSIONS.OPERATION_DRAFT_WRITE) ?? false);
 
   // Not connected to address book or no write perm — hide entirely to keep the footer clean.
   if (!canWrite) return null;

--- a/src/renderer/features/drafts/lib/useCanCreateDraft.ts
+++ b/src/renderer/features/drafts/lib/useCanCreateDraft.ts
@@ -1,0 +1,11 @@
+import { useUnit } from 'effector-react';
+
+import { PERMISSIONS } from '@/domains/backend';
+import { authModel } from '@/aggregates/backend';
+
+export const useCanCreateDraft = () => {
+  const isAuthenticated = useUnit(authModel.$isAuthenticated);
+  const authState = useUnit(authModel.$authState);
+
+  return isAuthenticated && (authState?.permissions.includes(PERMISSIONS.OPERATION_DRAFT_WRITE) ?? false);
+};

--- a/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
@@ -78,7 +78,7 @@ export const Confirmation = ({ id = 0, onGoBack, secondaryActionButton, hideSign
         )}
 
         <div className="flex gap-4">
-          {secondaryActionButton}
+          {!hideSignButton && !isMultisigExists && secondaryActionButton}
           {!hideSignButton && !isMultisigExists && (
             <SignButton
               isDefault={Boolean(secondaryActionButton)}

--- a/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
@@ -85,7 +85,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         )}
 
         <div className="flex gap-4">
-          {secondaryActionButton}
+          {!hideSignButton && secondaryActionButton}
 
           {!hideSignButton && (
             <SignButton

--- a/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
@@ -76,7 +76,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         )}
 
         <div className="flex gap-4">
-          {secondaryActionButton}
+          {!hideSignButton && secondaryActionButton}
 
           {!hideSignButton && (
             <SignButton

--- a/src/renderer/features/proxied-add-pure/ui/AddPureProxied.tsx
+++ b/src/renderer/features/proxied-add-pure/ui/AddPureProxied.tsx
@@ -10,6 +10,7 @@ import { Modal } from '@/shared/ui-kit';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
 import { OperationResult } from '@/entities/transaction';
+import { walletModel } from '@/entities/wallet';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { AddPureProxiedConfirmation } from '@/features/operations/OperationsConfirm/AddPureProxied';
 import { addPureProxiedUtils } from '../lib/add-pure-proxied-utils';
@@ -33,7 +34,11 @@ export const AddPureProxied = ({ wallet, onClose, children }: Props) => {
   const {
     fields: { chain },
   } = useForm(formModel.form);
-  const initiatorWallet = useUnit(addPureProxiedModel.$initiatorWallet);
+  const signatoryAccount = useUnit(formModel.form.fields.signatory.$value);
+  const wallets = useUnit(walletModel.$wallets);
+
+  const signatoryWallet = signatoryAccount ? (wallets.find(w => w.id === signatoryAccount.walletId) ?? null) : null;
+  const isBasketAvailable = signatoryWallet ? basketUtils.isBasketAvailable(signatoryWallet) : false;
 
   const [isBasketModalOpen, closeBasketModal] = useModalClose(
     addPureProxiedUtils.isBasketStep(step),
@@ -95,12 +100,11 @@ export const AddPureProxied = ({ wallet, onClose, children }: Props) => {
         {addPureProxiedUtils.isConfirmStep(step) && (
           <AddPureProxiedConfirmation
             secondaryActionButton={
-              initiatorWallet &&
-              basketUtils.isBasketAvailable(initiatorWallet) && (
-                <Button pallet="secondary" onClick={void addPureProxiedModel.events.txSaved}>
+              isBasketAvailable ? (
+                <Button pallet="secondary" onClick={() => addPureProxiedModel.events.txSaved()}>
                   {t('operation.addToBasket')}
                 </Button>
-              )
+              ) : undefined
             }
             onGoBack={() => addPureProxiedModel.events.stepChanged(Step.INIT)}
           />

--- a/src/renderer/features/proxy-add/ui/AddProxy.tsx
+++ b/src/renderer/features/proxy-add/ui/AddProxy.tsx
@@ -9,11 +9,13 @@ import { Modal } from '@/shared/ui-kit';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
 import { OperationResult } from '@/entities/transaction';
+import { walletModel } from '@/entities/wallet';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { AddProxyConfirmation } from '@/features/operations/OperationsConfirm/AddProxy';
 import { addProxyUtils } from '../lib/add-proxy-utils';
 import { Step } from '../lib/types';
 import { addProxyModel } from '../model/add-proxy-model';
+import { formModel } from '../model/form-model';
 
 import { AddProxyForm } from './AddProxyForm';
 
@@ -44,7 +46,11 @@ export const AddProxy = ({ wallet, onClose, children, launchOpen, hideTrigger }:
 
   const step = useUnit(addProxyModel.$step);
   const chain = useUnit(addProxyModel.$chain);
-  const initiatorWallet = useUnit(addProxyModel.$initiatorWallet);
+  const signatoryAccount = useUnit(formModel.form.fields.signatory.$value);
+  const wallets = useUnit(walletModel.$wallets);
+
+  const signatoryWallet = signatoryAccount ? (wallets.find((w) => w.id === signatoryAccount.walletId) ?? null) : null;
+  const isBasketAvailable = signatoryWallet ? basketUtils.isBasketAvailable(signatoryWallet) : false;
 
   const [isBasketModalOpen, closeBasketModal] = useModalClose(
     addProxyUtils.isBasketStep(step),
@@ -120,12 +126,11 @@ export const AddProxy = ({ wallet, onClose, children, launchOpen, hideTrigger }:
         {addProxyUtils.isConfirmStep(step) && (
           <AddProxyConfirmation
             secondaryActionButton={
-              initiatorWallet &&
-              basketUtils.isBasketAvailable(initiatorWallet) && (
+              isBasketAvailable ? (
                 <Button pallet="secondary" onClick={() => addProxyModel.events.txSaved()}>
                   {t('operation.addToBasket')}
                 </Button>
-              )
+              ) : undefined
             }
             onGoBack={() => addProxyModel.events.stepChanged(Step.INIT)}
           />

--- a/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
+++ b/src/renderer/features/proxy-remove/model/remove-proxy-model.ts
@@ -595,6 +595,8 @@ export const removeProxyModel = {
 
   $step,
   $wallet,
+  $coreTx,
+  $api,
   stepChanged,
   wentBackFromConfirm,
   txSaved,

--- a/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
@@ -7,9 +7,8 @@ import { Button } from '@/shared/ui';
 import { Modal } from '@/shared/ui-kit';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
-import { OperationResult, transactionService } from '@/entities/transaction';
+import { OperationResult } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
-import { InitiateDraftButton } from '@/features/drafts';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { RemoveProxyConfirmation as Confirmation } from '@/features/operations/OperationsConfirm/RemoveProxy';
 import { removeProxyUtils } from '../lib/remove-proxy-utils';
@@ -32,12 +31,8 @@ export const RemoveProxy = ({ wallet }: Props) => {
   const chainId = useUnit(removeProxyModel.$proxyAccount.map((proxy) => proxy?.chainId ?? null));
 
   const isPureProxiedNeedToBeKilled = useUnit(removeProxyModel.$isPureProxiedNeedToBeKilled);
-  const coreTx = useUnit(removeProxyModel.$coreTx);
-  const api = useUnit(removeProxyModel.$api);
   const signatoryAccount = useUnit(removeProxyModel.form.fields.signatory.$value);
   const wallets = useUnit(walletModel.$wallets);
-
-  const draftCallData = transactionService.getCallDataHex(coreTx, api);
 
   const signatoryWallet = signatoryAccount ? (wallets.find((w) => w.id === signatoryAccount.walletId) ?? null) : null;
   const isBasketAvailable = signatoryWallet ? basketUtils.isBasketAvailable(signatoryWallet) : false;
@@ -99,19 +94,11 @@ export const RemoveProxy = ({ wallet }: Props) => {
         {removeProxyUtils.isConfirmStep(step) && (
           <Confirmation
             secondaryActionButton={
-              <>
-                {isBasketAvailable && (
-                  <Button pallet="secondary" onClick={() => removeProxyModel.txSaved()}>
-                    {t('operation.addToBasket')}
-                  </Button>
-                )}
-                <InitiateDraftButton
-                  callData={draftCallData}
-                  chainId={chainId}
-                  source="remove-proxy"
-                  onDraftCreated={closeModal}
-                />
-              </>
+              isBasketAvailable ? (
+                <Button pallet="secondary" onClick={() => removeProxyModel.txSaved()}>
+                  {t('operation.addToBasket')}
+                </Button>
+              ) : undefined
             }
             onGoBack={removeProxyModel.wentBackFromConfirm}
           />

--- a/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxy.tsx
@@ -7,7 +7,9 @@ import { Button } from '@/shared/ui';
 import { Modal } from '@/shared/ui-kit';
 import { basketUtils } from '@/entities/basket';
 import { OperationTitle } from '@/entities/chain';
-import { OperationResult } from '@/entities/transaction';
+import { OperationResult, transactionService } from '@/entities/transaction';
+import { walletModel } from '@/entities/wallet';
+import { InitiateDraftButton } from '@/features/drafts';
 import { OperationSign, OperationSubmit } from '@/features/operations';
 import { RemoveProxyConfirmation as Confirmation } from '@/features/operations/OperationsConfirm/RemoveProxy';
 import { removeProxyUtils } from '../lib/remove-proxy-utils';
@@ -29,8 +31,16 @@ export const RemoveProxy = ({ wallet }: Props) => {
   const step = useUnit(removeProxyModel.$step);
   const chainId = useUnit(removeProxyModel.$proxyAccount.map((proxy) => proxy?.chainId ?? null));
 
-  const initiatorWallet = useUnit(removeProxyModel.$wallet);
   const isPureProxiedNeedToBeKilled = useUnit(removeProxyModel.$isPureProxiedNeedToBeKilled);
+  const coreTx = useUnit(removeProxyModel.$coreTx);
+  const api = useUnit(removeProxyModel.$api);
+  const signatoryAccount = useUnit(removeProxyModel.form.fields.signatory.$value);
+  const wallets = useUnit(walletModel.$wallets);
+
+  const draftCallData = transactionService.getCallDataHex(coreTx, api);
+
+  const signatoryWallet = signatoryAccount ? (wallets.find((w) => w.id === signatoryAccount.walletId) ?? null) : null;
+  const isBasketAvailable = signatoryWallet ? basketUtils.isBasketAvailable(signatoryWallet) : false;
 
   const [isModalOpen, closeModal] = useModalClose(!removeProxyUtils.isNoneStep(step), removeProxyModel.flowFinished);
 
@@ -89,12 +99,19 @@ export const RemoveProxy = ({ wallet }: Props) => {
         {removeProxyUtils.isConfirmStep(step) && (
           <Confirmation
             secondaryActionButton={
-              initiatorWallet &&
-              basketUtils.isBasketAvailable(initiatorWallet) && (
-                <Button pallet="secondary" onClick={void removeProxyModel.txSaved}>
-                  {t('operation.addToBasket')}
-                </Button>
-              )
+              <>
+                {isBasketAvailable && (
+                  <Button pallet="secondary" onClick={() => removeProxyModel.txSaved()}>
+                    {t('operation.addToBasket')}
+                  </Button>
+                )}
+                <InitiateDraftButton
+                  callData={draftCallData}
+                  chainId={chainId}
+                  source="remove-proxy"
+                  onDraftCreated={closeModal}
+                />
+              </>
             }
             onGoBack={removeProxyModel.wentBackFromConfirm}
           />

--- a/src/renderer/features/proxy-remove/ui/RemoveProxyForm.tsx
+++ b/src/renderer/features/proxy-remove/ui/RemoveProxyForm.tsx
@@ -8,7 +8,10 @@ import { Button } from '@/shared/ui';
 import { SignatorySelect, TransactionValidationError } from '@/shared/ui-entities';
 import { accounts } from '@/domains/network';
 import { balanceModel, balanceUtils } from '@/entities/balance';
+import { transactionService } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
+// eslint-disable-next-line boundaries/entry-point -- direct import to avoid circular: drafts -> accounts-structure -> wallet-details -> proxy-remove
+import { InitiateDraftButton } from '@/features/drafts/components/InitiateDraftButton';
 import { FeeWithLabel, MultisigDepositFee } from '@/widgets/transaction-fee';
 import { removeProxyModel } from '../model/remove-proxy-model';
 
@@ -113,15 +116,28 @@ const ActionSection = ({ onGoBack }: Props) => {
   const { t } = useI18n();
 
   const canSubmit = useUnit(removeProxyModel.$canSubmit);
+  const coreTx = useUnit(removeProxyModel.$coreTx);
+  const api = useUnit(removeProxyModel.$api);
+  const chainId = useUnit(removeProxyModel.$proxyAccount.map((proxy) => proxy?.chainId ?? null));
+
+  const draftCallData = transactionService.getCallDataHex(coreTx, api);
 
   return (
     <div className="mt-4 flex items-center justify-between">
       <Button variant="text" onClick={onGoBack}>
         {t('operation.goBackButton')}
       </Button>
-      <Button form="add-proxy-form" type="submit" disabled={!canSubmit}>
-        {t('operation.continueButton')}
-      </Button>
+      <div className="flex items-center gap-3">
+        <InitiateDraftButton
+          callData={draftCallData}
+          chainId={chainId}
+          source="remove-proxy"
+          onDraftCreated={removeProxyModel.flowFinished}
+        />
+        <Button form="add-proxy-form" type="submit" disabled={!canSubmit}>
+          {t('operation.continueButton')}
+        </Button>
+      </div>
     </div>
   );
 };


### PR DESCRIPTION
## Description

The Revoke Authority (Remove Proxy) flow had several issues with its secondary actions:
- The \"Save as Draft\" button was missing entirely from the form step
- The \"Add to Basket\" button was permanently invisible in Remove Proxy (and also in Add Proxy / Add Pure Proxied) because basket availability was checked against the proxied account's wallet (always `ProxiedWallet`, which never passes the Vault/SingleShard check) instead of the signatory's wallet
- `secondaryActionButton` was rendered even when `hideSignButton=true` on all three proxy Confirmation screens, causing it to appear in multisig or read-only contexts where it shouldn't

## Related Issues

Closes SPEK-527

## Changes Made

- **Added \"Save as Draft\" to the form step** — moved `InitiateDraftButton` into `RemoveProxyForm`'s `ActionSection`, placing it alongside the \"Continue\" button (consistent with where drafts are initiated in other flows)
- **Fixed \"Add to Basket\" never shown in Remove Proxy, Add Proxy, Add Pure Proxied** — all three flows were checking basket availability against `initiatorWallet` (the proxied account's wallet, always `ProxiedWallet`), which never passes the Vault/SingleShard check. Changed to derive basket availability from the signatory's wallet instead
- **Fixed \"Add to Basket\" click doing nothing in Remove Proxy** — `onClick={void removeProxyModel.txSaved}` evaluated to `undefined` due to misuse of the `void` operator; changed to `onClick={() => removeProxyModel.txSaved()}`
- **Fixed `secondaryActionButton` shown when `hideSignButton=true`** — guarded `secondaryActionButton` with the same `!hideSignButton` condition as the Sign button in AddProxy, AddPureProxied, and RemoveProxy Confirmation components
- **Extracted `useCanCreateDraft` hook** — deduplicated the auth/permissions check (`OPERATION_DRAFT_WRITE`) that was copy-pasted in both `InitiateDraftButton` and `DraftsSection`; now both use the shared hook
- **Worked around circular import** — `drafts → accounts-structure → wallet-details → proxy-remove` prevented importing `InitiateDraftButton` via barrel; used a direct component path with an eslint-disable comment explaining the reason

## Screenshots/Recordings
<img width="342" height="502" alt="Снимок экрана 2026-04-30 в 17 22 08" src="https://github.com/user-attachments/assets/b85f699f-9f08-4927-a7d5-9c6d7f9639df" />
<img width="350" height="275" alt="Снимок экрана 2026-04-30 в 17 21 57" src="https://github.com/user-attachments/assets/3e1ff66b-d361-4e5a-8719-1aa832801ca5" />
<img width="343" height="543" alt="Снимок экрана 2026-04-30 в 17 21 22" src="https://github.com/user-attachments/assets/6337d643-11e8-4def-9a25-7bef15f69c6e" />
<img width="351" height="508" alt="Снимок экрана 2026-04-30 в 17 21 15" src="https://github.com/user-attachments/assets/eaa2a856-dd43-4629-8e41-1766e641faa9" />
<img width="350" height="472" alt="Снимок экрана 2026-04-30 в 17 20 51" src="https://github.com/user-attachments/assets/dc69e352-930c-4bcc-8375-f3014a1700de" />
<img width="357" height="413" alt="Снимок экрана 2026-04-30 в 17 20 44" src="https://github.com/user-attachments/assets/d00c4251-77f0-4eff-9d88-06368bb8e850" />


## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines