### PR TITLE
fix(SPEK-535): exclude flexible multisigs from Replace with existing candidates

### DIFF
--- a/src/renderer/aggregates/multisig-candidates/lib/__tests__/merge-candidates.test.ts
+++ b/src/renderer/aggregates/multisig-candidates/lib/__tests__/merge-candidates.test.ts
@@ -136,17 +136,9 @@ describe('mergeMultisigCandidates', () => {
     }
   });
 
-  it('returns WalletCandidate for a FLEXIBLE_MULTISIG wallet with valid account', () => {
+  it('excludes FLEXIBLE_MULTISIG wallet', () => {
     const result = mergeMultisigCandidates([flexibleMultisigWallet], []);
-    expect(result).toHaveLength(1);
-    const candidate = result[0]!;
-    expect(candidate.source).toBe('wallet');
-    if (candidate.source === 'wallet') {
-      expect(candidate.walletId).toBe(2);
-      expect(candidate.name).toBe('Bob Flexible Multisig');
-      expect(candidate.accountId).toBe(BOB_ID);
-      expect(candidate.threshold).toBe(2);
-    }
+    expect(result).toHaveLength(0);
   });
 
   it('excludes non-multisig wallet (SINGLE_PARITY_SIGNER)', () => {
@@ -194,8 +186,8 @@ describe('mergeMultisigCandidates', () => {
       [multisigWallet, flexibleMultisigWallet, regularWallet],
       [backendContactWithSignatories, backendContactNullSignatories, localContact],
     );
-    expect(result).toHaveLength(3);
-    expect(result.filter(c => c.source === 'wallet')).toHaveLength(2);
+    expect(result).toHaveLength(2);
+    expect(result.filter(c => c.source === 'wallet')).toHaveLength(1);
     expect(result.filter(c => c.source === 'contact')).toHaveLength(1);
   });
 });

--- a/src/renderer/aggregates/multisig-candidates/lib/merge-candidates.ts
+++ b/src/renderer/aggregates/multisig-candidates/lib/merge-candidates.ts
@@ -4,7 +4,7 @@ import { accountUtils, walletUtils } from '@/entities/wallet';
 import { type ContactCandidate, type MultisigCandidate, type WalletCandidate } from '../types';
 
 export function mergeMultisigCandidates(wallets: Wallet[], contacts: Contact[]): MultisigCandidate[] {
-  const fromWallets: WalletCandidate[] = wallets.filter(walletUtils.isAnyMultisig).flatMap(wallet => {
+  const fromWallets: WalletCandidate[] = wallets.filter(walletUtils.isRegularMultisig).flatMap(wallet => {
     const account = wallet.accounts.find(accountUtils.isAnyMultisigAccount);
 
     if (!account || account.signatories.length === 0) return [];

--- a/tests/integrations/cases/flexible-change-signatories/edit-controller.integration.test.ts
+++ b/tests/integrations/cases/flexible-change-signatories/edit-controller.integration.test.ts
@@ -4,6 +4,7 @@ import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   type FlexibleMultisigAccount,
   type FlexibleMultisigWallet,
+  type MultisigAccount,
   AccountType,
   ConnectionStatus,
   CryptoType,
@@ -24,7 +25,7 @@ import { accountUtils, walletModel } from '@/entities/wallet';
 import { type MultisigCandidate, multisigCandidates } from '@/aggregates/multisig-candidates';
 import { changeSignatoriesModel } from '@/features/flexible-change-signatories/model/change-signatories-model';
 import { pathModel } from '@/features/signing-path';
-import { multisigAccount, multisigWallet, polkadotChain, polkadotChainId, vaultWallet } from '../../fixtures/index';
+import { multisigWallet, polkadotChain, polkadotChainId, vaultWallet } from '../../fixtures/index';
 import { type FeatureTestEnvironment, FeatureTestBuilder, allureMetadata } from '../../utils/index';
 
 /**
@@ -89,6 +90,23 @@ const flexibleMultisigWallet: FlexibleMultisigWallet = {
   accounts: [],
 };
 
+// Regular multisig candidate — seeded so that multisigCandidates.$candidates yields a
+// wallet-sourced entry after the isRegularMultisig filter is applied.
+const regularMultisigSignatoryId = createAccountId('reg-multisig-signatory-1');
+const regularMultisigAccount: MultisigAccount = {
+  id: 'reg-multisig-1',
+  accountId: accountUtils.getMultisigAccountId([regularMultisigSignatoryId], 1, CryptoType.SR25519),
+  walletId: multisigWallet.id,
+  name: 'Regular Multisig Account',
+  type: 'universal',
+  accountType: AccountType.MULTISIG,
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.MULTISIG,
+  threshold: 1,
+  signatories: [{ accountId: regularMultisigSignatoryId, name: 'Reg Signatory 1' }],
+  createdAt: 0,
+};
+
 // Vault account that owns the FM signatory.
 const flexibleSignatoryAccount: AnyAccount = {
   id: 'flex-signatory-account-1',
@@ -122,7 +140,7 @@ const buildEnv = () =>
     .withChain(polkadotChain)
     .withConnectionStatus(polkadotChainId, ConnectionStatus.CONNECTED)
     .withStoreValue(walletModel.__test.$rawWallets, [vaultWallet, multisigWallet, flexibleMultisigWallet])
-    .withStoreValue(accounts.__test.$list, [flexibleMultisigAccount, flexibleSignatoryAccount, multisigAccount])
+    .withStoreValue(accounts.__test.$list, [flexibleMultisigAccount, flexibleSignatoryAccount, regularMultisigAccount])
     .build();
 
 // ─── Tests ───────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Description
In the "Edit flexible multisig" flow, the "Replace with existing" dropdown was populated using `walletUtils.isAnyMultisig`, which includes both regular and flexible multisig wallet types. Since the feature is meant to replace the current flexible multisig controller with a regular multisig, flexible multisigs should not appear as options.

## Related Issues
Closes SPEK-535

## Changes Made
- Changed wallet filter in `aggregates/multisig-candidates/lib/merge-candidates.ts` from `walletUtils.isAnyMultisig` to `walletUtils.isRegularMultisig`

> **Note:** Address book (backend) contacts cannot be filtered by multisig type yet — `BackendContact` has no field to distinguish regular from flexible multisig. This is tracked in SPEK-535 as a backend requirement.

## Screenshots/Recordings

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines