### PR TITLE
fix(SPEK-538): prevent accordion sticky trigger from becoming translucent on hover

### DIFF
--- a/src/renderer/shared/ui-kit/Accordion/Accordion.tsx
+++ b/src/renderer/shared/ui-kit/Accordion/Accordion.tsx
@@ -45,12 +45,11 @@ const Trigger = ({ sticky, children }: TriggerProps) => {
 
   return (
     <RadixAccordion.Header asChild>
-      <div className={cnTw('block w-full', sticky && 'sticky top-0 z-10')}>
+      <div className={cnTw('block w-full', sticky && 'sticky top-0 z-10 bg-background-default')}>
         <RadixAccordion.Trigger
           className={cnTw(
             'group flex w-full cursor-pointer items-center gap-2 rounded-md px-2 py-1.5 text-caption text-text-secondary uppercase',
             'transition-colors duration-100 hover:bg-action-background-hover',
-            sticky && 'bg-background-default',
           )}
         >
           <div className="flex min-w-0 grow items-center gap-2 truncate text-start">{children}</div>


### PR DESCRIPTION
## Description

On the Operations page, when the Drafts list is expanded and scrolled, hovering over the sticky accordion trigger button made it translucent — scrolled content bled through.

**Root cause:** `bg-background-default` was applied to the inner `RadixAccordion.Trigger`. On hover, `hover:bg-action-background-hover` (semi-transparent) replaced it, removing the solid backdrop needed to cover scrolled content behind the sticky element.

**Fix:** Move `bg-background-default` to the outer sticky `div` wrapper so it always provides a solid background, regardless of the inner trigger's hover state.

## Related Issues

[SPEK-538](https://novasama-technologies.atlassian.net/browse/SPEK-538)

## Changes Made

- `src/renderer/shared/ui-kit/Accordion/Accordion.tsx` — moved `bg-background-default` from `RadixAccordion.Trigger` to the outer sticky `div`

## Screenshots/Recordings

https://github.com/user-attachments/assets/d490412c-4239-495a-b707-c00b936af234



## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

[SPEK-538]: https://novasama-technologies.atlassian.net/browse/SPEK-538?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ