### PR TITLE
fix: extrinsic_builder call filter. SPEK-537

### DIFF
--- a/src/renderer/features/extrinsic-builder/hooks/useComboboxFilter.ts
+++ b/src/renderer/features/extrinsic-builder/hooks/useComboboxFilter.ts
@@ -21,11 +21,8 @@ export function useComboboxFilter(options: string[], value: string | null, onCha
     (val: string) => {
       if (options.includes(val)) {
         onChange(val);
-        setIsEditing(false);
-        setInputText('');
-      } else {
-        setInputText(val);
       }
+      setInputText(val);
     },
     [options, onChange],
   );

--- a/src/renderer/features/extrinsic-builder/ui/parameterInputs/CallParamInput.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/parameterInputs/CallParamInput.tsx
@@ -44,10 +44,13 @@ const NestedBuilder = memo(({ api, value: hexValue, depth, onChange }: NestedBui
   const [paramValues, setParamValues] = useState<Record<string, unknown>>({});
   const [restored, setRestored] = useState(false);
 
-  // Restore nested builder state from hex on remount (e.g. back from Confirm)
+  // Restore nested builder state from hex on remount (e.g. back from Confirm).
+  // Only runs once on first render with api available — subsequent hexValue
+  // changes come from user edits and must not clobber the in-progress input.
   useEffect(() => {
-    if (restored || !api || !hexValue || !hexValue.startsWith('0x')) return;
+    if (restored || !api) return;
     setRestored(true);
+    if (!hexValue || !hexValue.startsWith('0x')) return;
     const parsed = parseCallData(api, hexValue);
     if (parsed) {
       setPallet(parsed.pallet);


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

fix for:
```filter the pallet/call correctly, until you write the full name - and then it shows the full list again```

and decode not hex value to hex format when input in bytes field for nested calls, for example - utility.batch([system.remark(0)]) will converted to utility.batch([system.remark(0x30)])

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

Closes SPEK-537, SPEK-536

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->


https://github.com/user-attachments/assets/29857040-7b55-4ee8-874d-fd6309a4efcf



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
