### PR TITLE
fix(SPEK-542): strip URL fragments and validate JSON in address book backend health check

### DIFF
--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -135,7 +135,7 @@ const logoutFx = createEffect(async (baseUrl: string) => {
 sample({
   clock: connectTriggered,
   source: backendConfigurationModel.$draftUrl,
-  fn: url => (url ? url.trim().replace(/\/+$/, '') : null) || null,
+  fn: url => (url ? url.trim().replace(/#.*$/, '').replace(/\/+$/, '') : null) || null,
   target: backendConfigurationModel.$backendUrl,
 });
 

--- a/src/renderer/aggregates/backend/model/backend-configuration-model.ts
+++ b/src/renderer/aggregates/backend/model/backend-configuration-model.ts
@@ -7,7 +7,7 @@ import { persist } from '@/shared/api/storage';
 type UrlReachability = null | 'checking' | 'reachable' | 'unreachable';
 
 function normalizeUrl(url: string): string {
-  return url.trim().replace(/\/+$/, '');
+  return url.trim().replace(/#.*$/, '').replace(/\/+$/, '');
 }
 
 const urlChanged = createEvent<string>();
@@ -77,6 +77,7 @@ $draftUrl.on(urlCleared, () => '');
 const checkUrlReachabilityFx = createEffect(async (url: string) => {
   const result = await authFetch(`${url}/health`, { method: 'GET' });
   if (!result.ok) throw new Error(`Status ${result.status}`);
+  JSON.parse(result.body);
 });
 
 const $urlReachable = createStore<UrlReachability>(null);


### PR DESCRIPTION
## Description

Fixes two bugs in the address book backend URL validation:

1. **Fragment in URL** — entering a URL like `https://example.com/#/something` showed "Server is reachable" but failed with `Authentication failed — Cannot POST /` on connect. Browsers strip the fragment from HTTP requests, so the health check hit the correct `/health` endpoint, but the fragment-containing URL was stored and used to build POST paths, which collapsed to `/`.

2. **Frontend SPA URL** — entering a Spektr frontend URL (e.g. `https://localhost:3000/#/address-book`) showed "Server is reachable" because a Vite dev server returns `index.html` (HTTP 200) for all routes. The health check only verified status code, so it passed. On connect, the server returned HTML instead of JSON, causing `Unexpected end of JSON input`.

## Related Issues

[SPEK-542](https://novasama-technologies.atlassian.net/browse/SPEK-542)

## Changes Made

- `aggregates/backend/model/backend-configuration-model.ts` — added `.replace(/#.*$/, '')` to `normalizeUrl()` to strip fragments before validation and health checks; added `JSON.parse(result.body)` to `checkUrlReachabilityFx` to reject non-JSON responses (HTML from SPAs)
- `aggregates/backend/model/auth-model.ts` — added the same fragment-stripping regex to the inline normalization in the `connectTriggered` sample that saves the URL to `$backendUrl`

## Screenshots/Recordings
<img width="1091" height="754" alt="Снимок экрана 2026-05-05 в 19 03 47" src="https://github.com/user-attachments/assets/40253222-ecac-4c92-b2f1-f9460f37e88a" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

[SPEK-542]: https://novasama-technologies.atlassian.net/browse/SPEK-542?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Fixes novasamatech/nova-spektr-tracker#13