### PR TITLE
refactor: connection-scoped external address book contacts

### DIFF
--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -390,6 +390,16 @@ $hasNetworkIssue.on(checkSessionFx.fail, () => true);
 $hasNetworkIssue.on(checkSessionFx.done, () => false);
 $hasNetworkIssue.on([verifySignatureFx.done, signOutClicked, backendConfigurationModel.events.urlCleared], () => false);
 
+const $isConnectionAlive = combine(
+  {
+    url: backendConfigurationModel.$backendUrl,
+    auth: $authState,
+    expired: $isSessionExpired,
+    networkIssue: $hasNetworkIssue,
+  },
+  ({ url, auth, expired, networkIssue }) => url !== null && auth !== null && !expired && !networkIssue,
+);
+
 const sessionExpired = createEvent();
 
 const showSessionExpiredToastFx = createEffect(() => {
@@ -418,6 +428,7 @@ export const authModel = {
   $signableAccounts,
   $isSessionExpired,
   $hasNetworkIssue,
+  $isConnectionAlive,
 
   events: {
     signInClicked,

--- a/src/renderer/entities/contact/model/__tests__/contact-model.test.ts
+++ b/src/renderer/entities/contact/model/__tests__/contact-model.test.ts
@@ -29,7 +29,7 @@ describe('entities/contact/model/contact-model', () => {
     const spyPut = jest.spyOn(storageService.contacts, 'put');
 
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, [existingContact]),
+      values: new Map().set(contactModel.$localContacts, [existingContact]),
     });
 
     // Try to undo delete with a contact that has the same accountId as existing
@@ -54,7 +54,7 @@ describe('entities/contact/model/contact-model', () => {
     const spyPut = jest.spyOn(storageService.contacts, 'put').mockResolvedValue(createdContact);
 
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, [existingContact]),
+      values: new Map().set(contactModel.$localContacts, [existingContact]),
     });
 
     // Try to undo delete with a contact that has different accountId

--- a/src/renderer/entities/contact/model/contact-model.ts
+++ b/src/renderer/entities/contact/model/contact-model.ts
@@ -1,28 +1,40 @@
-import { attach, createEffect, createStore, sample } from 'effector';
+import { attach, combine, createEffect, createEvent, createStore, sample } from 'effector';
 
 import { storageService } from '@/shared/api/storage';
 import { kernelModel } from '@/shared/core/model/kernel-model';
-import { type Contact, type LocalContact } from '@/shared/core/types/contact';
-import { isBackendContact, isLocalContact } from '@/shared/core/types/contact';
+import { type BackendContact, type Contact, type LocalContact } from '@/shared/core/types/contact';
+import { isLocalContact } from '@/shared/core/types/contact';
 import { merge, splice } from '@/shared/lib/utils';
 
-const $contacts = createStore<Contact[]>([]);
-const $localContacts = $contacts.map((cs) => cs.filter(isLocalContact));
-const $backendContacts = $contacts.map((cs) => cs.filter(isBackendContact));
+// Public events the BackendContacts feature uses to push the connection-scoped backend contact list
+// into this entity. Backend contacts are session-scoped and never persisted to Dexie.
+const backendContactsReceived = createEvent<BackendContact[]>();
+const backendContactsCleared = createEvent();
 
-const populateContactsFx = createEffect((): Promise<Contact[]> => {
-  return storageService.contacts.readAll();
+const $localContacts = createStore<LocalContact[]>([]);
+const $backendContacts = createStore<BackendContact[]>([])
+  .on(backendContactsReceived, (_, contacts) => contacts)
+  .reset(backendContactsCleared);
+
+const $contacts = combine($localContacts, $backendContacts, (local, backend): Contact[] => [...local, ...backend]);
+
+// Loads contacts from Dexie. Backend contacts are session-scoped and never persisted; legacy rows
+// from previous app versions are dropped at the schema level by migration-19.
+const populateLocalContactsFx = createEffect(async (): Promise<LocalContact[]> => {
+  const all = await storageService.contacts.readAll();
+
+  return all.filter(isLocalContact);
 });
 
-const createContactFx = createEffect(async (contact: Omit<LocalContact, 'id'>): Promise<Contact | undefined> => {
+const createContactFx = createEffect(async (contact: Omit<LocalContact, 'id'>): Promise<LocalContact | undefined> => {
   const full: LocalContact = { ...contact, id: crypto.randomUUID() };
 
-  return storageService.contacts.put(full);
+  return storageService.contacts.put(full) as Promise<LocalContact | undefined>;
 });
 
 const undoDeleteContactFx = attach({
-  source: $contacts,
-  mapParams: (contact: Omit<LocalContact, 'id'>, existingContacts: Contact[]) => ({
+  source: $localContacts,
+  mapParams: (contact: Omit<LocalContact, 'id'>, existingContacts: LocalContact[]) => ({
     contact,
     existingContacts,
   }),
@@ -32,38 +44,41 @@ const undoDeleteContactFx = attach({
       existingContacts,
     }: {
       contact: Omit<LocalContact, 'id'>;
-      existingContacts: Contact[];
-    }): Promise<Contact | undefined> => {
+      existingContacts: LocalContact[];
+    }): Promise<LocalContact | undefined> => {
       const hasDuplicate = existingContacts.some((c) => c.accountId === contact.accountId);
       if (hasDuplicate) {
         return undefined;
       }
       const full: LocalContact = { ...contact, id: crypto.randomUUID() };
 
-      return storageService.contacts.put(full);
+      return storageService.contacts.put(full) as Promise<LocalContact | undefined>;
     },
   ),
 });
 
-const createContactsFx = createEffect(async (contacts: Omit<LocalContact, 'id'>[]): Promise<Contact[] | undefined> => {
-  const fullContacts: LocalContact[] = contacts.map((c) => ({ ...c, id: crypto.randomUUID() }));
-  await storageService.contacts.insertAll(fullContacts);
+const createContactsFx = createEffect(
+  async (contacts: Omit<LocalContact, 'id'>[]): Promise<LocalContact[] | undefined> => {
+    const fullContacts: LocalContact[] = contacts.map((c) => ({ ...c, id: crypto.randomUUID() }));
+    await storageService.contacts.insertAll(fullContacts);
 
-  return fullContacts;
-});
+    return fullContacts;
+  },
+);
 
-const updateContactFx = createEffect(async ({ id, ...rest }: Contact): Promise<Contact> => {
+const updateContactFx = createEffect(async ({ id, ...rest }: LocalContact): Promise<LocalContact> => {
   await storageService.contacts.update(id, rest);
 
-  return { id, ...rest } satisfies Contact;
+  return { id, ...rest } satisfies LocalContact;
 });
 
-const updateContactsFx = createEffect(async (contacts: Contact[]): Promise<Contact[]> => {
-  if (contacts.length === 0) return [];
+const updateContactsFx = createEffect(async (contacts: Contact[]): Promise<LocalContact[]> => {
+  const localOnly = contacts.filter(isLocalContact);
+  if (localOnly.length === 0) return [];
 
-  await storageService.contacts.updateAll(contacts);
+  await storageService.contacts.updateAll(localOnly);
 
-  return contacts;
+  return localOnly;
 });
 
 const deleteContactFx = createEffect(async (contactId: string): Promise<string> => {
@@ -72,34 +87,8 @@ const deleteContactFx = createEffect(async (contactId: string): Promise<string> 
   return contactId;
 });
 
-const syncBackendContactsFx = createEffect(async (contacts: Contact[]): Promise<Contact[]> => {
-  const all = await storageService.contacts.readAll();
-  const oldBackendIds = all.filter((c) => c.source === 'backend').map((c) => c.id);
-  const newIds = new Set(contacts.map((c) => c.id));
-  const staleIds = oldBackendIds.filter((id) => !newIds.has(id));
-
-  if (staleIds.length > 0) {
-    await storageService.contacts.deleteAll(staleIds);
-  }
-  await storageService.contacts.insertAll(contacts);
-
-  return contacts;
-});
-
-const clearBackendContactsFx = createEffect(async (): Promise<string[]> => {
-  const all = await storageService.contacts.readAll();
-  const backendIds = all.filter((c) => c.source === 'backend').map((c) => c.id);
-  if (backendIds.length > 0) {
-    await storageService.contacts.deleteAll(backendIds);
-  }
-
-  return backendIds;
-});
-
-$contacts
-  .on(populateContactsFx.doneData, (_, contacts) => {
-    return contacts;
-  })
+$localContacts
+  .on(populateLocalContactsFx.doneData, (_, contacts) => contacts)
   .on([createContactFx.doneData, createContactsFx.doneData, undoDeleteContactFx.doneData], (state, contact) => {
     return contact ? state.concat(contact) : state;
   })
@@ -117,27 +106,21 @@ $contacts
       b: contacts,
       mergeBy: (c) => c.id,
     });
-  })
-  .on(syncBackendContactsFx.doneData, (state, backendContacts) => {
-    const withoutOldBackend: Contact[] = state.filter((c) => c.source !== 'backend');
-
-    return withoutOldBackend.concat(backendContacts);
-  })
-  .on(clearBackendContactsFx.doneData, (state, deletedIds) => {
-    const idSet = new Set(deletedIds);
-
-    return state.filter((c) => !idSet.has(c.id));
   });
 
 sample({
   clock: kernelModel.events.appStarted,
-  target: populateContactsFx,
+  target: populateLocalContactsFx,
 });
 
 export const contactModel = {
   $contacts,
   $localContacts,
   $backendContacts,
+  events: {
+    backendContactsReceived,
+    backendContactsCleared,
+  },
   effects: {
     createContactFx,
     createContactsFx,
@@ -145,7 +128,5 @@ export const contactModel = {
     deleteContactFx,
     updateContactFx,
     updateContactsFx,
-    syncBackendContactsFx,
-    clearBackendContactsFx,
   },
 };

--- a/src/renderer/features/contacts/BackendContacts/model/__tests__/backend-contacts-model.test.ts
+++ b/src/renderer/features/contacts/BackendContacts/model/__tests__/backend-contacts-model.test.ts
@@ -1,12 +1,12 @@
 import { allSettled, fork } from 'effector';
 
-import { type Contact } from '@/shared/core';
+import { type BackendContact } from '@/shared/core';
 import { toAccountId, toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
 import { authModel, backendConfigurationModel } from '@/aggregates/backend';
 import { backendContactsModel } from '../backend-contacts-model';
 
-const backendContacts: Contact[] = [
+const backendContacts: BackendContact[] = [
   {
     id: 'backend-1',
     name: 'Backend Contact 1',
@@ -43,90 +43,81 @@ const backendContacts: Contact[] = [
   },
 ];
 
-const localContact: Contact = {
-  id: 'local-1',
-  name: 'Local Contact',
-  address: toAddress('333'),
-  accountId: toAccountId('0x03'),
-  source: 'local',
-};
-
 describe('features/contacts/BackendContacts/model/backend-contacts-model', () => {
-  test('should clear backend contacts when connection is deleted (urlCleared)', async () => {
-    const clearSpy = jest.fn().mockResolvedValue(['backend-1', 'backend-2']);
-
+  test('should clear backend contacts when connection url is cleared', async () => {
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, [...backendContacts, localContact]),
-      handlers: [[contactModel.effects.clearBackendContactsFx, clearSpy]],
+      values: new Map().set(contactModel.$backendContacts, backendContacts),
     });
+
+    expect(scope.getState(contactModel.$backendContacts)).toEqual(backendContacts);
 
     await allSettled(backendConfigurationModel.events.urlCleared, { scope });
 
-    expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(scope.getState(contactModel.$contacts)).toEqual([localContact]);
+    expect(scope.getState(contactModel.$backendContacts)).toEqual([]);
   });
 
-  test('should NOT clear backend contacts when disconnecting (signOutClicked)', async () => {
-    const clearSpy = jest.fn().mockResolvedValue([]);
-
+  test('should clear backend contacts when user signs out', async () => {
     const scope = fork({
       values: new Map()
-        .set(contactModel.$contacts, [...backendContacts, localContact])
+        .set(contactModel.$backendContacts, backendContacts)
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
-      handlers: [
-        [contactModel.effects.clearBackendContactsFx, clearSpy],
-        [authModel.__test.logoutFx, jest.fn().mockResolvedValue(undefined)],
-      ],
+      handlers: [[authModel.__test.logoutFx, jest.fn().mockResolvedValue(undefined)]],
     });
 
     await allSettled(authModel.events.signOutClicked, { scope });
 
-    expect(clearSpy).not.toHaveBeenCalled();
-    expect(scope.getState(contactModel.$backendContacts)).toEqual(backendContacts);
+    expect(scope.getState(contactModel.$backendContacts)).toEqual([]);
   });
 
   test('should clear backend contacts when session expires', async () => {
-    const clearSpy = jest.fn().mockResolvedValue(['backend-1', 'backend-2']);
-
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, [...backendContacts, localContact]),
-      handlers: [[contactModel.effects.clearBackendContactsFx, clearSpy]],
+      values: new Map().set(contactModel.$backendContacts, backendContacts),
     });
 
     await allSettled(authModel.$isSessionExpired, { scope, params: true });
 
-    expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(scope.getState(contactModel.$contacts)).toEqual([localContact]);
+    expect(scope.getState(contactModel.$backendContacts)).toEqual([]);
   });
 
   test('should NOT clear backend contacts when $isSessionExpired transitions to false', async () => {
-    const clearSpy = jest.fn().mockResolvedValue([]);
-
     const scope = fork({
       values: new Map()
-        .set(contactModel.$contacts, [...backendContacts, localContact])
+        .set(contactModel.$backendContacts, backendContacts)
         .set(authModel.$isSessionExpired, true),
-      handlers: [[contactModel.effects.clearBackendContactsFx, clearSpy]],
     });
 
     await allSettled(authModel.$isSessionExpired, { scope, params: false });
 
-    expect(clearSpy).not.toHaveBeenCalled();
     expect(scope.getState(contactModel.$backendContacts)).toEqual(backendContacts);
   });
 
   test('should clear backend contacts on a network/reachability issue', async () => {
-    const clearSpy = jest.fn().mockResolvedValue(['backend-1', 'backend-2']);
-
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, [...backendContacts, localContact]),
-      handlers: [[contactModel.effects.clearBackendContactsFx, clearSpy]],
+      values: new Map().set(contactModel.$backendContacts, backendContacts),
     });
 
     await allSettled(authModel.$hasNetworkIssue, { scope, params: true });
 
-    expect(clearSpy).toHaveBeenCalledTimes(1);
-    expect(scope.getState(contactModel.$contacts)).toEqual([localContact]);
+    expect(scope.getState(contactModel.$backendContacts)).toEqual([]);
+  });
+
+  test('should clear backend contacts when fetch fails', async () => {
+    const scope = fork({
+      values: new Map().set(contactModel.$backendContacts, backendContacts),
+      handlers: [
+        [
+          backendContactsModel.__test.fetchBackendContactsFx,
+          jest.fn().mockRejectedValue(new Error('boom')),
+        ],
+      ],
+    });
+
+    await allSettled(backendContactsModel.__test.fetchBackendContactsFx, {
+      scope,
+      params: 'https://backend.example.com',
+    });
+
+    expect(scope.getState(contactModel.$backendContacts)).toEqual([]);
   });
 
   test('should refetch backend contacts when network issue clears (session still authed)', async () => {
@@ -141,10 +132,7 @@ describe('features/contacts/BackendContacts/model/backend-contacts-model', () =>
           permissions: [],
         })
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
-      handlers: [
-        [contactModel.effects.clearBackendContactsFx, jest.fn().mockResolvedValue([])],
-        [backendContactsModel.__test.fetchBackendContactsFx, fetchSpy],
-      ],
+      handlers: [[backendContactsModel.__test.fetchBackendContactsFx, fetchSpy]],
     });
 
     await allSettled(authModel.$hasNetworkIssue, { scope, params: false });
@@ -160,27 +148,11 @@ describe('features/contacts/BackendContacts/model/backend-contacts-model', () =>
         .set(authModel.$hasNetworkIssue, true)
         .set(authModel.$authState, null)
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
-      handlers: [
-        [contactModel.effects.clearBackendContactsFx, jest.fn().mockResolvedValue([])],
-        [backendContactsModel.__test.fetchBackendContactsFx, fetchSpy],
-      ],
+      handlers: [[backendContactsModel.__test.fetchBackendContactsFx, fetchSpy]],
     });
 
     await allSettled(authModel.$hasNetworkIssue, { scope, params: false });
 
     expect(fetchSpy).not.toHaveBeenCalled();
-  });
-
-  test('should preserve local contacts when connection is deleted', async () => {
-    const clearSpy = jest.fn().mockResolvedValue(['backend-1', 'backend-2']);
-
-    const scope = fork({
-      values: new Map().set(contactModel.$contacts, [...backendContacts, localContact]),
-      handlers: [[contactModel.effects.clearBackendContactsFx, clearSpy]],
-    });
-
-    await allSettled(backendConfigurationModel.events.urlCleared, { scope });
-
-    expect(scope.getState(contactModel.$localContacts)).toEqual([localContact]);
   });
 });

--- a/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
+++ b/src/renderer/features/contacts/BackendContacts/model/backend-contacts-model.ts
@@ -1,7 +1,7 @@
 import { createEffect, createEvent, createStore, sample } from 'effector';
 
 import { persist } from '@/shared/api/storage';
-import { type Contact } from '@/shared/core';
+import { type BackendContact } from '@/shared/core';
 import { HttpError, backendContactsService } from '@/domains/backend';
 import { type BackendError, contactModel } from '@/entities/contact';
 import { authModel, backendConfigurationModel } from '@/aggregates/backend';
@@ -31,8 +31,10 @@ const $lastSyncTime = createStore<number | null>(null);
 persist({ store: $lastSyncTime, key: 'address-book-last-sync-time' });
 const $syncStatus = createStore<SyncStatus>('idle');
 
-const fetchBackendContactsFx = createEffect(async (baseUrl: string): Promise<Contact[]> => {
-  return backendContactsService.fetchAllContacts(baseUrl);
+const fetchBackendContactsFx = createEffect(async (baseUrl: string): Promise<BackendContact[]> => {
+  const result = await backendContactsService.fetchAllContacts(baseUrl);
+
+  return result.filter((c): c is BackendContact => c.source === 'backend');
 });
 
 $isLoading.on(fetchBackendContactsFx, () => true);
@@ -83,10 +85,10 @@ sample({
 
 $syncStatusThrottled.on(ensureMinSyncTimeFx.doneData, (_, status) => status);
 
-// Persist fetched backend contacts to Dexie
+// Push freshly fetched contacts into the contact entity (in-memory, never persisted)
 sample({
   clock: fetchBackendContactsFx.doneData,
-  target: contactModel.effects.syncBackendContactsFx,
+  target: contactModel.events.backendContactsReceived,
 });
 
 // Auto-fetch when auth state changes to non-null
@@ -116,18 +118,21 @@ const sessionExpired = sample({
   filter: (expired) => expired,
 });
 
-const networkIssueDetected = sample({
-  clock: authModel.$hasNetworkIssue,
-  filter: (issue) => issue,
-});
-
 $error.on(sessionExpired, () => null);
 $lastSyncTime.on(sessionExpired, () => null);
 $syncStatus.on(sessionExpired, () => 'idle');
 
+// All disconnect signals reset the entity's backend-contact store. New disconnect events get added
+// here once and pick up the cleanup automatically — no per-trigger imperative clear is needed.
 sample({
-  clock: [backendConfigurationModel.events.urlCleared, sessionExpired, networkIssueDetected],
-  target: contactModel.effects.clearBackendContactsFx,
+  clock: [
+    backendConfigurationModel.events.urlCleared,
+    authModel.events.signOutClicked,
+    sessionExpired,
+    sample({ clock: authModel.$hasNetworkIssue, filter: (issue) => issue }),
+    fetchBackendContactsFx.failData,
+  ],
+  target: contactModel.events.backendContactsCleared,
 });
 
 const networkIssueCleared = sample({

--- a/src/renderer/features/contacts/ContactFilter/model/__tests__/contact-filter.test.tsx
+++ b/src/renderer/features/contacts/ContactFilter/model/__tests__/contact-filter.test.tsx
@@ -23,7 +23,7 @@ const contacts = [
 describe('features/contacts/model/contact-filter-model', () => {
   test('should return all contacts if no search query', () => {
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, contacts),
+      values: new Map().set(contactModel.$localContacts, contacts),
     });
 
     expect(scope.getState(filterModel.$filteredContacts)).toEqual(contacts);
@@ -31,7 +31,7 @@ describe('features/contacts/model/contact-filter-model', () => {
 
   test('should return nothing if there is no match', async () => {
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, contacts),
+      values: new Map().set(contactModel.$localContacts, contacts),
     });
 
     await allSettled(filterModel.events.queryChanged, { scope, params: 'nothing' });
@@ -41,7 +41,7 @@ describe('features/contacts/model/contact-filter-model', () => {
 
   test('should search by name', async () => {
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, contacts),
+      values: new Map().set(contactModel.$localContacts, contacts),
     });
 
     await allSettled(filterModel.events.queryChanged, { scope, params: contacts[0]!.name });
@@ -51,7 +51,7 @@ describe('features/contacts/model/contact-filter-model', () => {
 
   test('should search by address', async () => {
     const scope = fork({
-      values: new Map().set(contactModel.$contacts, contacts),
+      values: new Map().set(contactModel.$localContacts, contacts),
     });
 
     await allSettled(filterModel.events.queryChanged, { scope, params: contacts[0]!.address });

--- a/src/renderer/features/contacts/ContactFilter/model/__tests__/contact-source-model.test.ts
+++ b/src/renderer/features/contacts/ContactFilter/model/__tests__/contact-source-model.test.ts
@@ -1,12 +1,12 @@
 import { allSettled, fork } from 'effector';
 
-import { type Contact } from '@/shared/core';
+import { type BackendContact, type Contact } from '@/shared/core';
 import { toAccountId, toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
 import { authModel, backendConfigurationModel } from '@/aggregates/backend';
 import { contactSourceModel } from '../contact-source-model';
 
-const backendContacts: Contact[] = [
+const backendContacts: BackendContact[] = [
   {
     id: 'backend-1',
     name: 'Backend Contact',
@@ -39,9 +39,9 @@ describe('features/contacts/ContactFilter/model/contact-source-model', () => {
     const scope = fork({
       values: new Map()
         .set(contactSourceModel.$sourceTab, 'backend')
-        .set(contactModel.$contacts, [...backendContacts, localContact])
+        .set(contactModel.$localContacts, [localContact])
+        .set(contactModel.$backendContacts, backendContacts)
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
-      handlers: [[contactModel.effects.clearBackendContactsFx, () => ['backend-1']]],
     });
 
     expect(scope.getState(contactSourceModel.$sourceTab)).toBe('backend');
@@ -55,7 +55,8 @@ describe('features/contacts/ContactFilter/model/contact-source-model', () => {
     const scope = fork({
       values: new Map()
         .set(contactSourceModel.$sourceTab, 'backend')
-        .set(contactModel.$contacts, [...backendContacts, localContact])
+        .set(contactModel.$localContacts, [localContact])
+        .set(contactModel.$backendContacts, backendContacts)
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
       handlers: [[authModel.__test.logoutFx, jest.fn().mockResolvedValue(undefined)]],
     });
@@ -71,9 +72,8 @@ describe('features/contacts/ContactFilter/model/contact-source-model', () => {
     const scope = fork({
       values: new Map()
         .set(contactSourceModel.$sourceTab, 'backend')
-        .set(contactModel.$contacts, backendContacts)
+        .set(contactModel.$backendContacts, backendContacts)
         .set(backendConfigurationModel.$backendUrl, 'https://backend.example.com'),
-      handlers: [[contactModel.effects.clearBackendContactsFx, () => ['backend-1']]],
     });
 
     await allSettled(authModel.$isSessionExpired, { scope, params: true });
@@ -84,7 +84,7 @@ describe('features/contacts/ContactFilter/model/contact-source-model', () => {
   test('should show backend tab when backend contacts exist even without active connection', () => {
     const scope = fork({
       values: new Map()
-        .set(contactModel.$contacts, backendContacts)
+        .set(contactModel.$backendContacts, backendContacts)
         .set(backendConfigurationModel.$backendUrl, null)
         .set(authModel.$authState, null),
     });
@@ -97,7 +97,8 @@ describe('features/contacts/ContactFilter/model/contact-source-model', () => {
   test('should hide backend tab when no backend contacts and no active connection', () => {
     const scope = fork({
       values: new Map()
-        .set(contactModel.$contacts, [])
+        .set(contactModel.$localContacts, [])
+        .set(contactModel.$backendContacts, [])
         .set(backendConfigurationModel.$backendUrl, null)
         .set(authModel.$authState, null),
     });

--- a/src/renderer/features/contacts/ImportContacts/model/__tests__/import-contacts-model.test.ts
+++ b/src/renderer/features/contacts/ImportContacts/model/__tests__/import-contacts-model.test.ts
@@ -1,19 +1,19 @@
 import { allSettled, fork } from 'effector';
 import { describe, expect, it, vi } from 'vitest';
 
-import { type Contact } from '@/shared/core';
+import { type LocalContact } from '@/shared/core';
 import { toAccountId, toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
 import { importContactsModel } from '../import-contacts-model';
 
 import * as mockData from './mocks/import-data';
 
-function localContact(overrides: Partial<Contact> & { id: string; name: string; address: string }): Contact {
+function localContact(overrides: Partial<LocalContact> & { id: string; name: string; address: string }): LocalContact {
   return {
     accountId: toAccountId(overrides.address),
     source: 'local' as const,
     ...overrides,
-  } as Contact;
+  } as LocalContact;
 }
 
 const createMockFile = (data: unknown): File => {
@@ -259,7 +259,7 @@ describe('importContactsModel', () => {
       ];
 
       const scope = fork({
-        values: new Map().set(contactModel.$contacts, existingContacts),
+        values: new Map().set(contactModel.$localContacts, existingContacts),
       });
 
       await allSettled(importContactsModel.events.fileSelected, { scope, params: file });
@@ -297,7 +297,7 @@ describe('importContactsModel', () => {
       ]);
 
       const scope = fork({
-        values: new Map().set(contactModel.$contacts, existingContacts),
+        values: new Map().set(contactModel.$localContacts, existingContacts),
       });
 
       await allSettled(importContactsModel.events.fileSelected, { scope, params: file });
@@ -324,7 +324,7 @@ describe('importContactsModel', () => {
       const mockUpdate = vi.spyOn(contactModel.effects, 'updateContactsFx').mockResolvedValue([]);
 
       const scope = fork({
-        values: new Map().set(contactModel.$contacts, existingContacts),
+        values: new Map().set(contactModel.$localContacts, existingContacts),
       });
 
       await allSettled(importContactsModel.events.fileSelected, { scope, params: file });
@@ -369,7 +369,7 @@ describe('importContactsModel', () => {
       ]);
 
       const scope = fork({
-        values: new Map().set(contactModel.$contacts, existingContacts),
+        values: new Map().set(contactModel.$localContacts, existingContacts),
       });
 
       await allSettled(importContactsModel.events.fileSelected, { scope, params: file });

--- a/src/renderer/features/contacts/lib/create-contact-form-model.ts
+++ b/src/renderer/features/contacts/lib/create-contact-form-model.ts
@@ -3,7 +3,7 @@ import { createForm } from 'effector-forms';
 import { t } from 'i18next';
 import { not } from 'patronum';
 
-import { type Contact } from '@/shared/core';
+import { type Contact, type LocalContact } from '@/shared/core';
 import { isValidContactName, sanitizeContactName, toAccountId, toAddress, validateAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
 
@@ -207,12 +207,12 @@ export function createEditFormModel() {
   sample({
     clock: $contactForm.formValidated,
     source: $contactToEdit,
-    filter: (contactToEdit): contactToEdit is Contact => contactToEdit !== null,
-    fn: (contactToEdit, form) => {
+    filter: (contactToEdit): contactToEdit is LocalContact =>
+      contactToEdit !== null && contactToEdit.source === 'local',
+    fn: (contactToEdit: LocalContact, form): LocalContact => {
       const address = toAddress(form.address);
-      const base = { ...contactToEdit, name: sanitizeContactName(form.name), address, accountId: toAccountId(address) };
 
-      return base as Contact;
+      return { ...contactToEdit, name: sanitizeContactName(form.name), address, accountId: toAccountId(address) };
     },
     target: contactModel.effects.updateContactFx,
   });

--- a/src/renderer/features/signing-path/model/graph-model.test.ts
+++ b/src/renderer/features/signing-path/model/graph-model.test.ts
@@ -112,7 +112,7 @@ function makeValues(
   }
 
   return new Map<any, any>([
-    [contactModel.$contacts, contacts],
+    [contactModel.$backendContacts, contacts],
     [proxyModel.$proxies, proxiesDict],
     [accounts.__test.$list, ownAccounts],
   ]);

--- a/src/renderer/features/wallets/RenameWallet/model/__tests__/rename-wallet-model.test.ts
+++ b/src/renderer/features/wallets/RenameWallet/model/__tests__/rename-wallet-model.test.ts
@@ -73,7 +73,7 @@ describe('features/wallets/RenameWallet/model/rename-wallet-model', () => {
     };
 
     const scope = fork({
-      values: [[contactModel.$contacts, [backendContact]]],
+      values: [[contactModel.$backendContacts, [backendContact]]],
     });
 
     // Directly call the sync effect with only local contacts (empty, since we only have backend)

--- a/src/renderer/shared/api/storage/migration/index.ts
+++ b/src/renderer/shared/api/storage/migration/index.ts
@@ -16,3 +16,4 @@ export { migrateNotificationStructure } from './migration-15';
 export { addFlexibleMultisigProxyType } from './migration-16';
 export { addAccountCreatedAt } from './migration-17';
 export { backupContactsBeforePKChange, migrateContactsToStringIds, restoreContactsAfterPKChange } from './migration-18';
+export { dropPersistedBackendContacts } from './migration-19';

--- a/src/renderer/shared/api/storage/migration/migration-19.ts
+++ b/src/renderer/shared/api/storage/migration/migration-19.ts
@@ -1,0 +1,14 @@
+import { type Transaction } from 'dexie';
+
+/**
+ * Backend contacts are now session-scoped (in-memory only). Drop any rows that
+ * the previous persisted implementation left behind. Idempotent: a no-op if the
+ * table never had backend rows.
+ */
+export async function dropPersistedBackendContacts(t: Transaction): Promise<void> {
+  const all = await t.table('contacts').toArray();
+  const backendIds = all.filter((c) => c.source === 'backend').map((c) => c.id);
+  if (backendIds.length === 0) return;
+
+  await t.table('contacts').bulkDelete(backendIds);
+}

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -20,6 +20,7 @@ import {
   addAccountNameType,
   addFlexibleMultisigProxyType,
   backupContactsBeforePKChange,
+  dropPersistedBackendContacts,
   migrateAccounts,
   migrateBasketTransactionAfterAddressRemoval,
   migrateCASBasket,
@@ -172,6 +173,8 @@ class DexieStorage extends Dexie {
     this.version(49).stores({ operationDescriptions: 'id' });
 
     this.version(50).stores({ operationTemplates: '++id, chainId' });
+
+    this.version(51).upgrade(dropPersistedBackendContacts);
 
     this.connections = this.table('connections');
     this.balances2 = this.table('balances2');


### PR DESCRIPTION
## Description
Remove external address book contacts on session expire, disconnect.
Avoid caching external contacts, they exist in the spektr only when connection to backend is alive and user is authenticated. 

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-531

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#14