### PR TITLE
fix(portfolio): prevent token list collapse on empty shard selection

### DIFF
--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -51,6 +51,7 @@ sample({
     struct: shardsModel.$selectedStructure,
     selectedAccounts: walletSelect.$selectedAccounts,
   },
+  filter: ({ struct, selectedAccounts }) => shardsUtils.getSelectedShards(struct, selectedAccounts).length > 0,
   fn: ({ struct, selectedAccounts }) => shardsUtils.getSelectedShards(struct, selectedAccounts),
   target: $filteredAccounts,
 });


### PR DESCRIPTION
## Summary
- `$filteredAccounts` in `portfolio-model.ts` was overwritten with `[]` whenever `shardsConfirmed` fired with no shards checked (including dismissing `ShardSelectorModal` via overlay/close, which also triggers `shardsConfirmed`).
- Once empty, every token gets filtered out of `$activeTokens` (the `accountService.filterAccountsOnChain(filteredAccounts, chain).length > 0` check), so the portfolio shows the generic empty state "Nothing was found / Update the search or cancel filtering" — even though no search is active.
- Only switching wallets recovers, because that re-derives `$allInitiators` and reseeds `$filteredAccounts` via the `sample({ clock: $allInitiators, target: $filteredAccounts })` link.

## Fix
Skip the update when the computed shard selection is empty — keep the previous `$filteredAccounts` value instead of clearing it.

```ts
sample({
  clock: shardsModel.events.shardsConfirmed,
  source: { struct: shardsModel.$selectedStructure, selectedAccounts: walletSelect.$selectedAccounts },
  filter: ({ struct, selectedAccounts }) => shardsUtils.getSelectedShards(struct, selectedAccounts).length > 0,
  fn: ({ struct, selectedAccounts }) => shardsUtils.getSelectedShards(struct, selectedAccounts),
  target: $filteredAccounts,
});
```

## Out of scope (follow-ups worth considering)
- `EmptyAssetsState` shows the same "Update the search or cancel filtering" copy regardless of cause. It would be clearer to differentiate "no search match" from "no active accounts/networks".
- `ShardSelectorModal.onToggle` calls `shardsConfirmed`, so closing the modal via overlay/X is treated as Save. A separate "cancel" path would prevent accidental persisted changes.

## Test plan
- [ ] Open portfolio, open Shard Selector, deselect everything, click Save → token list should remain populated (previous selection preserved) instead of collapsing to empty.
- [ ] Open Shard Selector, deselect everything, close modal via X / overlay → same expected behavior.
- [ ] Open Shard Selector, select a non-empty subset, Save → list updates as before.
- [ ] Switch wallet → list still re-derives normally.
- [ ] Existing portfolio model tests still pass (`pnpm vitest run src/renderer/features/assets/AssetsPortfolioView/model/__tests__/portfolio-model.test.ts`).