### PR TITLE
fix(drafts): human-readable error when signing path account is absent from address book

### DIFF
--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -1,12 +1,13 @@
 import { useUnit } from 'effector-react';
-import { useDeferredValue, useMemo, useState } from 'react';
+import { type ReactElement, useDeferredValue, useMemo, useState } from 'react';
 
 import { type CallData, type ChainId, type DecodedTransaction } from '@/shared/core';
 import { useTransformer } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { formatSectionAndMethod, getNativeAssetId, isHex } from '@/shared/lib/utils';
+import { formatSectionAndMethod, getNativeAssetId, isHex, toAddress, toShortAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { Button } from '@/shared/ui';
+import { Identicon } from '@/shared/ui-entities';
 import { ConfirmModal, Modal, Tooltip, useNotification } from '@/shared/ui-kit';
 import { draftsResource, draftsService } from '@/domains/backend';
 import { contactModel } from '@/entities/contact';
@@ -208,8 +209,32 @@ export const CreateDraftModal = () => {
       toast.success(t('operations.drafts.createSuccess'));
       createDraftModel.modalClosed();
     } catch (e) {
-      const message = e instanceof Error ? e.message : t('operations.drafts.createError');
-      toast.error(t('operations.drafts.createError'), { description: message });
+      let description: string | ReactElement;
+
+      if (e instanceof Error) {
+        const match = e.message.match(/^Account (.+) not found$/);
+        if (match && selectedChain) {
+          const accountId = match[1] as AccountId;
+          const address = toAddress(accountId);
+          const name = resolveName(accountId, selectedChain.chainId);
+          description = (
+            <span className="flex flex-col gap-1" onPointerDown={(e) => e.stopPropagation()}>
+              <span className="flex items-center gap-1.5">
+                <Identicon address={address} size={20} background={false} canCopy />
+                <span className="font-medium">{name}</span>
+                <span className="text-text-tertiary">{toShortAddress(address)}</span>
+              </span>
+              <span>{t('operations.drafts.accountNotInAddressBook')}</span>
+            </span>
+          );
+        } else {
+          description = e.message;
+        }
+      } else {
+        description = t('operations.drafts.createError');
+      }
+
+      toast.error(t('operations.drafts.createError'), { description });
     } finally {
       setIsSubmitting(false);
     }

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2604,6 +2604,7 @@
       "createDraftButton": "Create",
       "createSuccess": "Draft created",
       "createError": "Failed to create draft",
+      "accountNotInAddressBook": "This account is not in the address book contacts. Add it to contacts before creating a draft.",
       "connectToCreate": "Sign in to create drafts",
       "connectToSubmit": "Sign in to submit drafts",
       "noWritePermission": "You do not have permission to create drafts. Contact your admin.", 


### PR DESCRIPTION
## Description
When creating a draft and the signing path contains an account not present in the address book contacts, the backend returns `Account {accountId} not found`. Previously the raw error was shown verbatim. This PR enriches that error into a user-friendly toast.

## Related Issues
Closes #SPEK-540

## Changes Made
- Parse the backend error in `CreateDraftModal` — detect `Account {accountId} not found` pattern and extract the account ID
- Resolve the account's display name via `resolveName` (wallet name → contact → on-chain identity → truncated address)
- Convert the hex account ID to SS58 (or EVM) address via `toAddress`
- Render an `Identicon` (click-to-copy the full address) alongside the name and truncated address in the toast description
- Stop `pointerdown` propagation on the toast description so clicking the identicon does not trigger Radix Dialog's outside-click handler (which was causing the "unsaved changes" confirmation modal to appear)
- Add `accountNotInAddressBook` i18n key with the action hint

## Screenshots/Recordings
https://github.com/user-attachments/assets/8456f039-7f3c-4d73-ad57-6ee9c29fa89f

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines