### PR TITLE
feat: add proxy status to signing path and UI representation

### DIFF
--- a/src/renderer/features/signing-path/model/graph-model.ts
+++ b/src/renderer/features/signing-path/model/graph-model.ts
@@ -128,6 +128,16 @@ const $ownSignerAccountIds = accounts.$list.map<Set<AccountId>>(
   (list) => new Set(list.filter((a) => a.signingType !== SigningType.WATCH_ONLY).map((a) => a.accountId)),
 );
 
+const $pureProxyAccountIds = accounts.$list.map<Set<AccountId>>((list) => {
+  const result = new Set<AccountId>();
+  for (const account of list) {
+    if (accountUtils.isPureProxiedAccount(account) || accountUtils.isFlexibleMultisigAccount(account)) {
+      result.add(account.accountId);
+    }
+  }
+  return result;
+});
+
 function extractVerifyProxyMarker(tx: DecodedTransaction | null | undefined) {
   if (nullable(tx)) return null;
   if (tx.section === 'proxy' && tx.method === 'proxy') {
@@ -147,13 +157,15 @@ const $proxyEdgeStatus = combine(
     proxiesByPure: proxyModel.$proxies,
     operations: multisigOperation.$list,
     opsLoaded: multisigOperation.$initialLoadingComplete,
+    pureProxyAccountIds: $pureProxyAccountIds,
   },
-  ({ proxiesByPure, operations, opsLoaded }): Map<string, ProxyEdgeStatus> | null => {
+  ({ proxiesByPure, operations, opsLoaded, pureProxyAccountIds }): Map<string, ProxyEdgeStatus> | null => {
     if (!opsLoaded) return null;
 
     const result = new Map<string, ProxyEdgeStatus>();
 
     for (const [pure, delegates] of entries(proxiesByPure)) {
+      if (!pureProxyAccountIds.has(pure)) continue;
       for (const delegate of delegates ?? []) {
         result.set(proxyEdgeKey(delegate.chainId, pure, delegate.accountId, delegate.proxyType), 'not_verified');
       }
@@ -161,6 +173,7 @@ const $proxyEdgeStatus = combine(
 
     for (const op of operations) {
       if (op.status !== 'executed' || !op.proxiedAccountId) continue;
+      if (!pureProxyAccountIds.has(op.proxiedAccountId)) continue;
       const delegates = proxiesByPure[op.proxiedAccountId] ?? [];
       for (const delegate of delegates) {
         if (delegate.chainId !== op.chainId) continue;
@@ -173,6 +186,7 @@ const $proxyEdgeStatus = combine(
       if (op.status !== 'pending') continue;
       const marker = extractVerifyProxyMarker(op.transaction);
       if (!marker) continue;
+      if (!pureProxyAccountIds.has(marker.pureProxyAccountId)) continue;
       const delegates = proxiesByPure[marker.pureProxyAccountId] ?? [];
       for (const delegate of delegates) {
         if (delegate.chainId !== op.chainId) continue;

--- a/src/renderer/features/signing-path/model/graph-model.ts
+++ b/src/renderer/features/signing-path/model/graph-model.ts
@@ -1,16 +1,20 @@
 import { type Store, combine, createEffect, createEvent, createStore, sample } from 'effector';
 
-import { type ChainId, SigningType, WalletType } from '@/shared/core';
+import { type ChainId, type DecodedTransaction, SigningType, WalletType } from '@/shared/core';
 import { type BackendContact } from '@/shared/core/types/contact';
 import { type ProxyAccount, type ProxyType } from '@/shared/core/types/proxy';
+import { entries, nullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { parseVerifyProxyMarker } from '@/shared/transactions';
 import { type PathNode } from '@/domains/backend';
-import { type AnyAccount, accountService, accounts, identity } from '@/domains/network';
+import { type AnyAccount, accountService, accounts, identity, multisigOperation } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { networkModel } from '@/entities/network';
 import { proxyModel } from '@/entities/proxy';
 import { accountUtils } from '@/entities/wallet';
 import { MAX_PATH_DEPTH } from '../lib/path-validation';
+
+export type ProxyEdgeStatus = 'verified' | 'not_verified' | 'pending_verification';
 
 export type PathSource = {
   accountId: AccountId;
@@ -34,6 +38,7 @@ export type PathNextOption =
        */
       disabled?: boolean;
       disabledReason?: string;
+      verificationStatus?: ProxyEdgeStatus;
     }
   | {
       kind: 'signer';
@@ -121,6 +126,66 @@ const $multisigByAccountId = combine(
 // that doesn't terminate at one of these.
 const $ownSignerAccountIds = accounts.$list.map<Set<AccountId>>(
   (list) => new Set(list.filter((a) => a.signingType !== SigningType.WATCH_ONLY).map((a) => a.accountId)),
+);
+
+function extractVerifyProxyMarker(tx: DecodedTransaction | null | undefined) {
+  if (nullable(tx)) return null;
+  if (tx.section === 'proxy' && tx.method === 'proxy') {
+    return extractVerifyProxyMarker(tx.args['transaction'] as DecodedTransaction | undefined);
+  }
+  if (tx.section !== 'system' || tx.method !== 'remarkWithEvent') return null;
+  const remark = tx.args['remark'];
+  if (typeof remark !== 'string') return null;
+  return parseVerifyProxyMarker(remark);
+}
+
+const proxyEdgeKey = (chainId: ChainId, pure: AccountId, delegate: AccountId, proxyType: ProxyType): string =>
+  `${chainId}:${pure}:${delegate}:${proxyType}`;
+
+const $proxyEdgeStatus = combine(
+  {
+    proxiesByPure: proxyModel.$proxies,
+    operations: multisigOperation.$list,
+    opsLoaded: multisigOperation.$initialLoadingComplete,
+  },
+  ({ proxiesByPure, operations, opsLoaded }): Map<string, ProxyEdgeStatus> | null => {
+    if (!opsLoaded) return null;
+
+    const result = new Map<string, ProxyEdgeStatus>();
+
+    for (const [pure, delegates] of entries(proxiesByPure)) {
+      for (const delegate of delegates ?? []) {
+        result.set(proxyEdgeKey(delegate.chainId, pure, delegate.accountId, delegate.proxyType), 'not_verified');
+      }
+    }
+
+    for (const op of operations) {
+      if (op.status !== 'executed' || !op.proxiedAccountId) continue;
+      const delegates = proxiesByPure[op.proxiedAccountId] ?? [];
+      for (const delegate of delegates) {
+        if (delegate.chainId !== op.chainId) continue;
+        if (delegate.accountId !== op.multisigAccountId) continue;
+        result.set(proxyEdgeKey(op.chainId, op.proxiedAccountId, delegate.accountId, delegate.proxyType), 'verified');
+      }
+    }
+
+    for (const op of operations) {
+      if (op.status !== 'pending') continue;
+      const marker = extractVerifyProxyMarker(op.transaction);
+      if (!marker) continue;
+      const delegates = proxiesByPure[marker.pureProxyAccountId] ?? [];
+      for (const delegate of delegates) {
+        if (delegate.chainId !== op.chainId) continue;
+        if (delegate.accountId !== marker.delegateAccountId) continue;
+        const key = proxyEdgeKey(op.chainId, marker.pureProxyAccountId, delegate.accountId, delegate.proxyType);
+        if (result.get(key) === 'not_verified') {
+          result.set(key, 'pending_verification');
+        }
+      }
+    }
+
+    return result;
+  },
 );
 
 /**
@@ -285,6 +350,7 @@ function buildNextOptions(
   allowedProxyTypes: ReadonlySet<string> | null,
   disabledProxyReason: string | null,
   resolveName: AccountNameResolver,
+  proxyEdgeStatus: Map<string, ProxyEdgeStatus> | null,
 ): PathNextOption[] {
   if (node.kind === 'signer') return [];
 
@@ -317,6 +383,10 @@ function buildNextOptions(
           // softer disable that needs to be visible.
           if (canReach && isProxyTypeAllowed && !canReach(p.accountId)) return [];
 
+          const verificationStatus = proxyEdgeStatus?.get(
+            proxyEdgeKey(chainId, nodeAccountId, p.accountId, p.proxyType),
+          );
+
           return [
             {
               kind: 'multisig',
@@ -325,6 +395,7 @@ function buildNextOptions(
               threshold: multisig.threshold,
               signatoriesCount: multisig.signatories.length,
               proxyType: p.proxyType,
+              ...(verificationStatus ? { verificationStatus } : {}),
               ...disabledExtras,
             },
           ];
@@ -445,6 +516,7 @@ function pickDefaultPath({
       allowedProxyTypeSet,
       null,
       resolveName,
+      null,
     );
     const next = options.find((opt) => opt.kind !== 'multisig' || !opt.disabled);
     if (!next) return [];
@@ -564,8 +636,9 @@ function $nextOptionsForNode(node: PathNode, chainId: ChainId, opts?: GraphOptio
           proxies: proxyModel.$proxies,
           allowed: $ownSignerAccountIds,
           resolveName: $nameResolver,
+          edgeStatus: $proxyEdgeStatus,
         },
-        ({ multisigByAccountId, proxies, allowed, resolveName }) =>
+        ({ multisigByAccountId, proxies, allowed, resolveName, edgeStatus }) =>
           buildNextOptions(
             node,
             multisigByAccountId,
@@ -575,11 +648,17 @@ function $nextOptionsForNode(node: PathNode, chainId: ChainId, opts?: GraphOptio
             allowedProxyTypes,
             disabledProxyReason,
             resolveName,
+            edgeStatus,
           ),
       )
     : combine(
-        { multisigByAccountId: $multisigByAccountId, proxies: proxyModel.$proxies, resolveName: $nameResolver },
-        ({ multisigByAccountId, proxies, resolveName }) =>
+        {
+          multisigByAccountId: $multisigByAccountId,
+          proxies: proxyModel.$proxies,
+          resolveName: $nameResolver,
+          edgeStatus: $proxyEdgeStatus,
+        },
+        ({ multisigByAccountId, proxies, resolveName, edgeStatus }) =>
           buildNextOptions(
             node,
             multisigByAccountId,
@@ -589,6 +668,7 @@ function $nextOptionsForNode(node: PathNode, chainId: ChainId, opts?: GraphOptio
             allowedProxyTypes,
             disabledProxyReason,
             resolveName,
+            edgeStatus,
           ),
       );
   nextOptionsCache.set(key, $store);

--- a/src/renderer/features/signing-path/ui/NextOptionRow.tsx
+++ b/src/renderer/features/signing-path/ui/NextOptionRow.tsx
@@ -6,8 +6,25 @@ import { useI18n } from '@/shared/i18n';
 import { cnTw, toAddress, toShortAddress } from '@/shared/lib/utils';
 import { BodyText, HelpText } from '@/shared/ui';
 import { AssetBalance, WalletAccountIcon } from '@/shared/ui-entities';
-import { Tooltip } from '@/shared/ui-kit';
-import { type PathNextOption } from '../model/graph-model';
+import { type LabelVariant, Label, Tooltip } from '@/shared/ui-kit';
+import { type PathNextOption, type ProxyEdgeStatus } from '../model/graph-model';
+
+const STATUS_TO_VARIANT: Record<ProxyEdgeStatus, LabelVariant> = {
+  verified: 'green',
+  not_verified: 'orange',
+  pending_verification: 'blue',
+};
+
+const STATUS_TO_LABEL_KEY: Record<ProxyEdgeStatus, string> = {
+  verified: 'walletDetails.proxies.statusVerified',
+  not_verified: 'walletDetails.proxies.statusNotVerified',
+  pending_verification: 'walletDetails.proxies.statusPendingVerification',
+};
+
+const STATUS_TO_TOOLTIP_KEY: Partial<Record<ProxyEdgeStatus, string>> = {
+  verified: 'walletDetails.proxies.verifiedHeadline',
+  not_verified: 'walletDetails.proxies.notVerifiedHeadline',
+};
 
 type NextOptionRowProps = {
   option: PathNextOption;
@@ -36,6 +53,7 @@ export const NextOptionRow = ({ option, selected, onClick, trailing, balance }: 
   const proxyType = option.proxyType;
   const isDisabled = Boolean(option.disabled);
   const disabledReason = option.disabledReason;
+  const verificationStatus = option.kind === 'multisig' ? option.verificationStatus : undefined;
 
   const row = (
     <button
@@ -61,6 +79,7 @@ export const NextOptionRow = ({ option, selected, onClick, trailing, balance }: 
         </BodyText>
         <HelpText className="truncate text-text-tertiary">{subtitle}</HelpText>
       </div>
+      {verificationStatus && <VerificationStatusBadge status={verificationStatus} disabled={isDisabled} />}
       {proxyType && (
         <span
           className={cnTw(
@@ -102,4 +121,29 @@ export const NextOptionRow = ({ option, selected, onClick, trailing, balance }: 
   }
 
   return row;
+};
+
+type VerificationStatusBadgeProps = {
+  status: ProxyEdgeStatus;
+  disabled: boolean;
+};
+
+const VerificationStatusBadge = ({ status, disabled }: VerificationStatusBadgeProps) => {
+  const { t } = useI18n();
+  const tooltipKey = STATUS_TO_TOOLTIP_KEY[status];
+
+  const badge = (
+    <span className={cnTw('inline-flex shrink-0', disabled && 'opacity-60')}>
+      <Label variant={STATUS_TO_VARIANT[status]}>{t(STATUS_TO_LABEL_KEY[status])}</Label>
+    </span>
+  );
+
+  if (!tooltipKey) return badge;
+
+  return (
+    <Tooltip>
+      <Tooltip.Trigger>{badge}</Tooltip.Trigger>
+      <Tooltip.Content>{t(tooltipKey)}</Tooltip.Content>
+    </Tooltip>
+  );
 };


### PR DESCRIPTION
## Description
This work derives a per-edge proxy verification state from existing proxy data and multisig operations (including verify-proxy flows), threads it through the signing-path graph, and surfaces it in the picker UI together with clearer proxy type presentation and optional allowed proxy type filtering for flows that only accept certain proxy types.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-554

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="638" height="677" alt="Screenshot 2026-05-12 at 1 29 54 PM" src="https://github.com/user-attachments/assets/6abc183e-7ebf-4643-9ab4-5724a593c4a0" />
<img width="626" height="674" alt="Screenshot 2026-05-12 at 1 30 22 PM" src="https://github.com/user-attachments/assets/3018746f-060d-4c1f-a3f5-1a11e59a172e" />
<img width="622" height="680" alt="Screenshot 2026-05-12 at 2 04 03 PM" src="https://github.com/user-attachments/assets/82ca883c-21fe-48ed-ae78-7055284b9dd0" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#30