### PR TITLE
fix: wrong proxy type and multisig when delegating from pure proxied account

### DIFF
--- a/src/renderer/features/proxy-add/model/form-model.ts
+++ b/src/renderer/features/proxy-add/model/form-model.ts
@@ -250,13 +250,14 @@ const $signatories = createSignatoriesStore({
   accounts: accounts.$list,
 });
 
-const { $signingPath, signingPathChanged, $signatoryFromPath, recomputeForSigner, $pathRoute } =
-  createSigningPathModel({
+const { $signingPath, signingPathChanged, $signatoryFromPath, recomputeForSigner, $pathRoute } = createSigningPathModel(
+  {
     initiator: form.fields.initiator.$value,
     chain: form.fields.chain.$value,
     resetOn: formInitiated,
     resetUserOverrideOn: form.fields.initiator.change,
-  });
+  },
+);
 
 const $availableAccounts = createInitiatorsStore({
   chain: form.fields.chain.$value,
@@ -355,11 +356,11 @@ const $coreTx = combine(
     isConnected: $isChainConnected,
   },
   ({ form, signatory, isConnected }): Transaction | null => {
-    if (!isConnected || !signatory || !form.delegate || !form.proxyType || !form.chain) return null;
+    if (!isConnected || !signatory || !form.initiator || !form.delegate || !form.proxyType || !form.chain) return null;
 
     return transactionBuilder.buildAddProxy({
       chain: form.chain,
-      accountId: signatory.accountId,
+      accountId: form.initiator.accountId,
       delegateAccountId: toAccountId(form.delegate),
       type: form.proxyType,
     });

--- a/src/renderer/features/signing-path/lib/createPathRouteStore.ts
+++ b/src/renderer/features/signing-path/lib/createPathRouteStore.ts
@@ -40,7 +40,14 @@ export const createPathRouteStore = (
 
       const resolved: AnyAccount[] = [];
       for (const node of path) {
-        const account = chainAccounts.find((a) => matchesNode(a, node));
+        // For proxied nodes prefer a concrete ProxiedAccount over a flex-multisig
+        // facade sharing the same accountId — otherwise the wrong forceProxyType
+        // ends up in the extrinsic when both exist in the wallet (SPEK-558).
+        const account =
+          node.kind === 'proxied'
+            ? (chainAccounts.find((a) => accountUtils.isProxiedAccount(a) && a.accountId === node.accountId) ??
+              chainAccounts.find((a) => matchesNode(a, node)))
+            : chainAccounts.find((a) => matchesNode(a, node));
         if (!account) return null;
         // Flex multisig spans two consecutive hops as one account; its
         // transformer wraps both layers in a single step.


### PR DESCRIPTION
## Description

When creating an **Add Proxy** operation from a pure proxied account through a multisig signing path, two issues caused the wrong extrinsic to be built:

1. `createPathRouteStore` resolved a flex-multisig facade (sharing the same `accountId`) instead of the pure proxied account for the `proxied` path node — causing the wrong `forceProxyType` in the extrinsic. PR #5865 partially addressed this but its `matchesNode` still allows both `isProxiedAccount` and `isFlexibleMultisigAccount` to match for a `proxied` node, so list ordering can still produce the wrong result.

2. `$coreTx` in the proxy-add form was using `signatory.accountId` instead of `form.initiator.accountId` as the proxy creator.

## Related Issues

[SPEK-558](https://novasama-technologies.atlassian.net/browse/SPEK-558)

## Changes Made

- `createPathRouteStore.ts` — for `proxied` path nodes, try `isProxiedAccount` first before falling back to the full `matchesNode` lookup; this ensures a concrete proxied account is always preferred over a flex-multisig facade sharing the same `accountId`
- `form-model.ts` — fixed `$coreTx` to use `form.initiator.accountId` instead of `signatory.accountId`; also added `form.initiator` to the null-guard

## Screenshots/Recordings
<img width="997" height="214" alt="Снимок экрана 2026-05-13 в 16 59 45" src="https://github.com/user-attachments/assets/ed8ebf6e-ed97-436e-afcc-19128e08c91e" />
<img width="609" height="339" alt="Снимок экрана 2026-05-13 в 16 59 51" src="https://github.com/user-attachments/assets/3340d429-e744-4e1e-94b5-db7ddcd6b4b0" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

[SPEK-558]: https://novasama-technologies.atlassian.net/browse/SPEK-558?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ