### PR TITLE
fix: CSP — add base-uri and form-action directives (SPEK-319)

### DIFF
--- a/src/main/factories/window.test.ts
+++ b/src/main/factories/window.test.ts
@@ -72,7 +72,7 @@ vi.mock('../shared/constants/environment', () => ({
 }));
 
 const EXPECTED_CSP =
-  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'";
+  "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'";
 
 type HeadersReceivedCallback = (
   details: Record<string, unknown>,
@@ -212,6 +212,20 @@ describe('window.ts — CSP header via session.webRequest.onHeadersReceived', ()
     expect(headers['Content-Type']).toEqual(['text/html; charset=utf-8']);
     expect(headers['X-Frame-Options']).toEqual(['DENY']);
     expect(headers['Content-Security-Policy']).toBeDefined();
+  });
+
+  it("should set directive base-uri 'self' (prevents base-tag hijacking)", async () => {
+    const cb = await getHeadersReceivedCallback();
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
+    expect(headers['Content-Security-Policy']?.[0]).toContain("base-uri 'self'");
+  });
+
+  it("should set directive form-action 'self' (prevents form submission hijacking)", async () => {
+    const cb = await getHeadersReceivedCallback();
+    const result = await invokeCallback(cb, {}, 'mainFrame');
+    const headers = result.responseHeaders as Record<string, string[]>;
+    expect(headers['Content-Security-Policy']?.[0]).toContain("form-action 'self'");
   });
 
   it('CSP value should match the full expected policy string exactly', async () => {

--- a/src/main/factories/window.ts
+++ b/src/main/factories/window.ts
@@ -71,7 +71,7 @@ export function createWindow(): BrowserWindow {
         responseHeaders: {
           ...details.responseHeaders,
           'Content-Security-Policy': [
-            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'",
+            "default-src 'self'; script-src 'self' 'wasm-unsafe-eval'; style-src 'self' 'unsafe-inline'; img-src 'self' data: blob: https:; connect-src 'self' data: wss: ws: https: http:; font-src 'self' data:; worker-src 'self' blob:; object-src 'none'; frame-src 'none'; base-uri 'self'; form-action 'self'",
           ],
         },
       });

--- a/src/renderer/app/csp.test.ts
+++ b/src/renderer/app/csp.test.ts
@@ -80,6 +80,14 @@ describe('src/renderer/app/index.html — Content-Security-Policy meta tag', () 
     expect(cspContent).toContain("worker-src 'self' blob:");
   });
 
+  it("should contain directive: base-uri 'self' (prevents base-tag hijacking)", () => {
+    expect(cspContent).toContain("base-uri 'self'");
+  });
+
+  it("should contain directive: form-action 'self' (prevents form submission hijacking)", () => {
+    expect(cspContent).toContain("form-action 'self'");
+  });
+
   it('should NOT allow unsafe-eval in script-src (prevents XSS)', () => {
     expect(cspContent).not.toContain("'unsafe-eval'");
   });

--- a/src/renderer/app/index.html
+++ b/src/renderer/app/index.html
@@ -15,7 +15,9 @@
         font-src 'self' data:;
         worker-src 'self' blob:;
         object-src 'none';
-        frame-src 'none'
+        frame-src 'none';
+        base-uri 'self';
+        form-action 'self'
       "
     />
 


### PR DESCRIPTION
## Description

Extends the Content Security Policy introduced in #5709 with two additional directives that do not inherit from `default-src` and must be set explicitly:

- **`base-uri 'self'`** — prevents injection of a `<base>` tag that would redirect all relative URLs to an attacker-controlled domain.
- **`form-action 'self'`** — restricts form submission targets, blocking rogue form exfiltration even if dynamic HTML is injected.

Both directives are applied at both enforcement layers: the Electron session header (`window.ts`) and the HTML meta tag (`index.html`).

## Related Issues

- https://novasama-technologies.atlassian.net/browse/SPEK-319

## Changes Made

- `src/main/factories/window.ts` — added `base-uri 'self'; form-action 'self'` to the CSP string injected via `session.defaultSession.webRequest.onHeadersReceived`
- `src/renderer/app/index.html` — added the same two directives to the `<meta http-equiv="Content-Security-Policy">` tag
- `src/main/factories/window.test.ts` — updated `EXPECTED_CSP` constant; added two new directive tests
- `src/renderer/app/csp.test.ts` — added two new directive tests

## Screenshots/Recordings

N/A — no UI changes.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines