### PR TITLE
fix(popover): prevent hover popover from dismissing when crossing trigger-to-content gap (SPEK-559)

### DIFF
--- a/src/renderer/shared/ui-kit/Popover/Popover.tsx
+++ b/src/renderer/shared/ui-kit/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import * as RadixPopover from '@radix-ui/react-popover';
-import { type PropsWithChildren, createContext, useContext, useMemo, useRef, useState } from 'react';
+import { type PropsWithChildren, createContext, useCallback, useContext, useMemo, useRef, useState } from 'react';
 
 import { type XOR } from '@/shared/core';
 import { useTheme } from '../Theme/useTheme';
@@ -48,35 +48,32 @@ const Root = ({
   const [hoverOpen, setHoverOpen] = useState(false);
   const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const openHover = useMemo(
-    () =>
-      enableHover
-        ? () => {
-            if (closeTimer.current !== null) {
-              clearTimeout(closeTimer.current);
-              closeTimer.current = null;
-            }
-            setHoverOpen(true);
-          }
-        : undefined,
-    [enableHover],
-  );
+  const openHover = useCallback(() => {
+    if (closeTimer.current !== null) {
+      clearTimeout(closeTimer.current);
+      closeTimer.current = null;
+    }
+    setHoverOpen(true);
+  }, []);
 
-  const closeHover = useMemo(
-    () =>
-      enableHover
-        ? () => {
-            closeTimer.current = setTimeout(() => {
-              setHoverOpen(false);
-              closeTimer.current = null;
-            }, HOVER_CLOSE_DELAY);
-          }
-        : undefined,
-    [enableHover],
-  );
+  const closeHover = useCallback(() => {
+    closeTimer.current = setTimeout(() => {
+      setHoverOpen(false);
+      closeTimer.current = null;
+    }, HOVER_CLOSE_DELAY);
+  }, []);
 
   const ctx = useMemo(
-    () => ({ side, sideOffset, align, alignOffset, testId, enableHover, openHover, closeHover }),
+    () => ({
+      side,
+      sideOffset,
+      align,
+      alignOffset,
+      testId,
+      enableHover,
+      openHover: enableHover ? openHover : undefined,
+      closeHover: enableHover ? closeHover : undefined,
+    }),
     [side, sideOffset, align, alignOffset, testId, enableHover, openHover, closeHover],
   );
 

--- a/src/renderer/shared/ui-kit/Popover/Popover.tsx
+++ b/src/renderer/shared/ui-kit/Popover/Popover.tsx
@@ -1,5 +1,5 @@
 import * as RadixPopover from '@radix-ui/react-popover';
-import { type PropsWithChildren, createContext, useContext, useMemo, useState } from 'react';
+import { type PropsWithChildren, createContext, useContext, useMemo, useRef, useState } from 'react';
 
 import { type XOR } from '@/shared/core';
 import { useTheme } from '../Theme/useTheme';
@@ -12,7 +12,8 @@ type ContextProps = {
   alignOffset?: number;
   testId?: string;
   enableHover?: boolean;
-  setHoverOpen?: (open: boolean) => void;
+  openHover?: () => void;
+  closeHover?: () => void;
 };
 
 const Context = createContext<ContextProps>({});
@@ -30,6 +31,8 @@ type RootProps = PropsWithChildren<
     }
 >;
 
+const HOVER_CLOSE_DELAY = 100;
+
 const Root = ({
   dialog,
   open,
@@ -43,18 +46,38 @@ const Root = ({
   children,
 }: RootProps) => {
   const [hoverOpen, setHoverOpen] = useState(false);
+  const closeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const openHover = useMemo(
+    () =>
+      enableHover
+        ? () => {
+            if (closeTimer.current !== null) {
+              clearTimeout(closeTimer.current);
+              closeTimer.current = null;
+            }
+            setHoverOpen(true);
+          }
+        : undefined,
+    [enableHover],
+  );
+
+  const closeHover = useMemo(
+    () =>
+      enableHover
+        ? () => {
+            closeTimer.current = setTimeout(() => {
+              setHoverOpen(false);
+              closeTimer.current = null;
+            }, HOVER_CLOSE_DELAY);
+          }
+        : undefined,
+    [enableHover],
+  );
 
   const ctx = useMemo(
-    () => ({
-      side,
-      sideOffset,
-      align,
-      alignOffset,
-      testId,
-      enableHover,
-      setHoverOpen: enableHover ? setHoverOpen : undefined,
-    }),
-    [side, sideOffset, align, alignOffset, testId, enableHover, setHoverOpen],
+    () => ({ side, sideOffset, align, alignOffset, testId, enableHover, openHover, closeHover }),
+    [side, sideOffset, align, alignOffset, testId, enableHover, openHover, closeHover],
   );
 
   return (
@@ -71,13 +94,13 @@ const Root = ({
 };
 
 const Trigger = ({ children }: PropsWithChildren) => {
-  const { enableHover, setHoverOpen } = useContext(Context);
+  const { enableHover, openHover, closeHover } = useContext(Context);
 
   return (
     <RadixPopover.Trigger
       asChild
-      onMouseEnter={enableHover && setHoverOpen ? () => setHoverOpen(true) : undefined}
-      onMouseLeave={enableHover && setHoverOpen ? () => setHoverOpen(false) : undefined}
+      onMouseEnter={enableHover && openHover ? openHover : undefined}
+      onMouseLeave={enableHover && closeHover ? closeHover : undefined}
     >
       {children}
     </RadixPopover.Trigger>
@@ -90,7 +113,7 @@ const Anchor = ({ children }: PropsWithChildren) => {
 
 const Content = ({ children }: PropsWithChildren) => {
   const { portalContainer } = useTheme();
-  const { align, alignOffset, side, sideOffset, testId, enableHover, setHoverOpen } = useContext(Context);
+  const { align, alignOffset, side, sideOffset, testId, enableHover, openHover, closeHover } = useContext(Context);
 
   return (
     <RadixPopover.Portal container={portalContainer}>
@@ -104,8 +127,8 @@ const Content = ({ children }: PropsWithChildren) => {
         sideOffset={sideOffset && gridSpaceConverter(sideOffset)}
         data-testid={testId}
         onClick={e => e.stopPropagation()}
-        onMouseEnter={enableHover && setHoverOpen ? () => setHoverOpen(true) : undefined}
-        onMouseLeave={enableHover && setHoverOpen ? () => setHoverOpen(false) : undefined}
+        onMouseEnter={enableHover && openHover ? openHover : undefined}
+        onMouseLeave={enableHover && closeHover ? closeHover : undefined}
       >
         <div className="pointer-events-auto z-50 h-fit max-h-(--radix-popper-available-height) min-h-0 origin-(--radix-popper-transform-origin) overflow-hidden rounded-md border border-token-container-border bg-block-background-default text-body shadow-shadow-2 duration-100 animate-in fade-in zoom-in-95">
           {children}


### PR DESCRIPTION
## Description
When using a hover-enabled `Popover`, moving the mouse from the trigger to the popover content caused the popover to dismiss mid-way. The default `sideOffset=2` creates an 8px gap between the trigger and the content. As the cursor crosses this gap, `onMouseLeave` fires on the trigger and synchronously sets `hoverOpen = false`, closing the popover before the cursor reaches the content.

The fix adds a 100ms debounced close: `onMouseLeave` starts a timer instead of closing immediately. If `onMouseEnter` fires on the popover content within that window, the timer is cancelled and the popover stays open.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-559

## Changes Made
- Added `openHover` / `closeHover` callbacks to the `Popover` hover context (replacing the raw `setHoverOpen` reference)
- `closeHover` defers `setHoverOpen(false)` by 100ms via a `useRef`-tracked timer
- `openHover` cancels any pending close timer before setting `hoverOpen = true`
- Both `Trigger` and `Content` use the new callbacks so hovering over either keeps the popover open

## Screenshots/Recordings

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines