### PR TITLE
Fix: drafts-strict-signing-path

### DIFF
--- a/src/renderer/features/drafts/components/DraftsSection.tsx
+++ b/src/renderer/features/drafts/components/DraftsSection.tsx
@@ -157,12 +157,17 @@ export const DraftsSection = () => {
     const chain = chains[draft.chainId as ChainId];
     if (!chain) return;
 
-    // For flex drafts, the routing initiator is the proxied (pure proxy) account,
-    // but the display initiator is the flex multisig account
+    // `initiator` here is a legacy fallback only: for path-driven drafts
+    // submitDraftModel derives `$initiator` from `signingPath[0]`. It still
+    // matters for legacy drafts (empty `signingPath`). Note this branch picks
+    // the deepest multisig for nested paths — that's wrong for routing but
+    // harmless because the model overrides it when a saved path is present.
     const initiatorAccount = draft.proxyAccountId
       ? (allAccounts.find((a) => a.accountId === draft.proxyAccountId) ?? null)
       : (allMultisigAccounts.find((a) => a.accountId === draft.multisigAccountId) ?? null);
 
+    // `displayInitiator` is consumed verbatim by the confirm UI — for flex
+    // drafts we want the multisig facade label, not the pure proxied address.
     const displayInitiator = draft.proxyAccountId
       ? (allMultisigAccounts.find((a) => a.accountId === draft.multisigAccountId) ?? null)
       : undefined;

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -80,7 +80,10 @@ const stepChanged = createEvent<Step>();
 const $step = readonly(restore(stepChanged, Step.NONE));
 const $draft = createStore<Draft | null>(null).reset(flowFinished);
 const $chain = createStore<Chain | null>(null).reset(flowFinished);
-const $initiator = createStore<AnyAccount | null>(null).reset(flowFinished);
+// Seed initiator from `flowStarted` — used as a fallback for legacy drafts
+// that have no `signingPath`. For path-driven drafts the canonical initiator
+// is the resolved `signingPath[0]` (see `$initiator` below).
+const $flowInitiator = createStore<AnyAccount | null>(null).reset(flowFinished);
 const $displayInitiator = createStore<AnyAccount | null>(null).reset(flowFinished);
 const $signatory = createEvent<AnyAccount | null>();
 const $signatoryStore = createStore<AnyAccount | null>(null).reset(flowFinished);
@@ -157,13 +160,6 @@ sample({
   target: showCallDataSubmitErrorFx,
 });
 
-const $bfsRoute = createRouteStore({
-  chain: $chain,
-  initiator: $initiator,
-  signatory: $signatoryStore,
-  accounts: walletModel.$availableAccounts,
-});
-
 // The picked path was persisted with the draft — resolve it back to accounts
 // and use it strictly. Falling back to BFS would silently sign through a
 // different route than the user authored the draft for.
@@ -171,6 +167,22 @@ const $draftSigningPath = $draft.map((draft): PathNode[] =>
   Array.isArray(draft?.signingPath) ? draft.signingPath : [],
 );
 const $pathRoute = createPathRouteStore($draftSigningPath, $chain);
+
+// Canonical initiator: for path-driven drafts the route's first node is the
+// authored top of the chain (matters for nested-multisig drafts where
+// `multisigAccountId` is the deepest hop, not the root). Legacy drafts have
+// no path → fall back to the seed initiator from `flowStarted`.
+const $initiator = combine(
+  { pathRoute: $pathRoute, flowInitiator: $flowInitiator },
+  ({ pathRoute, flowInitiator }) => pathRoute?.[0] ?? flowInitiator,
+);
+
+const $bfsRoute = createRouteStore({
+  chain: $chain,
+  initiator: $initiator,
+  signatory: $signatoryStore,
+  accounts: walletModel.$availableAccounts,
+});
 
 // Draft has a non-trivial saved path but it can't be resolved against the
 // current account list (e.g. a wallet that the path traversed has been
@@ -182,15 +194,14 @@ const $pathResolutionError = combine(
   ({ saved, resolved, chain }) => chain !== null && saved.length >= 2 && (resolved === null || resolved.length < 2),
 );
 
-// Saved path resolved → use it. No saved path (legacy drafts) → BFS.
-// Saved path present but unresolvable → empty route, the gating check below
-// flips $wrappedTxError so the UI surfaces the error.
+// Path-driven drafts: strictly follow the resolved path; never silently
+// re-route through BFS. Legacy drafts (no saved path) keep the BFS fallback
+// for backwards compatibility.
 const $route = combine(
   { bfs: $bfsRoute, saved: $draftSigningPath, resolved: $pathRoute },
   ({ bfs, saved, resolved }) => {
-    if (saved.length < 2) return bfs;
-    if (resolved && resolved.length >= 2) return resolved;
-    return [];
+    if (saved.length === 0) return bfs;
+    return resolved && resolved.length > 0 ? resolved : [];
   },
 );
 
@@ -379,7 +390,7 @@ sample({
 sample({
   clock: flowStarted,
   fn: ({ initiator }) => initiator,
-  target: $initiator,
+  target: $flowInitiator,
 });
 
 sample({
@@ -467,9 +478,11 @@ sample({
     nonNullable(s.fee) &&
     nonNullable(s.api) &&
     nonNullable(s.chain) &&
-    nonNullable(s.initiator),
+    nonNullable(s.initiator) &&
+    nonNullable(s.signatory),
   fn: (s) => {
     const uiInitiator = s.displayInitiator ?? s.initiator!;
+    const signatory = s.signatory!;
 
     return [
       {
@@ -477,8 +490,8 @@ sample({
         chain: s.chain!,
         transaction: s.wrappedTx!,
         initiator: uiInitiator,
-        signatory: s.signatory || uiInitiator,
-        route: s.route.length > 0 ? s.route : [s.signatory || uiInitiator],
+        signatory,
+        route: s.route.length > 0 ? s.route : [signatory],
         fee: s.fee!,
         draft: s.draft!,
       },
@@ -495,16 +508,13 @@ const sign = sample({
     api: $api,
     chain: $chain,
     signatory: $signatoryStore,
-    initiator: $initiator,
   },
-  fn({ wrappedTx, api, chain, signatory, initiator }) {
-    if (nullable(api) || nullable(wrappedTx) || nullable(chain)) return null;
-    const signer = signatory || initiator;
-    if (nullable(signer)) return null;
+  fn({ wrappedTx, api, chain, signatory }) {
+    if (nullable(api) || nullable(wrappedTx) || nullable(chain) || nullable(signatory)) return null;
 
     return {
       transaction: wrappedTx,
-      signatory: signer,
+      signatory,
       chain,
       api,
     } satisfies TransactionSigningPayload;
@@ -712,4 +722,11 @@ export const submitDraftModel = {
   confirmModel,
 
   Step,
+
+  __test: {
+    $route,
+    $pathRoute,
+    $pathResolutionError,
+    $flowInitiator,
+  },
 };

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -16,7 +16,6 @@ import {
   createTxValidationStore,
   createTxValidator,
 } from '@/shared/transactions';
-import { createRouteStore } from '@/shared/transactions/createRouteStore';
 import { createWrappedTxStore } from '@/shared/transactions/createWrappedTxStore';
 import {
   type Draft,
@@ -177,18 +176,33 @@ const $initiator = combine(
   ({ pathRoute, flowInitiator }) => pathRoute?.[0] ?? flowInitiator,
 );
 
-const $bfsRoute = createRouteStore({
-  chain: $chain,
-  initiator: $initiator,
-  signatory: $signatoryStore,
-  accounts: walletModel.$availableAccounts,
-});
+// Legacy BFS route — only consumed when the draft has no saved signing path.
+// The gate is *inside* the combine so `accountService.findRoute` (which
+// allocates an account graph) doesn't run at all for path-driven drafts.
+// `createRouteStore` would be simpler but it's unconditional, so we inline
+// the logic here.
+const $bfsRoute = combine(
+  {
+    saved: $draftSigningPath,
+    chain: $chain,
+    initiator: $initiator,
+    signatory: $signatoryStore,
+    accounts: walletModel.$availableAccounts,
+  },
+  ({ saved, chain, initiator, signatory, accounts }) => {
+    if (saved.length > 0) return [];
+    if (nullable(chain) || nullable(initiator) || nullable(signatory)) return [];
+
+    return accountService.findRoute(initiator, signatory, accounts, chain);
+  },
+);
 
 // Draft has a non-trivial saved path but it can't be resolved against the
 // current account list (e.g. a wallet that the path traversed has been
 // removed). Block the flow rather than wrap silently along a different route.
-// Gated on `$chain` so it doesn't fire transiently while `flowStarted` updates
-// `$draft` and `$chain` in separate samples.
+// Defence-in-depth: `$pathRoute` already returns `null` while `$chain` is
+// null, but the explicit guard avoids accidental regressions if the resolver
+// ever surfaces a non-null route before chain settles.
 const $pathResolutionError = combine(
   { saved: $draftSigningPath, resolved: $pathRoute, chain: $chain },
   ({ saved, resolved, chain }) => chain !== null && saved.length >= 2 && (resolved === null || resolved.length < 2),
@@ -346,16 +360,20 @@ sample({
 // watch-only entries, and a duplicate accountId imported under a watch-only
 // wallet would otherwise be picked first and route the flow to the watch-only
 // dead-end UI.
+//
+// `clock` includes `$draft` (not just `$availableAccounts`) so the sample
+// fires on flow start even when the account list is already populated — in
+// a steady-state session that's the common case.
 sample({
-  clock: walletModel.$availableAccounts,
-  source: $draft,
-  filter: (draft, accounts) =>
+  clock: [walletModel.$availableAccounts, $draft],
+  source: { draft: $draft, accounts: walletModel.$availableAccounts },
+  filter: ({ draft, accounts }) =>
     nonNullable(draft) &&
     Array.isArray(draft.signingPath) &&
     draft.signingPath.length > 0 &&
     nonNullable(draft.initiatorAccountId) &&
     accounts.some((a) => a.accountId === draft!.initiatorAccountId && accountService.hasPermissionToMakeActions(a)),
-  fn: (draft, accounts) =>
+  fn: ({ draft, accounts }) =>
     accounts.find((a) => a.accountId === draft!.initiatorAccountId && accountService.hasPermissionToMakeActions(a)) ??
     null,
   target: $signatory,
@@ -426,11 +444,16 @@ sample({
   target: multisigOperationDescription.setDraftFlowActive,
 });
 
-// Auto-select signatory when only one option
+// Auto-select signatory when only one option — but never overwrite an
+// already-chosen one. Without this guard, an auto-select fired by a later
+// `$signatories` recomputation would clobber the path-driven pre-selection
+// (e.g. for nested multisigs where the wallet exposes the root multisig as a
+// "leaf" because no children-pipeline handler is registered).
 sample({
   clock: $signatories,
-  filter: (signatories) => signatories.length === 1,
-  fn: (signatories) => signatories.at(0) ?? null,
+  source: $signatoryStore,
+  filter: (current, signatories) => current === null && signatories.length === 1,
+  fn: (_, signatories) => signatories.at(0) ?? null,
   target: $signatory,
 });
 
@@ -458,9 +481,12 @@ sample({
 
 // --- Confirm → Sign → Submit ---
 
-// When wrappedTx + fee are ready and step is CONFIRM, auto-init confirm
+// When wrappedTx + fee are ready and step is CONFIRM, auto-init confirm.
+// `$signatoryStore` is in `clock` so init re-fires when auto-/pre-selection
+// resolves the signatory after fee/wrappedTx have already settled — without
+// it the previous fallback (`signatory || initiator`) used to mask the gap.
 sample({
-  clock: [flowStarted, $wrappedTx, $fee],
+  clock: [flowStarted, $wrappedTx, $fee, $signatoryStore],
   source: {
     draft: $draft,
     wrappedTx: $wrappedTx,
@@ -552,6 +578,12 @@ const postSubmitFx = createEffect(
     timepoint: { height: number; index: number };
     baseUrl: string;
   }) => {
+    // `draft.multisigAccountId` is guaranteed by the caller (DraftsSection
+    // refuses to submit without it). The `?? initiator.accountId` fallback is
+    // a last-resort safety net — note that for flex drafts `initiator` is now
+    // the resolved `FlexibleMultisigAccount` whose `accountId` is the *pure
+    // proxied* accountId, not the inner multisig. The fallback path is only
+    // reachable if a future caller bypasses the entrypoint guard.
     await operationsService.createDescription(baseUrl, {
       multisigAccountId: draft.multisigAccountId ?? initiator.accountId,
       chainId: draft.chainId,
@@ -702,6 +734,8 @@ export const submitDraftModel = {
   $wrappedExtrinsic,
   $wrappedTxError,
   $wrappedTxErrorKind,
+  $route,
+  $pathResolutionError,
   $submittedDraftIds,
   $validationErrors,
   $validationValid,
@@ -724,9 +758,7 @@ export const submitDraftModel = {
   Step,
 
   __test: {
-    $route,
     $pathRoute,
-    $pathResolutionError,
     $flowInitiator,
   },
 };

--- a/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
+++ b/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
@@ -1,0 +1,342 @@
+import { type Scope, allSettled } from 'effector';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+
+import {
+  type MultisigAccount,
+  type ProxiedAccount,
+  AccountType,
+  ConnectionStatus,
+  CryptoType,
+  ProxyVariant,
+  SigningType,
+} from '@/shared/core';
+import { createAccountId } from '@/shared/mocks';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type Draft, type PathNode } from '@/domains/backend';
+import { type AnyAccount, accountService, accounts } from '@/domains/network';
+import { walletModel } from '@/entities/wallet';
+import { submitDraftModel } from '@/features/drafts/model/submit-draft-model';
+import { polkadotChain, polkadotChainId, vaultWallet } from '../../fixtures/index';
+import { type FeatureTestEnvironment, FeatureTestBuilder, allureMetadata } from '../../utils/index';
+
+// --- Local fixtures: production typeguards check `accountType` (added by
+// account-sync), while the shared fixtures lack it. Build accounts with the
+// real `accountType` field so `isMultisigAccount` / `isProxiedAccount`
+// resolve correctly inside `createPathRouteStore`.
+
+// Use distinct string seeds — `createAccountId` reduces the seed to a sum of
+// char codes, so numeric seeds like 101/110 collide (both sum to 146).
+const SIGNER_ID: AccountId = createAccountId('signer-alpha');
+const SIGNER_2_ID: AccountId = createAccountId('signer-beta');
+const MULTISIG_TOP_ID: AccountId = createAccountId('multisig-top');
+const MULTISIG_MID_ID: AccountId = createAccountId('multisig-mid');
+const PROXIED_ID: AccountId = createAccountId('proxied-root');
+const MISSING_MULTISIG_ID: AccountId = createAccountId('missing-ghost');
+
+const signerAccount: AnyAccount = {
+  id: 'signer-1',
+  accountId: SIGNER_ID,
+  walletId: vaultWallet.id,
+  name: 'Signer 1',
+  type: 'universal',
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.POLKADOT_VAULT,
+  createdAt: 0,
+};
+
+const signerAccount2: AnyAccount = {
+  id: 'signer-2',
+  accountId: SIGNER_2_ID,
+  walletId: vaultWallet.id,
+  name: 'Signer 2',
+  type: 'universal',
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.POLKADOT_VAULT,
+  createdAt: 0,
+};
+
+const multisigTop = {
+  id: 'multisig-top',
+  accountId: MULTISIG_TOP_ID,
+  walletId: vaultWallet.id,
+  name: 'Multisig Top',
+  type: 'universal',
+  accountType: AccountType.MULTISIG,
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.MULTISIG,
+  threshold: 1,
+  signatories: [{ accountId: MULTISIG_MID_ID, name: 'Mid' }],
+  createdAt: 0,
+} satisfies MultisigAccount as unknown as AnyAccount;
+
+const multisigMid = {
+  id: 'multisig-mid',
+  accountId: MULTISIG_MID_ID,
+  walletId: vaultWallet.id,
+  name: 'Multisig Mid',
+  type: 'universal',
+  accountType: AccountType.MULTISIG,
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.MULTISIG,
+  threshold: 1,
+  signatories: [{ accountId: SIGNER_ID, name: 'Signer 1' }],
+  createdAt: 0,
+} satisfies MultisigAccount as unknown as AnyAccount;
+
+const proxiedAccount = {
+  id: 'proxied-1',
+  accountId: PROXIED_ID,
+  walletId: vaultWallet.id,
+  name: 'Proxied',
+  type: 'chain',
+  chainId: polkadotChainId,
+  accountType: AccountType.PROXIED,
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.POLKADOT_VAULT,
+  proxyVariant: ProxyVariant.REGULAR,
+  connections: [{ proxyAccountId: SIGNER_ID, delay: 0, proxyType: 'Any' }],
+  deposit: '100000000000',
+  extrinsicIndex: 0,
+  entropyBlockNumber: 0,
+  createdAt: 0,
+} satisfies ProxiedAccount as unknown as AnyAccount;
+
+const makeDraft = (signingPath: PathNode[], overrides: Partial<Draft> = {}): Draft => ({
+  id: 'draft-test',
+  multisigAccountId: null,
+  proxyAccountId: null,
+  chainId: polkadotChainId,
+  callData: '0x0000',
+  description: 'test',
+  createdBy: 'tester',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  signingPath,
+  initiatorAccountId: null,
+  ...overrides,
+});
+
+// Handlers must be installed in the fork scope — `combine` reads them via
+// `$handlers.getState()` from the currently-active scope, not the global
+// default. Registering through `allSettled(... { scope })` writes to the
+// fork's `$handlers` store so `filterAccountsOnChain` works inside derived
+// stores under test.
+const setupAccountHandlers = async (scope: Scope) => {
+  await allSettled(accountService.accountAvailabilityOnChainAnyOf.registerHandler, {
+    scope,
+    params: {
+      body: ({ account, chain }) => (accountService.isChainAccount(account) ? account.chainId === chain.chainId : true),
+      available: () => true,
+    },
+  });
+  await allSettled(accountService.accountActionPermissionAnyOf.registerHandler, {
+    scope,
+    params: {
+      body: ({ account }) => account.signingType !== SigningType.WATCH_ONLY,
+      available: () => true,
+    },
+  });
+};
+
+const buildEnv = async (testAccounts: AnyAccount[]): Promise<FeatureTestEnvironment> => {
+  // `autoPopulate: false` + direct `withStoreValue` — the test storage uses a
+  // private IDB name, so `accounts.populate` (which reads from production
+  // `spektr` db) would otherwise leave the store empty. Seeding the effector
+  // stores directly is the documented path for store-level assertions.
+  const env = await new FeatureTestBuilder({ autoPopulate: false })
+    .withChain(polkadotChain)
+    .withConnectionStatus(polkadotChainId, ConnectionStatus.CONNECTED)
+    .withStoreValue(walletModel.__test.$rawWallets, [vaultWallet])
+    .withStoreValue(accounts.__test.$list, testAccounts)
+    .build();
+  await setupAccountHandlers(env.scope);
+
+  return env;
+};
+
+describe('Submit Draft — signing path drives the route', () => {
+  let env: FeatureTestEnvironment;
+
+  afterEach(async () => {
+    if (env) await env.cleanup();
+  });
+
+  describe('$initiator resolution', () => {
+    beforeEach(async () => {
+      await allureMetadata({
+        epic: 'Drafts',
+        feature: 'Submit Draft',
+        story: 'Initiator resolves from signingPath[0]',
+      });
+    });
+
+    it('resolves $initiator from path[0] for a single-multisig draft', async () => {
+      env = await buildEnv([multisigTop, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigTop, chain: polkadotChain },
+      });
+
+      const initiator = env.getState(submitDraftModel.$initiator);
+      expect(initiator).not.toBeNull();
+      expect(initiator!.accountId).toBe(MULTISIG_TOP_ID);
+    });
+
+    it('takes path[0] over the flowStarted initiator for nested multisigs', async () => {
+      // Authored route: top → mid → signer. `multisigAccountId` is the deepest
+      // multisig (mid). The caller (DraftsSection) seeds flowInitiator from
+      // `multisigAccountId`, but $initiator must canonicalize to path[0] (top).
+      env = await buildEnv([multisigTop, multisigMid, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'multisig', accountId: MULTISIG_MID_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_MID_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        // Intentionally seed with the deepest multisig — the bug we're guarding
+        // against. The derived $initiator should override to path[0].
+        params: { draft, initiator: multisigMid, chain: polkadotChain },
+      });
+
+      const initiator = env.getState(submitDraftModel.$initiator);
+      expect(initiator).not.toBeNull();
+      expect(initiator!.accountId).toBe(MULTISIG_TOP_ID);
+      // Sanity: $flowInitiator still holds the seed value.
+      const flowInitiator = env.getState(submitDraftModel.__test.$flowInitiator);
+      expect(flowInitiator!.accountId).toBe(MULTISIG_MID_ID);
+    });
+
+    it('resolves $initiator from path[0] for a proxied draft', async () => {
+      env = await buildEnv([proxiedAccount, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'proxied', accountId: PROXIED_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { proxyAccountId: PROXIED_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: proxiedAccount, chain: polkadotChain },
+      });
+
+      const initiator = env.getState(submitDraftModel.$initiator);
+      expect(initiator).not.toBeNull();
+      expect(initiator!.accountId).toBe(PROXIED_ID);
+    });
+
+    it('falls back to $flowInitiator for legacy drafts (empty signingPath)', async () => {
+      env = await buildEnv([signerAccount]);
+
+      // Legacy draft has no path saved → $pathRoute is null → must use the
+      // seed initiator passed via flowStarted.
+      const draft = makeDraft([]);
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: signerAccount, chain: polkadotChain },
+      });
+
+      const initiator = env.getState(submitDraftModel.$initiator);
+      expect(initiator).not.toBeNull();
+      expect(initiator!.accountId).toBe(SIGNER_ID);
+    });
+  });
+
+  describe('$route resolution', () => {
+    beforeEach(async () => {
+      await allureMetadata({
+        epic: 'Drafts',
+        feature: 'Submit Draft',
+        story: 'Route strictly mirrors signingPath',
+      });
+    });
+
+    it('mirrors the full signingPath for a nested multisig draft', async () => {
+      env = await buildEnv([multisigTop, multisigMid, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'multisig', accountId: MULTISIG_MID_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_MID_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigMid, chain: polkadotChain },
+      });
+
+      const route = env.getState(submitDraftModel.__test.$route);
+      expect(route.map((a) => a.accountId)).toEqual([MULTISIG_TOP_ID, MULTISIG_MID_ID, SIGNER_ID]);
+    });
+
+    it('reports unresolved path and blocks routing when path[0] is missing from wallet accounts', async () => {
+      // The signer is present but the top multisig was removed (e.g. wallet
+      // wiped). Path can't be reconstructed — must NOT silently re-route.
+      env = await buildEnv([signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MISSING_MULTISIG_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MISSING_MULTISIG_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: null, chain: polkadotChain },
+      });
+
+      expect(env.getState(submitDraftModel.__test.$route)).toEqual([]);
+      expect(env.getState(submitDraftModel.__test.$pathResolutionError)).toBe(true);
+      expect(env.getState(submitDraftModel.$wrappedTxErrorKind)).toBe('signing-path-unresolved');
+    });
+
+    it('strictly follows the saved path even when BFS could connect a different way', async () => {
+      // multisigTop has signatory `mid`, mid has signatory `signer-1`. We
+      // also drop `signer-2` into the wallet, fully disconnected from the
+      // multisig graph — BFS shouldn't pull it in, and we shouldn't even try
+      // BFS since the draft authored a path.
+      env = await buildEnv([multisigTop, multisigMid, signerAccount, signerAccount2]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'multisig', accountId: MULTISIG_MID_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_MID_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigMid, chain: polkadotChain },
+      });
+
+      const route = env.getState(submitDraftModel.__test.$route);
+      // signer-2 never appears; the resolved path is authoritative.
+      expect(route.map((a) => a.accountId)).toEqual([MULTISIG_TOP_ID, MULTISIG_MID_ID, SIGNER_ID]);
+    });
+  });
+});

--- a/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
+++ b/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
@@ -19,10 +19,12 @@ import { submitDraftModel } from '@/features/drafts/model/submit-draft-model';
 import { polkadotChain, polkadotChainId, vaultWallet } from '../../fixtures/index';
 import { type FeatureTestEnvironment, FeatureTestBuilder, allureMetadata } from '../../utils/index';
 
-// --- Local fixtures: production typeguards check `accountType` (added by
-// account-sync), while the shared fixtures lack it. Build accounts with the
-// real `accountType` field so `isMultisigAccount` / `isProxiedAccount`
-// resolve correctly inside `createPathRouteStore`.
+// --- Local fixtures: production typeguards check the `accountType`
+// discriminator (set when the account is persisted — see
+// `features/multisig-wallet`, `features/proxied-wallet`), while the shared
+// fixtures lack it. Build accounts with the real `accountType` field so
+// `isMultisigAccount` / `isProxiedAccount` resolve correctly inside
+// `createPathRouteStore`.
 
 // Use distinct string seeds — `createAccountId` reduces the seed to a sum of
 // char codes, so numeric seeds like 101/110 collide (both sum to 146).
@@ -286,7 +288,7 @@ describe('Submit Draft — signing path drives the route', () => {
         params: { draft, initiator: multisigMid, chain: polkadotChain },
       });
 
-      const route = env.getState(submitDraftModel.__test.$route);
+      const route = env.getState(submitDraftModel.$route);
       expect(route.map((a) => a.accountId)).toEqual([MULTISIG_TOP_ID, MULTISIG_MID_ID, SIGNER_ID]);
     });
 
@@ -308,16 +310,22 @@ describe('Submit Draft — signing path drives the route', () => {
         params: { draft, initiator: null, chain: polkadotChain },
       });
 
-      expect(env.getState(submitDraftModel.__test.$route)).toEqual([]);
-      expect(env.getState(submitDraftModel.__test.$pathResolutionError)).toBe(true);
+      expect(env.getState(submitDraftModel.$route)).toEqual([]);
+      expect(env.getState(submitDraftModel.$pathResolutionError)).toBe(true);
       expect(env.getState(submitDraftModel.$wrappedTxErrorKind)).toBe('signing-path-unresolved');
     });
 
-    it('strictly follows the saved path even when BFS could connect a different way', async () => {
-      // multisigTop has signatory `mid`, mid has signatory `signer-1`. We
-      // also drop `signer-2` into the wallet, fully disconnected from the
-      // multisig graph — BFS shouldn't pull it in, and we shouldn't even try
-      // BFS since the draft authored a path.
+    it('ignores stray wallet accounts outside the saved path', async () => {
+      // Drop an unrelated `signer-2` into the wallet alongside the authored
+      // path. The resolved route must contain exactly the path nodes — no
+      // accidental inclusion of extra accounts.
+      //
+      // Note: this test does NOT prove BFS itself is bypassed (the
+      // `accountCollectChildrenPipeline` DI handler isn't registered here, so
+      // `findRoute` returns [] regardless). Verifying BFS-bypass directly
+      // would require wiring the multisig children pipeline; until then, the
+      // BFS-vs-saved branch is covered by the resolution tests above and by
+      // production usage in `aggregates/multisig`.
       env = await buildEnv([multisigTop, multisigMid, signerAccount, signerAccount2]);
 
       const draft = makeDraft(
@@ -334,9 +342,45 @@ describe('Submit Draft — signing path drives the route', () => {
         params: { draft, initiator: multisigMid, chain: polkadotChain },
       });
 
-      const route = env.getState(submitDraftModel.__test.$route);
-      // signer-2 never appears; the resolved path is authoritative.
+      const route = env.getState(submitDraftModel.$route);
       expect(route.map((a) => a.accountId)).toEqual([MULTISIG_TOP_ID, MULTISIG_MID_ID, SIGNER_ID]);
+      expect(route).toHaveLength(3);
+      expect(route.every((a) => a.accountId !== SIGNER_2_ID)).toBe(true);
+    });
+  });
+
+  describe('signatory auto-selection (regression: dropped signatory→initiator fallback)', () => {
+    beforeEach(async () => {
+      await allureMetadata({
+        epic: 'Drafts',
+        feature: 'Submit Draft',
+        story: 'Signatory pre-select fires on flow start',
+      });
+    });
+
+    it('pre-selects $signatoryStore from draft.initiatorAccountId on flow start', async () => {
+      // After removing the `signer = signatory || initiator` fallback, the
+      // confirm/sign chain depends on `$signatoryStore` being non-null. The
+      // path-driven pre-select sample (clock: `[$availableAccounts, $draft]`)
+      // must fire on flow start so the user isn't stuck on a loader.
+      env = await buildEnv([multisigTop, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigTop, chain: polkadotChain },
+      });
+
+      const signatory = env.getState(submitDraftModel.$signatoryStore);
+      expect(signatory).not.toBeNull();
+      expect(signatory!.accountId).toBe(SIGNER_ID);
     });
   });
 });


### PR DESCRIPTION
## Description

When a draft contains a non-trivial signing path (nested multisig, flex multisig, proxied multisig), the submit flow was rebuilding the transaction route through ad-hoc inputs from `DraftsSection` instead of strictly following the path the draft author saved. For nested multisigs (`[multisigA, multisigB, signer]`), `multisigAccountId` is `path.findLast(n => n.kind === 'multisig')` — the deepest hop — and the caller seeded `$initiator` with that, while the actual route root is `path[0]`. As a result, the wrapped extrinsic could be assembled with a different initiator than the user authored the draft against.

This PR makes the submit flow strictly path-driven: `$initiator` and `$route` derive from `draft.signingPath`, BFS is reserved for legacy drafts only, and the dropped `signatory || initiator` fallback in confirm/sign is replaced with explicit signatory pre-selection guarantees.

## Changes Made

**`submit-draft-model.ts`**
- `$initiator` is now derived as `pathRoute[0] ?? flowInitiator` — for path-driven drafts the canonical initiator is `signingPath[0]`. The `flowStarted` seed (renamed to `$flowInitiator`) is kept as a fallback for legacy drafts with empty `signingPath`.
- `$route` strictly mirrors the resolved path; BFS only runs when `signingPath.length === 0`. The BFS gate is inlined into the `combine` so `findRoute` doesn't run at all for path-driven drafts.
- `confirmModel.init` filter now requires `nonNullable(s.signatory)`; the previous `signatory || initiator` fallback is removed — for path-driven drafts the signer is unambiguously `path.at(-1)`, and `$signatoryStore` is in the sample's `clock` so init re-fires once pre-selection lands.
- Path-driven signatory pre-select sample now uses `clock: [$availableAccounts, $draft]` (was `$availableAccounts` only) so it fires on flow start even when the account list is stable.
- Auto-select signatory (single-option) now guards against overwriting an existing selection — previously it could clobber the path-driven pre-selection because `findSignatories` returns the multisig itself as a "leaf" when the children pipeline isn't wired.
- `$route` and `$pathResolutionError` promoted to the public surface.

**`DraftsSection.tsx`**
- Added clarifying comments that the `initiator` passed to `flowStarted` is a legacy fallback only and acknowledges the deepest-multisig pick is wrong for nested routing but harmless because the model overrides it when a saved path is present.

**Tests** (`tests/integrations/cases/drafts/draft-signing-path.integration.test.ts`)
- 8 new integration tests covering: `$initiator` resolution from `path[0]` for single-multisig / nested-multisig / proxied / legacy drafts; full-path mirroring in `$route` for nested multisigs; `$wrappedTxErrorKind = 'signing-path-unresolved'` when the path can't be resolved; stray-account isolation; and `$signatoryStore` pre-selection regression after the dropped fallback.

## Screenshots/Recordings

N/A — internal routing/state changes, no UI surface added.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable) — N/A
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#17