### PR TITLE
feat: add CallData to confirmation screens and save as temaplate functionality

### DIFF
--- a/src/renderer/features/multi-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/multi-transfer/components/Confirmation.tsx
@@ -6,8 +6,10 @@ import { getNativeAsset } from '@/shared/lib/utils';
 import { Button, DetailRow, Icon, Separator } from '@/shared/ui';
 import { AssetBalance, TransactionDetails } from '@/shared/ui-entities';
 import { Box, Modal } from '@/shared/ui-kit';
+import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { walletModel } from '@/entities/wallet';
+import { CallDataConfirmSection } from '@/features/operations/OperationsConfirm/common/CallDataConfirmSection';
 import { MultiTransferPreview } from '@/widgets/multi-transfer-preview';
 import { AssetFiatBalance } from '@/widgets/price';
 import { FeeWithLabel, MultisigDepositFee } from '@/widgets/transaction-fee';
@@ -21,6 +23,7 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
+  const apis = useUnit(networkModel.$apis);
   const confirms = useUnit(confirmModel.$confirms);
   const confirm = confirms.at(0) ?? null;
 
@@ -30,6 +33,7 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
     confirm.meta;
 
   const asset = getNativeAsset(chain.assets);
+  const api = apis?.[chain.chainId] ?? null;
 
   return (
     <>
@@ -67,6 +71,9 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
           </DetailRow>
           {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
           <FeeWithLabel asset={asset} fee={fee} />
+          {api && (
+            <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
+          )}
         </TransactionDetails>
       </Box>
 

--- a/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
+++ b/src/renderer/features/multisig-operations/components/ActionSteps/Confirmation.tsx
@@ -18,6 +18,7 @@ import { type AnyAccount, type MultisigOperation } from '@/domains/network';
 import { SignButton, operationDetailsUtils } from '@/entities/operations';
 import { transactionService } from '@/entities/transaction';
 import { walletModel } from '@/entities/wallet';
+import { CallDataConfirmSection } from '@/features/operations/OperationsConfirm/common/CallDataConfirmSection';
 import { FeeWithLabel, MultisigDepositFee } from '@/widgets/transaction-fee';
 import { Details } from '../Details';
 
@@ -39,6 +40,7 @@ type Props = {
   valid: boolean;
   isFeeLoading: boolean;
   isDepositRequired?: boolean;
+  showUnderlyingTransaction?: boolean;
   onSign: () => void;
   onGoBack?: () => void;
   errors?: (
@@ -62,6 +64,7 @@ export const Confirmation = ({
   onGoBack,
   errors,
   isDepositRequired = false,
+  showUnderlyingTransaction = false,
 }: Props) => {
   const { t } = useI18n();
 
@@ -101,7 +104,12 @@ export const Confirmation = ({
           signatory={signAccount}
         />
       )}
-      <OperationMeta operation={operation} chain={chain} api={api} />
+      <OperationMeta
+        operation={operation}
+        chain={chain}
+        api={api}
+        showUnderlyingTransaction={showUnderlyingTransaction}
+      />
       {asset && isDepositRequired && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
       {asset && <FeeWithLabel fee={fee} asset={asset} isLoading={isFeeLoading} />}
       <div className="mt-3 flex w-full justify-between">
@@ -119,7 +127,17 @@ export const Confirmation = ({
 const InteractionStyle =
   'rounded-sm hover:bg-action-background-hover hover:text-text-primary cursor-pointer py-[3px] px-2 -mr-2';
 
-const OperationMeta = ({ operation, chain, api }: { operation: MultisigOperation; chain: Chain; api: ApiPromise }) => {
+const OperationMeta = ({
+  operation,
+  chain,
+  api,
+  showUnderlyingTransaction = false,
+}: {
+  operation: MultisigOperation;
+  chain: Chain;
+  api: ApiPromise;
+  showUnderlyingTransaction?: boolean;
+}) => {
   const { t } = useI18n();
 
   const { callHash, callData, blockCreated, indexCreated } = operation;
@@ -172,7 +190,17 @@ const OperationMeta = ({ operation, chain, api }: { operation: MultisigOperation
         </DetailRow>
       )}
 
-      {callData && (
+      {callData && showUnderlyingTransaction && (
+        <CallDataConfirmSection
+          api={api}
+          chain={chain}
+          resultCallData={callData}
+          resultLabel={t('operation.details.coreTx')}
+          coreCallData={callData}
+        />
+      )}
+
+      {callData && !showUnderlyingTransaction && (
         <DetailRow label={t('operation.details.callData')} className="text-text-secondary">
           <div className="flex items-center gap-1">
             <Copy value={callData}>

--- a/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
+++ b/src/renderer/features/multisig-operations/components/modals/ApproveTx.tsx
@@ -180,6 +180,7 @@ export const ApproveTxModal = memo(({ operation, account, api, chain, children }
               signAccount={signAccount}
               multisigDeposit={multisigDeposit}
               valid={valid}
+              showUnderlyingTransaction
               onSign={handleConfirm}
               onGoBack={() => setActiveStep(Step.FORM)}
             />

--- a/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddProxy/ui/Confirmation.tsx
@@ -58,6 +58,8 @@ export const Confirmation = ({ id = 0, onGoBack, secondaryActionButton, hideSign
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         <DetailRow label={t('proxy.details.grantAccessType')} className="pr-2">
           <FootnoteText>{proxyType}</FootnoteText>

--- a/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/AddPureProxied/ui/Confirmation.tsx
@@ -58,6 +58,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirmStore.meta.tx}
+        coreTx={confirmStore.meta.coreTx}
       >
         <DetailRow
           className="text-text-primary"

--- a/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondExtra/ui/Confirmation.tsx
@@ -79,6 +79,8 @@ export const Confirmation = ({
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         {hasMultisigAccount && (
           <DetailRow

--- a/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/BondNominate/ui/Confirmation.tsx
@@ -115,6 +115,8 @@ export const Confirmation = ({
           wallets={wallets}
           initiators={initiators}
           signatory={confirm.meta.signatory}
+          resultTx={confirm.meta.tx}
+          coreTx={confirm.meta.coreTx}
         >
           <DetailRow label={t('staking.confirmation.validatorsLabel')}>
             <button

--- a/src/renderer/features/operations/OperationsConfirm/Delegate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Delegate/ui/Confirmation.tsx
@@ -100,6 +100,8 @@ export const Confirmation = ({
         wallets={wallets}
         initiators={initiators}
         signatory={meta.signatory}
+        resultTx={meta.tx}
+        coreTx={meta.coreTx}
       >
         <DetailRow label={t('governance.addDelegation.confirmation.target')}>
           <NamedAccount variant="short" chain={meta.chain} accountId={toAccountId(meta.target)} />

--- a/src/renderer/features/operations/OperationsConfirm/EditDelegation/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/EditDelegation/ui/Confirmation.tsx
@@ -101,6 +101,8 @@ export const Confirmation = ({
         wallets={wallets}
         initiators={initiators}
         signatory={meta.signatory}
+        resultTx={meta.tx}
+        coreTx={meta.coreTx}
       >
         <DetailRow label={t('governance.addDelegation.confirmation.target')}>
           <NamedAccount variant="short" chain={meta.chain} accountId={toAccountId(meta.target)} />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipEvidenceVoting/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipEvidenceVoting/ui/Confirmation.tsx
@@ -1,12 +1,14 @@
-import { useStoreMap } from 'effector-react';
+import { useStoreMap, useUnit } from 'effector-react';
 import { type ReactNode, memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
 import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { Box } from '@/shared/ui-kit';
+import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { EvidenceVotingConfirmation } from '@/features/fellowship-evidence';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirmModel } from '../model/confirm-model';
 
@@ -26,10 +28,13 @@ export const Confirmation = memo(({ id, secondaryActionButton, hideSignButton, o
     fn: (value, [id]) => (id ? value[id] : null) ?? null,
   });
 
+  const apis = useUnit(networkModel.$apis);
+
   if (nullable(confirm) || nullable(confirm.meta)) return null;
 
   const { wallets, chain, asset, fee, aye, tracks, maxRank, evidence, votingMember, proposerMember, initiator } =
     confirm.meta;
+  const api = apis?.[chain.chainId] ?? null;
 
   return (
     <Box padding={[4, 5]}>
@@ -46,6 +51,15 @@ export const Confirmation = memo(({ id, secondaryActionButton, hideSignButton, o
         proposerMember={proposerMember}
         evidence={evidence}
       />
+
+      {api && (
+        <CallDataConfirmSection
+          api={api}
+          chain={confirm.meta.chain}
+          resultTx={confirm.meta.tx}
+          coreTx={confirm.meta.coreTx}
+        />
+      )}
 
       <MultisigOperationDescriptionField />
 

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryInduct/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryInduct/ui/Confirmation.tsx
@@ -6,6 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { SignButton } from '@/entities/operations';
 import { SalaryRegisterConfirmation } from '@/features/fellowship-salary';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirm } from '../model/confirm';
 
@@ -37,6 +38,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         chain={record.meta.chain}
         wallets={record.meta.wallets}
         fee={record.meta.fee}
+      />
+
+      <CallDataConfirmSection
+        api={record.meta.api}
+        chain={record.meta.chain}
+        resultTx={record.meta.tx}
+        coreTx={record.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryPayout/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryPayout/ui/Confirmation.tsx
@@ -6,6 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { SignButton } from '@/entities/operations';
 import { SalaryPayoutConfirmation } from '@/features/fellowship-salary';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirm } from '../model/confirm';
 
@@ -38,6 +39,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         chain={record.meta.chain}
         wallets={record.meta.wallets}
         fee={record.meta.fee}
+      />
+
+      <CallDataConfirmSection
+        api={record.meta.api}
+        chain={record.meta.chain}
+        resultTx={record.meta.tx}
+        coreTx={record.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryRequest/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipSalaryRequest/ui/Confirmation.tsx
@@ -6,6 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { SignButton } from '@/entities/operations';
 import { SalaryRegisterConfirmation } from '@/features/fellowship-salary';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirm } from '../model/confirm';
 
@@ -37,6 +38,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         chain={record.meta.chain}
         wallets={record.meta.wallets}
         fee={record.meta.fee}
+      />
+
+      <CallDataConfirmSection
+        api={record.meta.api}
+        chain={record.meta.chain}
+        resultTx={record.meta.tx}
+        coreTx={record.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipSetActive/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipSetActive/ui/Confirmation.tsx
@@ -6,6 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { SignButton } from '@/entities/operations';
 import { SetActiveConfirmation, setActive } from '@/features/fellowship-profile';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirmModel } from '../model/confirm-model';
 
@@ -40,6 +41,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         wallets={confirm.meta.wallets}
         fee={confirm.meta.fee}
         isActive={confirm.meta.isActive}
+      />
+
+      <CallDataConfirmSection
+        api={confirm.meta.api}
+        chain={confirm.meta.chain}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipSubmitEvidence/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipSubmitEvidence/ui/Confirmation.tsx
@@ -6,6 +6,7 @@ import { nullable } from '@/shared/lib/utils';
 import { Button } from '@/shared/ui';
 import { SignButton } from '@/entities/operations';
 import { SubmitEvidenceConfirmation } from '@/features/fellowship-evidence';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirmModel } from '../model/confirm-model';
 
@@ -39,6 +40,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         fee={confirm.meta.fee}
         wish={confirm.meta.wish}
         evidence={confirm.meta.evidence}
+      />
+
+      <CallDataConfirmSection
+        api={confirm.meta.api}
+        chain={confirm.meta.chain}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/FellowshipVoting/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/FellowshipVoting/ui/Confirmation.tsx
@@ -8,6 +8,7 @@ import { Box } from '@/shared/ui-kit';
 import { referendumService, useCoreMembers, useMaxRank, useReferendums, useTracks } from '@/domains/collectives';
 import { SignButton } from '@/entities/operations';
 import { VotingConfirmation } from '@/features/fellowship-voting';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirmModel } from '../model/confirm-model';
 
@@ -81,6 +82,13 @@ export const Confirmation = ({ id, secondaryActionButton, hideSignButton, onGoBa
         maxRank={maxRank}
         fee={confirm.meta.fee}
         rank={confirm.meta.rank}
+      />
+
+      <CallDataConfirmSection
+        api={confirm.meta.api}
+        chain={confirm.meta.chain}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       />
 
       <MultisigOperationDescriptionField />

--- a/src/renderer/features/operations/OperationsConfirm/Nominate/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Nominate/ui/Confirmation.tsx
@@ -66,6 +66,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
           wallets={wallets}
           initiators={confirms.map((c) => c.meta.initiator)}
           signatory={signatory}
+          resultTx={confirmStore.meta.tx}
+          coreTx={confirmStore.meta.coreTx}
         >
           <DetailRow label={t('staking.confirmation.validatorsLabel')}>
             <button

--- a/src/renderer/features/operations/OperationsConfirm/Payee/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Payee/ui/Confirmation.tsx
@@ -60,6 +60,8 @@ export const Confirmation = ({ id = 0, onGoBack, secondaryActionButton, hideSign
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         <DetailRow label={t('staking.confirmation.rewardsDestinationLabel')}>
           {destination ? (

--- a/src/renderer/features/operations/OperationsConfirm/Referendum/RemoveVote/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Referendum/RemoveVote/ui/Confirmation.tsx
@@ -107,6 +107,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton }: 
         wallets={wallets}
         initiators={[confirm.meta.initiator]}
         signatory={confirm.meta.signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         {votingPower && amount && conviction ? (
           <>

--- a/src/renderer/features/operations/OperationsConfirm/Referendum/Vote/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Referendum/Vote/ui/Confirmation.tsx
@@ -111,6 +111,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         wallets={wallets}
         initiators={[confirm.meta.initiator]}
         signatory={confirm.meta.signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         <DetailRow label={t('governance.vote.field.decision')}>{t(`governance.referendum.${decision}`)}</DetailRow>
         <DetailRow label={t('governance.vote.field.governanceLock')} wrapperClassName="items-start">

--- a/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/RemoveProxy/ui/Confirmation.tsx
@@ -60,6 +60,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirmStore.meta.tx}
+        coreTx={confirmStore.meta.coreTx}
       >
         <DetailRow label={t('proxy.details.accessType')} className="pr-2">
           <FootnoteText>{proxyType}</FootnoteText>

--- a/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Restake/ui/Confirmation.tsx
@@ -68,6 +68,8 @@ export const Confirmation = ({ id = 0, onGoBack, secondaryActionButton, hideSign
         wallets={wallets}
         initiators={confirms.map((confirm) => confirm.meta.initiator)}
         signatory={confirm.meta.signatory}
+        resultTx={confirm.meta.tx}
+        coreTx={confirm.meta.coreTx}
       >
         {hasMultisigAccount && (
           <DetailRow

--- a/src/renderer/features/operations/OperationsConfirm/RevokeDelegation/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/RevokeDelegation/ui/Confirmation.tsx
@@ -97,6 +97,8 @@ export const Confirmation = ({
         wallets={wallets}
         initiators={initiators}
         signatory={confirmStore.meta.signatory}
+        resultTx={confirmStore.meta.tx}
+        coreTx={confirmStore.meta.coreTx}
       >
         <DetailRow label={t('governance.addDelegation.confirmation.target')}>
           <NamedAccount

--- a/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
@@ -8,11 +8,13 @@ import { Button, DetailRow, FootnoteText, Icon, Loader } from '@/shared/ui';
 import { AssetBalance, TransactionDetails, TransactionValidationError } from '@/shared/ui-entities';
 import { Box, Tooltip } from '@/shared/ui-kit';
 import { ChainTitle } from '@/entities/chain';
+import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { PathBreadcrumb, PathReviewPopover } from '@/features/signing-path';
 import { NamedAccount } from '@/widgets/NameResolver';
 import { AssetFiatBalance } from '@/widgets/price';
+import { CallDataConfirmSection } from '../../common/CallDataConfirmSection';
 import { MultisigExistsAlert } from '../../common/MultisigExistsAlert';
 import { MultisigOperationDescriptionField } from '../../common/MultisigOperationDescriptionField';
 import { confirmModel } from '../model/confirm-model';
@@ -28,6 +30,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
   const { t } = useI18n();
 
   const wallets = useUnit(walletModel.$wallets);
+  const apis = useUnit(networkModel.$apis);
   const isMultisigExists = useUnit(confirmModel.$isMultisigExists);
   const validationErrors = useUnit(confirmModel.$validationErrors);
   const canSubmit = useUnit(confirmModel.$canSubmit);
@@ -56,6 +59,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
   const initiators = confirms.map((confirm) => confirm.meta.initiator);
   const nativeAsset = getNativeAsset(meta.chain.assets);
   const isMultiHopPath = nonNullable(meta.signingPath) && meta.signingPath.length >= 2;
+  const api = apis?.[meta.chain.chainId] ?? null;
 
   // Reused below TransactionDetails (trivial) AND below PathBreadcrumb
   // (multi-hop) — the same recipient / fee / deposit detail rows.
@@ -138,6 +142,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
           </div>
         </DetailRow>
       )}
+
+      {api && <CallDataConfirmSection api={api} chain={meta.chain} resultTx={meta.tx} coreTx={meta.coreTx} />}
     </>
   );
 

--- a/src/renderer/features/operations/OperationsConfirm/Unlock/ui/UnlockConfirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Unlock/ui/UnlockConfirmation.tsx
@@ -87,6 +87,8 @@ export const UnlockConfirmation = ({ id = 0, hideSignButton, secondaryActionButt
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={confirmStore.meta.tx}
+        coreTx={confirmStore.meta.coreTx}
       >
         <DetailRow label={t('governance.operations.transferable')} wrapperClassName="items-start">
           <BalanceDiff from={transferableBalance} to={transferableBalance.add(new BN(amount))} asset={asset} />

--- a/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Unstake/ui/Confirmation.tsx
@@ -73,6 +73,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
         wallets={wallets}
         initiators={confirms.map((c) => c.meta.initiator)}
         signatory={signatory}
+        resultTx={confirmStore.meta.tx}
+        coreTx={confirmStore.meta.coreTx}
       >
         {hasMultisigAccount && (
           <DetailRow

--- a/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Withdraw/ui/Confirmation.tsx
@@ -71,6 +71,8 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
           wallets={wallets}
           initiators={[initiator]}
           signatory={signatory}
+          resultTx={confirmStore.meta.tx}
+          coreTx={confirmStore.meta.coreTx}
         >
           {hasMultisigAccount && (
             <DetailRow

--- a/src/renderer/features/operations/OperationsConfirm/common/CallDataConfirmSection.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/common/CallDataConfirmSection.tsx
@@ -1,0 +1,182 @@
+import { type ApiPromise } from '@polkadot/api';
+
+import { type Chain, type HexString, type Transaction } from '@/shared/core';
+import { useI18n } from '@/shared/i18n';
+import { cnTw, truncate } from '@/shared/lib/utils';
+import { Button, DetailRow, FootnoteText, Icon } from '@/shared/ui';
+import { Box, Copy, Json, Modal, Tooltip } from '@/shared/ui-kit';
+import { useNotification } from '@/shared/ui-kit/NotificationContext';
+import { useTemplateMutations } from '@/domains/operation-templates';
+import { transactionService } from '@/entities/transaction';
+
+const capitalize = (value: string) => (value.length === 0 ? value : value[0]!.toUpperCase() + value.slice(1));
+
+const humanize = (value: string) => {
+  return value
+    .replace(/([a-z0-9])([A-Z])/g, '$1 $2')
+    .split(/[_\s]+/)
+    .filter(Boolean)
+    .map(capitalize)
+    .join(' ');
+};
+
+const getTemplateName = (api: ApiPromise, callData: HexString): string => {
+  try {
+    const extrinsicCall = api.createType('Call', callData);
+    const { method, section } = api.registry.findMetaCall(extrinsicCall.callIndex);
+
+    return humanize(section) + ': ' + humanize(method);
+  } catch {
+    return 'Untitled template';
+  }
+};
+
+type Props = {
+  api: ApiPromise;
+  chain: Chain;
+  resultTx?: Transaction;
+  resultCallData?: HexString | null;
+  resultLabel?: string;
+  coreTx?: Transaction | null;
+  coreCallData?: HexString | null;
+};
+
+type RowProps = {
+  label: string;
+  callData: string;
+  jsonArgs: object | null;
+  onSave?: () => void;
+  saveTooltip?: string;
+};
+
+const InteractionStyle =
+  'rounded-sm hover:bg-action-background-hover hover:text-text-primary cursor-pointer py-[3px] px-2 -mr-2';
+
+const getCallData = (transaction: Transaction | null | undefined, api: ApiPromise): string | null => {
+  return transactionService.getCallDataHex(transaction, api);
+};
+
+const toHexString = (value: string | null): HexString | null => {
+  if (!value?.startsWith('0x')) return null;
+
+  // eslint-disable-next-line @typescript-eslint/consistent-type-assertions -- call data is validated by the 0x prefix and produced by transactionService.
+  return value as HexString;
+};
+
+const getJsonArgs = (callData: string, api: ApiPromise, chain: Chain): object | null => {
+  const hexCallData = toHexString(callData);
+  if (!hexCallData) return null;
+
+  try {
+    const call = transactionService.createCallFromCallData(hexCallData, api);
+    if (!call) return null;
+
+    return transactionService.formatCall(call, chain);
+  } catch {
+    return null;
+  }
+};
+
+const CallDataRow = ({ label, callData, jsonArgs, onSave, saveTooltip }: RowProps) => {
+  const { t } = useI18n();
+
+  return (
+    <DetailRow label={label} className="text-text-secondary">
+      <div className="flex items-center gap-1">
+        {onSave && (
+          <Tooltip>
+            <Tooltip.Trigger>
+              <div>
+                <Button className="px-2" size="sm" variant="text" onClick={onSave}>
+                  {t('operationTemplates.saveCoreTxButton')}
+                </Button>
+              </div>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{saveTooltip}</Tooltip.Content>
+          </Tooltip>
+        )}
+
+        <Copy value={callData} notification={t('operationTemplates.toastCallDataCopied')}>
+          <button type="button" className={cnTw('group flex items-center gap-x-1', InteractionStyle)}>
+            <FootnoteText className="text-inherit">{truncate(callData, 7, 8)}</FootnoteText>
+            <Icon name="copy" size={16} className="group-hover:text-icon-hover" />
+          </button>
+        </Copy>
+
+        {jsonArgs && (
+          <Modal size="lg" height="fit">
+            <Modal.Trigger>
+              <button type="button" className={cnTw('group', InteractionStyle)}>
+                <Icon name="details" size={16} className="group-hover:text-icon-hover" />
+              </button>
+            </Modal.Trigger>
+            <Modal.Title close>{t('operation.viewJSON.label')}</Modal.Title>
+            <Modal.Content>
+              <Box padding={5}>
+                <Json value={jsonArgs} name="callData" />
+              </Box>
+            </Modal.Content>
+          </Modal>
+        )}
+      </div>
+    </DetailRow>
+  );
+};
+
+export const CallDataConfirmSection = ({
+  api,
+  chain,
+  resultTx,
+  resultCallData: resultCallDataProp,
+  resultLabel,
+  coreTx,
+  coreCallData: coreCallDataProp,
+}: Props) => {
+  const { t } = useI18n();
+  const { toast } = useNotification();
+  const { save } = useTemplateMutations();
+
+  const resultCallData = resultCallDataProp ?? getCallData(resultTx, api);
+  const coreCallData = coreCallDataProp ?? getCallData(coreTx ?? resultTx, api);
+
+  if (!resultCallData) return null;
+
+  const coreDiffers = Boolean(coreCallData && coreCallData !== resultCallData);
+  const resultJsonArgs = getJsonArgs(resultCallData, api, chain);
+  const coreJsonArgs = coreCallData ? getJsonArgs(coreCallData, api, chain) : null;
+
+  const handleSaveCoreTx = async () => {
+    const coreHexCallData = toHexString(coreCallData);
+    if (!coreHexCallData) return;
+
+    await save({
+      name: getTemplateName(api, coreHexCallData),
+      chainId: chain.chainId,
+      callData: coreHexCallData,
+      specVersion: api.runtimeVersion.specVersion.toNumber(),
+    });
+    toast.success(t('operationTemplates.toastCreated'));
+  };
+
+  return (
+    <>
+      <CallDataRow
+        label={resultLabel ?? t('operation.details.callData')}
+        callData={resultCallData}
+        jsonArgs={resultJsonArgs}
+        saveTooltip={t('operationTemplates.saveCallDataTooltip')}
+        onSave={!coreDiffers && coreCallData ? handleSaveCoreTx : undefined}
+      />
+
+      {coreDiffers && coreCallData && (
+        <CallDataRow
+          label={t('operation.details.coreTx')}
+          callData={coreCallData}
+          jsonArgs={coreJsonArgs}
+          saveTooltip={t('operationTemplates.saveCoreTxTooltip')}
+          onSave={handleSaveCoreTx}
+        />
+      )}
+    </>
+  );
+};

--- a/src/renderer/features/operations/OperationsConfirm/common/SigningPathConfirmSection.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/common/SigningPathConfirmSection.tsx
@@ -1,10 +1,15 @@
+import { type ApiPromise } from '@polkadot/api';
+import { useUnit } from 'effector-react';
 import { type ReactNode } from 'react';
 
-import { type Chain, type Wallet } from '@/shared/core';
+import { type Chain, type Transaction, type Wallet } from '@/shared/core';
 import { TransactionDetails } from '@/shared/ui-entities';
 import { type PathNode } from '@/domains/backend';
 import { type AnyAccount } from '@/domains/network';
+import { networkModel } from '@/entities/network';
 import { PathBreadcrumb, PathReviewPopover } from '@/features/signing-path';
+
+import { CallDataConfirmSection } from './CallDataConfirmSection';
 
 type Props = {
   signingPath: PathNode[] | undefined;
@@ -13,9 +18,29 @@ type Props = {
   initiators: AnyAccount[];
   signatory: AnyAccount;
   children: ReactNode;
+  api?: ApiPromise;
+  resultTx?: Transaction;
+  coreTx?: Transaction | null;
 };
 
-export const SigningPathConfirmSection = ({ signingPath, chain, wallets, initiators, signatory, children }: Props) => {
+export const SigningPathConfirmSection = ({
+  signingPath,
+  chain,
+  wallets,
+  initiators,
+  signatory,
+  children,
+  api,
+  resultTx,
+  coreTx,
+}: Props) => {
+  const apis = useUnit(networkModel.$apis);
+  const resolvedApi = api ?? apis?.[chain.chainId] ?? null;
+  const callDataSection =
+    resolvedApi && resultTx ? (
+      <CallDataConfirmSection api={resolvedApi} chain={chain} resultTx={resultTx} coreTx={coreTx} />
+    ) : null;
+
   if (signingPath && signingPath.length >= 2) {
     return (
       <div className="flex w-full flex-col gap-y-4">
@@ -24,7 +49,10 @@ export const SigningPathConfirmSection = ({ signingPath, chain, wallets, initiat
         </div>
         <PathBreadcrumb path={signingPath} chainId={chain.chainId} size="sm" />
         <hr className="w-full border-filter-border pr-2" />
-        <dl className="flex w-full flex-col gap-y-4 text-footnote">{children}</dl>
+        <dl className="flex w-full flex-col gap-y-4 text-footnote">
+          {children}
+          {callDataSection}
+        </dl>
       </div>
     );
   }
@@ -32,6 +60,7 @@ export const SigningPathConfirmSection = ({ signingPath, chain, wallets, initiat
   return (
     <TransactionDetails chain={chain} wallets={wallets} initiators={initiators} signatory={signatory}>
       {children}
+      {callDataSection}
     </TransactionDetails>
   );
 };

--- a/src/renderer/features/proxy-verify/ui/VerifyProxyConfirmation.tsx
+++ b/src/renderer/features/proxy-verify/ui/VerifyProxyConfirmation.tsx
@@ -81,6 +81,8 @@ export const VerifyProxyConfirmation = ({ id = 0, secondaryActionButton, hideSig
         wallets={wallets}
         initiators={initiators}
         signatory={signatory}
+        resultTx={meta.tx}
+        coreTx={meta.coreTx}
       >
         <DetailRow label={t('proxy.details.accessType')} className="pr-2">
           <FootnoteText>{proxyType}</FootnoteText>

--- a/src/renderer/features/vested-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/vested-transfer/components/Confirmation.tsx
@@ -10,6 +10,7 @@ import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { type VestingScheduleRaw } from '@/entities/vesting';
 import { walletModel } from '@/entities/wallet';
+import { CallDataConfirmSection } from '@/features/operations/OperationsConfirm/common/CallDataConfirmSection';
 import { AssetFiatBalance } from '@/widgets/price';
 import { FeeWithLabel, MultisigDepositFee } from '@/widgets/transaction-fee';
 import { VestingSchedulePreview } from '@/widgets/vesting-schedule-preview';
@@ -42,6 +43,7 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
   const timelineChainId = chain.additional?.timelineChain;
   const timelineApi = (nonNullable(timelineChainId) ? apis[timelineChainId] : apis[chain.chainId]) ?? null;
   const asset = getNativeAsset(chain.assets);
+  const api = apis?.[chain.chainId] ?? null;
 
   return (
     <>
@@ -85,6 +87,9 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
           </DetailRow>
           {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
           <FeeWithLabel asset={asset} fee={fee} />
+          {api && (
+            <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
+          )}
         </TransactionDetails>
       </Box>
 

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2453,6 +2453,8 @@
       "account": "Account",
       "amount": "Amount",
       "callData": "Call Data",
+      "coreTx": "Underlying transaction",
+      "coreTxSame": "Underlying transaction",
       "callHash": "Call Hash",
       "controller": "Controller",
       "dateTime": "Date & Time",
@@ -3755,6 +3757,9 @@
   },
   "operationTemplates": {
     "saveButton": "Save as template",
+    "saveCoreTxButton": "Save as template",
+    "saveCallDataTooltip": "Save this transaction as a template to reuse the operation later.",
+    "saveCoreTxTooltip": "This is the transaction inside the proxy or multisig wrapper. Save it as a template to reuse the operation later.",
     "panelTitle": "Templates",
     "apply": "Apply",
     "delete": "Delete template",


### PR DESCRIPTION
## Description
Add call data display to all confirmation pages and a "Save as template" button on the confirmation page

## Related Issues
https://novasama-technologies.atlassian.net/browse/SPEK-564

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

https://github.com/user-attachments/assets/9c97ff6d-3697-4e76-bf52-deb04b5439ee



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#39