### PR TITLE
fix: reset address book connection memory on delete

### DIFF
--- a/src/renderer/aggregates/backend/model/connection-history-model.ts
+++ b/src/renderer/aggregates/backend/model/connection-history-model.ts
@@ -2,6 +2,7 @@ import { createStore, sample } from 'effector';
 import { persist } from 'effector-storage/local';
 
 import { authModel } from './auth-model';
+import { backendConfigurationModel } from './backend-configuration-model';
 
 const $hasEverConnected = createStore(false);
 
@@ -17,6 +18,8 @@ sample({
   fn: () => true,
   target: $hasEverConnected,
 });
+
+$hasEverConnected.on(backendConfigurationModel.events.urlCleared, () => false);
 
 export const connectionHistoryModel = {
   $hasEverConnected,


### PR DESCRIPTION
## Summary
- Clear `$hasEverConnected` when the user deletes the address book backend URL so the reconnect pill, status dot and drafts UI stop rendering.
- Before this change the persisted `address-book-has-ever-connected` localStorage flag survived a manual disconnect, so reconnect CTAs kept pointing at a backend the user had explicitly removed.


https://github.com/user-attachments/assets/b51d5a38-5f73-499a-aee9-d435f31cb55b


## Test plan
- [ ] Connect address book backend, sign in successfully
- [ ] Confirm reconnect pill / status dot / drafts surface as expected
- [ ] Open backend configuration modal, click **Delete**
- [ ] Verify reconnect pill, status dot and drafts UI disappear (no "you previously connected" residue)
- [ ] Reload the app — flag stays `false`, no stale UI