### PR TITLE
feat: chain selector + derivation hint in address book auth

### DIFF
--- a/src/renderer/aggregates/backend/lib/auth-chain.ts
+++ b/src/renderer/aggregates/backend/lib/auth-chain.ts
@@ -1,6 +1,4 @@
 import { type ChainId } from '@/shared/core';
 
-// Polkadot Asset Hub — picked as the auth QR default because Polkadot Vault
-// always provisions its keyring and users who derived their keys on the relay
-// or other parachains can pre-select another chain via the UI selector.
+// Polkadot Asset Hub: Polkadot Vault always provisions this keyring, so it's a safe auth QR default.
 export const DEFAULT_AUTH_CHAIN_ID: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f';

--- a/src/renderer/aggregates/backend/lib/auth-chain.ts
+++ b/src/renderer/aggregates/backend/lib/auth-chain.ts
@@ -1,0 +1,6 @@
+import { type ChainId } from '@/shared/core';
+
+// Polkadot Asset Hub — picked as the auth QR default because Polkadot Vault
+// always provisions its keyring and users who derived their keys on the relay
+// or other parachains can pre-select another chain via the UI selector.
+export const DEFAULT_AUTH_CHAIN_ID: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f';

--- a/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
+++ b/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
@@ -1,0 +1,60 @@
+import { allSettled, createWatch, fork } from 'effector';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type ChainId } from '@/shared/core';
+import { messageSignModel } from '@/features/operations/OperationMessageSign';
+import { DEFAULT_AUTH_CHAIN_ID } from '../../lib/auth-chain';
+import { authModel } from '../auth-model';
+import { backendConfigurationModel } from '../backend-configuration-model';
+
+const KUSAMA: ChainId = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
+
+describe('authModel — chain selector', () => {
+  it('defaults $selectedChainId to Polkadot Asset Hub', () => {
+    const scope = fork();
+    expect(scope.getState(authModel.$selectedChainId)).toBe(DEFAULT_AUTH_CHAIN_ID);
+  });
+
+  it('chainSelected updates $selectedChainId', async () => {
+    const scope = fork();
+    await allSettled(authModel.events.chainSelected, { scope, params: KUSAMA });
+    expect(scope.getState(authModel.$selectedChainId)).toBe(KUSAMA);
+  });
+
+  it('resets $selectedChainId to default on modalClosed', async () => {
+    const scope = fork({ values: [[authModel.$selectedChainId, KUSAMA]] });
+    expect(scope.getState(authModel.$selectedChainId)).toBe(KUSAMA);
+
+    await allSettled(authModel.events.modalClosed, { scope });
+    expect(scope.getState(authModel.$selectedChainId)).toBe(DEFAULT_AUTH_CHAIN_ID);
+  });
+
+  it('resets $selectedChainId to default on urlCleared', async () => {
+    const scope = fork({ values: [[authModel.$selectedChainId, KUSAMA]] });
+    await allSettled(backendConfigurationModel.events.urlCleared, { scope });
+    expect(scope.getState(authModel.$selectedChainId)).toBe(DEFAULT_AUTH_CHAIN_ID);
+  });
+
+  it('forwards chain changes to messageSignModel.chainIdChanged while in signing step', async () => {
+    const scope = fork({ values: [[authModel.$authStep, 'signing']] });
+
+    const spy = vi.fn();
+    createWatch({ unit: messageSignModel.chainIdChanged, fn: spy, scope });
+
+    await allSettled(authModel.events.chainSelected, { scope, params: KUSAMA });
+
+    expect(spy).toHaveBeenCalledTimes(1);
+    expect(spy).toHaveBeenCalledWith(KUSAMA);
+  });
+
+  it('does not forward chain changes when not in signing step', async () => {
+    const scope = fork({ values: [[authModel.$authStep, 'selectAccount']] });
+
+    const spy = vi.fn();
+    createWatch({ unit: messageSignModel.chainIdChanged, fn: spy, scope });
+
+    await allSettled(authModel.events.chainSelected, { scope, params: KUSAMA });
+
+    expect(spy).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -4,13 +4,15 @@ import { interval, once } from 'patronum';
 import { toast } from 'sonner';
 
 import { persist } from '@/shared/api/storage';
-import { RelayChains, assert, toAccountId } from '@/shared/lib/utils';
+import { type ChainId } from '@/shared/core';
+import { assert, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { backendAuthService } from '@/domains/backend';
-import { type AnyAccount, accountService } from '@/domains/network';
+import { type AnyAccount } from '@/domains/network';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { polkadotExtensionService } from '@/features/extension-wallet';
 import { messageSignModel } from '@/features/operations/OperationMessageSign';
+import { DEFAULT_AUTH_CHAIN_ID } from '../lib/auth-chain';
 import { buildSignMessage } from '../lib/sign-message';
 
 import { backendConfigurationModel } from './backend-configuration-model';
@@ -36,6 +38,7 @@ export type SignableAccount = {
 const signInClicked = createEvent();
 const signOutClicked = createEvent();
 const accountSelected = createEvent<AccountId>();
+const chainSelected = createEvent<ChainId>();
 const signConfirmed = createEvent();
 const connectTriggered = createEvent();
 const modalClosed = createEvent();
@@ -46,9 +49,12 @@ const unauthorizedResponseReceived = createEvent();
 const $authState = createStore<AuthState | null>(null);
 const $authStep = createStore<AuthStep>('selectAccount');
 const $selectedAccountId = createStore<AccountId | null>(null);
+const $selectedChainId = createStore<ChainId>(DEFAULT_AUTH_CHAIN_ID);
 const $error = createStore<string | null>(null);
 const $connectionResult = createStore<ConnectionResult>({ status: 'idle' });
 const $challengeId = createStore<string | null>(null);
+
+$selectedChainId.on(chainSelected, (_, chainId) => chainId);
 
 const $lastAuthedAccountId = createStore<AccountId | null>(null);
 persist({ store: $lastAuthedAccountId, key: 'address-book-last-authed-account-id' });
@@ -190,6 +196,7 @@ const resetAuthUiTriggers = [
 
 $authStep.on(resetAuthUiTriggers, () => 'selectAccount');
 $selectedAccountId.on(resetAuthUiTriggers, () => null);
+$selectedChainId.on(resetAuthUiTriggers, () => DEFAULT_AUTH_CHAIN_ID);
 $error.on(resetAuthUiTriggers, () => null);
 $challengeId.on(resetAuthUiTriggers, () => null);
 
@@ -216,13 +223,12 @@ sample({
 
 sample({
   clock: requestChallengeFx.doneData,
-  source: { account: $selectedAccount },
+  source: { account: $selectedAccount, chainId: $selectedChainId },
   filter: ({ account }) => account !== null,
-  fn: ({ account }, challengeData) => {
+  fn: ({ account, chainId }, challengeData) => {
     const signatory = account!.account;
     const messageText = buildSignMessage(challengeData.nonce);
     const message = new TextEncoder().encode(messageText);
-    const chainId = accountService.isChainAccount(signatory) ? signatory.chainId : RelayChains.POLKADOT;
 
     return { message, signatory, chainId };
   },
@@ -429,6 +435,7 @@ export const authModel = {
   $authState,
   $authStep,
   $selectedAccountId,
+  $selectedChainId,
   $error,
   $connectionResult,
   $isAuthenticated,
@@ -442,6 +449,7 @@ export const authModel = {
     signInSucceeded,
     signOutClicked,
     accountSelected,
+    chainSelected,
     signConfirmed,
     connectTriggered,
     modalClosed,

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -235,9 +235,7 @@ sample({
   target: messageSignModel.init,
 });
 
-// Re-render the QR live when the user picks a different network on the
-// signing step. We only forward updates while the signing step is open so a
-// later reset of $selectedChainId doesn't bleed into the model.
+// Gate on 'signing' step so a later $selectedChainId reset doesn't leak into messageSignModel.
 sample({
   clock: $selectedChainId,
   source: $authStep,

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -235,6 +235,17 @@ sample({
   target: messageSignModel.init,
 });
 
+// Re-render the QR live when the user picks a different network on the
+// signing step. We only forward updates while the signing step is open so a
+// later reset of $selectedChainId doesn't bleed into the model.
+sample({
+  clock: $selectedChainId,
+  source: $authStep,
+  filter: step => step === 'signing',
+  fn: (_, chainId) => chainId,
+  target: messageSignModel.chainIdChanged,
+});
+
 // Wiring: messageSignModel.signed → verifySignatureFx
 sample({
   clock: messageSignModel.signed,

--- a/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
@@ -159,7 +159,7 @@ export const BackendConfigurationModal = () => {
                 <ChainSelectorField
                   value={selectedChain}
                   options={chainOptions}
-                  onSelect={(chain: Chain) => authModel.events.chainSelected(chain.chainId)}
+                  onSelect={(chain) => authModel.events.chainSelected(chain.chainId)}
                 />
               )}
               <OperationMessageSign onGoBack={() => authModel.events.signingCancelled()} />

--- a/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
@@ -1,13 +1,15 @@
 import { useUnit } from 'effector-react';
-import { useEffect } from 'react';
+import { useEffect, useMemo } from 'react';
 
+import { type Chain } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { toAddress, toShortAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { useConfirmContext } from '@/shared/providers/ConfirmContext';
 import { Alert, Button, FootnoteText, Icon, InputHint, Loader, SmallTitleText } from '@/shared/ui';
-import { Address, Identicon } from '@/shared/ui-entities';
-import { Box, Field, Input, Modal, Select, Surface, useNotification } from '@/shared/ui-kit';
+import { Address, ChainSelect, Identicon } from '@/shared/ui-entities';
+import { Box, Field, Input, Modal, Select, Surface, Tooltip, useNotification } from '@/shared/ui-kit';
+import { networkModel } from '@/entities/network';
 import { type SignableAccount, authModel, backendConfigurationModel } from '@/aggregates/backend';
 import { OperationMessageSign } from '@/features/operations/OperationMessageSign';
 
@@ -27,10 +29,15 @@ export const BackendConfigurationModal = () => {
   const authState = useUnit(authModel.$authState);
   const authStep = useUnit(authModel.$authStep);
   const selectedAccountId = useUnit(authModel.$selectedAccountId);
+  const selectedChainId = useUnit(authModel.$selectedChainId);
   const signableAccounts = useUnit(authModel.$signableAccounts);
+  const chainsMap = useUnit(networkModel.$chains);
   const error = useUnit(authModel.$error);
   const isSessionExpired = useUnit(authModel.$isSessionExpired);
   const hasNetworkIssue = useUnit(authModel.$hasNetworkIssue);
+
+  const chainOptions = useMemo(() => Object.values(chainsMap), [chainsMap]);
+  const selectedChain = chainsMap[selectedChainId] ?? null;
 
   useEffect(() => {
     // eslint-disable-next-line effector/no-watch
@@ -140,11 +147,18 @@ export const BackendConfigurationModal = () => {
           {isSigning && <OperationMessageSign onGoBack={() => authModel.events.signingCancelled()} />}
 
           {showAccountSelector && (
-            <AccountSelector
-              accounts={signableAccounts}
-              selectedAccountId={selectedAccountId}
-              onSelect={(id) => authModel.events.accountSelected(id)}
-            />
+            <>
+              <AccountSelector
+                accounts={signableAccounts}
+                selectedAccountId={selectedAccountId}
+                onSelect={(id) => authModel.events.accountSelected(id)}
+              />
+              <ChainSelectorField
+                value={selectedChain}
+                options={chainOptions}
+                onSelect={(chain: Chain) => authModel.events.chainSelected(chain.chainId)}
+              />
+            </>
           )}
 
           <Alert active={isError} title={t('addressBook.auth.errorTitle')} variant="error">
@@ -234,6 +248,43 @@ const AccountSelector = ({
           </Select.Item>
         ))}
       </Select>
+    </Field>
+  );
+};
+
+const ChainSelectorField = ({
+  value,
+  options,
+  onSelect,
+}: {
+  value: Chain | null;
+  options: Chain[];
+  onSelect: (chain: Chain) => void;
+}) => {
+  const { t } = useI18n();
+
+  return (
+    <Field
+      text={
+        <span className="flex items-center gap-x-1">
+          {t('addressBook.auth.selectChainLabel')}
+          <Tooltip>
+            <Tooltip.Trigger>
+              <span tabIndex={0} className="text-text-tertiary hover:text-primary-button-background-default">
+                <Icon name="info" size={12} className="text-inherit" />
+              </span>
+            </Tooltip.Trigger>
+            <Tooltip.Content>{t('addressBook.auth.chainHintTooltip')}</Tooltip.Content>
+          </Tooltip>
+        </span>
+      }
+    >
+      <ChainSelect
+        value={value}
+        options={options}
+        placeholder={t('addressBook.auth.selectChainPlaceholder')}
+        onChange={onSelect}
+      />
     </Field>
   );
 };

--- a/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
+++ b/src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx
@@ -1,7 +1,7 @@
 import { useUnit } from 'effector-react';
 import { useEffect, useMemo } from 'react';
 
-import { type Chain } from '@/shared/core';
+import { type Chain, SigningType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { toAddress, toShortAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
@@ -12,6 +12,8 @@ import { Box, Field, Input, Modal, Select, Surface, Tooltip, useNotification } f
 import { networkModel } from '@/entities/network';
 import { type SignableAccount, authModel, backendConfigurationModel } from '@/aggregates/backend';
 import { OperationMessageSign } from '@/features/operations/OperationMessageSign';
+
+const VAULT_SIGNING_TYPES = new Set<SigningType>([SigningType.POLKADOT_VAULT, SigningType.PARITY_SIGNER]);
 
 export const BackendConfigurationModal = () => {
   const { t } = useI18n();
@@ -38,6 +40,13 @@ export const BackendConfigurationModal = () => {
 
   const chainOptions = useMemo(() => Object.values(chainsMap), [chainsMap]);
   const selectedChain = chainsMap[selectedChainId] ?? null;
+
+  const selectedAccount = useMemo(
+    () => signableAccounts.find((a) => a.accountId === selectedAccountId) ?? null,
+    [signableAccounts, selectedAccountId],
+  );
+  const showSigningChainSelector =
+    selectedAccount !== null && VAULT_SIGNING_TYPES.has(selectedAccount.account.signingType);
 
   useEffect(() => {
     // eslint-disable-next-line effector/no-watch
@@ -144,21 +153,25 @@ export const BackendConfigurationModal = () => {
             </Field>
           )}
 
-          {isSigning && <OperationMessageSign onGoBack={() => authModel.events.signingCancelled()} />}
+          {isSigning && (
+            <>
+              {showSigningChainSelector && (
+                <ChainSelectorField
+                  value={selectedChain}
+                  options={chainOptions}
+                  onSelect={(chain: Chain) => authModel.events.chainSelected(chain.chainId)}
+                />
+              )}
+              <OperationMessageSign onGoBack={() => authModel.events.signingCancelled()} />
+            </>
+          )}
 
           {showAccountSelector && (
-            <>
-              <AccountSelector
-                accounts={signableAccounts}
-                selectedAccountId={selectedAccountId}
-                onSelect={(id) => authModel.events.accountSelected(id)}
-              />
-              <ChainSelectorField
-                value={selectedChain}
-                options={chainOptions}
-                onSelect={(chain: Chain) => authModel.events.chainSelected(chain.chainId)}
-              />
-            </>
+            <AccountSelector
+              accounts={signableAccounts}
+              selectedAccountId={selectedAccountId}
+              onSelect={(id) => authModel.events.accountSelected(id)}
+            />
           )}
 
           <Alert active={isError} title={t('addressBook.auth.errorTitle')} variant="error">

--- a/src/renderer/features/operations/OperationMessageSign/model/__tests__/message-sign-model.test.ts
+++ b/src/renderer/features/operations/OperationMessageSign/model/__tests__/message-sign-model.test.ts
@@ -1,0 +1,56 @@
+import { allSettled, fork } from 'effector';
+import { describe, expect, it } from 'vitest';
+
+import { type ChainId, type VaultBaseAccount, AccountType, CryptoType, SigningType } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type MessageSigningPayload } from '../../lib/types';
+import { messageSignModel } from '../message-sign-model';
+
+const POLKADOT: ChainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
+const KUSAMA: ChainId = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
+
+const signatory: VaultBaseAccount = {
+  id: '1',
+  type: 'universal',
+  name: 'Alice',
+  walletId: 1,
+  accountId: '0xaaaa' as AccountId,
+  cryptoType: CryptoType.SR25519,
+  signingType: SigningType.POLKADOT_VAULT,
+  accountType: AccountType.BASE,
+  createdAt: 0,
+};
+
+const payload: MessageSigningPayload = {
+  message: new TextEncoder().encode('hello'),
+  signatory,
+  chainId: POLKADOT,
+};
+
+describe('messageSignModel', () => {
+  it('starts with an empty store', () => {
+    const scope = fork();
+    expect(scope.getState(messageSignModel.$signStore)).toEqual(null);
+  });
+
+  it('init populates $signStore with the payload', async () => {
+    const scope = fork();
+    await allSettled(messageSignModel.init, { scope, params: payload });
+    expect(scope.getState(messageSignModel.$signStore)).toEqual(payload);
+  });
+
+  it('chainIdChanged updates chainId in $signStore without touching other fields', async () => {
+    const scope = fork();
+    await allSettled(messageSignModel.init, { scope, params: payload });
+    await allSettled(messageSignModel.chainIdChanged, { scope, params: KUSAMA });
+
+    const store = scope.getState(messageSignModel.$signStore);
+    expect(store).toEqual({ ...payload, chainId: KUSAMA });
+  });
+
+  it('chainIdChanged is a no-op when $signStore is empty', async () => {
+    const scope = fork();
+    await allSettled(messageSignModel.chainIdChanged, { scope, params: KUSAMA });
+    expect(scope.getState(messageSignModel.$signStore)).toEqual(null);
+  });
+});

--- a/src/renderer/features/operations/OperationMessageSign/model/message-sign-model.ts
+++ b/src/renderer/features/operations/OperationMessageSign/model/message-sign-model.ts
@@ -1,6 +1,7 @@
 import { combine, createEvent, createStore, sample } from 'effector';
 import { createGate } from 'effector-react';
 
+import { type ChainId } from '@/shared/core';
 import { nullable } from '@/shared/lib/utils';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { type MessageSignatureResult, type MessageSigningPayload } from '../lib/types';
@@ -8,6 +9,7 @@ import { type MessageSignatureResult, type MessageSigningPayload } from '../lib/
 const flow = createGate();
 
 const init = createEvent<MessageSigningPayload>();
+const chainIdChanged = createEvent<ChainId>();
 const signed = createEvent<MessageSignatureResult>();
 
 const $signStore = createStore<MessageSigningPayload | null>(null).reset(flow.close);
@@ -16,6 +18,8 @@ sample({
   clock: init,
   target: $signStore,
 });
+
+$signStore.on(chainIdChanged, (store, chainId) => (store ? { ...store, chainId } : store));
 
 const $signerWallet = combine(
   {
@@ -34,6 +38,7 @@ export const messageSignModel = {
   $signerWallet,
 
   init,
+  chainIdChanged,
   signed,
 
   gates: {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -37,6 +37,7 @@
       "delete": "Delete"
     },
     "auth": {
+      "chainHintTooltip": "If you use a derivation in Polkadot Vault, select the network this derivation was created in to avoid the \"Transaction author public key not found\" error.",
       "connectedAccountLabel": "Connected account",
       "connectionSuccess": "Connected successfully",
       "disconnectButton": "Disconnect",
@@ -51,6 +52,8 @@
       "scanSignatureTitle": "Scan signature QR",
       "selectAccountLabel": "Select account",
       "selectAccountPlaceholder": "Choose an account",
+      "selectChainLabel": "Signing network",
+      "selectChainPlaceholder": "Choose a network",
       "sessionExpired": "Session expired",
       "sessionExpiredToast": "Address Book session expired",
       "signingMessage": "Waiting for signature...",


### PR DESCRIPTION
## Summary
The previous chain-agnostic attempts in this branch were superseded — Polkadot Vault scopes its key lookup to the per-network keyring picked by `genesisHash`, so we cannot pin a single chain for everyone. This change makes the network an explicit user choice in the auth modal.

- Added a **Signing network** selector to the Backend Configuration modal, rendered alongside the Account selector.
- Default value: **Polkadot Asset Hub** (`0x68d56f15…3c3de2f`). Vault always has this keyring provisioned, so it works for most users without changes.
- The selector drives the genesisHash inside the auth challenge QR (`messageSignModel.init` now sources `chainId` from `authModel.$selectedChainId`).
- The previous chain inference (`signatory.chainId` / `RelayChains.POLKADOT` fallback) is removed.
- An info tooltip next to the selector tells the user: _"If you use a derivation in Polkadot Vault, select the network this derivation was created in to avoid the 'Transaction author public key not found' error."_
- New constant `DEFAULT_AUTH_CHAIN_ID` lives in `aggregates/backend/lib/auth-chain.ts`.

## Files
- `src/renderer/aggregates/backend/lib/auth-chain.ts` — new constant
- `src/renderer/aggregates/backend/model/auth-model.ts` — `\$selectedChainId` store + `chainSelected` event + reset wiring + sample → `messageSignModel.init`
- `src/renderer/features/contacts/BackendConfiguration/ui/BackendConfigurationModal.tsx` — `ChainSelectorField` with `ChainSelect` from `@/shared/ui-entities` + Tooltip
- `src/renderer/shared/i18n/locales/en.json` — `selectChainLabel`, `selectChainPlaceholder`, `chainHintTooltip`



https://github.com/user-attachments/assets/47e19da2-8758-4d42-a38c-e51f70a61311




## Test plan
- [ ] Open Backend Configuration modal → Signing network is **Polkadot Asset Hub** by default.
- [ ] Connect a Polkadot Vault wallet whose key was derived under Polkadot Asset Hub → succeeds without 'public key not found'.
- [ ] Pick Kusama in the selector, sign with a Kusama-derived key → succeeds.
- [ ] Hover the info icon next to the selector → tooltip appears with the derivation hint.
- [ ] Cancel signing / close modal / delete backend URL → selector resets to Polkadot Asset Hub on next open.

Fixes novasamatech/nova-spektr-tracker#18