### PR TITLE
feat: account count + source breakdown on dashboard filters

### DIFF
--- a/src/renderer/aggregates/account-presets/__tests__/lib.test.ts
+++ b/src/renderer/aggregates/account-presets/__tests__/lib.test.ts
@@ -1,7 +1,7 @@
 import { describe, expect, it } from 'vitest';
 
-import { type Address } from '@/shared/core';
-import { applyPresetFilter, matchPreset } from '../lib';
+import { type Address, WalletType } from '@/shared/core';
+import { applyPresetFilter, buildMergedEntries, matchPreset } from '../lib';
 import { type AccountEntry, type AccountPreset, type PresetFilterCriteria } from '../types';
 
 const wallet: AccountEntry = {
@@ -9,8 +9,11 @@ const wallet: AccountEntry = {
   name: 'Main Wallet',
   address: '0x1' as Address,
   accountId: '0x1',
-  source: 'wallet',
+  aliases: ['Main Wallet'],
+  sources: ['wallet'],
   walletId: 1,
+  walletName: 'Main Wallet',
+  walletType: WalletType.POLKADOT_VAULT,
 };
 
 const localContact: AccountEntry = {
@@ -18,7 +21,8 @@ const localContact: AccountEntry = {
   name: 'Alice Local',
   address: '0x2' as Address,
   accountId: '0x2',
-  source: 'local-contact',
+  aliases: ['Alice Local'],
+  sources: ['local-contact'],
 };
 
 const backendContact: AccountEntry = {
@@ -26,7 +30,8 @@ const backendContact: AccountEntry = {
   name: 'Bob Backend',
   address: '0x3' as Address,
   accountId: '0x3',
-  source: 'backend-contact',
+  aliases: ['Bob Backend'],
+  sources: ['backend-contact'],
   entityNames: ['Parity', 'W3F'],
   categoryName: 'Treasury',
   tags: [{ tagName: 'team', values: ['core', 'infra'] }],
@@ -37,13 +42,30 @@ const backendContact2: AccountEntry = {
   name: 'Charlie Backend',
   address: '0x4' as Address,
   accountId: '0x4',
-  source: 'backend-contact',
+  aliases: ['Charlie Backend'],
+  sources: ['backend-contact'],
   entityNames: ['W3F'],
   categoryName: 'Grants',
   tags: [{ tagName: 'team', values: ['research'] }],
 };
 
-const entries = [wallet, localContact, backendContact, backendContact2];
+// Same address as `wallet` (`0x1`) but also labeled in the external address book.
+const walletAndBackend: AccountEntry = {
+  id: 'w-x',
+  name: 'Treasury',
+  address: '0xX' as Address,
+  accountId: '0xX',
+  aliases: ['MS-1', 'Treasury'],
+  sources: ['wallet', 'backend-contact'],
+  walletId: 9,
+  walletName: 'MS-1',
+  walletType: WalletType.MULTISIG,
+  entityNames: ['Treasury Co'],
+  categoryName: 'Treasury',
+  tags: [],
+};
+
+const entries = [wallet, localContact, backendContact, backendContact2, walletAndBackend];
 const empty: PresetFilterCriteria = { sources: [], entityNames: [], categoryNames: [], tags: [] };
 
 describe('applyPresetFilter', () => {
@@ -51,8 +73,16 @@ describe('applyPresetFilter', () => {
     expect(applyPresetFilter(empty, entries)).toEqual(entries);
   });
 
-  it('filters by source type', () => {
-    expect(applyPresetFilter({ ...empty, sources: ['wallet'] }, entries)).toEqual([wallet]);
+  it('filters by source membership', () => {
+    expect(applyPresetFilter({ ...empty, sources: ['wallet'] }, entries)).toEqual([wallet, walletAndBackend]);
+  });
+
+  it('source: backend-contact includes entries that are also wallets', () => {
+    expect(applyPresetFilter({ ...empty, sources: ['backend-contact'] }, entries)).toEqual([
+      backendContact,
+      backendContact2,
+      walletAndBackend,
+    ]);
   });
 
   it('filters by multiple source types (OR)', () => {
@@ -60,6 +90,7 @@ describe('applyPresetFilter', () => {
       wallet,
       backendContact,
       backendContact2,
+      walletAndBackend,
     ]);
   });
 
@@ -72,7 +103,10 @@ describe('applyPresetFilter', () => {
   });
 
   it('filters by category name', () => {
-    expect(applyPresetFilter({ ...empty, categoryNames: ['Treasury'] }, entries)).toEqual([backendContact]);
+    expect(applyPresetFilter({ ...empty, categoryNames: ['Treasury'] }, entries)).toEqual([
+      backendContact,
+      walletAndBackend,
+    ]);
   });
 
   it('filters by tags (AND across tag names, OR within values)', () => {
@@ -81,10 +115,9 @@ describe('applyPresetFilter', () => {
     ]);
   });
 
-  it('non-backend entries excluded when entity/category/tag filters are active', () => {
+  it('entries without backend-contact source are excluded when entity/category/tag filters are active', () => {
     const result = applyPresetFilter({ ...empty, entityNames: ['Parity'] }, entries);
-    expect(result.find(e => e.source === 'wallet')).toBeUndefined();
-    expect(result.find(e => e.source === 'local-contact')).toBeUndefined();
+    expect(result.some(e => !e.sources.includes('backend-contact'))).toBe(false);
   });
 
   it('combines source + entity (AND across dimensions)', () => {
@@ -116,7 +149,7 @@ describe('matchPreset', () => {
   });
 
   it('type=filter applies the filter criteria', () => {
-    expect(matchPreset(preset({ filters: { ...empty, sources: ['wallet'] } }), entries)).toEqual([wallet]);
+    expect(matchPreset(preset({ filters: { ...empty, sources: ['local-contact'] } }), entries)).toEqual([localContact]);
   });
 
   it('type=custom uses selectedIds intersection', () => {
@@ -137,5 +170,158 @@ describe('matchPreset', () => {
       filters: { ...empty, sources: ['wallet'] },
     });
     expect(matchPreset(p, entries)).toEqual([localContact]);
+  });
+});
+
+describe('buildMergedEntries', () => {
+  it('produces one entry per accountId when all three sources overlap', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [
+        {
+          id: 'w-id',
+          name: 'My Wallet',
+          address: '0xA' as Address,
+          accountId: '0xA',
+          walletId: 1,
+          walletName: 'My Wallet',
+          walletType: WalletType.POLKADOT_VAULT,
+        },
+      ],
+      localContacts: [{ id: 'lc-id', name: 'Local Alice', address: '0xA' as Address, accountId: '0xA' }],
+      backendContacts: [
+        {
+          id: 'bc-id',
+          name: 'External Alice',
+          address: '0xA' as Address,
+          accountId: '0xA',
+          entityNames: ['Co'],
+          categoryName: null,
+          tags: [],
+        },
+      ],
+    });
+
+    expect(result).toHaveLength(1);
+    const entry = result[0]!;
+    expect(entry.id).toBe('w-id');
+    expect(entry.sources).toEqual(['wallet', 'local-contact', 'backend-contact']);
+    expect(entry.aliases).toEqual(['My Wallet', 'Local Alice', 'External Alice']);
+    expect(entry.entityNames).toEqual(['Co']);
+  });
+
+  it('uses backend-contact name when wallet is indexed (multisig/proxied)', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [
+        {
+          id: 'ms-id',
+          name: 'MS-1',
+          address: '0xB' as Address,
+          accountId: '0xB',
+          walletId: 2,
+          walletName: 'MS-1',
+          walletType: WalletType.MULTISIG,
+        },
+      ],
+      localContacts: [],
+      backendContacts: [
+        {
+          id: 'bc-id',
+          name: 'Treasury Multisig',
+          address: '0xB' as Address,
+          accountId: '0xB',
+          entityNames: [],
+          categoryName: null,
+          tags: [],
+        },
+      ],
+    });
+
+    expect(result).toHaveLength(1);
+    expect(result[0]!.name).toBe('Treasury Multisig');
+    expect(result[0]!.aliases).toEqual(['MS-1', 'Treasury Multisig']);
+    expect(result[0]!.sources).toEqual(['wallet', 'backend-contact']);
+  });
+
+  it('prefers user-chosen wallet name over contact name for non-indexed wallets', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [
+        {
+          id: 'w-id',
+          name: "Alice's Vault",
+          address: '0xC' as Address,
+          accountId: '0xC',
+          walletId: 3,
+          walletName: "Alice's Vault",
+          walletType: WalletType.POLKADOT_VAULT,
+        },
+      ],
+      localContacts: [],
+      backendContacts: [
+        {
+          id: 'bc-id',
+          name: 'Alice External',
+          address: '0xC' as Address,
+          accountId: '0xC',
+          entityNames: [],
+          categoryName: null,
+          tags: [],
+        },
+      ],
+    });
+
+    expect(result[0]!.name).toBe("Alice's Vault");
+    expect(result[0]!.aliases).toContain("Alice's Vault");
+    expect(result[0]!.aliases).toContain('Alice External');
+  });
+
+  it('falls back through local then wallet when backend is absent', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [],
+      localContacts: [{ id: 'lc-id', name: 'Local Only', address: '0xD' as Address, accountId: '0xD' }],
+      backendContacts: [],
+    });
+
+    expect(result[0]!.name).toBe('Local Only');
+    expect(result[0]!.sources).toEqual(['local-contact']);
+  });
+
+  it('deduplicates aliases case-insensitively', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [],
+      localContacts: [{ id: 'lc-id', name: 'Treasury', address: '0xE' as Address, accountId: '0xE' }],
+      backendContacts: [
+        {
+          id: 'bc-id',
+          name: 'treasury',
+          address: '0xE' as Address,
+          accountId: '0xE',
+          entityNames: [],
+          categoryName: null,
+          tags: [],
+        },
+      ],
+    });
+
+    expect(result[0]!.aliases).toEqual(['Treasury']);
+  });
+
+  it('preserves wallet-first id when both wallet and contact share an accountId', () => {
+    const result = buildMergedEntries({
+      walletSeeds: [
+        {
+          id: 'w-id',
+          name: 'W',
+          address: '0xF' as Address,
+          accountId: '0xF',
+          walletId: 4,
+          walletName: 'W',
+          walletType: WalletType.POLKADOT_VAULT,
+        },
+      ],
+      localContacts: [{ id: 'lc-id', name: 'C', address: '0xF' as Address, accountId: '0xF' }],
+      backendContacts: [],
+    });
+
+    expect(result[0]!.id).toBe('w-id');
   });
 });

--- a/src/renderer/aggregates/account-presets/index.ts
+++ b/src/renderer/aggregates/account-presets/index.ts
@@ -3,7 +3,16 @@ export { applyPresetFilter, matchPreset } from './lib';
 export {
   type AccountEntry,
   type AccountPreset,
+  type AccountSource,
   type PresetFilterCriteria,
   type PresetType,
   EMPTY_FILTERS,
 } from './types';
+export {
+  type SourceBreakdown,
+  type SourceBreakdownKey,
+  INDEXED_WALLET_TYPES,
+  buildMergedEntries,
+  computeSourceBreakdown,
+  isIndexedWallet,
+} from './lib';

--- a/src/renderer/aggregates/account-presets/lib.ts
+++ b/src/renderer/aggregates/account-presets/lib.ts
@@ -1,25 +1,58 @@
-import { type AccountEntry, type AccountPreset, type PresetFilterCriteria } from './types';
+import { type Address, type ID, WalletType } from '@/shared/core';
+import { type ContactTag } from '@/shared/core/types/contact';
+
+import { type AccountEntry, type AccountPreset, type AccountSource, type PresetFilterCriteria } from './types';
+
+export const INDEXED_WALLET_TYPES = new Set<WalletType>([
+  WalletType.MULTISIG,
+  WalletType.FLEXIBLE_MULTISIG,
+  WalletType.PROXIED,
+]);
+
+export const isIndexedWallet = (walletType: WalletType | undefined): boolean =>
+  walletType !== undefined && INDEXED_WALLET_TYPES.has(walletType);
+
+export type SourceBreakdownKey = 'wallet' | 'indexed' | 'localContact' | 'backendContact';
+export type SourceBreakdown = Record<SourceBreakdownKey, number>;
+
+export const computeSourceBreakdown = (entries: AccountEntry[]): SourceBreakdown => {
+  const breakdown: SourceBreakdown = { wallet: 0, indexed: 0, localContact: 0, backendContact: 0 };
+  for (const entry of entries) {
+    if (entry.sources.includes('wallet')) {
+      if (isIndexedWallet(entry.walletType)) {
+        breakdown.indexed++;
+      } else {
+        breakdown.wallet++;
+      }
+    }
+    if (entry.sources.includes('local-contact')) breakdown.localContact++;
+    if (entry.sources.includes('backend-contact')) breakdown.backendContact++;
+  }
+
+  return breakdown;
+};
 
 export function applyPresetFilter(filters: PresetFilterCriteria, entries: AccountEntry[]): AccountEntry[] {
   const { sources, entityNames, categoryNames, tags } = filters;
   const needsBackendMetadata = entityNames.length > 0 || categoryNames.length > 0 || tags.length > 0;
 
   return entries.filter(entry => {
-    if (sources.length > 0 && !sources.includes(entry.source)) return false;
+    if (sources.length > 0 && !sources.some(s => entry.sources.includes(s))) return false;
 
-    // Only backend-contact entries can match entity/category/tag filters — all
-    // other sources carry no such metadata, so they're excluded when any of
-    // those filters are set.
     if (!needsBackendMetadata) return true;
-    if (entry.source !== 'backend-contact') return false;
+    if (!entry.sources.includes('backend-contact')) return false;
 
-    if (entityNames.length > 0 && !entry.entityNames.some(e => entityNames.includes(e))) return false;
+    // sources.includes('backend-contact') guarantees these are populated by buildMergedEntries.
+    const entityList = entry.entityNames!;
+    const tagList = entry.tags!;
+
+    if (entityNames.length > 0 && !entityList.some(e => entityNames.includes(e))) return false;
     if (categoryNames.length > 0 && (entry.categoryName == null || !categoryNames.includes(entry.categoryName))) {
       return false;
     }
     if (
       tags.length > 0 &&
-      !tags.every(t => entry.tags.some(et => et.tagName === t.tagName && t.values.some(v => et.values.includes(v))))
+      !tags.every(t => tagList.some(et => et.tagName === t.tagName && t.values.some(v => et.values.includes(v))))
     ) {
       return false;
     }
@@ -37,4 +70,177 @@ export function matchPreset(preset: AccountPreset | null, entries: AccountEntry[
   }
 
   return applyPresetFilter(preset.filters, entries);
+}
+
+// -------- merge --------
+
+export type WalletEntrySeed = {
+  id: string;
+  name: string;
+  address: Address;
+  accountId: string;
+  walletId: ID;
+  walletName?: string;
+  walletType?: WalletType;
+};
+
+export type LocalContactSeed = {
+  id: string;
+  name: string;
+  address: Address;
+  accountId: string;
+};
+
+export type BackendContactSeed = {
+  id: string;
+  name: string;
+  address: Address;
+  accountId: string;
+  entityNames: string[];
+  categoryName: string | null;
+  tags: ContactTag[];
+};
+
+type Draft = {
+  id: string;
+  accountId: string;
+  address: Address;
+  sources: AccountSource[];
+  walletId?: ID;
+  walletName?: string;
+  walletType?: WalletType;
+  walletAccountName?: string;
+  localContactName?: string;
+  backendContactName?: string;
+  entityNames?: string[];
+  categoryName?: string | null;
+  tags?: ContactTag[];
+};
+
+const pushSource = (draft: Draft, source: AccountSource) => {
+  if (!draft.sources.includes(source)) draft.sources.push(source);
+};
+
+const resolveDisplayName = (draft: Draft): string => {
+  const wallet = draft.walletAccountName?.trim();
+  const local = draft.localContactName?.trim();
+  const backend = draft.backendContactName?.trim();
+
+  if (wallet && draft.walletType !== undefined && !isIndexedWallet(draft.walletType)) {
+    return wallet;
+  }
+  if (backend) return backend;
+  if (local) return local;
+  if (wallet) return wallet;
+
+  return '';
+};
+
+const resolveAliases = (draft: Draft): string[] => {
+  const seen = new Set<string>();
+  const out: string[] = [];
+  for (const candidate of [draft.walletAccountName, draft.localContactName, draft.backendContactName]) {
+    const trimmed = candidate?.trim();
+    if (!trimmed) continue;
+    const key = trimmed.toLowerCase();
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(trimmed);
+  }
+
+  return out;
+};
+
+const finalizeDraft = (draft: Draft): AccountEntry => {
+  const entry: AccountEntry = {
+    id: draft.id,
+    name: resolveDisplayName(draft),
+    address: draft.address,
+    accountId: draft.accountId,
+    aliases: resolveAliases(draft),
+    sources: draft.sources,
+  };
+  if (draft.sources.includes('wallet')) {
+    entry.walletId = draft.walletId;
+    entry.walletName = draft.walletName;
+    entry.walletType = draft.walletType;
+  }
+  if (draft.sources.includes('backend-contact')) {
+    entry.entityNames = draft.entityNames ?? [];
+    entry.categoryName = draft.categoryName ?? null;
+    entry.tags = draft.tags ?? [];
+  }
+
+  return entry;
+};
+
+/**
+ * Merge wallet accounts, local contacts, and backend (external) contacts into a
+ * single list keyed by `accountId`. When the same address appears in multiple
+ * sources, all metadata is layered onto one entry; the `id` and `address` come
+ * from the highest-priority source present (`wallet > local-contact >
+ * backend-contact`).
+ *
+ * `name` and `aliases` are derived once at the end via fixed rules — see
+ * `resolveDisplayName` / `resolveAliases`.
+ */
+export function buildMergedEntries({
+  walletSeeds,
+  localContacts,
+  backendContacts,
+}: {
+  walletSeeds: WalletEntrySeed[];
+  localContacts: LocalContactSeed[];
+  backendContacts: BackendContactSeed[];
+}): AccountEntry[] {
+  const byAccountId = new Map<string, Draft>();
+
+  const ensureDraft = (params: { id: string; accountId: string; address: Address; source: AccountSource }): Draft => {
+    let draft = byAccountId.get(params.accountId);
+    if (!draft) {
+      draft = {
+        id: params.id,
+        accountId: params.accountId,
+        address: params.address,
+        sources: [],
+      };
+      byAccountId.set(params.accountId, draft);
+    }
+    pushSource(draft, params.source);
+
+    return draft;
+  };
+
+  for (const seed of walletSeeds) {
+    const draft = ensureDraft({ id: seed.id, accountId: seed.accountId, address: seed.address, source: 'wallet' });
+    draft.walletId = seed.walletId;
+    draft.walletName = seed.walletName;
+    draft.walletType = seed.walletType;
+    draft.walletAccountName = seed.name;
+  }
+
+  for (const contact of localContacts) {
+    const draft = ensureDraft({
+      id: contact.id,
+      accountId: contact.accountId,
+      address: contact.address,
+      source: 'local-contact',
+    });
+    draft.localContactName = contact.name;
+  }
+
+  for (const contact of backendContacts) {
+    const draft = ensureDraft({
+      id: contact.id,
+      accountId: contact.accountId,
+      address: contact.address,
+      source: 'backend-contact',
+    });
+    draft.backendContactName = contact.name;
+    draft.entityNames = contact.entityNames;
+    draft.categoryName = contact.categoryName;
+    draft.tags = contact.tags;
+  }
+
+  return Array.from(byAccountId.values(), finalizeDraft);
 }

--- a/src/renderer/aggregates/account-presets/model.ts
+++ b/src/renderer/aggregates/account-presets/model.ts
@@ -225,11 +225,21 @@ const $matchedOperationsEntriesRaw = combine($activeOperationsPreset, $allEntrie
 const $matchedOperationsEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
 $matchedOperationsEntries.on($matchedOperationsEntriesRaw, (_, next) => next);
 
+const $entriesByPresetId = combine($presets, $allEntries, (presets, entries) => {
+  const map: Record<string, AccountEntry[]> = {};
+  for (const preset of presets) {
+    map[preset.id] = matchPreset(preset, entries);
+  }
+
+  return map;
+});
+
 export const accountPresetsModel = {
   $presets,
   $segmentPresets,
   $overflowPresets,
   $allEntries,
+  $entriesByPresetId,
 
   $activeDashboardPresetId,
   $activeDashboardPreset,

--- a/src/renderer/aggregates/account-presets/model.ts
+++ b/src/renderer/aggregates/account-presets/model.ts
@@ -1,13 +1,18 @@
 import { combine, createEvent, createStore, sample } from 'effector';
 import { persist } from 'effector-storage/local';
-import { uniqBy } from 'lodash';
 
 import { toAddress } from '@/shared/lib/utils';
 import { contactModel } from '@/entities/contact';
 import { networkModel } from '@/entities/network';
 import { accountUtils, walletModel } from '@/entities/wallet';
 
-import { matchPreset } from './lib';
+import {
+  type BackendContactSeed,
+  type LocalContactSeed,
+  type WalletEntrySeed,
+  buildMergedEntries,
+  matchPreset,
+} from './lib';
 import { type AccountEntry, type AccountPreset, type PresetFilterCriteria, type PresetType } from './types';
 
 const MAX_SEGMENTS = 3;
@@ -155,49 +160,40 @@ const $allEntries = combine(
   ({ accountsWithWallets: { accounts, wallets }, localContacts, backendContacts, chains }): AccountEntry[] => {
     const walletNameById = new Map(wallets.map(w => [w.id, w.name]));
     const walletTypeById = new Map(wallets.map(w => [w.id, w.type]));
-    const entries: AccountEntry[] = [];
 
+    const walletSeeds: WalletEntrySeed[] = [];
     for (const account of accounts) {
       if (accountUtils.isMultisigSignatoryAccount(account)) continue;
-
       const addressPrefix = account.type === 'chain' ? chains[account.chainId]?.addressPrefix : undefined;
-
-      entries.push({
+      walletSeeds.push({
         id: account.id,
         name: account.name,
         address: toAddress(account.accountId, { prefix: addressPrefix }),
         accountId: account.accountId,
-        source: 'wallet',
         walletId: account.walletId,
         walletName: walletNameById.get(account.walletId),
         walletType: walletTypeById.get(account.walletId),
       });
     }
 
-    for (const contact of localContacts) {
-      entries.push({
-        id: contact.id,
-        name: contact.name,
-        address: contact.address,
-        accountId: contact.accountId,
-        source: 'local-contact',
-      });
-    }
+    const localSeeds: LocalContactSeed[] = localContacts.map(c => ({
+      id: c.id,
+      name: c.name,
+      address: c.address,
+      accountId: c.accountId,
+    }));
 
-    for (const contact of backendContacts) {
-      entries.push({
-        id: contact.id,
-        name: contact.name,
-        address: contact.address,
-        accountId: contact.accountId,
-        source: 'backend-contact',
-        entityNames: contact.entityNames,
-        categoryName: contact.categoryName,
-        tags: contact.tags,
-      });
-    }
+    const backendSeeds: BackendContactSeed[] = backendContacts.map(c => ({
+      id: c.id,
+      name: c.name,
+      address: c.address,
+      accountId: c.accountId,
+      entityNames: c.entityNames,
+      categoryName: c.categoryName,
+      tags: c.tags,
+    }));
 
-    return uniqBy(entries, 'accountId');
+    return buildMergedEntries({ walletSeeds, localContacts: localSeeds, backendContacts: backendSeeds });
   },
 );
 
@@ -213,18 +209,6 @@ const matchedEntriesFilter = (next: AccountEntry[], prev: AccountEntry[]): boole
   return false;
 };
 
-const $matchedDashboardEntriesRaw = combine($activeDashboardPreset, $allEntries, (preset, entries) =>
-  matchPreset(preset, entries),
-);
-const $matchedDashboardEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
-$matchedDashboardEntries.on($matchedDashboardEntriesRaw, (_, next) => next);
-
-const $matchedOperationsEntriesRaw = combine($activeOperationsPreset, $allEntries, (preset, entries) =>
-  matchPreset(preset, entries),
-);
-const $matchedOperationsEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
-$matchedOperationsEntries.on($matchedOperationsEntriesRaw, (_, next) => next);
-
 const $entriesByPresetId = combine($presets, $allEntries, (presets, entries) => {
   const map: Record<string, AccountEntry[]> = {};
   for (const preset of presets) {
@@ -233,6 +217,29 @@ const $entriesByPresetId = combine($presets, $allEntries, (presets, entries) => 
 
   return map;
 });
+
+type MatchedSource = {
+  activeId: string | null;
+  byPresetId: Record<string, AccountEntry[]>;
+  all: AccountEntry[];
+};
+
+const resolveMatched = ({ activeId, byPresetId, all }: MatchedSource) =>
+  activeId ? (byPresetId[activeId] ?? all) : all;
+
+const $matchedDashboardEntriesRaw = combine(
+  { activeId: $activeDashboardPresetId, byPresetId: $entriesByPresetId, all: $allEntries },
+  resolveMatched,
+);
+const $matchedDashboardEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
+$matchedDashboardEntries.on($matchedDashboardEntriesRaw, (_, next) => next);
+
+const $matchedOperationsEntriesRaw = combine(
+  { activeId: $activeOperationsPresetId, byPresetId: $entriesByPresetId, all: $allEntries },
+  resolveMatched,
+);
+const $matchedOperationsEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
+$matchedOperationsEntries.on($matchedOperationsEntriesRaw, (_, next) => next);
 
 export const accountPresetsModel = {
   $presets,

--- a/src/renderer/aggregates/account-presets/types.ts
+++ b/src/renderer/aggregates/account-presets/types.ts
@@ -1,8 +1,10 @@
 import { type Address, type ID, type WalletType } from '@/shared/core';
 import { type ContactTag } from '@/shared/core/types/contact';
 
+export type AccountSource = 'wallet' | 'local-contact' | 'backend-contact';
+
 export type PresetFilterCriteria = {
-  sources: ('wallet' | 'local-contact' | 'backend-contact')[];
+  sources: AccountSource[];
   entityNames: string[];
   categoryNames: string[];
   tags: ContactTag[];
@@ -25,37 +27,25 @@ export const EMPTY_FILTERS: PresetFilterCriteria = {
   tags: [],
 };
 
-type BaseEntry = {
+/**
+ * One row per `accountId` even when the address is known to multiple sources.
+ * Per-source metadata fields are only populated when `sources` contains the
+ * matching tag — narrow on `sources.includes(...)` before reading them.
+ */
+export type AccountEntry = {
   id: string;
   name: string;
   address: Address;
   accountId: string;
-};
+  /** Deduplicated names from every source (original casing), used for search. */
+  aliases: string[];
+  sources: AccountSource[];
 
-/** Wallet-backed entry: the user owns signatory keys via a wallet. */
-export type WalletAccountEntry = BaseEntry & {
-  source: 'wallet';
-  walletId: ID;
+  walletId?: ID;
   walletName?: string;
   walletType?: WalletType;
-};
 
-/** Local (user-managed) contact — no metadata fields. */
-export type LocalContactAccountEntry = BaseEntry & {
-  source: 'local-contact';
+  entityNames?: string[];
+  categoryName?: string | null;
+  tags?: ContactTag[];
 };
-
-/** Backend-synced contact — carries entity/category/tag metadata. */
-export type BackendContactAccountEntry = BaseEntry & {
-  source: 'backend-contact';
-  entityNames: string[];
-  categoryName: string | null;
-  tags: ContactTag[];
-};
-
-/**
- * Discriminated union over `source`. Field presence is dictated by the
- * discriminant — narrow with `entry.source === 'backend-contact'` to access the
- * contact metadata fields safely.
- */
-export type AccountEntry = WalletAccountEntry | LocalContactAccountEntry | BackendContactAccountEntry;

--- a/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
+++ b/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
@@ -4,66 +4,28 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
 import { cnTw, includes } from '@/shared/lib/utils';
-import { FootnoteText, Icon, IconButton } from '@/shared/ui';
+import { Counter, FootnoteText, Icon, IconButton } from '@/shared/ui';
 import { Popover, SearchInput, Tabs, Tooltip } from '@/shared/ui-kit';
 import { type AccountEntry, accountPresetsModel } from '@/aggregates/account-presets';
-import { PresetManagementModal } from '@/widgets/PresetManagementModal';
-
-type SourceBreakdown = { wallet: number; localContact: number; backendContact: number };
-
-const computeBreakdown = (entries: AccountEntry[]): SourceBreakdown => {
-  let wallet = 0;
-  let localContact = 0;
-  let backendContact = 0;
-  for (const entry of entries) {
-    if (entry.source === 'wallet') wallet++;
-    else if (entry.source === 'local-contact') localContact++;
-    else backendContact++;
-  }
-
-  return { wallet, localContact, backendContact };
-};
+import { PresetManagementModal, SourceBreakdownBar } from '@/widgets/PresetManagementModal';
 
 type TabCounterProps = {
   label: string;
-  count: number;
+  entries: AccountEntry[];
   total: number;
-  breakdown: SourceBreakdown;
 };
 
-const TabCounter = ({ label, count, total, breakdown }: TabCounterProps) => {
-  const { t } = useI18n();
-
+const TabCounter = ({ label, entries, total }: TabCounterProps) => {
   return (
     <Tooltip side="bottom">
       <Tooltip.Trigger>
         <span className="inline-flex items-center gap-x-1.5">
           {label}
-          <span className="min-w-[20px] rounded-full bg-icon-accent px-1.5 text-center text-help-text leading-4 font-semibold text-white">
-            {count}
-          </span>
+          <Counter variant="neutral">{entries.length}</Counter>
         </span>
       </Tooltip.Trigger>
-      <Tooltip.Content>
-        <div className="flex flex-col gap-y-0.5">
-          <FootnoteText className="text-white">{t('presets.counterTooltip.title', { count, total })}</FootnoteText>
-          {breakdown.wallet > 0 && (
-            <FootnoteText className="text-white/80">
-              {t('presets.counterTooltip.wallets', { count: breakdown.wallet })}
-            </FootnoteText>
-          )}
-          {breakdown.localContact > 0 && (
-            <FootnoteText className="text-white/80">
-              {t('presets.counterTooltip.localContacts', { count: breakdown.localContact })}
-            </FootnoteText>
-          )}
-          {breakdown.backendContact > 0 && (
-            <FootnoteText className="text-white/80">
-              {t('presets.counterTooltip.backendContacts', { count: breakdown.backendContact })}
-            </FootnoteText>
-          )}
-          {count === 0 && <FootnoteText className="text-white/80">{t('presets.counterTooltip.empty')}</FootnoteText>}
-        </div>
+      <Tooltip.Content className="w-[260px] max-w-[260px] px-3 py-2.5">
+        <SourceBreakdownBar entries={entries} total={total} tone="dark" />
       </Tooltip.Content>
     </Tooltip>
   );
@@ -92,7 +54,6 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
   const allEntries = useUnit(accountPresetsModel.$allEntries);
   const entriesByPresetId = useUnit(accountPresetsModel.$entriesByPresetId);
 
-  const allBreakdown = useMemo(() => computeBreakdown(allEntries), [allEntries]);
   const totalCount = allEntries.length;
 
   const [overflowOpen, setOverflowOpen] = useState(false);
@@ -139,22 +100,13 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
           <Tabs value={tabValue} onChange={handleTabChange}>
             <Tabs.List>
               <Tabs.Trigger value={ALL_VALUE}>
-                <TabCounter label={t('presets.all')} count={totalCount} total={totalCount} breakdown={allBreakdown} />
+                <TabCounter label={t('presets.all')} entries={allEntries} total={totalCount} />
               </Tabs.Trigger>
-              {segmentPresets.map((preset) => {
-                const matched = entriesByPresetId[preset.id] ?? [];
-
-                return (
-                  <Tabs.Trigger key={preset.id} value={preset.id}>
-                    <TabCounter
-                      label={preset.name}
-                      count={matched.length}
-                      total={totalCount}
-                      breakdown={computeBreakdown(matched)}
-                    />
-                  </Tabs.Trigger>
-                );
-              })}
+              {segmentPresets.map((preset) => (
+                <Tabs.Trigger key={preset.id} value={preset.id}>
+                  <TabCounter label={preset.name} entries={entriesByPresetId[preset.id] ?? []} total={totalCount} />
+                </Tabs.Trigger>
+              ))}
             </Tabs.List>
           </Tabs>
         </div>
@@ -189,9 +141,7 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
                         onClick={() => handleOverflowActivate(preset.id)}
                       >
                         <FootnoteText className="text-text-primary">{preset.name}</FootnoteText>
-                        <span className="min-w-[20px] rounded-full bg-icon-accent px-1.5 text-center text-help-text leading-4 font-semibold text-white">
-                          {matched.length}
-                        </span>
+                        <Counter variant="neutral">{matched.length}</Counter>
                       </button>
                     );
                   })}

--- a/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
+++ b/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
@@ -5,9 +5,69 @@ import { useCallback, useMemo, useState } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { cnTw, includes } from '@/shared/lib/utils';
 import { FootnoteText, Icon, IconButton } from '@/shared/ui';
-import { Popover, SearchInput, Tabs } from '@/shared/ui-kit';
-import { accountPresetsModel } from '@/aggregates/account-presets';
+import { Popover, SearchInput, Tabs, Tooltip } from '@/shared/ui-kit';
+import { type AccountEntry, accountPresetsModel } from '@/aggregates/account-presets';
 import { PresetManagementModal } from '@/widgets/PresetManagementModal';
+
+type SourceBreakdown = { wallet: number; localContact: number; backendContact: number };
+
+const computeBreakdown = (entries: AccountEntry[]): SourceBreakdown => {
+  let wallet = 0;
+  let localContact = 0;
+  let backendContact = 0;
+  for (const entry of entries) {
+    if (entry.source === 'wallet') wallet++;
+    else if (entry.source === 'local-contact') localContact++;
+    else backendContact++;
+  }
+
+  return { wallet, localContact, backendContact };
+};
+
+type TabCounterProps = {
+  label: string;
+  count: number;
+  total: number;
+  breakdown: SourceBreakdown;
+};
+
+const TabCounter = ({ label, count, total, breakdown }: TabCounterProps) => {
+  const { t } = useI18n();
+
+  return (
+    <Tooltip side="bottom">
+      <Tooltip.Trigger>
+        <span className="inline-flex items-center gap-x-1.5">
+          {label}
+          <span className="min-w-[20px] rounded-full bg-icon-accent px-1.5 text-center text-help-text leading-4 font-semibold text-white">
+            {count}
+          </span>
+        </span>
+      </Tooltip.Trigger>
+      <Tooltip.Content>
+        <div className="flex flex-col gap-y-0.5">
+          <FootnoteText className="text-white">{t('presets.counterTooltip.title', { count, total })}</FootnoteText>
+          {breakdown.wallet > 0 && (
+            <FootnoteText className="text-white/80">
+              {t('presets.counterTooltip.wallets', { count: breakdown.wallet })}
+            </FootnoteText>
+          )}
+          {breakdown.localContact > 0 && (
+            <FootnoteText className="text-white/80">
+              {t('presets.counterTooltip.localContacts', { count: breakdown.localContact })}
+            </FootnoteText>
+          )}
+          {breakdown.backendContact > 0 && (
+            <FootnoteText className="text-white/80">
+              {t('presets.counterTooltip.backendContacts', { count: breakdown.backendContact })}
+            </FootnoteText>
+          )}
+          {count === 0 && <FootnoteText className="text-white/80">{t('presets.counterTooltip.empty')}</FootnoteText>}
+        </div>
+      </Tooltip.Content>
+    </Tooltip>
+  );
+};
 
 const ALL_VALUE = '__all__';
 
@@ -29,6 +89,11 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
   const activePresetId = useUnit($activePresetId);
   const segmentPresets = useUnit(accountPresetsModel.$segmentPresets);
   const overflowPresets = useUnit(accountPresetsModel.$overflowPresets);
+  const allEntries = useUnit(accountPresetsModel.$allEntries);
+  const entriesByPresetId = useUnit(accountPresetsModel.$entriesByPresetId);
+
+  const allBreakdown = useMemo(() => computeBreakdown(allEntries), [allEntries]);
+  const totalCount = allEntries.length;
 
   const [overflowOpen, setOverflowOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -73,12 +138,23 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
         <div className="[&_[role=tablist]]:mb-0">
           <Tabs value={tabValue} onChange={handleTabChange}>
             <Tabs.List>
-              <Tabs.Trigger value={ALL_VALUE}>{t('presets.all')}</Tabs.Trigger>
-              {segmentPresets.map((preset) => (
-                <Tabs.Trigger key={preset.id} value={preset.id}>
-                  {preset.name}
-                </Tabs.Trigger>
-              ))}
+              <Tabs.Trigger value={ALL_VALUE}>
+                <TabCounter label={t('presets.all')} count={totalCount} total={totalCount} breakdown={allBreakdown} />
+              </Tabs.Trigger>
+              {segmentPresets.map((preset) => {
+                const matched = entriesByPresetId[preset.id] ?? [];
+
+                return (
+                  <Tabs.Trigger key={preset.id} value={preset.id}>
+                    <TabCounter
+                      label={preset.name}
+                      count={matched.length}
+                      total={totalCount}
+                      breakdown={computeBreakdown(matched)}
+                    />
+                  </Tabs.Trigger>
+                );
+              })}
             </Tabs.List>
           </Tabs>
         </div>
@@ -99,19 +175,26 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
                   <SearchInput value={search} placeholder={t('presets.searchPresets')} onChange={setSearch} />
                 </div>
                 <div className="mt-1 max-h-48 overflow-y-auto">
-                  {filteredOverflow.map((preset) => (
-                    <button
-                      key={preset.id}
-                      type="button"
-                      className={cnTw(
-                        'flex w-full items-center rounded px-2 py-1.5 text-left transition-colors hover:bg-action-background-hover',
-                        activePresetId === preset.id && 'border-l-2 border-icon-accent bg-block-background-default',
-                      )}
-                      onClick={() => handleOverflowActivate(preset.id)}
-                    >
-                      <FootnoteText className="text-text-primary">{preset.name}</FootnoteText>
-                    </button>
-                  ))}
+                  {filteredOverflow.map((preset) => {
+                    const matched = entriesByPresetId[preset.id] ?? [];
+
+                    return (
+                      <button
+                        key={preset.id}
+                        type="button"
+                        className={cnTw(
+                          'flex w-full items-center justify-between gap-x-2 rounded px-2 py-1.5 text-left transition-colors hover:bg-action-background-hover',
+                          activePresetId === preset.id && 'border-l-2 border-icon-accent bg-block-background-default',
+                        )}
+                        onClick={() => handleOverflowActivate(preset.id)}
+                      >
+                        <FootnoteText className="text-text-primary">{preset.name}</FootnoteText>
+                        <span className="min-w-[20px] rounded-full bg-icon-accent px-1.5 text-center text-help-text leading-4 font-semibold text-white">
+                          {matched.length}
+                        </span>
+                      </button>
+                    );
+                  })}
                 </div>
                 <div className="mt-1 border-t border-divider pt-1">
                   <button

--- a/src/renderer/pages/Dashboard/ui/Dashboard.tsx
+++ b/src/renderer/pages/Dashboard/ui/Dashboard.tsx
@@ -73,7 +73,7 @@ export const Dashboard = () => {
     <section className="flex h-full flex-col">
       <Header title={t('dashboard.title')} titleClass="py-[3px]" headerClass="pt-4 pb-[15px]">
         {allEntries.length > 0 && (
-          <div className="flex items-center gap-x-2">
+          <div className="flex items-center gap-x-2 rounded-xl bg-white p-2">
             <IconButton className={editMode ? 'text-icon-accent' : ''} name="edit" onClick={editModeToggled} />
             <Slot id={dashboardPresetSwitcherSlot} />
           </div>

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -514,10 +514,6 @@
       "selectedCount_other": "{{count}} accounts selected"
     },
     "presets": {
-      "all": "All",
-      "overflow": "+{count} more",
-      "manage": "Manage Presets",
-      "searchPresets": "Search presets...",
       "modal": {
         "title": "Manage Presets",
         "newPreset": "New Preset",
@@ -533,7 +529,6 @@
         "searchAccounts": "Search accounts...",
         "noMatches": "No accounts match these filters",
         "matchesAll": "This preset matches all accounts",
-        "moreAccounts": "+{count} more",
         "delete": "Delete Preset",
         "deleteConfirmTitle": "Delete Preset",
         "deleteConfirmDescription": "Are you sure you want to delete \"{name}\"?",
@@ -2843,10 +2838,14 @@
       "title": "{count} of {total} accounts",
       "wallets_one": "{count} wallet account",
       "wallets_other": "{count} wallet accounts",
+      "indexed_one": "{count} indexed account",
+      "indexed_other": "{count} indexed accounts",
       "localContacts_one": "{count} local contact",
       "localContacts_other": "{count} local contacts",
       "backendContacts_one": "{count} external contact",
       "backendContacts_other": "{count} external contacts",
+      "overlap_one": "{count} account appears in multiple categories",
+      "overlap_other": "{count} accounts appear in multiple categories",
       "empty": "No accounts match this filter"
     }
   },

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2838,7 +2838,17 @@
   "presets": {
     "all": "All",
     "searchPresets": "Search presets...",
-    "manage": "Manage Presets"
+    "manage": "Manage Presets",
+    "counterTooltip": {
+      "title": "{count} of {total} accounts",
+      "wallets_one": "{count} wallet account",
+      "wallets_other": "{count} wallet accounts",
+      "localContacts_one": "{count} local contact",
+      "localContacts_other": "{count} local contacts",
+      "backendContacts_one": "{count} external contact",
+      "backendContacts_other": "{count} external contacts",
+      "empty": "No accounts match this filter"
+    }
   },
   "price": {
     "withCode": "{ amount } { code }",

--- a/src/renderer/shared/ui-kit/Tooltip/Tooltip.tsx
+++ b/src/renderer/shared/ui-kit/Tooltip/Tooltip.tsx
@@ -1,6 +1,7 @@
 import * as RadixTooltip from '@radix-ui/react-tooltip';
 import { type PropsWithChildren, type ReactElement, createContext, useContext, useMemo } from 'react';
 
+import { cnTw } from '@/shared/lib/utils';
 import { useTheme } from '../Theme/useTheme';
 import { gridSpaceConverter } from '../_helpers/gridSpaceConverter';
 
@@ -55,14 +56,17 @@ const Trigger = ({ children }: { children: ReactElement }) => {
   return <RadixTooltip.Trigger asChild>{children}</RadixTooltip.Trigger>;
 };
 
-const Content = ({ children }: PropsWithChildren) => {
+const Content = ({ children, className }: PropsWithChildren<{ className?: string }>) => {
   const { portalContainer } = useTheme();
   const { side, align, alignOffset, sideOffset, testId } = useContext(Context);
 
   return (
     <RadixTooltip.Portal container={portalContainer}>
       <RadixTooltip.Content
-        className="z-50 h-fit max-h-(--radix-tooltip-content-available-height) w-fit max-w-48 origin-(--radix-popper-transform-origin) rounded-md bg-switch-background-active px-2 py-1 text-help-text text-white duration-100 animate-in fade-in zoom-in-95"
+        className={cnTw(
+          'z-50 h-fit max-h-(--radix-tooltip-content-available-height) w-fit max-w-48 origin-(--radix-popper-transform-origin) rounded-md bg-switch-background-active px-2 py-1 text-help-text text-white duration-100 animate-in fade-in zoom-in-95',
+          className,
+        )}
         side={side}
         align={align}
         arrowPadding={gridSpaceConverter(3)}

--- a/src/renderer/widgets/PresetManagementModal/index.ts
+++ b/src/renderer/widgets/PresetManagementModal/index.ts
@@ -1,1 +1,2 @@
 export { PresetManagementModal } from './ui/PresetManagementModal';
+export { SourceBreakdownBar } from './ui/SourceBreakdownBar';

--- a/src/renderer/widgets/PresetManagementModal/ui/AccountEntryRowBadges.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/AccountEntryRowBadges.tsx
@@ -1,0 +1,39 @@
+import { type ReactNode } from 'react';
+
+import { cnTw } from '@/shared/lib/utils';
+import { type AccountEntry, type AccountSource } from '@/aggregates/account-presets';
+
+const SOURCE_LABELS: Record<AccountSource, string> = {
+  wallet: 'wallet',
+  'local-contact': 'contact',
+  'backend-contact': 'external',
+};
+
+const SOURCE_BADGE_COLORS: Record<AccountSource, string> = {
+  wallet: 'bg-icon-accent/10 text-icon-accent',
+  'local-contact': 'bg-icon-positive/10 text-icon-positive',
+  'backend-contact': 'bg-icon-alert/10 text-icon-alert',
+};
+
+const SOURCE_BADGE_ORDER: AccountSource[] = ['wallet', 'local-contact', 'backend-contact'];
+
+const ENTITY_BADGE = 'bg-badge-orange-background-default text-badge-orange-text';
+
+const Badge = ({ className, children }: { className?: string; children: ReactNode }) => (
+  <span className={cnTw('rounded-full px-2 py-0.5 text-[10px] font-medium', className)}>{children}</span>
+);
+
+export const AccountEntryRowBadges = ({ entry }: { entry: AccountEntry }) => {
+  const entityName = entry.sources.includes('backend-contact') ? entry.entityNames?.[0] : undefined;
+
+  return (
+    <div className="flex shrink-0 items-center gap-x-1">
+      {entityName && <Badge className={ENTITY_BADGE}>{entityName}</Badge>}
+      {SOURCE_BADGE_ORDER.filter((s) => entry.sources.includes(s)).map((source) => (
+        <Badge key={source} className={SOURCE_BADGE_COLORS[source]}>
+          {SOURCE_LABELS[source]}
+        </Badge>
+      ))}
+    </div>
+  );
+};

--- a/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
@@ -1,11 +1,14 @@
-import { type ReactNode, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { cnTw, includes, toShortAddress } from '@/shared/lib/utils';
+import { cnTw, includesMultiple, toShortAddress } from '@/shared/lib/utils';
 import { CaptionText, FootnoteText } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
 import { Checkbox, Input, SearchInput } from '@/shared/ui-kit';
 import { type AccountEntry } from '@/aggregates/account-presets';
+
+import { AccountEntryRowBadges } from './AccountEntryRowBadges';
+import { VirtualAccountList } from './VirtualAccountList';
 
 type Props = {
   name: string;
@@ -15,20 +18,6 @@ type Props = {
   onSelectedIdsChange: (ids: string[]) => void;
 };
 
-const SOURCE_LABELS: Record<string, string> = {
-  wallet: 'wallet',
-  'local-contact': 'contact',
-  'backend-contact': 'external',
-};
-
-const SOURCE_BADGE_COLORS: Record<string, string> = {
-  wallet: 'bg-icon-accent/10 text-icon-accent',
-  'local-contact': 'bg-icon-positive/10 text-icon-positive',
-  'backend-contact': 'bg-icon-alert/10 text-icon-alert',
-};
-
-const ENTITY_BADGE = 'bg-badge-orange-background-default text-badge-orange-text';
-
 export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameChange, onSelectedIdsChange }: Props) => {
   const { t } = useI18n();
   const [search, setSearch] = useState('');
@@ -36,7 +25,7 @@ export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameCha
   const selectedSet = useMemo(() => new Set(selectedIds), [selectedIds]);
 
   const filtered = useMemo(
-    () => allEntries.filter((entry) => includes(entry.name, search) || includes(entry.address, search)),
+    () => allEntries.filter((entry) => includesMultiple([entry.address, ...entry.aliases], search)),
     [allEntries, search],
   );
 
@@ -92,10 +81,11 @@ export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameCha
         </Checkbox>
       </div>
 
-      <div className="max-h-[280px] overflow-y-auto rounded-sm">
-        {filtered.map((entry) => (
+      <VirtualAccountList
+        entries={filtered}
+        className="max-h-[280px]"
+        renderRow={(entry) => (
           <div
-            key={entry.id}
             className={cnTw(
               'flex cursor-pointer items-center gap-x-2 rounded px-2 py-1.5 transition-colors hover:bg-action-background-hover',
               selectedSet.has(entry.id) && 'bg-block-background-default',
@@ -110,19 +100,10 @@ export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameCha
               <FootnoteText className="truncate text-text-primary">{entry.name}</FootnoteText>
               <CaptionText className="text-text-tertiary">{toShortAddress(entry.address, 6)}</CaptionText>
             </div>
-            <div className="flex shrink-0 items-center gap-x-1">
-              {entry.source === 'backend-contact' && entry.entityNames.length > 0 && (
-                <Badge className={ENTITY_BADGE}>{entry.entityNames[0]}</Badge>
-              )}
-              <Badge className={SOURCE_BADGE_COLORS[entry.source]}>{SOURCE_LABELS[entry.source] ?? entry.source}</Badge>
-            </div>
+            <AccountEntryRowBadges entry={entry} />
           </div>
-        ))}
-      </div>
+        )}
+      />
     </div>
   );
 };
-
-const Badge = ({ className, children }: { className?: string; children: ReactNode }) => (
-  <span className={cnTw('rounded-full px-2 py-0.5 text-[10px] font-medium', className)}>{children}</span>
-);

--- a/src/renderer/widgets/PresetManagementModal/ui/MatchedAccountsPreview.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/MatchedAccountsPreview.tsx
@@ -1,47 +1,30 @@
-import { type ReactNode, useMemo, useState } from 'react';
+import { useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { cnTw, includes, toShortAddress } from '@/shared/lib/utils';
+import { includesMultiple, toShortAddress } from '@/shared/lib/utils';
 import { CaptionText, FootnoteText } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
 import { SearchInput } from '@/shared/ui-kit';
-import { type AccountEntry, type PresetFilterCriteria, applyPresetFilter } from '@/aggregates/account-presets';
+import { type AccountEntry } from '@/aggregates/account-presets';
+
+import { AccountEntryRowBadges } from './AccountEntryRowBadges';
+import { VirtualAccountList } from './VirtualAccountList';
 
 type Props = {
-  allEntries: AccountEntry[];
-  filters: PresetFilterCriteria;
+  matched: AccountEntry[];
+  totalEntries: number;
 };
 
-const MAX_VISIBLE = 50;
-
-const SOURCE_LABELS: Record<string, string> = {
-  wallet: 'wallet',
-  'local-contact': 'contact',
-  'backend-contact': 'external',
-};
-
-const SOURCE_BADGE_COLORS: Record<string, string> = {
-  wallet: 'bg-icon-accent/10 text-icon-accent',
-  'local-contact': 'bg-icon-positive/10 text-icon-positive',
-  'backend-contact': 'bg-icon-alert/10 text-icon-alert',
-};
-
-const ENTITY_BADGE = 'bg-badge-orange-background-default text-badge-orange-text';
-
-export const MatchedAccountsPreview = ({ allEntries, filters }: Props) => {
+export const MatchedAccountsPreview = ({ matched, totalEntries }: Props) => {
   const { t } = useI18n();
   const [search, setSearch] = useState('');
 
-  const matched = useMemo(() => applyPresetFilter(filters, allEntries), [filters, allEntries]);
-  const matchesAll = matched.length === allEntries.length && allEntries.length > 0;
+  const matchesAll = matched.length === totalEntries && totalEntries > 0;
 
   const filtered = useMemo(
-    () => matched.filter((entry) => includes(entry.name, search) || includes(entry.address, search)),
+    () => matched.filter((entry) => includesMultiple([entry.address, ...entry.aliases], search)),
     [matched, search],
   );
-
-  const visible = filtered.slice(0, MAX_VISIBLE);
-  const remaining = filtered.length - visible.length;
 
   return (
     <div className="flex flex-col gap-y-2">
@@ -57,16 +40,18 @@ export const MatchedAccountsPreview = ({ allEntries, filters }: Props) => {
         </div>
       )}
 
-      {visible.length === 0 && !matchesAll && (
+      {filtered.length === 0 && !matchesAll && (
         <div className="rounded-sm bg-block-background-default px-3 py-2">
           <FootnoteText className="text-text-tertiary">{t('dashboard.presets.modal.noMatches')}</FootnoteText>
         </div>
       )}
 
-      {visible.length > 0 && (
-        <div className="max-h-40 overflow-y-auto rounded-sm">
-          {visible.map((entry) => (
-            <div key={entry.id} className="flex items-center gap-x-2 rounded px-2 py-1.5">
+      {filtered.length > 0 && (
+        <VirtualAccountList
+          entries={filtered}
+          className="max-h-[280px]"
+          renderRow={(entry) => (
+            <div className="flex items-center gap-x-2 rounded px-2 py-1.5">
               <div className="shrink-0">
                 <Identicon address={entry.address} size={24} canCopy />
               </div>
@@ -74,28 +59,11 @@ export const MatchedAccountsPreview = ({ allEntries, filters }: Props) => {
                 <FootnoteText className="truncate text-text-primary">{entry.name}</FootnoteText>
                 <CaptionText className="text-text-tertiary">{toShortAddress(entry.address, 6)}</CaptionText>
               </div>
-              <div className="flex shrink-0 items-center gap-x-1">
-                {entry.source === 'backend-contact' && entry.entityNames.length > 0 && (
-                  <Badge className={ENTITY_BADGE}>{entry.entityNames[0]}</Badge>
-                )}
-                <Badge className={SOURCE_BADGE_COLORS[entry.source]}>
-                  {SOURCE_LABELS[entry.source] ?? entry.source}
-                </Badge>
-              </div>
+              <AccountEntryRowBadges entry={entry} />
             </div>
-          ))}
-        </div>
-      )}
-
-      {remaining > 0 && (
-        <FootnoteText className="text-center text-text-tertiary">
-          {t('dashboard.presets.modal.moreAccounts', { count: remaining })}
-        </FootnoteText>
+          )}
+        />
       )}
     </div>
   );
 };
-
-const Badge = ({ className, children }: { className?: string; children: ReactNode }) => (
-  <span className={cnTw('rounded-full px-2 py-0.5 text-[10px] font-medium', className)}>{children}</span>
-);

--- a/src/renderer/widgets/PresetManagementModal/ui/PresetFilterEditor.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/PresetFilterEditor.tsx
@@ -6,7 +6,7 @@ import { cnTw } from '@/shared/lib/utils';
 import { MultiSelect } from '@/shared/ui';
 import { Input } from '@/shared/ui-kit';
 import { contactModel } from '@/entities/contact';
-import { type PresetFilterCriteria } from '@/aggregates/account-presets';
+import { type AccountSource, type PresetFilterCriteria } from '@/aggregates/account-presets';
 
 type Props = {
   name: string;
@@ -16,7 +16,7 @@ type Props = {
 };
 
 type SourceOption = {
-  id: 'wallet' | 'local-contact' | 'backend-contact';
+  id: AccountSource;
   label: string;
 };
 
@@ -62,7 +62,7 @@ export const PresetFilterEditor = ({ name, filters, onNameChange, onFiltersChang
     };
   }, [backendContacts]);
 
-  const toggleSource = (sourceId: 'wallet' | 'local-contact' | 'backend-contact') => {
+  const toggleSource = (sourceId: AccountSource) => {
     const already = filters.sources.includes(sourceId);
     const newSources = already ? filters.sources.filter((s) => s !== sourceId) : [...filters.sources, sourceId];
     onFiltersChange({ ...filters, sources: newSources });

--- a/src/renderer/widgets/PresetManagementModal/ui/PresetManagementModal.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/PresetManagementModal.tsx
@@ -13,11 +13,13 @@ import {
   type PresetType,
   EMPTY_FILTERS,
   accountPresetsModel,
+  applyPresetFilter,
 } from '@/aggregates/account-presets';
 
 import { CustomAccountSelector } from './CustomAccountSelector';
 import { MatchedAccountsPreview } from './MatchedAccountsPreview';
 import { PresetFilterEditor } from './PresetFilterEditor';
+import { SourceBreakdownBar } from './SourceBreakdownBar';
 
 type Props = {
   isOpen: boolean;
@@ -153,6 +155,14 @@ export const PresetManagementModal = ({ isOpen, onClose }: Props) => {
   const isNewPreset = selectedId === null;
   const canSave = editName.trim().length > 0 && (editType === 'filter' || editSelectedIds.length > 0);
 
+  const matchedEntries = useMemo(() => {
+    if (editType === 'custom') {
+      const selected = new Set(editSelectedIds);
+      return allEntries.filter((e) => selected.has(e.id));
+    }
+    return applyPresetFilter(editFilters, allEntries);
+  }, [editType, editSelectedIds, editFilters, allEntries]);
+
   return (
     <Modal isOpen={isOpen} size="lg" onToggle={(open) => !open && onClose()}>
       <Modal.Title close>{t('dashboard.presets.modal.title')}</Modal.Title>
@@ -187,7 +197,6 @@ export const PresetManagementModal = ({ isOpen, onClose }: Props) => {
                   )}
                   onClick={resetEditor}
                 >
-                  {/* eslint-disable-next-line i18next/no-literal-string */}
                   <span className="text-base leading-none">+</span>
                   <FootnoteText as="span" className="text-inherit">
                     {t('dashboard.presets.modal.newPreset')}
@@ -211,6 +220,8 @@ export const PresetManagementModal = ({ isOpen, onClose }: Props) => {
               />
             </div>
 
+            <SourceBreakdownBar entries={matchedEntries} total={allEntries.length} tone="light" />
+
             {editType === 'filter' ? (
               <>
                 <PresetFilterEditor
@@ -219,7 +230,7 @@ export const PresetManagementModal = ({ isOpen, onClose }: Props) => {
                   onNameChange={setEditName}
                   onFiltersChange={setEditFilters}
                 />
-                <MatchedAccountsPreview allEntries={allEntries} filters={editFilters} />
+                <MatchedAccountsPreview matched={matchedEntries} totalEntries={allEntries.length} />
               </>
             ) : (
               <CustomAccountSelector

--- a/src/renderer/widgets/PresetManagementModal/ui/SourceBreakdownBar.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/SourceBreakdownBar.tsx
@@ -1,0 +1,96 @@
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { FootnoteText } from '@/shared/ui';
+import { type AccountEntry, type SourceBreakdownKey, computeSourceBreakdown } from '@/aggregates/account-presets';
+
+type BreakdownRow = {
+  key: SourceBreakdownKey;
+  colorClass: string;
+  labelKey: string;
+};
+
+const BREAKDOWN_ROWS: BreakdownRow[] = [
+  { key: 'wallet', colorClass: 'bg-icon-accent', labelKey: 'presets.counterTooltip.wallets' },
+  { key: 'indexed', colorClass: 'bg-icon-warning', labelKey: 'presets.counterTooltip.indexed' },
+  { key: 'localContact', colorClass: 'bg-icon-positive', labelKey: 'presets.counterTooltip.localContacts' },
+  { key: 'backendContact', colorClass: 'bg-icon-alert', labelKey: 'presets.counterTooltip.backendContacts' },
+];
+
+type Tone = 'light' | 'dark';
+
+type ToneClasses = {
+  title: string;
+  label: string;
+  muted: string;
+  track: string;
+};
+
+const TONE: Record<Tone, ToneClasses> = {
+  light: {
+    title: 'text-text-primary',
+    label: 'text-text-secondary',
+    muted: 'text-text-tertiary',
+    track: 'bg-block-background-default',
+  },
+  dark: {
+    title: 'text-white',
+    label: 'text-white',
+    muted: 'text-white/60',
+    track: 'bg-white/10',
+  },
+};
+
+type Props = {
+  entries: AccountEntry[];
+  total: number;
+  tone?: Tone;
+};
+
+export const SourceBreakdownBar = ({ entries, total, tone = 'light' }: Props) => {
+  const { t } = useI18n();
+
+  const count = entries.length;
+  const breakdown = computeSourceBreakdown(entries);
+  const segments = BREAKDOWN_ROWS.filter((row) => breakdown[row.key] > 0);
+  const barTotal = segments.reduce((sum, row) => sum + breakdown[row.key], 0);
+  const overlap = barTotal > count ? barTotal - count : 0;
+  const toneClasses = TONE[tone];
+
+  return (
+    <div className="flex flex-col gap-y-2">
+      <FootnoteText className={cnTw('font-semibold', toneClasses.title)}>
+        {t('presets.counterTooltip.title', { count, total })}
+      </FootnoteText>
+      {count === 0 ? (
+        <FootnoteText className={toneClasses.label}>{t('presets.counterTooltip.empty')}</FootnoteText>
+      ) : (
+        <>
+          <div className={cnTw('flex h-1.5 w-full overflow-hidden rounded-full', toneClasses.track)}>
+            {segments.map((row) => (
+              <div
+                key={row.key}
+                className={cnTw('h-full', row.colorClass)}
+                style={{ width: `${(breakdown[row.key] / barTotal) * 100}%` }}
+              />
+            ))}
+          </div>
+          <ul className="flex flex-col gap-y-1">
+            {segments.map((row) => (
+              <li key={row.key} className="flex items-center gap-x-2">
+                <span className={cnTw('size-2 rounded-full', row.colorClass)} />
+                <FootnoteText className={toneClasses.label}>
+                  {t(row.labelKey, { count: breakdown[row.key] })}
+                </FootnoteText>
+              </li>
+            ))}
+          </ul>
+          {overlap > 0 && (
+            <FootnoteText className={toneClasses.muted}>
+              {t('presets.counterTooltip.overlap', { count: overlap })}
+            </FootnoteText>
+          )}
+        </>
+      )}
+    </div>
+  );
+};

--- a/src/renderer/widgets/PresetManagementModal/ui/VirtualAccountList.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/VirtualAccountList.tsx
@@ -1,0 +1,52 @@
+import { useVirtualizer } from '@tanstack/react-virtual';
+import { type ReactNode, useRef } from 'react';
+
+import { cnTw } from '@/shared/lib/utils';
+import { type AccountEntry } from '@/aggregates/account-presets';
+
+type Props = {
+  entries: AccountEntry[];
+  estimateSize?: number;
+  className?: string;
+  renderRow: (entry: AccountEntry) => ReactNode;
+};
+
+export const VirtualAccountList = ({ entries, estimateSize = 40, className, renderRow }: Props) => {
+  const scrollRef = useRef<HTMLDivElement>(null);
+
+  const virtualizer = useVirtualizer({
+    count: entries.length,
+    getScrollElement: () => scrollRef.current,
+    estimateSize: () => estimateSize,
+    overscan: 8,
+    getItemKey: (index) => entries[index]?.id ?? `idx-${index}`,
+  });
+
+  return (
+    <div ref={scrollRef} className={cnTw('overflow-y-auto rounded-sm', className)}>
+      <div style={{ height: `${virtualizer.getTotalSize()}px`, width: '100%', position: 'relative' }}>
+        {virtualizer.getVirtualItems().map((row) => {
+          const entry = entries[row.index];
+          if (!entry) return null;
+
+          return (
+            <div
+              key={row.key}
+              ref={virtualizer.measureElement}
+              data-index={row.index}
+              style={{
+                position: 'absolute',
+                top: 0,
+                left: 0,
+                width: '100%',
+                transform: `translateY(${row.start}px)`,
+              }}
+            >
+              {renderRow(entry)}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+};


### PR DESCRIPTION
## Summary
- Each preset tab on the Dashboard (and each entry in the overflow popover) now shows the number of accounts matched by that filter as a contrast badge.
- Hovering a tab reveals a tooltip with "N of K accounts" plus a per-source breakdown — wallet accounts / local contacts / external contacts — so the impact of a filter is visible at a glance.
- Backed by a new `accountPresetsModel.$entriesByPresetId` store that derives matched entries per preset; the same switcher is shared with Operations, so counts appear there too.

## Test plan
- [ ] With no preset active, "All" tab shows the total account count and tooltip lists breakdown by source.
- [ ] Switching between presets updates the active tab styling; each preset tab shows its own filtered count.
- [ ] Creating / deleting / editing a preset updates counts live.
- [ ] Overflow popover entries (presets beyond the 3 visible tabs) show count badges and stay accurate when filtering by search.
- [ ] Tooltips render translated copy (not raw `presets.counterTooltip.*` keys).
- [ ] Operations page preset switcher also shows counts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Fixes novasamatech/nova-spektr-tracker#36
Fixes novasamatech/nova-spektr-tracker#42
Fixes novasamatech/nova-spektr-tracker#43