### PR TITLE
feat: redirect to dashboard after onboarding

### DIFF
--- a/src/renderer/features/wallets/OnboardingRouteGuard/ui/OnboardingRouteGuard.tsx
+++ b/src/renderer/features/wallets/OnboardingRouteGuard/ui/OnboardingRouteGuard.tsx
@@ -17,7 +17,7 @@ export const OnboardingRouteGuard = ({ children }: Props) => {
 
   useEffect(() => {
     if (!isLoadingWallets && wallets.length > 0) {
-      navigate(Paths.ASSETS, { replace: true });
+      navigate(Paths.DASHBOARD, { replace: true });
     }
   }, [isLoadingWallets, wallets.length, navigate]);
 


### PR DESCRIPTION
## Summary
- Changed the post-onboarding redirect in `OnboardingRouteGuard` from `Paths.ASSETS` (portfolio) to `Paths.DASHBOARD` so that dashboard is the default landing page after wallet creation.
- Root (`/`) and wildcard (`*`) routes already navigated to `Paths.DASHBOARD`; this aligns the only remaining default-entry path with them.

## Test plan
- [ ] Complete onboarding (create/import a wallet) → app opens on Dashboard, not Portfolio.
- [ ] Reopen app with existing wallets at `/onboarding` → redirects to Dashboard.
- [ ] Manual navigation to Portfolio via sidebar still works.

Fixes novasamatech/nova-spektr-tracker#46