### PR TITLE
fix: notification handling for multisig operations

### DIFF
--- a/src/renderer/features/multisig-operations/model/notifications.test.ts
+++ b/src/renderer/features/multisig-operations/model/notifications.test.ts
@@ -1,0 +1,92 @@
+import { allSettled, createEvent, fork, sample } from 'effector';
+import { describe, expect, it, vi } from 'vitest';
+
+import { storageService } from '@/shared/api/storage';
+import { type Chain, type ChainId, AccountType, NotificationEvent } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type MultisigOperation, accounts, multisigOperation } from '@/domains/network';
+import { networkModel } from '@/entities/network';
+import { notificationModel } from '@/entities/notification';
+
+vi.mock('../components/Operation', () => ({
+  operationTitleTransformer: () => undefined,
+}));
+
+import './notifications';
+
+const setCachedOperations = createEvent<MultisigOperation[]>();
+
+sample({ clock: setCachedOperations, target: multisigOperation.__test.$cachedOperations });
+
+const chainId = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3' as ChainId;
+const multisigAccountId = '0xmultisig' as AccountId;
+
+const chain = {
+  chainId,
+  assets: [],
+} as unknown as Chain;
+
+const multisigAccount = {
+  id: 'multisig-account',
+  type: 'universal',
+  accountType: AccountType.MULTISIG,
+  accountId: multisigAccountId,
+  walletId: 1,
+  name: 'Test multisig',
+  createdAt: 1,
+};
+
+const operation = {
+  id: 'operation-1',
+  status: 'pending',
+  transaction: null,
+  method: null,
+  section: null,
+  callHash: '0x1234',
+  callData: null,
+  chainId,
+  multisigAccountId,
+  depositor: '0xdepositor' as AccountId,
+  blockCreated: 100,
+  indexCreated: 0,
+  events: [],
+  timestamp: 2,
+} as unknown as MultisigOperation;
+
+const enableAllNotifications = async (scope: ReturnType<typeof fork>) => {
+  await allSettled(notificationModel.events.settingsSaved, {
+    scope,
+    params: {
+      disabledWalletIds: [],
+      notificationEvents: [
+        NotificationEvent.WALLET_CREATED,
+        NotificationEvent.OPERATION_CREATED,
+        NotificationEvent.OPERATION_EXECUTED,
+        NotificationEvent.OPERATION_REJECTED,
+      ],
+      soundEnabled: false,
+    },
+  });
+};
+
+describe('features/multisig-operations/model/notifications', () => {
+  it('does not create notifications for historical operations loaded before initial sync completes', async () => {
+    const createAll = vi.spyOn(storageService.notifications, 'createAll').mockResolvedValue([]);
+    vi.spyOn(storageService.notifications, 'readAll').mockResolvedValue([]);
+
+    const scope = fork({
+      values: new Map<any, any>([
+        [accounts.__test.$list, [multisigAccount]],
+        [networkModel.$chains, { [chainId]: chain }],
+        [multisigOperation.__test.$populated, true],
+      ]),
+    });
+
+    await enableAllNotifications(scope);
+    await allSettled(setCachedOperations, { scope, params: [] });
+    await allSettled(setCachedOperations, { scope, params: [operation] });
+    await allSettled(scope);
+
+    expect(createAll).not.toHaveBeenCalled();
+  });
+});

--- a/src/renderer/features/multisig-operations/model/notifications.ts
+++ b/src/renderer/features/multisig-operations/model/notifications.ts
@@ -253,6 +253,21 @@ const getOperationId = (op: MultisigOperation) =>
 const getNotificationKey = (op: MultisigOperation) =>
   `${NotificationType.MULTISIG_OPERATION}-${getOperationId(op)}-${op.status}`;
 
+const $notificationCutoffTimestamp = createStore(Date.now()).on(
+  multisigOperation.$initialLoadingComplete,
+  (cutoffTimestamp, initialLoadingComplete) => {
+    return initialLoadingComplete ? cutoffTimestamp : Date.now();
+  },
+);
+
+const isAfterNotificationCutoff = (timestamp: number, notificationCutoffTimestamp: number): boolean => {
+  return timestamp >= notificationCutoffTimestamp;
+};
+
+const getLatestOperationTimestamp = (operation: MultisigOperation): number => {
+  return Math.max(operation.timestamp, ...operation.events.map(event => event.timestamp));
+};
+
 const operationChanges = pairwise(multisigOperation.$list)
   .map(({ prev: prevState, current: update }) => {
     const previousOpsMap = new Map(prevState.map((op: MultisigOperation) => [getOperationId(op), op]));
@@ -298,13 +313,18 @@ const $allAccounts = accounts.$list;
 sample({
   clock: operationChanges,
   source: {
-    populated: multisigOperation.$populated,
+    initialLoadingComplete: multisigOperation.$initialLoadingComplete,
+    notificationCutoffTimestamp: $notificationCutoffTimestamp,
     anyMultisigAccounts: $anyMultisigAccounts,
     allAccounts: $allAccounts,
     chains: networkModel.$chains,
   },
-  filter: ({ populated }) => populated,
-  fn: ({ anyMultisigAccounts, allAccounts, chains }, { newOperations, statusChanges, removedKeys, newEvents }) => {
+  filter: ({ initialLoadingComplete }) => initialLoadingComplete,
+  fn: (
+    { anyMultisigAccounts, allAccounts, chains, notificationCutoffTimestamp },
+    { newOperations, statusChanges, removedKeys, newEvents },
+  ) => {
+    const notificationCutoff = notificationCutoffTimestamp;
     // Filter new operations - apply timestamp filter to exclude operations created before account was connected
     const newOperationNotifications = newOperations
       .filter(operation => {
@@ -315,7 +335,11 @@ sample({
 
         const account = findAccountForOperation(operation, anyMultisigAccounts);
         // Show only operations created after account was connected
-        return nonNullable(account) && operation.timestamp >= account.createdAt;
+        return (
+          nonNullable(account) &&
+          operation.timestamp >= account.createdAt &&
+          isAfterNotificationCutoff(operation.timestamp, notificationCutoff)
+        );
       })
       .map(operation => {
         const account = findAccountForOperation(operation, anyMultisigAccounts);
@@ -323,15 +347,36 @@ sample({
         return createOperationNotification(operation, chains, account);
       });
 
-    // Status changes should always create notifications regardless of when the operation was created
-    const statusChangeNotifications = statusChanges.map(operation => {
-      const account = findAccountForOperation(operation, anyMultisigAccounts);
+    // Status changes notify only when the latest operation activity is fresh for this account
+    const statusChangeNotifications = statusChanges
+      .filter(operation => {
+        const account = findAccountForOperation(operation, anyMultisigAccounts);
+        const latestTimestamp = getLatestOperationTimestamp(operation);
 
-      return createOperationNotification(operation, chains, account);
-    });
+        return (
+          nonNullable(account) &&
+          latestTimestamp >= account.createdAt &&
+          isAfterNotificationCutoff(latestTimestamp, notificationCutoff)
+        );
+      })
+      .map(operation => {
+        const account = findAccountForOperation(operation, anyMultisigAccounts);
+
+        return createOperationNotification(operation, chains, account);
+      });
 
     const eventNotifications = newEvents
-      .filter(({ event }) => {
+      .filter(({ operation, event }) => {
+        const account = findAccountForOperation(operation, anyMultisigAccounts);
+
+        if (!nonNullable(account) || event.timestamp < account.createdAt) {
+          return false;
+        }
+
+        if (!isAfterNotificationCutoff(event.timestamp, notificationCutoff)) {
+          return false;
+        }
+
         // Don't notify if the current user caused the event
         if (anyMultisigAccounts.some(a => a.accountId === event.accountId) && event.status !== 'reject') {
           return false;


### PR DESCRIPTION
## Description
Multisig operation notifications were firing for historical operations when the local cache was filled during the first sync after opening the app. The model gated on $populated, which becomes true as soon as cached data exists, so every operation that appeared in $list during that load was treated as “new.”

This PR waits for $initialLoadingComplete and records a notification cutoff timestamp at that moment. New operations, status changes, and events are only notified if their relevant timestamp is at or after that cutoff (and still after the account’s createdAt). Status changes and events use the latest activity timestamp, not only the operation’s base timestamp.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-572

## Changes Made
- Gate notification creation on multisigOperation.$initialLoadingComplete instead of $populated
- Add $notificationCutoffTimestamp set when initial loading completes; filter new ops, status changes, and events against it
- Apply the same freshness rules to status-change notifications (previously always notified)
- Add integration test: historical ops loaded while populated but before initial sync complete do not call createAll

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#22