### PR TITLE
feat: default external address book auth chain to polkadot relay

### DIFF
--- a/src/renderer/aggregates/backend/lib/auth-chain.ts
+++ b/src/renderer/aggregates/backend/lib/auth-chain.ts
@@ -1,4 +1,4 @@
 import { type ChainId } from '@/shared/core';
+import { RelayChains } from '@/shared/lib/utils';
 
-// Polkadot Asset Hub: Polkadot Vault always provisions this keyring, so it's a safe auth QR default.
-export const DEFAULT_AUTH_CHAIN_ID: ChainId = '0x68d56f15f85d3136970ec16946040bc1752654e906147f7e43e9d539d7c3de2f';
+export const DEFAULT_AUTH_CHAIN_ID: ChainId = RelayChains.POLKADOT;


### PR DESCRIPTION
## Summary
- Change `DEFAULT_AUTH_CHAIN_ID` in the external address book auth signing flow from Polkadot Asset Hub to the Polkadot relay chain.
- Use the named `RelayChains.POLKADOT` constant instead of an inline chain hash; drop the stale Asset Hub keyring comment.

## Test plan
- [ ] Open Settings → Backend / external address book connection on a Vault/Parity Signer wallet
- [ ] Verify the chain selector in the auth QR step defaults to Polkadot (not Polkadot Asset Hub)
- [ ] Switch chains in the selector, close and reopen the modal — confirm it resets to Polkadot