### PR TITLE
fix: dashboard widget ring and drag handle clipped in edit mode

### DIFF
--- a/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
+++ b/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
@@ -90,7 +90,7 @@ const DashboardGridInner = <P extends SlotProps>({ slot, tab, props, editMode }:
 
   return (
     <DragDropProvider onDragStart={handleDragStart} onDragOver={handleDragOver} onDragEnd={handleDragEnd}>
-      <div className="grid h-full w-full grid-cols-4 items-start gap-4 overflow-y-auto">
+      <div className="grid h-full w-full grid-cols-4 items-start gap-4 overflow-y-auto p-3">
         {displayKeys.map((key, index) => {
           const handler = handlersByKey.get(key);
           if (!handler) return null;


### PR DESCRIPTION
## Summary
- In edit mode the widget `ring-2` outline and the 24px drag-handle button (positioned at `-top-2.5 -left-2.5`, 10px outside the widget) were being clipped by the parent `Tabs.Content` (`overflow-hidden`) and the grid's own `overflow-y-auto`, leaving broken stubs at top-row / leftmost-column widgets
- Added `p-3` (12px) to the dashboard grid container so the ring (+2px) and drag handle (+10px) fit inside the clipping bounds

### Before:
<img width="2550" height="985" alt="Screenshot 2026-05-21 at 11 48 01" src="https://github.com/user-attachments/assets/72534b70-f655-40f2-8bfe-254504d4a395" />


### After:
<img width="1484" height="912" alt="Screenshot 2026-05-21 at 11 39 15" src="https://github.com/user-attachments/assets/b711363b-5053-44ea-95bd-d60422cf753e" />

<img width="2560" height="1291" alt="Screenshot 2026-05-21 at 11 47 19" src="https://github.com/user-attachments/assets/84a74420-56bb-4735-9200-eface8d9f62c" />

## Test plan
- [ ] Open Dashboard, toggle edit mode — confirm full purple ring around every widget on Overview / Staking / Governance tabs
- [ ] Verify the round drag handle renders as a full 24px circle at the top-left of top-row and leftmost widgets (not a clipped stub)
- [ ] Drag a widget to reorder — confirm dnd-kit reordering still works
- [ ] Scroll the dashboard with many widgets — confirm `overflow-y-auto` still scrolls properly