### PR TITLE
refactor: remove redundant accounts filter from multisig operations (SPEK-446)

### DIFF
--- a/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
@@ -4,14 +4,10 @@ import { memo, useMemo, useState } from 'react';
 
 import { ProxyTypeOrder, TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { nonNullable, performSearch, toAddress } from '@/shared/lib/utils';
+import { performSearch } from '@/shared/lib/utils';
 import { Button, MultiSelect } from '@/shared/ui';
-import { Hash, WalletAccountIcon } from '@/shared/ui-entities';
 import { DateRangePicker } from '@/shared/ui-kit';
-import { accountService, useWalletsNames } from '@/domains/network';
 import { networkModel } from '@/entities/network';
-import { accountUtils } from '@/entities/wallet';
-import { walletSelectService } from '@/aggregates/wallet-select';
 import { operationsContextModel } from '../model/context';
 
 export const OperationsFilter = memo(() => {
@@ -19,18 +15,8 @@ export const OperationsFilter = memo(() => {
 
   const selectedOptions = useUnit(operationsContextModel.$filter);
   const isFiltersSelected = useUnit(operationsContextModel.$isFiltersSelected);
-  const chains = useUnit(networkModel.$chains);
   const chainsList = useUnit(networkModel.$chainsList);
-  const multisigAccounts = useUnit(operationsContextModel.$presetScopedMultisigAccounts);
-  const multisigWallets = useUnit(operationsContextModel.$multisigWallets);
 
-  // When an active preset narrows the account list down to 0 or 1, the account multi-select
-  // becomes redundant — hide it entirely so the preset is the single source of account scope.
-  const showAccountFilter = multisigAccounts.length > 1;
-
-  const resolvedWallets = useWalletsNames(multisigWallets);
-
-  const [accountSearchQuery, setAccountSearchQuery] = useState('');
   const [networkSearchQuery, setNetworkSearchQuery] = useState('');
   const [typeSearchQuery, setTypeSearchQuery] = useState('');
   const [proxyTypeSearchQuery, setProxyTypeSearchQuery] = useState('');
@@ -48,51 +34,6 @@ export const OperationsFilter = memo(() => {
   }));
 
   const filtersOptions = useMemo(() => {
-    const filteredAccountOptions = performSearch({
-      query: accountSearchQuery,
-      records: multisigAccounts
-        .map(multisigAccount => {
-          const wallet = resolvedWallets.find(w => w.id === multisigAccount.walletId);
-          const addressPrefix = accountUtils.isFlexibleMultisigAccount(multisigAccount)
-            ? chains[multisigAccount.chainId]?.addressPrefix
-            : undefined;
-          const accountAddress = toAddress(multisigAccount.accountId, { prefix: addressPrefix });
-
-          return wallet
-            ? {
-                multisigAccount,
-                walletName: wallet.name,
-                accountAddress,
-                wallet,
-              }
-            : null;
-        })
-        .filter(nonNullable),
-      getMeta: ({ walletName, wallet }) => ({
-        name: walletName,
-        address: walletSelectService.composeWalletMeta(
-          wallet,
-          accountService.filterAccountsByWallet(multisigAccounts, wallet.id),
-          chains,
-        ),
-      }),
-      weights: { name: 1, address: 0.8 },
-    }).map(({ multisigAccount, walletName, accountAddress, wallet }) => ({
-      id: multisigAccount.accountId,
-      value: multisigAccount.accountId,
-      element: (
-        <span className="flex w-full min-w-0 items-center gap-x-2 overflow-hidden">
-          {wallet && <WalletAccountIcon address={accountAddress} type={wallet.type} size={24} iconSize={12} />}
-          <span className="flex w-full flex-col overflow-hidden">
-            {walletName && <span className="w-fit max-w-full truncate">{walletName}</span>}
-            <span className="w-full text-help-text text-text-tertiary">
-              <Hash value={accountAddress} variant="truncate" />
-            </span>
-          </span>
-        </span>
-      ),
-    }));
-
     const filteredNetworkOptions = performSearch({
       query: networkSearchQuery,
       records: NetworkOptions,
@@ -112,23 +53,11 @@ export const OperationsFilter = memo(() => {
     });
 
     return {
-      account: filteredAccountOptions,
       network: filteredNetworkOptions,
       type: filteredTypeOptions,
       proxyType: filteredProxyTypeOptions,
     };
-  }, [
-    multisigAccounts,
-    resolvedWallets,
-    chains,
-    NetworkOptions,
-    TransactionOptions,
-    ProxyTypeOptions,
-    accountSearchQuery,
-    networkSearchQuery,
-    typeSearchQuery,
-    proxyTypeSearchQuery,
-  ]);
+  }, [NetworkOptions, TransactionOptions, ProxyTypeOptions, networkSearchQuery, typeSearchQuery, proxyTypeSearchQuery]);
 
   const clearFilters = () => {
     operationsContextModel.resetFilters();
@@ -148,17 +77,6 @@ export const OperationsFilter = memo(() => {
           onChange={range => operationsContextModel.setFilter({ dateRange: range })}
         />
       </div>
-      {showAccountFilter && (
-        <MultiSelect
-          showSelectAll
-          className="w-[136px]"
-          placeholder={t('operations.filters.accountPlaceholder')}
-          selectedIds={selectedOptions.account}
-          options={[...filtersOptions.account]}
-          onChange={value => operationsContextModel.setFilter({ account: value.map(({ id }) => id) })}
-          onSearch={setAccountSearchQuery}
-        />
-      )}
       <MultiSelect
         showSelectAll
         className="w-[136px]"

--- a/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
@@ -7,7 +7,6 @@ import {
   type OperationsFilterContext,
   filterOperation,
   getFilterableTxType,
-  matchesAccount,
   matchesDateRange,
   matchesNetwork,
   matchesProxyType,
@@ -42,7 +41,6 @@ const mockMultisigAccount = { accountId: MOCK_ACCOUNT_ID, accountType: 'multisig
 
 const emptyContext: OperationsFilterContext = {
   filters: {
-    account: [],
     network: [],
     type: [],
     proxyType: [],
@@ -158,27 +156,6 @@ describe('operations-filter', () => {
 
     test('history: returns false when not hidden but status is pending', () => {
       expect(matchesTab(createMockOperation({ status: 'pending' }), 'history', [])).toBe(false);
-    });
-  });
-
-  describe('matchesAccount', () => {
-    test('returns true when account list is empty', () => {
-      const op = createMockOperation();
-      expect(matchesAccount(op, [])).toBe(true);
-    });
-
-    test('returns true when operation accountId is in list', () => {
-      const op = createMockOperation();
-      expect(matchesAccount(op, [MOCK_ACCOUNT_ID, '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty' as never])).toBe(
-        true,
-      );
-    });
-
-    test('returns false when operation accountId is not in list', () => {
-      const op = createMockOperation({
-        multisigAccountId: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty' as never,
-      });
-      expect(matchesAccount(op, [MOCK_ACCOUNT_ID])).toBe(false);
     });
   });
 
@@ -370,17 +347,6 @@ describe('operations-filter', () => {
       expect(filterOperation(op, mockMultisigAccount, emptyContext)).toBe(false);
     });
 
-    test('returns false when account filter excludes operation', () => {
-      const op = createMockOperation({
-        multisigAccountId: '5FHneW46xGXgs5mUiveU4sbTyGBzmstUspZC92UhjJM694ty' as never,
-      });
-      const ctx: OperationsFilterContext = {
-        ...emptyContext,
-        filters: { ...emptyContext.filters, account: [MOCK_ACCOUNT_ID] },
-      };
-      expect(filterOperation(op, mockMultisigAccount, ctx)).toBe(false);
-    });
-
     test('returns true when all predicates pass', () => {
       const op = createMockOperation({
         id: 'op-1',
@@ -391,7 +357,6 @@ describe('operations-filter', () => {
         ...emptyContext,
         filters: {
           ...emptyContext.filters,
-          account: [MOCK_ACCOUNT_ID],
           network: [MOCK_CHAIN_ID],
           searchQuery: 'match',
         },

--- a/src/renderer/features/multisig-operations/lib/operations-filter.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.ts
@@ -16,7 +16,6 @@ import { TransferTypes, XcmTypes, findCoreBatchAll } from '@/entities/transactio
 import { accountUtils } from '@/entities/wallet';
 
 export interface OperationsFilterCriteria {
-  account: string[];
   network: string[];
   type: string[];
   proxyType: string[];
@@ -92,9 +91,6 @@ export const matchesTab = (operation: MultisigOperation, tab: OperationsFilterTa
   }
 };
 
-export const matchesAccount = (operation: MultisigOperation, accountIds: string[]) =>
-  accountIds.length === 0 || accountIds.includes(operation.multisigAccountId);
-
 export const matchesNetwork = (operation: MultisigOperation, networkIds: string[]) => {
   if (networkIds.length === 0) return true;
   const xcmDestination = operation.transaction?.args.destinationChain;
@@ -156,7 +152,6 @@ export const filterOperation = (
   const { filters, tab, hiddenIds, multisigWallets, chains } = context;
 
   if (!matchesTab(operation, tab, hiddenIds)) return false;
-  if (!matchesAccount(operation, filters.account)) return false;
   if (!matchesNetwork(operation, filters.network)) return false;
   if (!matchesTxType(operation, filters.type)) return false;
   if (!matchesProxyType(filters.proxyType, account)) return false;

--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -30,7 +30,6 @@ export type OperationWithAccount = {
 };
 
 interface SelectedFilters {
-  account: string[];
   network: string[];
   type: string[];
   proxyType: string[];
@@ -51,7 +50,6 @@ $hiddenOperationIds
   .on(unhideOperation, (state, id) => state.filter(opId => opId !== id));
 
 const initialFilter: SelectedFilters = {
-  account: [],
   network: [],
   type: [],
   proxyType: [],
@@ -73,8 +71,7 @@ const $filter = createStore(initialFilter)
 
 const $isFiltersSelected = $filter.map(filter =>
   Boolean(
-    filter.account.length ||
-      filter.network.length ||
+    filter.network.length ||
       filter.type.length ||
       filter.proxyType.length ||
       filter.dateRange?.from ||

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2696,7 +2696,6 @@
       "tooltip": "Export operations to CSV"
     },
     "filters": {
-      "accountPlaceholder": "Accounts",
       "clearAll": "operations.filters.clearAll",
       "clearFilters": "Clear filters",
       "dateRangePlaceholder": "Date range",


### PR DESCRIPTION
## Summary

- Remove the **Accounts** multi-select from the Multisig Operations filter bar — it duplicates the global wallet / account-preset scoping that already filters visible operations.
- Drop the `account: string[]` field from filter state, the `matchesAccount` predicate, the corresponding tests, and the `operations.filters.accountPlaceholder` localization key.
- Filter bar is now Date range + Proxy type + Networks + Operation type only.

JIRA: [SPEK-446](https://novasamatech.atlassian.net/browse/SPEK-446)

<img width="1484" height="912" alt="Screenshot 2026-05-21 at 12 25 23" src="https://github.com/user-attachments/assets/09801442-a919-495a-b76a-1b04157a88dc" />

## Test plan

- [ ] Open Multisig Operations page — Accounts dropdown is gone; remaining filters (Date range, Proxy type, Networks, Operation type) still work.
- [ ] Switch active wallet / account preset — operations list scopes correctly without the dropdown.
- [ ] Apply Networks / Operation type / Proxy type / Date range filters in any combination — operations filter correctly and **Clear filters** appears + clears them.
- [ ] `pnpm vitest run src/renderer/features/multisig-operations` passes.

[SPEK-446]: https://novasama-technologies.atlassian.net/browse/SPEK-446?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ