### PR TITLE
fix: whitelist referenda

### DIFF
--- a/src/renderer/features/fellowship-tasks/components/tasks/OngoingReferendumVoting.tsx
+++ b/src/renderer/features/fellowship-tasks/components/tasks/OngoingReferendumVoting.tsx
@@ -90,10 +90,12 @@ export const OngoingReferendumVoting = ({
   }, [meta, rfc, isPending, connectedGovernanceReferendumSummary, t]);
 
   const title = useMemo(() => {
+    if (meta?.title) return meta.title;
+
     return isSpendProposal
       ? t('governance.referendums.spendReferendumTitle')
       : t('governance.referendums.referendumTitle', { index: referendum.id });
-  }, [isSpendProposal, referendum.id]);
+  }, [meta, isSpendProposal, referendum.id]);
 
   return (
     <Box direction="row" gap={2}>


### PR DESCRIPTION
## Description

Whitelist referenda in the Fellowship tasks **Active** tab fell back to the generic `Referendum #N` title, while the same referenda in the **Completed** tab showed the proper off-chain title (e.g. `Whitelist proposal #1850`). The active-task title builder only special-cased spend proposals and never consulted the metadata title that the description already used.

## Related Issues

https://novasama-technologies.atlassian.net/browse/SPEK-312

## Changes Made

- `OngoingReferendumVoting`: prefer `meta?.title` as the title source, falling back to the spend / generic title only when metadata has no title — matches `CompletedReferendumVoting`'s behaviour.

## Screenshots/Recordings

### Before

<img width="857" height="868" alt="Screenshot 2026-05-21 at 12 54 59" src="https://github.com/user-attachments/assets/7e9c0196-1fb5-43ef-a8cd-23f5c9ad6a2f" />

### After
<img width="1583" height="912" alt="Screenshot 2026-05-21 at 12 44 34" src="https://github.com/user-attachments/assets/17137cbb-1627-4b7f-b240-65240ef20953" />

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines