### PR TITLE
Fix/network-reconnect-status

### DIFF
--- a/src/renderer/entities/network/model/network-model.ts
+++ b/src/renderer/entities/network/model/network-model.ts
@@ -31,6 +31,7 @@ const connectionStatusChanged = createEvent<{ chainId: ChainId; status: Connecti
 
 const disconnected = createEvent<ChainId>();
 const failed = createEvent<ChainId>();
+const providerReconnected = createEvent<ChainId>();
 
 const $chains = createStore<Record<ChainId, Chain>>({});
 const $chainsList = $chains.map((chains) => chainsService.sortChains(Object.values(chains)));
@@ -109,6 +110,7 @@ const createProviderFx = createEffect(
   ({ chainId, nodes, metadata, providerType, DEBUG_NETWORKS }: CreateProviderParams) => {
     const boundDisconnected = scopeBind(disconnected, { safe: true });
     const boundFailed = scopeBind(failed, { safe: true });
+    const boundReconnected = scopeBind(providerReconnected, { safe: true });
 
     const provider = networkService.createProvider(
       chainId,
@@ -119,6 +121,7 @@ const createProviderFx = createEffect(
           if (DEBUG_NETWORKS) {
             console.info('🟢 Provider connected ==> ', chainId);
           }
+          boundReconnected(chainId);
         },
         onDisconnected: () => {
           if (DEBUG_NETWORKS) {
@@ -390,6 +393,40 @@ sample({
   fn: (statuses, chainId) => ({
     newStatuses: { ...statuses, [chainId]: ConnectionStatus.ERROR },
     event: { chainId, status: ConnectionStatus.ERROR },
+  }),
+  target: spread({
+    newStatuses: $connectionStatuses,
+    event: connectionStatusChanged,
+  }),
+});
+
+// When provider reconnects after a network blip, restore the connection:
+// - if API exists: createApiFx returns immediately with the existing API → status = CONNECTED
+// - if API is absent (failed during init): createApiFx creates a new ApiPromise → status = CONNECTED when ready
+// Skip if already CONNECTED or still in initial CONNECTING (createApiFx already pending)
+sample({
+  clock: providerReconnected,
+  source: { apis: $apis, providers: $providers, statuses: $connectionStatuses },
+  filter: ({ providers, statuses }, chainId) => {
+    const status = statuses[chainId];
+    return (
+      nonNullable(providers[chainId]) && status !== ConnectionStatus.CONNECTED && status !== ConnectionStatus.CONNECTING
+    );
+  },
+  fn: ({ apis, providers }, chainId) => ({
+    chainId,
+    provider: providers[chainId]!,
+    existingApi: apis[chainId] ?? null,
+  }),
+  target: createApiFx,
+});
+
+sample({
+  clock: createApiFx.fail,
+  source: $connectionStatuses,
+  fn: (statuses, { params }) => ({
+    newStatuses: { ...statuses, [params.chainId]: ConnectionStatus.ERROR },
+    event: { chainId: params.chainId, status: ConnectionStatus.ERROR },
   }),
   target: spread({
     newStatuses: $connectionStatuses,


### PR DESCRIPTION
## Description
<!-- Provide a clear and concise description of the changes. Explain the problem this PR solves and the approach taken. -->

When a network blip caused WebSocket 1006 Abnormal Closure across all chains, WsProvider would auto-retry and reconnect internally but the Effector model had no handler for the `onConnected` callback - so all statuses stayed stuck at DISCONNECTED (shown as "Connecting..." in the UI) indefinitely.

Two bugs fixed:
- `onConnected` now fires `providerReconnected`, which re-runs `createApiFx` (immediate for existing APIs, fresh ApiPromise for failed inits) and transitions status back to CONNECTED
- `createApiFx.fail` now sets status to ERROR instead of leaving it stuck at CONNECTING when `isReady` rejects during initial connection

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
