### PR TITLE
Feat: improve_confirmation_popup

### DIFF
--- a/src/renderer/features/drafts/components/SubmitDraftModal.tsx
+++ b/src/renderer/features/drafts/components/SubmitDraftModal.tsx
@@ -29,7 +29,7 @@ import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { walletSelect } from '@/aggregates/wallet-select';
 import { EmptyAccountMessage } from '@/features/emptyList';
 import { OperationSign, OperationSubmit } from '@/features/operations';
-import { PathBreadcrumb } from '@/features/signing-path';
+import { PathBreadcrumb, PathReviewPopover } from '@/features/signing-path';
 import { WalletDetails } from '@/features/wallet-details';
 import { NamedAccount } from '@/widgets/NameResolver';
 import { FeeWithLabel } from '@/widgets/transaction-fee';
@@ -285,8 +285,13 @@ const ConfirmStep = () => {
   return (
     <>
       {signingPath.length > 0 && draft && (
-        <div className="mx-5 mt-4">
-          <PathBreadcrumb path={signingPath} chainId={draft.chainId as ChainId} size="sm" />
+        <div className="mx-5 mt-4 flex flex-col gap-y-3">
+          {signingPath.length >= 2 && (
+            <div className="flex justify-start">
+              <PathReviewPopover path={signingPath} chainId={draft.chainId as ChainId} />
+            </div>
+          )}
+          <PathBreadcrumb path={signingPath} chainId={draft.chainId as ChainId} size="sm" orientation="auto" />
         </div>
       )}
 

--- a/src/renderer/features/drafts/steps/StepReview.tsx
+++ b/src/renderer/features/drafts/steps/StepReview.tsx
@@ -64,7 +64,7 @@ export const StepReview = ({
               <PathReviewPopover path={path} chainId={chain.chainId} />
             </div>
           )}
-          {chain && <PathBreadcrumb path={path} chainId={chain.chainId} size="sm" />}
+          {chain && <PathBreadcrumb path={path} chainId={chain.chainId} size="sm" orientation="auto" />}
         </section>
       )}
 

--- a/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/Transfer/ui/Confirmation.tsx
@@ -172,7 +172,7 @@ export const Confirmation = ({ id = 0, secondaryActionButton, hideSignButton, on
           <div className="flex w-full justify-start">
             <PathReviewPopover path={meta.signingPath} chainId={meta.chain.chainId} />
           </div>
-          <PathBreadcrumb path={meta.signingPath} chainId={meta.chain.chainId} size="sm" />
+          <PathBreadcrumb path={meta.signingPath} chainId={meta.chain.chainId} size="sm" orientation="auto" />
           <hr className="w-full border-filter-border pr-2" />
           <dl className="flex w-full flex-col gap-y-4 text-footnote">{detailRows}</dl>
         </div>

--- a/src/renderer/features/operations/OperationsConfirm/common/SigningPathConfirmSection.tsx
+++ b/src/renderer/features/operations/OperationsConfirm/common/SigningPathConfirmSection.tsx
@@ -47,7 +47,7 @@ export const SigningPathConfirmSection = ({
         <div className="flex w-full justify-start">
           <PathReviewPopover path={signingPath} chainId={chain.chainId} />
         </div>
-        <PathBreadcrumb path={signingPath} chainId={chain.chainId} size="sm" />
+        <PathBreadcrumb path={signingPath} chainId={chain.chainId} size="sm" orientation="auto" />
         <hr className="w-full border-filter-border pr-2" />
         <dl className="flex w-full flex-col gap-y-4 text-footnote">
           {children}

--- a/src/renderer/features/signing-path/ui/PathBreadcrumb.tsx
+++ b/src/renderer/features/signing-path/ui/PathBreadcrumb.tsx
@@ -11,6 +11,7 @@ import { graphModel } from '../model/graph-model';
 import { EllipsisCard } from './EllipsisCard';
 import { PathArrow } from './PathArrow';
 import { PathCard } from './PathCard';
+import { PathHopRow } from './PathHopRow';
 import { type PathCardSize, type PathNodeView, enrichConnectionEdge, nodeView } from './path-views';
 
 type Props = {
@@ -18,9 +19,17 @@ type Props = {
   chainId: ChainId;
   size?: PathCardSize;
   onNodeClick?: (index: number) => void;
+  /**
+   * `'auto'` switches to a vertical, full-width hop list once the path has 3+
+   * hops, where horizontal cards would otherwise squeeze wallet names down to a
+   * few characters. Defaults to `'horizontal'` so the path builder keeps its
+   * left-to-right card flow.
+   */
+  orientation?: 'horizontal' | 'auto';
 };
 
 const MAX_VISIBLE = 3;
+const VERTICAL_THRESHOLD = 3;
 
 const buildBreadcrumbElements = (
   views: PathNodeView[],
@@ -78,7 +87,7 @@ const buildBreadcrumbElements = (
   return elements;
 };
 
-export const PathBreadcrumb = ({ path, chainId, size = 'sm', onNodeClick }: Props) => {
+export const PathBreadcrumb = ({ path, chainId, size = 'sm', onNodeClick, orientation = 'horizontal' }: Props) => {
   const { t } = useI18n();
   const resolveName = useUnit(graphModel.$nameResolver);
   const chains = useUnit(networkModel.$chains);
@@ -92,6 +101,16 @@ export const PathBreadcrumb = ({ path, chainId, size = 'sm', onNodeClick }: Prop
 
   if (views.length === 0) {
     return null;
+  }
+
+  if (orientation === 'auto' && views.length >= VERTICAL_THRESHOLD) {
+    return (
+      <div className="flex flex-col rounded-lg bg-block-background-default p-3">
+        {views.map((view, i) => (
+          <PathHopRow key={`hop-${i}-${view.label}`} view={view} index={i} isLast={i === views.length - 1} />
+        ))}
+      </div>
+    );
   }
 
   return (

--- a/src/renderer/features/signing-path/ui/PathHopRow.tsx
+++ b/src/renderer/features/signing-path/ui/PathHopRow.tsx
@@ -1,0 +1,56 @@
+import { type ReactNode } from 'react';
+
+import { CaptionText, FootnoteText, HelpText } from '@/shared/ui';
+import { WalletAccountIcon } from '@/shared/ui-entities';
+
+import { type PathNodeView } from './path-views';
+
+type Props = {
+  view: PathNodeView;
+  index: number;
+  isLast: boolean;
+  /** Optional trailing content, e.g. a per-hop balance. */
+  rightSlot?: ReactNode;
+};
+
+/**
+ * One numbered hop in a vertical signing-path list: a rail (step number +
+ * connector line) plus the hop's label, connection type, icon, name, and
+ * subtitle. Shared by PathOverviewBody (popover) and PathBreadcrumb's vertical
+ * mode so the hop layout is defined once.
+ */
+export const PathHopRow = ({ view, index, isLast, rightSlot }: Props) => {
+  return (
+    <div className="flex gap-3">
+      <div className="flex flex-col items-center">
+        <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-container-border bg-white">
+          <CaptionText className="text-text-secondary">{index + 1}</CaptionText>
+        </div>
+        {!isLast && <div className="h-8 w-px bg-shade-12" />}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col pb-4">
+        <CaptionText className="flex min-w-0 items-baseline gap-1 truncate text-text-tertiary">
+          <span className="truncate uppercase">{view.label}</span>
+          {view.connectionType && (
+            <>
+              <span className="text-text-tertiary" aria-hidden>
+                ·
+              </span>
+              <span className="truncate text-icon-accent normal-case">{view.connectionType}</span>
+            </>
+          )}
+        </CaptionText>
+        <div className="mt-1 flex min-w-0 items-center gap-2">
+          {view.formattedAddress && (
+            <WalletAccountIcon address={view.formattedAddress} type={view.walletType ?? null} size={22} iconSize={10} />
+          )}
+          <div className="flex min-w-0 flex-1 flex-col">
+            <FootnoteText className="truncate text-text-primary">{view.title}</FootnoteText>
+            <HelpText className="truncate text-text-tertiary">{view.subtitle}</HelpText>
+          </div>
+          {rightSlot}
+        </div>
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/features/signing-path/ui/PathOverviewBody.tsx
+++ b/src/renderer/features/signing-path/ui/PathOverviewBody.tsx
@@ -4,10 +4,11 @@ import { type Asset } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { CaptionText, FootnoteText, HelpText } from '@/shared/ui';
-import { AssetBalance, WalletAccountIcon } from '@/shared/ui-entities';
+import { CaptionText, HelpText } from '@/shared/ui';
+import { AssetBalance } from '@/shared/ui-entities';
 import { type PathNode } from '@/domains/backend';
 
+import { PathHopRow } from './PathHopRow';
 import { type PathNodeView } from './path-views';
 
 type Props = {
@@ -61,50 +62,23 @@ export const PathOverviewBody = ({ path, views, getBalance, asset, feeAsset, err
           const hopAsset = isFeeHop ? feeAsset : asset;
           const balanceValue = getBalance ? getBalance(node.accountId, isFeeHop) : null;
           const hasError = errorAccountIds?.has(node.accountId) ?? false;
+          const balanceNode =
+            balanceValue && hopAsset ? (
+              <AssetBalance
+                value={balanceValue}
+                asset={hopAsset}
+                className={cnTw('text-footnote', hasError ? 'text-text-negative' : 'text-text-secondary')}
+              />
+            ) : null;
 
           return (
-            <div key={`${idx}-${node.kind}-${node.accountId}`} className="flex gap-3">
-              <div className="flex flex-col items-center">
-                <div className="flex h-7 w-7 shrink-0 items-center justify-center rounded-full border border-container-border bg-white">
-                  <CaptionText className="text-text-secondary">{idx + 1}</CaptionText>
-                </div>
-                {!isLast && <div className="h-8 w-px bg-shade-12" />}
-              </div>
-              <div className="flex min-w-0 flex-1 flex-col pb-4">
-                <CaptionText className="flex min-w-0 items-baseline gap-1 truncate text-text-tertiary">
-                  <span className="truncate uppercase">{v.label}</span>
-                  {v.connectionType && (
-                    <>
-                      <span className="text-text-tertiary" aria-hidden>
-                        ·
-                      </span>
-                      <span className="truncate text-icon-accent normal-case">{v.connectionType}</span>
-                    </>
-                  )}
-                </CaptionText>
-                <div className="mt-1 flex min-w-0 items-center gap-2">
-                  {v.formattedAddress && (
-                    <WalletAccountIcon
-                      address={v.formattedAddress}
-                      type={v.walletType ?? null}
-                      size={22}
-                      iconSize={10}
-                    />
-                  )}
-                  <div className="flex min-w-0 flex-1 flex-col">
-                    <FootnoteText className="truncate text-text-primary">{v.title}</FootnoteText>
-                    <HelpText className="truncate text-text-tertiary">{v.subtitle}</HelpText>
-                  </div>
-                  {balanceValue && hopAsset && (
-                    <AssetBalance
-                      value={balanceValue}
-                      asset={hopAsset}
-                      className={cnTw('text-footnote', hasError ? 'text-text-negative' : 'text-text-secondary')}
-                    />
-                  )}
-                </div>
-              </div>
-            </div>
+            <PathHopRow
+              key={`${idx}-${node.kind}-${node.accountId}`}
+              view={v}
+              index={idx}
+              isLast={isLast}
+              rightSlot={balanceNode}
+            />
           );
         })}
       </div>


### PR DESCRIPTION
## Description

Confirmation screens with long signing paths (3+ hops) squeezed wallet names down to a few characters in the horizontal breadcrumb layout. This PR fixes that by adding an `orientation="auto"` mode to `PathBreadcrumb` that switches to a vertical hop list when the path has 3 or more hops.

Additionally, `SubmitDraftModal` was missing the `PathReviewPopover` popover for multi-hop paths — it now shows the full signing path overview when the path has 2+ hops.

## Changes Made

- **`PathHopRow`** — new shared component for a single numbered hop row (step circle + connector line + icon + name/subtitle + optional right slot). Extracted so both the popover (`PathOverviewBody`) and the breadcrumb vertical mode share one layout definition.
- **`PathBreadcrumb`** — added `orientation?: 'horizontal' | 'auto'` prop. When `'auto'` and the path has 3+ hops, renders a vertical `PathHopRow` list instead of the horizontal card strip.
- **`PathOverviewBody`** — refactored to use `PathHopRow` instead of inlined JSX; no visual change.
- **`SubmitDraftModal`** — added `PathReviewPopover` for paths with 2+ hops; switched breadcrumb to `orientation="auto"`.
- **Confirmation screens** (`SigningPathConfirmSection`, `Transfer/Confirmation`, `StepReview`) — switched breadcrumb to `orientation="auto"`.

## Screenshots/Recordings
<!-- Add before/after screenshots of the signing path in confirmation for 3+ hop paths -->


<img width="1583" height="912" alt="Screenshot 2026-05-25 at 12 29 17" src="https://github.com/user-attachments/assets/146718f8-461c-4502-aa6e-fe7c2d300afe" />
<img width="1583" height="912" alt="Screenshot 2026-05-25 at 12 29 26" src="https://github.com/user-attachments/assets/060367c2-41a4-4590-9109-1c802856dbd3" />

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#45