### PR TITLE
fix: show template count in "Other chains" accordion label

### DIFF
--- a/src/renderer/features/operation-templates/ui/TemplatesPanel.tsx
+++ b/src/renderer/features/operation-templates/ui/TemplatesPanel.tsx
@@ -27,7 +27,7 @@ export const TemplatesPanel = ({ api, chainId, callData, specVersion, onApply }:
   const { data: allTemplates } = useAllTemplates();
   const { save } = useTemplateMutations();
 
-  const { current, byOtherChain } = useMemo(() => {
+  const { current, byOtherChain, otherCount } = useMemo(() => {
     const current: OperationTemplate[] = [];
     const byOtherChain = new Map<ChainId, OperationTemplate[]>();
 
@@ -41,7 +41,10 @@ export const TemplatesPanel = ({ api, chainId, callData, specVersion, onApply }:
       }
     }
 
-    return { current, byOtherChain };
+    let otherCount = 0;
+    for (const list of byOtherChain.values()) otherCount += list.length;
+
+    return { current, byOtherChain, otherCount };
   }, [allTemplates, chainId]);
 
   const canSave = isHex(callData) && specVersion !== null;
@@ -91,7 +94,7 @@ export const TemplatesPanel = ({ api, chainId, callData, specVersion, onApply }:
               <Accordion>
                 <Accordion.Trigger>
                   <FootnoteText className="text-text-tertiary">
-                    {t('operationTemplates.otherChains', { num: byOtherChain.size })}
+                    {t('operationTemplates.otherChains', { num: otherCount })}
                   </FootnoteText>
                 </Accordion.Trigger>
                 <Accordion.Content>


### PR DESCRIPTION
## Description

The "Other chains" accordion trigger in the Templates Panel was displaying the number of *chains* instead of the total number of *templates* available in the accordion.

## Related Issues

SPEK-589

## Changes Made

- Compute `otherCount` (sum of all templates across other chains) inside the existing `useMemo`
- Pass `otherCount` to the `operationTemplates.otherChains` translation key instead of `byOtherChain.size`

## Screenshots

Before:
<img width="746" height="577" alt="Снимок экрана 2026-05-25 в 17 56 20" src="https://github.com/user-attachments/assets/d1170d3c-cd5a-46b4-a177-b3ed9983af4a" />

After:
<img width="753" height="572" alt="Снимок экрана 2026-05-25 в 17 54 26" src="https://github.com/user-attachments/assets/a0beb656-2e98-426e-808a-aecc14063e16" />


## Checklist

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes