### PR TITLE
fix: Save as template button hidden under footer on confirmation screens

### DIFF
--- a/src/renderer/features/multi-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/multi-transfer/components/Confirmation.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { getNativeAsset } from '@/shared/lib/utils';
 import { Button, DetailRow, Icon, Separator } from '@/shared/ui';
 import { AssetBalance, TransactionDetails } from '@/shared/ui-entities';
-import { Box, Modal } from '@/shared/ui-kit';
+import { Box, Modal, ScrollArea } from '@/shared/ui-kit';
 import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { walletModel } from '@/entities/wallet';
@@ -37,45 +37,47 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
 
   return (
     <>
-      <div className="mb-2 flex flex-col items-center gap-y-3">
-        <Icon className="text-icon-default" name="multiTransfer" size={60} />
+      <ScrollArea>
+        <div className="mb-2 flex flex-col items-center gap-y-3">
+          <Icon className="text-icon-default" name="multiTransfer" size={60} />
 
-        <div className="flex flex-col items-center gap-y-1">
-          <AssetBalance
-            value={amount}
-            asset={asset}
-            keepPrecision={true}
-            className="text-center font-manrope text-[32px] leading-[36px] font-bold text-text-primary"
-          />
-          <AssetFiatBalance asset={asset} amount={amount} className="text-center text-headline" />
+          <div className="flex flex-col items-center gap-y-1">
+            <AssetBalance
+              value={amount}
+              asset={asset}
+              keepPrecision={true}
+              className="text-center font-manrope text-[32px] leading-[36px] font-bold text-text-primary"
+            />
+            <AssetFiatBalance asset={asset} amount={amount} className="text-center text-headline" />
+          </div>
         </div>
-      </div>
 
-      <Box padding={[4, 5]}>
-        <TransactionDetails chain={chain} wallets={wallets} initiators={[initiator]} signatory={signatory}>
-          <DetailRow label={t('multiTransfer.confirmation.labels.parsedFile', 'Parsed file')}>
-            <MultiTransferPreview chain={chain} asset={asset} transfers={transfers} issues={issues}>
-              <Button className="p-0" size="sm" variant="text">
-                {t('multiTransfer.parsedFile.buttons.openPreview', 'Preview')}
-              </Button>
-            </MultiTransferPreview>
-          </DetailRow>
+        <Box padding={[4, 5]}>
+          <TransactionDetails chain={chain} wallets={wallets} initiators={[initiator]} signatory={signatory}>
+            <DetailRow label={t('multiTransfer.confirmation.labels.parsedFile', 'Parsed file')}>
+              <MultiTransferPreview chain={chain} asset={asset} transfers={transfers} issues={issues}>
+                <Button className="p-0" size="sm" variant="text">
+                  {t('multiTransfer.parsedFile.buttons.openPreview', 'Preview')}
+                </Button>
+              </MultiTransferPreview>
+            </DetailRow>
 
-          <Separator className="border-filter-border" />
+            <Separator className="border-filter-border" />
 
-          <DetailRow label={t('multiTransfer.confirmation.labels.totalAmount', 'Total amount')}>
-            <div className="flex flex-col items-end gap-y-0.5">
-              <AssetBalance value={amount} asset={asset} showSymbol />
-              <AssetFiatBalance asset={asset} amount={amount} />
-            </div>
-          </DetailRow>
-          {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
-          <FeeWithLabel asset={asset} fee={fee} />
-          {api && (
-            <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
-          )}
-        </TransactionDetails>
-      </Box>
+            <DetailRow label={t('multiTransfer.confirmation.labels.totalAmount', 'Total amount')}>
+              <div className="flex flex-col items-end gap-y-0.5">
+                <AssetBalance value={amount} asset={asset} showSymbol />
+                <AssetFiatBalance asset={asset} amount={amount} />
+              </div>
+            </DetailRow>
+            {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
+            <FeeWithLabel asset={asset} fee={fee} />
+            {api && (
+              <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
+            )}
+          </TransactionDetails>
+        </Box>
+      </ScrollArea>
 
       <Modal.Footer align="between">
         {onGoBack && (

--- a/src/renderer/features/vested-transfer/components/Confirmation.tsx
+++ b/src/renderer/features/vested-transfer/components/Confirmation.tsx
@@ -5,7 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { getNativeAsset, nonNullable } from '@/shared/lib/utils';
 import { Button, DetailRow, Icon, Separator } from '@/shared/ui';
 import { AssetBalance, TransactionDetails } from '@/shared/ui-entities';
-import { Box, Modal } from '@/shared/ui-kit';
+import { Box, Modal, ScrollArea } from '@/shared/ui-kit';
 import { networkModel } from '@/entities/network';
 import { SignButton } from '@/entities/operations';
 import { type VestingScheduleRaw } from '@/entities/vesting';
@@ -47,51 +47,53 @@ export const Confirmation = memo(({ onGoBack }: Props) => {
 
   return (
     <>
-      <div className="mb-2 flex flex-col items-center gap-y-3">
-        <Icon className="text-icon-default" name="vestedTransferConfirm" size={60} />
+      <ScrollArea>
+        <div className="mb-2 flex flex-col items-center gap-y-3">
+          <Icon className="text-icon-default" name="vestedTransferConfirm" size={60} />
 
-        <div className="flex flex-col items-center gap-y-1">
-          <AssetBalance
-            value={amount}
-            asset={asset}
-            keepPrecision={true}
-            className="text-center font-manrope text-[32px] leading-[36px] font-bold text-text-primary"
-          />
-          <AssetFiatBalance asset={asset} amount={amount} className="text-center text-headline" />
-        </div>
-      </div>
-
-      <Box padding={[4, 5]}>
-        <TransactionDetails chain={chain} wallets={wallets} initiators={[initiator]} signatory={signatory}>
-          <DetailRow label={t('vestedTransfer.confirmation.labels.parsedFile')}>
-            <VestingSchedulePreview
-              timelineApi={timelineApi}
-              chain={chain}
+          <div className="flex flex-col items-center gap-y-1">
+            <AssetBalance
+              value={amount}
               asset={asset}
-              vestingSchedule={vestingScheduleRaw}
-              issues={issues}
-            >
-              <Button className="p-0" size="sm" variant="text">
-                {t('vestedTransfer.parsedFile.buttons.openPreview')}
-              </Button>
-            </VestingSchedulePreview>
-          </DetailRow>
+              keepPrecision={true}
+              className="text-center font-manrope text-[32px] leading-[36px] font-bold text-text-primary"
+            />
+            <AssetFiatBalance asset={asset} amount={amount} className="text-center text-headline" />
+          </div>
+        </div>
 
-          <Separator className="border-filter-border" />
+        <Box padding={[4, 5]}>
+          <TransactionDetails chain={chain} wallets={wallets} initiators={[initiator]} signatory={signatory}>
+            <DetailRow label={t('vestedTransfer.confirmation.labels.parsedFile')}>
+              <VestingSchedulePreview
+                timelineApi={timelineApi}
+                chain={chain}
+                asset={asset}
+                vestingSchedule={vestingScheduleRaw}
+                issues={issues}
+              >
+                <Button className="p-0" size="sm" variant="text">
+                  {t('vestedTransfer.parsedFile.buttons.openPreview')}
+                </Button>
+              </VestingSchedulePreview>
+            </DetailRow>
 
-          <DetailRow label={t('vestedTransfer.confirmation.labels.totalAmount')}>
-            <div className="flex flex-col items-end gap-y-0.5">
-              <AssetBalance value={amount} asset={asset} showSymbol />
-              <AssetFiatBalance asset={asset} amount={amount} />
-            </div>
-          </DetailRow>
-          {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
-          <FeeWithLabel asset={asset} fee={fee} />
-          {api && (
-            <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
-          )}
-        </TransactionDetails>
-      </Box>
+            <Separator className="border-filter-border" />
+
+            <DetailRow label={t('vestedTransfer.confirmation.labels.totalAmount')}>
+              <div className="flex flex-col items-end gap-y-0.5">
+                <AssetBalance value={amount} asset={asset} showSymbol />
+                <AssetFiatBalance asset={asset} amount={amount} />
+              </div>
+            </DetailRow>
+            {hasMultisigAccount && <MultisigDepositFee asset={asset} multisigDeposit={multisigDeposit} />}
+            <FeeWithLabel asset={asset} fee={fee} />
+            {api && (
+              <CallDataConfirmSection api={api} chain={chain} resultTx={confirm.meta.tx} coreTx={confirm.meta.coreTx} />
+            )}
+          </TransactionDetails>
+        </Box>
+      </ScrollArea>
 
       <Modal.Footer align="between">
         {onGoBack && (


### PR DESCRIPTION
## Description

On the confirmation screen of **multi-transfer** and **vested-transfer** flows, the "Save as template" button row was clipped/hidden beneath the Back/Sign footer buttons and was unreachable.

## Related Issues

[SPEK-590](https://novasama-technologies.atlassian.net/browse/SPEK-590)

## Changes Made

- Wrapped the scrollable content (icon/amounts + TransactionDetails) in a `ScrollArea` in both confirmation components
- `Modal.Footer` (Back/Sign buttons) remains outside the scroll area, staying pinned at the bottom
- Matches the existing pattern used in `MultiTransferForm.tsx`

**Root cause:** `Modal.Content disableScroll` has `overflow-hidden`. Without a `ScrollArea` wrapper, when `CallDataConfirmSection` renders its row (once the API loads), the content height increases and the row gets clipped behind the footer.

## Screenshots

https://github.com/user-attachments/assets/e1590dd2-7b6c-4f0c-ba60-6b3a67784c0b




## Checklist

- [ ] I have performed a self-review of my code
- [ ] I have tested the changes locally
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

[SPEK-590]: https://novasama-technologies.atlassian.net/browse/SPEK-590?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ