### PR TITLE
fix(dashboard): compute staking APY from actual era inflation instead of legacy curve

### DIFF
--- a/src/renderer/domains/staking/index.ts
+++ b/src/renderer/domains/staking/index.ts
@@ -11,7 +11,7 @@ export { stakingService } from './staking/service';
 export { useStaking } from './staking/hooks';
 
 export { nominators, validators } from './validators/store';
-export { getAvgApy, validatorsService } from './validators/service';
+export { validatorsService } from './validators/service';
 export { useNetworkApy, useNominators, useValidators } from './validators/hooks';
 
 export { rewards } from './rewards/store';

--- a/src/renderer/domains/staking/validators/__tests__/networkApy.test.ts
+++ b/src/renderer/domains/staking/validators/__tests__/networkApy.test.ts
@@ -1,0 +1,131 @@
+import { type ApiPromise } from '@polkadot/api';
+
+import { type Chain } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { AssetHubChains } from '../../constants';
+import { type ApyValidator } from '../../types';
+import { getNetworkApy } from '../service';
+
+// Polkadot Asset Hub-like figures (observed onchain): a fixed per-era staker mint
+// of 130 162 DOT over a 24h era, against ~873.9M DOT staked → ~5.44% APR.
+const TO_STAKERS = '1301621489239150';
+const TOTAL_STAKED = '8739307348715573817';
+
+type ApiOverrides = {
+  toStakers?: string | number | null;
+  totalStaked?: string;
+  withInflationApi?: boolean;
+  eraReward?: string | null;
+};
+
+const mockApi = ({
+  toStakers = TO_STAKERS,
+  totalStaked = TOTAL_STAKED,
+  withInflationApi = true,
+  eraReward = null,
+}: ApiOverrides = {}): ApiPromise => {
+  const inflation = withInflationApi
+    ? {
+        experimentalIssuancePredictionInfo: jest.fn().mockResolvedValue({
+          toJSON: () => ({ issuance: '0x0', nextMint: [toStakers, '229697909865732'] }),
+        }),
+      }
+    : undefined;
+
+  return {
+    call: { inflation },
+    consts: { staking: { sessionsPerEra: { toNumber: () => 6 } } },
+    query: {
+      staking: {
+        erasTotalStake: jest.fn().mockResolvedValue({ toString: () => totalStaked }),
+        erasValidatorReward: jest
+          .fn()
+          .mockResolvedValue(
+            eraReward === null ? { isSome: false } : { isSome: true, unwrap: () => ({ toString: () => eraReward }) },
+          ),
+      },
+    },
+  } as unknown as ApiPromise;
+};
+
+// Relay chain: 24h era = 6 sessions × 2400 blocks × 6000ms.
+const relayApi = (epochDuration = 2400, blockTime = 6000): ApiPromise =>
+  ({
+    consts: {
+      babe: { epochDuration: { toNumber: () => epochDuration }, expectedBlockTime: { toNumber: () => blockTime } },
+    },
+  }) as unknown as ApiPromise;
+
+const polkadotAh = { chainId: AssetHubChains.POLKADOT_AH } as Chain;
+
+const validators = (...commissions: number[]): ApyValidator[] =>
+  commissions.map((commission, index) => ({
+    accountId: String(index) as AccountId,
+    totalStake: '0',
+    commission,
+  }));
+
+describe('getNetworkApy', () => {
+  test('annualises the per-era staker mint over the era duration', async () => {
+    const apy = await getNetworkApy({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0, 0, 0),
+    });
+
+    // 1301621489239150 × 365.25 / 8739307348715573817 × 100
+    expect(apy).toEqual('5.44');
+  });
+
+  test('reduces gross APR by the median validator commission', async () => {
+    const apy = await getNetworkApy({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(10, 10, 10),
+    });
+
+    // 5.44 × (1 − 0.10)
+    expect(apy).toEqual('4.90');
+  });
+
+  test('falls back to the last completed era reward when the inflation API is missing', async () => {
+    const apy = await getNetworkApy({
+      api: mockApi({ withInflationApi: false, eraReward: TO_STAKERS }),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(apy).toEqual('5.44');
+  });
+
+  test('falls back to a per-chain era duration when relay Babe consts are unavailable', async () => {
+    const apy = await getNetworkApy({
+      api: mockApi(),
+      timelineApi: { consts: {} } as unknown as ApiPromise,
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    // Polkadot AH fallback is also 24h, so the result matches the dynamic case.
+    expect(apy).toEqual('5.44');
+  });
+
+  test('returns null when no staker reward can be resolved', async () => {
+    const apy = await getNetworkApy({
+      api: mockApi({ withInflationApi: false, eraReward: null }),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(apy).toBeNull();
+  });
+});

--- a/src/renderer/domains/staking/validators/resource.ts
+++ b/src/renderer/domains/staking/validators/resource.ts
@@ -1,12 +1,12 @@
 import { type ApiPromise } from '@polkadot/api';
 import { createStore } from 'effector';
 
-import { type ChainId, type EraIndex } from '@/shared/core';
+import { type Chain, type ChainId, type EraIndex } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { createQueryResource } from '@/shared/query';
 import { type ValidatorMap } from '../types';
 
-import { getAvgApy, validatorsService } from './service';
+import { getNetworkApy, validatorsService } from './service';
 
 export type ValidatorsResourceParams = {
   chainId: ChainId;
@@ -67,6 +67,9 @@ export { cacheKey as nominatorsCacheKey };
 
 export type ApyResourceParams = {
   api: ApiPromise;
+  // Relay-chain api, used to derive the era duration (Asset Hub has no Babe pallet).
+  timelineApi: ApiPromise;
+  chain: Chain;
   chainId: ChainId;
   era: EraIndex;
 };
@@ -77,14 +80,11 @@ export const apyResource = createQueryResource<ApyResourceParams>({
   key: ({ chainId, era }) => [chainId, String(era)],
 })
   .name('networkApy')
-  .request<string | null>(async ({ api, era }) => {
+  .request<string | null>(async ({ api, timelineApi, chain, era }) => {
     const validatorMap = await validatorsService.getValidatorsWithInfo(api, era);
-    const apyValidators = Object.values(validatorMap).filter(
-      v => v.totalStake !== undefined && v.commission !== undefined,
-    );
-    if (apyValidators.length === 0) return null;
-    const result = await getAvgApy(api, apyValidators);
-    return result || null;
+    const validators = Object.values(validatorMap).filter(v => v.commission !== undefined);
+
+    return getNetworkApy({ api, timelineApi, chain, era, validators });
   })
   .cache({
     store: $apyCache,

--- a/src/renderer/domains/staking/validators/service.ts
+++ b/src/renderer/domains/staking/validators/service.ts
@@ -2,10 +2,11 @@ import { type ApiPromise } from '@polkadot/api';
 import { default as BigNumber } from 'bignumber.js';
 import { merge } from 'lodash';
 
-import { type EraIndex, type Validator } from '@/shared/core';
+import { type Chain, type EraIndex, type Validator } from '@/shared/core';
 import { keys, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import {
+  AssetHubChains,
   DECAY_RATE,
   DEFAULT_MAX_NOMINATORS,
   INTEREST_IDEAL,
@@ -264,24 +265,148 @@ export const getValidatorsApy = async (api: ApiPromise, validators: ApyValidator
   return getApyForValidators(totalStaked, avgRewardPercent, validators);
 };
 
+const MILLISECONDS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+const DEFAULT_ERA_DURATION_MS = 24 * 60 * 60 * 1000;
+
 /**
- * Get average APY
- *
- * @param api ApiPromise to make RPC calls
- * @param validators Array of calculated APYs'
- *
- * @returns {Promise}
+ * Era duration fallback (ms), used when the relay-chain Babe consts are not yet
+ * available (e.g. the relay api hasn't connected). Keeps APY visible without
+ * making the dashboard depend on the relay connection.
  */
-export const getAvgApy = async (api: ApiPromise, validators: ApyValidator[]): Promise<string> => {
-  if (validators.length === 0) return '';
+const FALLBACK_ERA_DURATION_MS: Record<string, number> = {
+  [AssetHubChains.POLKADOT_AH]: 24 * 60 * 60 * 1000, // 24h
+  [AssetHubChains.KUSAMA_AH]: 6 * 60 * 60 * 1000, // 6h
+};
 
-  const totalIssuance = await getTotalIssuance(api);
-  const stake = validators.reduce((acc, { totalStake }) => {
-    return acc.plus(new BigNumber(totalStake));
-  }, new BigNumber(0));
+type IssuancePredictionCall = () => Promise<{ toJSON: () => unknown }>;
 
-  const avgRewardPercent = getAvgRewardPercent(stake, totalIssuance);
+function hasKey<K extends string>(value: unknown, key: K): value is Record<K, unknown> {
+  return typeof value === 'object' && value !== null && key in value;
+}
+
+/**
+ * Era duration in milliseconds.
+ *
+ * Asset Hub is a parachain and has no Babe pallet, so the era length is derived
+ * from the relay chain: `sessionsPerEra (Asset Hub) × epochDuration × blockTime
+ * (relay)`. The relay block time (≈6s) must be used here — using the Asset Hub
+ * block time (≈12s) would double the era length and halve the resulting APY.
+ */
+function getEraDurationMs(api: ApiPromise, timelineApi: ApiPromise, chain: Chain): number {
+  try {
+    const { babe } = timelineApi.consts;
+    if (babe?.epochDuration && babe?.expectedBlockTime) {
+      const sessionsPerEra = api.consts.staking.sessionsPerEra.toNumber();
+      const eraDuration = sessionsPerEra * babe.epochDuration.toNumber() * babe.expectedBlockTime.toNumber();
+      if (eraDuration > 0) return eraDuration;
+    }
+  } catch (error) {
+    console.warn('Unable to derive era duration from relay chain', error);
+  }
+
+  return FALLBACK_ERA_DURATION_MS[chain.chainId] ?? DEFAULT_ERA_DURATION_MS;
+}
+
+function parsePlanck(value: unknown): BigNumber | null {
+  if (typeof value === 'number') return new BigNumber(value);
+  if (typeof value === 'string') {
+    const parsed = value.startsWith('0x') ? new BigNumber(value.slice(2), 16) : new BigNumber(value);
+
+    return parsed.isFinite() ? parsed : null;
+  }
+
+  return null;
+}
+
+// Reads `nextMint = [toStakers, toTreasury]` from the inflation prediction result.
+function readStakersMint(json: unknown): BigNumber | null {
+  if (!hasKey(json, 'nextMint')) return null;
+
+  const { nextMint } = json;
+  if (!Array.isArray(nextMint) || nextMint.length === 0) return null;
+
+  return parsePlanck(nextMint[0]);
+}
+
+// Resolves the `inflation.experimentalIssuancePredictionInfo` runtime call if the chain exposes it.
+function getIssuancePredictionCall(api: ApiPromise): IssuancePredictionCall | null {
+  if (!hasKey(api.call, 'inflation')) return null;
+
+  const { inflation } = api.call;
+  if (!hasKey(inflation, 'experimentalIssuancePredictionInfo')) return null;
+
+  const predict = inflation.experimentalIssuancePredictionInfo;
+
+  // The signature cannot be inferred from the dynamically-typed runtime api.
+  return typeof predict === 'function' ? (predict as IssuancePredictionCall) : null;
+}
+
+/**
+ * Per-era reward minted to stakers (validators + nominators), before
+ * commission.
+ *
+ * Uses the `inflation.experimentalIssuancePredictionInfo` runtime API, which
+ * the runtime documents as the recommended source over re-deriving the onchain
+ * logic and which reflects the chain's real inflation model (fixed on Polkadot,
+ * curve-based on Kusama). Falls back to the last completed era's realized
+ * payout when the runtime API is unavailable.
+ */
+async function getStakersEraReward(api: ApiPromise, era: EraIndex): Promise<BigNumber | null> {
+  const predict = getIssuancePredictionCall(api);
+
+  if (predict) {
+    try {
+      const info = await predict();
+      const toStakers = readStakersMint(info.toJSON());
+      if (toStakers && toStakers.isGreaterThan(0)) return toStakers;
+    } catch (error) {
+      console.warn('inflation prediction API failed, falling back to era reward', error);
+    }
+  }
+
+  try {
+    const reward = await api.query.staking.erasValidatorReward(Math.max(era - 1, 0));
+    if (reward.isSome) return new BigNumber(reward.unwrap().toString());
+  } catch (error) {
+    console.warn(error);
+  }
+
+  return null;
+}
+
+type NetworkApyParams = {
+  api: ApiPromise;
+  timelineApi: ApiPromise;
+  chain: Chain;
+  era: EraIndex;
+  validators: ApyValidator[];
+};
+
+/**
+ * Network average staking APY shown on the dashboard.
+ *
+ * Computed from the chain's actual per-era staker reward, annualised over the
+ * era length (`reward × erasPerYear / totalStaked`) and reduced by the median
+ * validator commission. This is correct for both the legacy NPoS inflation
+ * curve (Kusama) and the fixed inflation model (Polkadot, ref. 1139) — unlike
+ * re-deriving the curve, which over-states Polkadot APY by ~2.7×.
+ */
+export const getNetworkApy = async (params: NetworkApyParams): Promise<string | null> => {
+  const { api, timelineApi, chain, era, validators } = params;
+
+  const stakersEraReward = await getStakersEraReward(api, era);
+  if (!stakersEraReward) return null;
+
+  const totalStaked = new BigNumber((await api.query.staking.erasTotalStake(era)).toString());
+  if (totalStaked.isZero()) return null;
+
+  const erasPerYear = MILLISECONDS_PER_YEAR / getEraDurationMs(api, timelineApi, chain);
+
+  const grossApr = stakersEraReward.multipliedBy(erasPerYear).div(totalStaked);
   const median = getMedianCommission(validators);
 
-  return (avgRewardPercent * (1 - median / 100) * 100).toFixed(2);
+  return grossApr
+    .multipliedBy(1 - median / 100)
+    .multipliedBy(100)
+    .toFixed(2);
 };

--- a/src/renderer/features/dashboard-staking/hooks/useStakingOverview.ts
+++ b/src/renderer/features/dashboard-staking/hooks/useStakingOverview.ts
@@ -93,6 +93,10 @@ export const useStakingOverview = (accountIds: string[]): StakingOverviewData =>
   const polkadotApi = useApi(POLKADOT_AH_CHAIN_ID);
   const kusamaApi = useApi(KUSAMA_AH_CHAIN_ID);
 
+  // Relay-chain apis — needed to derive the era duration for APY (Asset Hub has no Babe pallet).
+  const polkadotRelayApi = useApi(chains[POLKADOT_AH_CHAIN_ID]?.parentId ?? POLKADOT_AH_CHAIN_ID);
+  const kusamaRelayApi = useApi(chains[KUSAMA_AH_CHAIN_ID]?.parentId ?? KUSAMA_AH_CHAIN_ID);
+
   const { data: polkadotEra } = useActiveEra({ chainId: POLKADOT_AH_CHAIN_ID, api: polkadotApi });
   const { data: kusamaEra } = useActiveEra({ chainId: KUSAMA_AH_CHAIN_ID, api: kusamaApi });
 
@@ -120,11 +124,15 @@ export const useStakingOverview = (accountIds: string[]): StakingOverviewData =>
 
   const { data: polkadotApy, pending: polkadotApyPending } = useNetworkApy({
     api: polkadotApi,
+    timelineApi: polkadotRelayApi ?? polkadotApi,
+    chain: chains[POLKADOT_AH_CHAIN_ID] ?? null,
     era: polkadotEra,
     chainId: POLKADOT_AH_CHAIN_ID,
   });
   const { data: kusamaApy, pending: kusamaApyPending } = useNetworkApy({
     api: kusamaApi,
+    timelineApi: kusamaRelayApi ?? kusamaApi,
+    chain: chains[KUSAMA_AH_CHAIN_ID] ?? null,
     era: kusamaEra,
     chainId: KUSAMA_AH_CHAIN_ID,
   });


### PR DESCRIPTION
## Description

The dashboard staking **APY** was re-deriving the legacy Polkadot NPoS inflation curve (`I(x)/x`) on the client. Polkadot Asset Hub has since moved to a **fixed inflation model** (Referendum 1139), where the per-era staker mint is constant and independent of the staking ratio. As a result the curve **over-stated Polkadot APY by ~2.7×** (showed ~14.8% vs the chain's real ~5.4%). Kusama still uses the NPoS curve and was already correct.

This PR replaces the curve with a **realized** calculation that is correct for both inflation models:

```
APY = stakerReward × erasPerYear / totalStaked × (1 − medianCommission)
```

### How it was verified

Computed the realized network APR directly from on-chain era rewards (model-independent) on both live Asset Hubs and compared to the formula:

| Chain | On-chain signal | Realized APR (pre-commission) | New formula | Old curve |
|---|---|---|---|---|
| Kusama AH | per-era reward **varies** with stake → curve model | **15.39%** | **15.39%** ✅ | 15.39% ✅ |
| Polkadot AH | per-era reward **pinned constant** → fixed inflation | **5.44%** | **5.44%** ✅ | 14.82% ❌ |

The per-era staker mint from `inflation.experimentalIssuancePredictionInfo.nextMint[0]` matches `erasValidatorReward` exactly, and the treasury share confirms ref-1139 (Polkadot 15%).

## Related Issues
<!-- add Jira/issue link if applicable -->

## Changes Made

- **`domains/staking/validators/service.ts`**: replaced `getAvgApy` (curve) with `getNetworkApy`, which annualizes the actual per-era staker reward.
  - Staker reward from the `inflation.experimentalIssuancePredictionInfo` runtime API (the runtime-recommended source), falling back to the last completed era's `erasValidatorReward`.
  - Era duration derived from the **relay chain's** Babe consts — Asset Hub is a parachain with no Babe pallet — with a per-chain constant fallback (Polkadot 24h / Kusama 6h) so APY stays visible if the relay api isn't connected yet. (Note: deliberately not reusing `stakingService.getEraDurationSeconds`, which uses the Asset Hub block time and yields double the real era length.)
- **`domains/staking/validators/resource.ts`**: `apyResource` now takes `timelineApi` (relay) + `chain`.
- **`features/dashboard-staking/hooks/useStakingOverview.ts`**: resolves each Asset Hub's relay api via `parentId` and passes it through.
- **`domains/staking/index.ts`**: dropped the now-removed `getAvgApy` export.
- Added `networkApy.test.ts` (runtime-API path, commission haircut, both fallbacks, null case).

### Scope / follow-up
Network (dashboard) APY only. Per-validator `getValidatorsApy` used in validator-selection screens still uses the curve and shares the Polkadot inaccuracy — left for a separate change since per-validator realized data is more involved (the era reward is a single network total).

## Screenshots/Recordings
<!-- dashboard staking widget APY before/after -->


<img width="1484" height="912" alt="Screenshot 2026-05-26 at 16 23 52" src="https://github.com/user-attachments/assets/27e95a7b-f944-436b-a419-c3888170305b" />
<img width="1484" height="912" alt="Screenshot 2026-05-26 at 16 23 54" src="https://github.com/user-attachments/assets/766edb0b-7822-4b92-9383-74e9e8dc6b44" />

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#55