### PR TITLE
fix(SPEK-597): fix multisig operations disappearing on scroll when drafts are visible

### DIFF
--- a/src/renderer/features/multisig-operations/components/Operations.tsx
+++ b/src/renderer/features/multisig-operations/components/Operations.tsx
@@ -1,6 +1,6 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
 import { useUnit } from 'effector-react';
-import { useEffect, useMemo, useRef } from 'react';
+import { useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
 import { groupByDate } from '@/shared/lib/utils';
@@ -73,12 +73,25 @@ export const Operations = () => {
   }, [sortedOps, formatDate]);
 
   const scrollRef = useRef<HTMLDivElement>(null);
+  const listContainerRef = useRef<HTMLDivElement>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  // Keep scrollMargin in sync with the container's offset from the scroll root.
+  // DraftsSection above the list has variable height; without this the virtualizer
+  // computes scroll offsets relative to the wrong origin and items disappear on scroll.
+  useLayoutEffect(() => {
+    const el = listContainerRef.current;
+    if (!el) return;
+    const newMargin = el.offsetTop;
+    setScrollMargin(prev => (prev === newMargin ? prev : newMargin));
+  });
 
   const virtualizer = useVirtualizer({
     count: flatItems.length,
     getScrollElement: () => scrollRef.current,
     estimateSize: index => (flatItems[index]?.type === 'header' ? 44 : 74),
     overscan: 15,
+    scrollMargin,
     getItemKey: index => {
       const item = flatItems[index];
       if (!item) return `unknown-${index}`;
@@ -130,6 +143,7 @@ export const Operations = () => {
 
           {deferredOps.length > 0 && (
             <div
+              ref={listContainerRef}
               style={{
                 height: `${virtualizer.getTotalSize()}px`,
                 width: '100%',
@@ -150,7 +164,7 @@ export const Operations = () => {
                       top: 0,
                       left: 0,
                       width: '100%',
-                      transform: `translateY(${virtualRow.start}px)`,
+                      transform: `translateY(${virtualRow.start - scrollMargin}px)`,
                     }}
                   >
                     {isHeaderItem(item) ? (


### PR DESCRIPTION
## Description

When the Drafts section is visible on the Pending tab, multisig operations disappear while scrolling down and reappear when scrolling back up.

The operations list uses `@tanstack/react-virtual`. The virtualizer measures scroll position from the top of the `ScrollArea` viewport but positions items with `translateY(virtualRow.start)` relative to its own container — which starts *below* the DraftsSection. When scrolling through the DraftsSection, `scrollTop` includes the drafts height, causing the virtualizer to translate operations far below the visible area.

Fix: pass `scrollMargin` (= `listContainer.offsetTop`) to the virtualizer so it accounts for the offset when computing visible items. The `translateY` is adjusted by the same amount. A `useLayoutEffect` keeps the margin accurate when DraftsSection expands or collapses.

## Related Issues

Closes https://novasama-technologies.atlassian.net/browse/SPEK-597

## Changes Made

- `src/renderer/features/multisig-operations/components/Operations.tsx` — add `scrollMargin` state, `listContainerRef`, `useLayoutEffect` to track container offset; pass `scrollMargin` to virtualizer; subtract it from `translateY`

## Screenshots/Recordings
Before:

https://github.com/user-attachments/assets/89185985-1915-4222-83c6-2519fd0b474e

After:

https://github.com/user-attachments/assets/93bc375a-1a5f-4fd6-b337-4d76d1f97453

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines