### PR TITLE
fix: wrap operation queue widget under separate feature flag

### DIFF
--- a/src/renderer/features/dashboard-operations-queue/index.ts
+++ b/src/renderer/features/dashboard-operations-queue/index.ts
@@ -9,7 +9,7 @@ import { OperationsQueueWidget } from './ui/OperationsQueueWidget';
 export const dashboardOperationsQueueFeature = createFeature({
   name: 'dashboard/operationsQueue',
   input: createStore({}),
-  enable: $features.map(({ dashboard }) => dashboard),
+  enable: $features.map(({ operationsQueueWidget }) => operationsQueueWidget),
 });
 
 dashboardOperationsQueueFeature.inject(dashboardWidgetsSlot, {

--- a/src/renderer/shared/config/features/index.ts
+++ b/src/renderer/shared/config/features/index.ts
@@ -19,6 +19,7 @@ export const $defaultFeatures = createStore({
   codex: false,
   importDB: isDev(),
   operations: true,
+  operationsQueueWidget: false,
   basket: true,
   contacts: true,
   addressBookStatus: true,


### PR DESCRIPTION
## Summary

The dashboard **operation queue** widget was gated by the shared `dashboard` feature flag, so it couldn't be toggled independently. This adds a dedicated `operationsQueueWidget` flag so the widget can be enabled/disabled on its own — same mechanism as `importDB` / `codex`.

## Changes

- `shared/config/features` — added `operationsQueueWidget: false` to `$defaultFeatures` (hidden by default, opt-in).
- `features/dashboard-operations-queue` — `enable` now maps to `operationsQueueWidget` instead of `dashboard`.

## How to toggle (dev builds)

```js
window.__spektr_config.enableFeature('operationsQueueWidget')
window.__spektr_config.disableFeature('operationsQueueWidget')
```

State persists via localStorage (`spektr_features_v1`), consistent with the other flags.

## Note

⚠️ Default is `false`, so the widget is now hidden until the flag is enabled. If it should remain visible for everyone by default, the default can be switched to `true` / `isDev()`.