### PR TITLE
fix(transfer): show resolved recipient name in transfer form

### DIFF
--- a/src/renderer/features/transfer/ui/TransferForm.tsx
+++ b/src/renderer/features/transfer/ui/TransferForm.tsx
@@ -23,7 +23,7 @@ import {
   withdrawableAmount,
 } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { Alert, Button, CaptionText, FootnoteText, Icon, InputHint, Switch } from '@/shared/ui';
+import { Alert, Button, CaptionText, FootnoteText, Icon, IconButton, InputHint, Switch } from '@/shared/ui';
 import { AccountSelect, Address, Identicon, TransactionValidationError, WalletIcon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Select, Tooltip } from '@/shared/ui-kit';
 import { accountService, useAccountName, useAccountsNames } from '@/domains/network';
@@ -36,6 +36,7 @@ import { AmountInput } from '@/features/assets-balances';
 import { DraftFormBody, DraftModeCard, DraftSigningPath } from '@/features/drafts';
 import { SigningPathSection, graphModel } from '@/features/signing-path';
 import { walletSelectFeature } from '@/features/wallet-select';
+import { NamedAccount } from '@/widgets/NameResolver';
 import { FeeWithLabel, MultisigDepositWithLabel } from '@/widgets/transaction-fee';
 import { TRANSFER_ALLOWED_PROXY_TYPES, formModel } from '../model/form-model';
 import { xcmSpellTransferModel } from '../model/xcm-spell-transfer-model';
@@ -428,6 +429,32 @@ const Destination = memo(() => {
 
   const resolvedAccounts = useAccountsNames(accountsList, chain);
 
+  // A committed, valid recipient address — drives the "selected" display below.
+  const recipientAccountId = useMemo(() => {
+    const trimmed = destination.value.trim();
+    if (!chain || !validateAddress(trimmed, chain)) return null;
+
+    return toAccountId(trimmed);
+  }, [destination.value, chain]);
+
+  // Local wallet that owns the recipient address — enables wallet-name resolution.
+  const recipientWallet = useMemo(() => {
+    if (nullable(recipientAccountId)) return null;
+
+    return wallets.find((wallet) => wallet.accounts.some((a) => a.accountId === recipientAccountId)) ?? null;
+  }, [wallets, recipientAccountId]);
+
+  // Show the named (Account-style) display only when a real name source exists
+  // (local wallet or contact). Otherwise NamedAccount falls back to a short address
+  // as the title and renders the address twice — for unknown recipients we want
+  // just the address.
+  const recipientHasName = useMemo(() => {
+    if (nullable(recipientAccountId)) return false;
+    if (nonNullable(recipientWallet)) return true;
+
+    return contacts.some((contact) => contact.accountId === recipientAccountId);
+  }, [recipientAccountId, recipientWallet, contacts]);
+
   const walletsOptions = useMemo<ComboboxGroup[]>(() => {
     if (nullable(chain)) return [];
 
@@ -531,6 +558,12 @@ const Destination = memo(() => {
     setQuery('');
   };
 
+  const handleClearRecipient = () => {
+    destination.onChange('');
+    destination.markAsTouched();
+    setQuery('');
+  };
+
   const prefixElement = (
     <Identicon
       invalid={destination.touched && destination.hasError}
@@ -542,35 +575,63 @@ const Destination = memo(() => {
 
   return (
     <Field text={t('transfer.recipientLabel')}>
-      <Box direction="row" gap={2} horizontalAlign="center" verticalAlign="center">
-        <Combobox
-          data-testid={TEST_IDS.OPERATIONS.RECIPIENT_INPUT}
-          placeholder={t('transfer.recipientPlaceholder')}
-          invalid={destination.touched && destination.hasError}
-          disabled={isDestinationReadonly}
-          value={destination.value.trim()}
-          prefixElement={prefixElement}
-          height="md"
-          onChange={destination.onChange}
-          onBlur={destination.markAsTouched}
-          onInput={setQuery}
-        >
-          {allOptions.map((group) => (
-            <Combobox.Group key={group.id} title={group.label}>
-              {group.items.map((option) => (
-                <Combobox.Item key={`${option.id}-${option.value.walletId ?? 'unknown'}`} value={option.value.address}>
-                  {option.label}
-                </Combobox.Item>
-              ))}
-            </Combobox.Group>
-          ))}
-        </Combobox>
-        {isMyselfXcmEnabled && !isDestinationReadonly && (
-          <Button pallet="secondary" testId={TEST_IDS.OPERATIONS.MYSELF_BUTTON} onClick={handleChange}>
-            {t('transfer.myselfButton')}
-          </Button>
-        )}
-      </Box>
+      {recipientAccountId ? (
+        <div className="flex min-h-[42px] w-full items-center gap-x-2 rounded-sm border border-filter-border bg-input-background px-[11px] py-1.5">
+          <div className="min-w-0 flex-1">
+            {recipientHasName ? (
+              <NamedAccount
+                accountId={recipientAccountId}
+                chain={chain}
+                wallet={recipientWallet}
+                variant="truncate"
+                iconSize={20}
+                hideExplorers
+              />
+            ) : (
+              <Address
+                showIcon
+                iconSize={20}
+                variant="truncate"
+                address={toAddress(recipientAccountId, { prefix: chain?.addressPrefix })}
+              />
+            )}
+          </div>
+          {!isDestinationReadonly && <IconButton name="close" size={16} onClick={handleClearRecipient} />}
+        </div>
+      ) : (
+        <Box direction="row" gap={2} horizontalAlign="center" verticalAlign="center">
+          <Combobox
+            data-testid={TEST_IDS.OPERATIONS.RECIPIENT_INPUT}
+            placeholder={t('transfer.recipientPlaceholder')}
+            invalid={destination.touched && destination.hasError}
+            disabled={isDestinationReadonly}
+            value={destination.value.trim()}
+            prefixElement={prefixElement}
+            height="md"
+            onChange={destination.onChange}
+            onBlur={destination.markAsTouched}
+            onInput={setQuery}
+          >
+            {allOptions.map((group) => (
+              <Combobox.Group key={group.id} title={group.label}>
+                {group.items.map((option) => (
+                  <Combobox.Item
+                    key={`${option.id}-${option.value.walletId ?? 'unknown'}`}
+                    value={option.value.address}
+                  >
+                    {option.label}
+                  </Combobox.Item>
+                ))}
+              </Combobox.Group>
+            ))}
+          </Combobox>
+          {isMyselfXcmEnabled && !isDestinationReadonly && (
+            <Button pallet="secondary" testId={TEST_IDS.OPERATIONS.MYSELF_BUTTON} onClick={handleChange}>
+              {t('transfer.myselfButton')}
+            </Button>
+          )}
+        </Box>
+      )}
 
       <InputHint active={destination.touched && destination.hasError} variant="error">
         {t(destination.errorMessage, destination.errorValues)}


### PR DESCRIPTION
## Problem

In the transfer flow, once a recipient was selected the **Recipient** field showed only the raw address — even when the address belonged to a contact in *My Contacts* or to a local wallet account. The name was visible in the search dropdown but never carried over to the selected state, because the field is a single-line text `Combobox`.

## Change

`features/transfer/ui/TransferForm.tsx` — the `Destination` field now has two modes:

- **Selected** (a valid recipient is committed): a taller, input-styled box that renders the resolved **name + address** via `<NamedAccount>` (standard resolution: custom name → contact → identity → wallet name). Pass `wallet` so local-wallet names resolve. A ✕ button clears the field back to the input (hidden when the field is read-only).
- **No name source** (address is neither a contact nor a local wallet): show the **address only** — avoids `useAccountName`'s short-address fallback rendering the address twice.
- **Editing / empty**: the original `Combobox` + "Myself" button, unchanged.

No changes to the shared name resolver.

## Before / After

- Before: selected recipient → `Cidy1Bs9k…JaVEdRy36` only.
- After: selected contact → `nominator` + address; local wallet → wallet name + address; unknown address → address only.

## Verification

- `pnpm types:go` — clean
- eslint — clean (pre-existing `import-x/max-dependencies` warning only)
- Manually verified in-app: selecting a named contact shows name + address in the recipient field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)