### PR TITLE
fix(transfer): show resolved recipient name in transfer form

### DIFF
--- a/src/renderer/features/transfer/ui/TransferForm.tsx
+++ b/src/renderer/features/transfer/ui/TransferForm.tsx
@@ -19,6 +19,7 @@ import {
   performSearch,
   toAccountId,
   toAddress,
+  toShortAddress,
   validateAddress,
   withdrawableAmount,
 } from '@/shared/lib/utils';
@@ -26,7 +27,7 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { Alert, Button, CaptionText, FootnoteText, Icon, IconButton, InputHint, Switch } from '@/shared/ui';
 import { AccountSelect, Address, Identicon, TransactionValidationError, WalletIcon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Select, Tooltip } from '@/shared/ui-kit';
-import { accountService, useAccountName, useAccountsNames } from '@/domains/network';
+import { accountService, useAccountName, useAccountsNames, useWalletName } from '@/domains/network';
 import { balanceModel } from '@/entities/balance';
 import { ChainTitle } from '@/entities/chain';
 import { contactModel } from '@/entities/contact';
@@ -410,6 +411,13 @@ const Destination = memo(() => {
   const isDestinationReadonly = useUnit(formModel.$isDestinationReadonly);
 
   const [query, setQuery] = useState('');
+  // Keep the editable Combobox mounted while the field is focused; only swap to
+  // the read-only name card once the recipient is committed (blur/selection).
+  // Swapping on raw value validity yanks focus mid-typing/paste and blocks edits.
+  const [isRecipientFocused, setRecipientFocused] = useState(false);
+  // Pulls focus into the Combobox the next time it mounts (after clear or when
+  // re-entering edit from the card), so the user doesn't have to click again.
+  const [autoFocusRecipient, setAutoFocusRecipient] = useState(false);
 
   const isMyselfXcmEnabled = useUnit(formModel.$isMyselfXcmEnabled);
 
@@ -442,11 +450,23 @@ const Destination = memo(() => {
     return wallets.find((wallet) => wallet.accounts.some((a) => a.accountId === recipientAccountId)) ?? null;
   }, [wallets, recipientAccountId]);
 
-  // Show the named display only for a contact or local wallet; otherwise NamedAccount's
-  // short-address fallback would render the address twice instead of just once.
+  // Run the standard resolution chain (custom name → contact → on-chain identity
+  // → wallet name). `resolveAccountName` falls back to a short address when none
+  // match, so we render the rich NamedAccount only when resolution produced a
+  // real name — otherwise NamedAccount would print the address twice.
+  const recipientWalletName = useWalletName(recipientWallet);
+  const recipientName = useAccountName({
+    accountId: recipientAccountId,
+    chain,
+    title: recipientWalletName ?? undefined,
+  });
   const recipientHasName = useMemo(() => {
-    return nonNullable(recipientWallet) || contacts.some((contact) => contact.accountId === recipientAccountId);
-  }, [recipientAccountId, recipientWallet, contacts]);
+    if (nullable(recipientAccountId) || !recipientName) return false;
+
+    const shortAddress = toShortAddress(toAddress(recipientAccountId, { prefix: chain?.addressPrefix }), 5);
+
+    return recipientName !== shortAddress;
+  }, [recipientAccountId, recipientName, chain]);
 
   const walletsOptions = useMemo<ComboboxGroup[]>(() => {
     if (nullable(chain)) return [];
@@ -555,6 +575,18 @@ const Destination = memo(() => {
     destination.onChange('');
     destination.markAsTouched();
     setQuery('');
+    // The card unmounts and the Combobox remounts; ask it to grab focus so the
+    // user can immediately retype instead of clicking the field again.
+    setAutoFocusRecipient(true);
+  };
+
+  // Return to the editable Combobox with the value intact so a committed
+  // recipient can be edited in place instead of cleared and retyped.
+  const handleEditRecipient = () => {
+    if (isDestinationReadonly) return;
+
+    setRecipientFocused(true);
+    setAutoFocusRecipient(true);
   };
 
   const prefixElement = (
@@ -569,9 +601,17 @@ const Destination = memo(() => {
   return (
     <Field text={t('transfer.recipientLabel')}>
       <Box direction="row" gap={2} horizontalAlign="center" verticalAlign="center">
-        {recipientAccountId ? (
-          <div className="flex min-h-[42px] w-full items-center gap-x-2 rounded-sm border border-filter-border bg-input-background px-[11px] py-1.5">
-            <div className="min-w-0 flex-1">
+        {recipientAccountId && !isRecipientFocused ? (
+          <div
+            data-testid={TEST_IDS.OPERATIONS.RECIPIENT_CARD}
+            className="flex h-[42px] w-full items-center gap-x-2 rounded-sm border border-filter-border bg-input-background px-[11px]"
+          >
+            <button
+              type="button"
+              className="min-w-0 flex-1 cursor-text text-left"
+              disabled={isDestinationReadonly}
+              onClick={handleEditRecipient}
+            >
               {recipientHasName ? (
                 <NamedAccount
                   accountId={recipientAccountId}
@@ -589,8 +629,15 @@ const Destination = memo(() => {
                   address={toAddress(recipientAccountId, { prefix: chain?.addressPrefix })}
                 />
               )}
-            </div>
-            {!isDestinationReadonly && <IconButton name="close" size={16} onClick={handleClearRecipient} />}
+            </button>
+            {!isDestinationReadonly && (
+              <IconButton
+                name="close"
+                size={16}
+                testId={TEST_IDS.OPERATIONS.RECIPIENT_CLEAR}
+                onClick={handleClearRecipient}
+              />
+            )}
           </div>
         ) : (
           <Combobox
@@ -601,8 +648,16 @@ const Destination = memo(() => {
             value={destination.value.trim()}
             prefixElement={prefixElement}
             height="md"
+            autoFocus={autoFocusRecipient}
             onChange={destination.onChange}
-            onBlur={destination.markAsTouched}
+            onFocus={() => {
+              setRecipientFocused(true);
+              setAutoFocusRecipient(false);
+            }}
+            onBlur={() => {
+              setRecipientFocused(false);
+              destination.markAsTouched();
+            }}
             onInput={setQuery}
           >
             {allOptions.map((group) => (

--- a/src/renderer/features/transfer/ui/TransferForm.tsx
+++ b/src/renderer/features/transfer/ui/TransferForm.tsx
@@ -23,7 +23,7 @@ import {
   withdrawableAmount,
 } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { Alert, Button, CaptionText, FootnoteText, Icon, InputHint, Switch } from '@/shared/ui';
+import { Alert, Button, CaptionText, FootnoteText, Icon, IconButton, InputHint, Switch } from '@/shared/ui';
 import { AccountSelect, Address, Identicon, TransactionValidationError, WalletIcon } from '@/shared/ui-entities';
 import { Box, Combobox, Field, Select, Tooltip } from '@/shared/ui-kit';
 import { accountService, useAccountName, useAccountsNames } from '@/domains/network';
@@ -36,6 +36,7 @@ import { AmountInput } from '@/features/assets-balances';
 import { DraftFormBody, DraftModeCard, DraftSigningPath } from '@/features/drafts';
 import { SigningPathSection, graphModel } from '@/features/signing-path';
 import { walletSelectFeature } from '@/features/wallet-select';
+import { NamedAccount } from '@/widgets/NameResolver';
 import { FeeWithLabel, MultisigDepositWithLabel } from '@/widgets/transaction-fee';
 import { TRANSFER_ALLOWED_PROXY_TYPES, formModel } from '../model/form-model';
 import { xcmSpellTransferModel } from '../model/xcm-spell-transfer-model';
@@ -428,6 +429,25 @@ const Destination = memo(() => {
 
   const resolvedAccounts = useAccountsNames(accountsList, chain);
 
+  const recipientAccountId = useMemo(() => {
+    const trimmed = destination.value.trim();
+    if (!chain || !validateAddress(trimmed, chain)) return null;
+
+    return toAccountId(trimmed);
+  }, [destination.value, chain]);
+
+  const recipientWallet = useMemo(() => {
+    if (nullable(recipientAccountId)) return null;
+
+    return wallets.find((wallet) => wallet.accounts.some((a) => a.accountId === recipientAccountId)) ?? null;
+  }, [wallets, recipientAccountId]);
+
+  // Show the named display only for a contact or local wallet; otherwise NamedAccount's
+  // short-address fallback would render the address twice instead of just once.
+  const recipientHasName = useMemo(() => {
+    return nonNullable(recipientWallet) || contacts.some((contact) => contact.accountId === recipientAccountId);
+  }, [recipientAccountId, recipientWallet, contacts]);
+
   const walletsOptions = useMemo<ComboboxGroup[]>(() => {
     if (nullable(chain)) return [];
 
@@ -531,6 +551,12 @@ const Destination = memo(() => {
     setQuery('');
   };
 
+  const handleClearRecipient = () => {
+    destination.onChange('');
+    destination.markAsTouched();
+    setQuery('');
+  };
+
   const prefixElement = (
     <Identicon
       invalid={destination.touched && destination.hasError}
@@ -543,28 +569,56 @@ const Destination = memo(() => {
   return (
     <Field text={t('transfer.recipientLabel')}>
       <Box direction="row" gap={2} horizontalAlign="center" verticalAlign="center">
-        <Combobox
-          data-testid={TEST_IDS.OPERATIONS.RECIPIENT_INPUT}
-          placeholder={t('transfer.recipientPlaceholder')}
-          invalid={destination.touched && destination.hasError}
-          disabled={isDestinationReadonly}
-          value={destination.value.trim()}
-          prefixElement={prefixElement}
-          height="md"
-          onChange={destination.onChange}
-          onBlur={destination.markAsTouched}
-          onInput={setQuery}
-        >
-          {allOptions.map((group) => (
-            <Combobox.Group key={group.id} title={group.label}>
-              {group.items.map((option) => (
-                <Combobox.Item key={`${option.id}-${option.value.walletId ?? 'unknown'}`} value={option.value.address}>
-                  {option.label}
-                </Combobox.Item>
-              ))}
-            </Combobox.Group>
-          ))}
-        </Combobox>
+        {recipientAccountId ? (
+          <div className="flex min-h-[42px] w-full items-center gap-x-2 rounded-sm border border-filter-border bg-input-background px-[11px] py-1.5">
+            <div className="min-w-0 flex-1">
+              {recipientHasName ? (
+                <NamedAccount
+                  accountId={recipientAccountId}
+                  chain={chain}
+                  wallet={recipientWallet}
+                  variant="truncate"
+                  iconSize={20}
+                  hideExplorers
+                />
+              ) : (
+                <Address
+                  showIcon
+                  iconSize={20}
+                  variant="truncate"
+                  address={toAddress(recipientAccountId, { prefix: chain?.addressPrefix })}
+                />
+              )}
+            </div>
+            {!isDestinationReadonly && <IconButton name="close" size={16} onClick={handleClearRecipient} />}
+          </div>
+        ) : (
+          <Combobox
+            data-testid={TEST_IDS.OPERATIONS.RECIPIENT_INPUT}
+            placeholder={t('transfer.recipientPlaceholder')}
+            invalid={destination.touched && destination.hasError}
+            disabled={isDestinationReadonly}
+            value={destination.value.trim()}
+            prefixElement={prefixElement}
+            height="md"
+            onChange={destination.onChange}
+            onBlur={destination.markAsTouched}
+            onInput={setQuery}
+          >
+            {allOptions.map((group) => (
+              <Combobox.Group key={group.id} title={group.label}>
+                {group.items.map((option) => (
+                  <Combobox.Item
+                    key={`${option.id}-${option.value.walletId ?? 'unknown'}`}
+                    value={option.value.address}
+                  >
+                    {option.label}
+                  </Combobox.Item>
+                ))}
+              </Combobox.Group>
+            ))}
+          </Combobox>
+        )}
         {isMyselfXcmEnabled && !isDestinationReadonly && (
           <Button pallet="secondary" testId={TEST_IDS.OPERATIONS.MYSELF_BUTTON} onClick={handleChange}>
             {t('transfer.myselfButton')}

--- a/src/renderer/shared/constants/testIds.ts
+++ b/src/renderer/shared/constants/testIds.ts
@@ -43,6 +43,8 @@ export const TEST_IDS = {
     AVAILABLE_BALANCE: 'available-balance',
     AVAILABLE_BALANCE_LOADER: 'available-balance-loader',
     RECIPIENT_INPUT: 'operations-recipient-input',
+    RECIPIENT_CARD: 'operations-recipient-card',
+    RECIPIENT_CLEAR: 'operations-recipient-clear',
     QR_CODE_CONTAINER: 'operations-qr-code-container',
     SIGNATORY_SELECTOR: 'operations-signatory-selector',
     SIGNATORY_SELECTOR_OPTION: 'Address',

--- a/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
+++ b/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
@@ -38,7 +38,7 @@ const Context = createContext<ContextProps & ExpandedContextProps>({});
 
 type InputProps = Pick<
   ComponentProps<typeof Input>,
-  'disabled' | 'invalid' | 'placeholder' | 'height' | 'prefixElement' | 'onChange' | 'onBlur'
+  'disabled' | 'invalid' | 'placeholder' | 'height' | 'prefixElement' | 'onChange' | 'onBlur' | 'onFocus' | 'autoFocus'
 >;
 
 type ControlledPopoverProps = {
@@ -81,7 +81,7 @@ const Root = ({ testId = 'Combobox', value, onChange, onInput, children, ...inpu
   );
 };
 
-const Trigger = ({ placeholder, onBlur, ...inputProps }: InputProps) => {
+const Trigger = ({ placeholder, onBlur, onFocus, ...inputProps }: InputProps) => {
   const { onOpenChange, comboboxRef, anchorRef } = useContext(Context);
 
   return (
@@ -92,7 +92,10 @@ const Trigger = ({ placeholder, onBlur, ...inputProps }: InputProps) => {
           ref={comboboxRef}
           placeholder={placeholder}
           render={({ onChange, ...props }) => <Input {...props} {...inputProps} onChangeEvent={onChange} />}
-          onFocus={() => onOpenChange?.(true)}
+          onFocus={event => {
+            onOpenChange?.(true);
+            onFocus?.(event);
+          }}
           onBlur={event => {
             onOpenChange?.(false);
             onBlur?.(event);

--- a/tests/system/pages/_elements/TransferModalElements.ts
+++ b/tests/system/pages/_elements/TransferModalElements.ts
@@ -8,6 +8,8 @@ export class TransferModalElements {
   static tokenAmountLocator = 'AssetBalance';
   static amountInputLocator = TEST_IDS.OPERATIONS.AMOUNT_INPUT;
   static recipientInputLocator = TEST_IDS.OPERATIONS.RECIPIENT_INPUT;
+  static recipientCardLocator = TEST_IDS.OPERATIONS.RECIPIENT_CARD;
+  static recipientClearLocator = TEST_IDS.OPERATIONS.RECIPIENT_CLEAR;
   static myselfButton = TEST_IDS.OPERATIONS.MYSELF_BUTTON;
   static signatoryLocator = TEST_IDS.OPERATIONS.SIGNATORY_SELECTOR;
   static signatoryOptionLocator = TEST_IDS.OPERATIONS.SIGNATORY_SELECTOR_OPTION;

--- a/tests/system/pages/modals/TransferModalWindow.ts
+++ b/tests/system/pages/modals/TransferModalWindow.ts
@@ -135,6 +135,14 @@ export class TransferModalWindow extends BaseModal<TransferModalElements> {
     });
   }
 
+  public async clearRecipient(): Promise<void> {
+    await step('Clear the committed recipient back to the address input', async () => {
+      // Blurring the input commits the value and reveals the read-only card with its clear button.
+      await this.page.getByTestId(TransferModalElements.recipientInputLocator).blur();
+      await this.page.getByTestId(TransferModalElements.recipientClearLocator).click();
+    });
+  }
+
   public async clickMyselfButton(): Promise<void> {
     await step(`Click 'Myself' button to fill in address`, async () => {
       await this.page.getByTestId(TransferModalElements.myselfButton).click();


### PR DESCRIPTION
## Problem

In the transfer flow, once a recipient was selected the **Recipient** field showed only the raw address — even when the address belonged to a contact in *My Contacts* or to a local wallet account. The name was visible in the search dropdown but never carried over to the selected state, because the field is a single-line text `Combobox`.

## Change

`features/transfer/ui/TransferForm.tsx` — the `Destination` field now has two modes:

- **Selected** (a valid recipient is committed): a taller, input-styled box that renders the resolved **name + address** via `<NamedAccount>` (standard resolution: custom name → contact → identity → wallet name). Pass `wallet` so local-wallet names resolve. A ✕ button clears the field back to the input (hidden when the field is read-only).
- **No name source** (address is neither a contact nor a local wallet): show the **address only** — avoids `useAccountName`'s short-address fallback rendering the address twice.
- **Editing / empty**: the original `Combobox` + "Myself" button, unchanged.

No changes to the shared name resolver.

## Before / After

- Before: selected recipient → `Cidy1Bs9k…JaVEdRy36` only.
- After: selected contact → `nominator` + address; local wallet → wallet name + address; unknown address → address only.


https://github.com/user-attachments/assets/2bb89440-326f-4a51-8129-b87f83dddad1


Fixes novasamatech/nova-spektr-tracker#61