### PR TITLE
chore: update pnpm to v11

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -26,7 +26,7 @@
       "onAutoForward": "notify"
     }
   },
-  "postCreateCommand": "npm install -g pnpm@latest && pnpm install",
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@11.4.0 --activate && pnpm install",
   "customizations": {
     "vscode": {
       "settings": {

--- a/.github/workflows/install-pnpm/action.yaml
+++ b/.github/workflows/install-pnpm/action.yaml
@@ -5,7 +5,7 @@ runs:
       uses: pnpm/action-setup@v4
       id: pnpm-install
       with:
-        version: 10
+        version: 11.4.0
         run_install: false
 
     - name: 🤞 Use Node.js

--- a/.npmrc
+++ b/.npmrc
@@ -1,3 +1,0 @@
-save-exact=true
-# 3 days, in minutes (pnpm unit)
-minimum-release-age=4320

--- a/README.md
+++ b/README.md
@@ -47,9 +47,9 @@
 
 ## Requirements
 
-Minimum version of `Node.js` is `v20.x`.
+Minimum version of `Node.js` is `v24.x`.
 
-Minimum version of `pnpm` is `v9.x`.
+Minimum version of `pnpm` is `v11.x`.
 
 ## Commands
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -3,10 +3,10 @@ ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 
 RUN corepack enable && \
-    corepack prepare pnpm@9
+    corepack prepare pnpm@11.4.0 --activate
 
 WORKDIR /app
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY .papi ./.papi/
 
 RUN pnpm install --frozen-lockfile

--- a/docker/Dockerfile.release
+++ b/docker/Dockerfile.release
@@ -11,7 +11,7 @@ ADD . /project
 WORKDIR /project
 
 RUN corepack enable && \
-    corepack prepare pnpm@10 --activate
+    corepack prepare pnpm@11.4.0 --activate
 
 RUN pnpm install --frozen-lockfile
 

--- a/docker/Dockerfile.tests
+++ b/docker/Dockerfile.tests
@@ -1,13 +1,13 @@
-FROM mcr.microsoft.com/playwright:v1.38.0-jammy
+FROM mcr.microsoft.com/playwright:v1.58.0-noble
 
 ENV PNPM_HOME="/pnpm"
 ENV PATH="$PNPM_HOME:$PATH"
 RUN corepack enable && \
-    corepack prepare pnpm@9
+    corepack prepare pnpm@11.4.0 --activate
 
 WORKDIR /tests
 
-COPY package.json pnpm-lock.yaml ./
+COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY .papi ./.papi/
 
 RUN pnpm install --frozen-lockfile

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "description": "Polkadot Enterprise application",
   "type": "module",
   "version": "2.10.0",
+  "packageManager": "pnpm@11.4.0",
   "main": "./release/build/main.cjs",
   "repository": "https://github.com/novasamatech/nova-spektr",
   "license": "MIT",
@@ -81,7 +82,7 @@
   },
   "engines": {
     "node": ">=24.x",
-    "pnpm": ">=9.x"
+    "pnpm": ">=11 <12"
   },
   "dependencies": {
     "@apollo/client": "3.13.9",
@@ -281,22 +282,5 @@
   "sideEffects": [
     "*.css",
     "*.ts"
-  ],
-  "pnpm": {
-    "peerDependencyRules": {
-      "allowedVersions": {
-        "vite": "8"
-      }
-    },
-    "onlyBuiltDependencies": [
-      "@swc/core",
-      "@tailwindcss/oxide",
-      "electron",
-      "electron-winstaller",
-      "esbuild",
-      "oxc-resolver",
-      "sharp",
-      "unrs-resolver"
-    ]
-  }
+  ]
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -293,7 +293,7 @@ importers:
     devDependencies:
       '@astrojs/starlight':
         specifier: 0.35.2
-        version: 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+        version: 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       '@commitlint/cli':
         specifier: 19.8.1
         version: 19.8.1(@types/node@22.17.0)(typescript@5.9.2)
@@ -323,22 +323,22 @@ importers:
         version: 2.3.1
       '@peterek/vite-plugin-favicons':
         specifier: 2.1.0
-        version: 2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@playwright/test':
         specifier: 1.58.0
         version: 1.58.0
       '@storybook/addon-a11y':
         specifier: 9.1.12
-        version: 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/addon-docs':
         specifier: 9.1.12
-        version: 9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/addon-links':
         specifier: 9.1.12
-        version: 9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+        version: 9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/react-vite':
         specifier: 9.1.12
-        version: 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@svgr/plugin-svgo':
         specifier: 8.1.0
         version: 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))(typescript@5.9.2)
@@ -353,7 +353,7 @@ importers:
         version: 0.14.26
       '@tailwindcss/vite':
         specifier: 4.1.12
-        version: 4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@testing-library/jest-dom':
         specifier: 6.6.4
         version: 6.6.4
@@ -389,7 +389,7 @@ importers:
         version: 7.0.0-dev.20260126.1
       '@vitejs/plugin-react-swc':
         specifier: 4.3.0
-        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@vitest/coverage-v8':
         specifier: 4.1.0
         version: 4.1.0(vitest@4.1.0)
@@ -407,7 +407,7 @@ importers:
         version: 3.7.0(@vitest/runner@4.1.0)(allure-playwright@3.7.0(@playwright/test@1.58.0))(vitest@4.1.0)
       astro:
         specifier: 5.13.1
-        version: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+        version: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       camelcase:
         specifier: 6.3.0
         version: 6.3.0
@@ -473,7 +473,7 @@ importers:
         version: 4.16.1(@typescript-eslint/utils@8.54.0(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.2))(eslint-import-resolver-node@0.3.9)(eslint@9.39.2(jiti@2.5.1))
       eslint-plugin-prettier:
         specifier: 5.5.3
-        version: 5.5.3(@types/eslint@9.6.1)(eslint@9.39.2(jiti@2.5.1))(prettier@3.6.2)
+        version: 5.5.3(eslint@9.39.2(jiti@2.5.1))(prettier@3.6.2)
       eslint-plugin-react:
         specifier: 7.37.5
         version: 7.37.5(eslint@9.39.2(jiti@2.5.1))
@@ -539,10 +539,10 @@ importers:
         version: 0.5.21
       starlight-typedoc:
         specifier: 0.21.3
-        version: 0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2))
+        version: 0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2))
       storybook:
         specifier: 9.1.12
-        version: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       tailwindcss:
         specifier: 4.1.12
         version: 4.1.12
@@ -563,25 +563,25 @@ importers:
         version: 8.39.1(eslint@9.39.2(jiti@2.5.1))(typescript@5.9.2)
       vite:
         specifier: 8.0.0
-        version: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+        version: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
       vite-plugin-compression2:
         specifier: 2.2.1
         version: 2.2.1(rollup@4.52.5)
       vite-plugin-mkcert:
         specifier: 1.17.8
-        version: 1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-node-polyfills:
         specifier: 0.24.0
-        version: 0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-svgr:
         specifier: 4.5.0
-        version: 4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       vite-plugin-target:
         specifier: 0.1.1
         version: 0.1.1
       vitest:
         specifier: 4.1.0
-        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+        version: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
 
 packages:
 
@@ -915,7 +915,7 @@ packages:
     engines: {node: '>=12'}
 
   '@electron/node-gyp@https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2':
-    resolution: {tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
+    resolution: {gitHosted: true, tarball: https://codeload.github.com/electron/node-gyp/tar.gz/06b29aafb7708acef8b3669835c8a7857ebc92d2}
     version: 10.2.0-electron.1
     engines: {node: '>=12.13.0'}
     hasBin: true
@@ -1899,9 +1899,6 @@ packages:
     resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
     engines: {node: '>=6.0.0'}
 
-  '@jridgewell/source-map@0.3.11':
-    resolution: {integrity: sha512-ZMp1V8ZFcPG5dIWnQLr3NSI1MiCU7UETdS/A0G8V/XWHvJv3ZsFqutJn1Y5RPmAPX6F3BiE397OqveU/9NCuIA==}
-
   '@jridgewell/sourcemap-codec@1.5.5':
     resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
 
@@ -1997,12 +1994,15 @@ packages:
 
   '@novasamatech/spektr-dapp-host-container@0.0.12':
     resolution: {integrity: sha512-S3OfzQpUBRimkB7FGV6DP62ui74gZTzYJOEXbeCMQhvEXo+a1vzajTTxbANz/qEluUJ7edS8g0ot9X8lFsWufw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@novasamatech/spektr-sdk-shared@0.0.12':
     resolution: {integrity: sha512-XDZbf5hkI6uYrfJBrvY+R6RSnTayCL55jPih8ZxFLiBFARhYCMPE0VD5w66V7tle7MFWjusg4UIUQEtv+uYbzA==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@novasamatech/spektr-sdk-transport@0.0.12':
     resolution: {integrity: sha512-Bj2FlSmfg7tXfcabBjqKe8XiqZlQ5mIwb/IUvNmz/oWAh1fymI9iJpWk0amoQ3pyflnhi4yDVVpC7kq/2hmkAw==}
+    deprecated: Package no longer supported. Contact Support at https://www.npmjs.com/support for more info.
 
   '@npmcli/fs@2.1.2':
     resolution: {integrity: sha512-yOJKRvohFOaLqipNtwYB9WugyZKhC/DZC4VYPmpaCzDBrA8YpK3qHZ8/HGscMnE4GqbkLNuVcCnxkeQEdGt6LQ==}
@@ -3942,9 +3942,6 @@ packages:
   '@types/doctrine@0.0.9':
     resolution: {integrity: sha512-eOIHzCUSH7SMfonMG1LsC2f8vxBFtho6NGBznK41R84YzPuvSBzrhEps33IsQiOW9+VL6NQ9DbjQJznk/S4uRA==}
 
-  '@types/eslint@9.6.1':
-    resolution: {integrity: sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==}
-
   '@types/estree-jsx@1.0.5':
     resolution: {integrity: sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==}
 
@@ -4236,6 +4233,7 @@ packages:
 
   '@ungap/structured-clone@1.3.0':
     resolution: {integrity: sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==}
+    deprecated: Potential CWE-502 - Update to 1.3.1 or higher
 
   '@unrs/resolver-binding-android-arm-eabi@1.11.1':
     resolution: {integrity: sha512-ppLRUgHVaGRWUx0R0Ut06Mjo9gBaBkg3v/8AxusGLhsIotbBLuRk51rAzqLC8gq6NyyAojEXglNjzf6R948DNw==}
@@ -4494,6 +4492,7 @@ packages:
   '@xmldom/xmldom@0.8.10':
     resolution: {integrity: sha512-2WALfTl4xo2SkGCYRt6rDTFfk9R1czmBvUQy12gK2KuRKIpWEhcbbzy8EZXtz/jkRqHX8bFEc6FC1HjX4TUWYw==}
     engines: {node: '>=10.0.0'}
+    deprecated: this version has critical issues, please update to the latest version
 
   '@xyflow/react@12.8.6':
     resolution: {integrity: sha512-SksAm2m4ySupjChphMmzvm55djtgMDPr+eovPDdTnyGvShf73cvydfoBfWDFllooIQ4IaiUL5yfxHRwU0c37EA==}
@@ -4520,10 +4519,6 @@ packages:
     resolution: {integrity: sha512-E+iruNOY8VV9s4JEbe1aNEm6MiszPRr/UfcHMz0TQh1BXSxHK+ASV1R6W4HpjBhSeS+54PIsAMCBmwD06LLsqQ==}
     hasBin: true
 
-  abab@2.0.6:
-    resolution: {integrity: sha512-j2afSsaIENvHZN2B8GOpF566vZ5WVk5opAiMTvWgaQT8DkbOqsTfvNAvHoRGU2zzP8cPoqys+xHTRDWW8L+/BA==}
-    deprecated: Use your platform's native atob() and btoa() methods instead
-
   abbrev@1.1.1:
     resolution: {integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==}
 
@@ -4549,9 +4544,6 @@ packages:
       zod:
         optional: true
 
-  acorn-globals@7.0.1:
-    resolution: {integrity: sha512-umOSDSDrfHbTNPuNpC2NSnnA3LUrqpevPb4T9jRx4MagXNS0rs+gwiTcAvqCRmsD6utzsrzNt+ebm00SNWiC3Q==}
-
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
     peerDependencies:
@@ -4561,17 +4553,8 @@ packages:
     resolution: {integrity: sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==}
     engines: {node: '>=0.4.0'}
 
-  acorn-walk@8.3.5:
-    resolution: {integrity: sha512-HEHNfbars9v4pgpW6SO1KSPkfoS0xVOM/9UzkJltjlsHZmJasxg8aXkuZa7SMf8vKGIBhpUsPluQSqhJFCqebw==}
-    engines: {node: '>=0.4.0'}
-
   acorn@8.15.0:
     resolution: {integrity: sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==}
-    engines: {node: '>=0.4.0'}
-    hasBin: true
-
-  acorn@8.16.0:
-    resolution: {integrity: sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw==}
     engines: {node: '>=0.4.0'}
     hasBin: true
 
@@ -5234,9 +5217,6 @@ packages:
     resolution: {integrity: sha512-2JkV3gUZUVrbNA+1sjBOYLsMZ5cEEl8GTFP2a4AVz5hvasAMCQ1D2l2le/cX+pV4N6ZU17zjUahLpIXRrnWL8A==}
     engines: {node: '>=20'}
 
-  commander@2.20.3:
-    resolution: {integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==}
-
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
     engines: {node: '>= 6'}
@@ -5444,16 +5424,6 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
-  cssom@0.3.8:
-    resolution: {integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==}
-
-  cssom@0.5.0:
-    resolution: {integrity: sha512-iKuQcq+NdHqlAcwUY0o/HL69XQrUaQdMjmStJ8JFmUaiiQErlhrmuigkg/CU4E2J0IyUKUrMAgl36TvN67MqTw==}
-
-  cssstyle@2.3.0:
-    resolution: {integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==}
-    engines: {node: '>=8'}
-
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
 
@@ -5533,10 +5503,6 @@ packages:
   data-uri-to-buffer@4.0.1:
     resolution: {integrity: sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==}
     engines: {node: '>= 12'}
-
-  data-urls@3.0.2:
-    resolution: {integrity: sha512-Jy/tj3ldjZJo63sVAvg6LHt2mHvl4V6AgRAmNDtLdm7faqtsx+aJG42rsyCo9JCoRVKwPFzKlIPx3DIibwSIaQ==}
-    engines: {node: '>=12'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -5764,11 +5730,6 @@ packages:
 
   domelementtype@2.3.0:
     resolution: {integrity: sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw==}
-
-  domexception@4.0.0:
-    resolution: {integrity: sha512-A2is4PLG+eeSfoTMA95/s4pvAoSo2mKtiM5jlHkAVewmiO8ISFTFKZjH7UAM1Atli/OT/7JHOrJRJiMKUZKYBw==}
-    engines: {node: '>=12'}
-    deprecated: Use your platform's native DOMException instead
 
   domhandler@5.0.3:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
@@ -6025,11 +5986,6 @@ packages:
   escape-string-regexp@5.0.0:
     resolution: {integrity: sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==}
     engines: {node: '>=12'}
-
-  escodegen@2.1.0:
-    resolution: {integrity: sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==}
-    engines: {node: '>=6.0'}
-    hasBin: true
 
   eslint-import-context@0.1.9:
     resolution: {integrity: sha512-K9Hb+yRaGAGUbwjhFNHvSmmkZs9+zbuoe3kFQ4V1wYjrepUFYM2dZAfNtjbbj3qsPfUfsA68Bx/ICWQMi+C8Eg==}
@@ -6420,10 +6376,6 @@ packages:
     resolution: {integrity: sha512-KrGhL9Q4zjj0kiUt5OO4Mr/A/jlI2jDYs5eHBpYHPcBEVSiipAvn2Ko2HnPe20rmcuuvMHNdZFp+4IlGTMF0Ow==}
     engines: {node: '>= 6'}
 
-  form-data@4.0.5:
-    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
-    engines: {node: '>= 6'}
-
   formatly@0.2.4:
     resolution: {integrity: sha512-lIN7GpcvX/l/i24r/L9bnJ0I8Qn01qijWpQpDDvTLL29nKqSaJJu4h20+7VJ6m2CAhQ2/En/GbxDiHCzq/0MyA==}
     engines: {node: '>=18.3.0'}
@@ -6540,6 +6492,7 @@ packages:
   git-raw-commits@4.0.0:
     resolution: {integrity: sha512-ICsMM1Wk8xSGMowkOmPrzo2Fgmfo4bMHLNX6ytHjajRJUqvHOw/TFapQ+QG75c3X/tTDDhOSRPGC52dDbNM8FQ==}
     engines: {node: '>=16'}
+    deprecated: This package is no longer maintained. For the JavaScript API, please use @conventional-changelog/git-client instead.
     hasBin: true
 
   github-slugger@2.0.0:
@@ -6559,16 +6512,18 @@ packages:
 
   glob@10.4.5:
     resolution: {integrity: sha512-7Bv8RF0k6xjo7d4A/PxYLbUCfb6c+Vpd2/mB2yRDlew7Jb5hEXiCD9ibfO7wpk8i4sevK6DFny9h7EYbM3/sHg==}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@11.0.3:
     resolution: {integrity: sha512-2Nim7dha1KVkaiF4q6Dj+ngPPMdfvLJEOpZk/jKiUAkqKebpGAWQXAq9z1xu9HKu5lWfqw/FASuccEjyznjPaA==}
     engines: {node: 20 || >=22}
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
     hasBin: true
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
+    deprecated: Old versions of glob are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
@@ -6771,10 +6726,6 @@ packages:
     resolution: {integrity: sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w==}
     engines: {node: ^16.14.0 || >=18.0.0}
 
-  html-encoding-sniffer@3.0.0:
-    resolution: {integrity: sha512-oWv4T4yJ52iKrufjnyZPkrN0CH3QnrUqdB6In1g5Fe1mia8GmF36gnfNySxoZtxD5+NmYw1EElVXiBk93UeskA==}
-    engines: {node: '>=12'}
-
   html-escaper@2.0.2:
     resolution: {integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==}
 
@@ -6837,6 +6788,7 @@ packages:
   i18next-parser@9.3.0:
     resolution: {integrity: sha512-VaQqk/6nLzTFx1MDiCZFtzZXKKyBV6Dv0cJMFM/hOt4/BWHWRgYafzYfVQRUzotwUwjqeNCprWnutzD/YAGczg==}
     engines: {node: ^18.0.0 || ^20.0.0 || ^22.0.0, npm: '>=6', yarn: '>=1'}
+    deprecated: Project is deprecated, use i18next-cli instead
     hasBin: true
 
   i18next@23.16.8:
@@ -7099,9 +7051,6 @@ packages:
     resolution: {integrity: sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==}
     engines: {node: '>=12'}
 
-  is-potential-custom-element-name@1.0.1:
-    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
-
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -7276,15 +7225,6 @@ packages:
   js-yaml@4.1.1:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
-
-  jsdom@20.0.3:
-    resolution: {integrity: sha512-SYhBvTh89tTfCD/CRdSOm13mOBa42iTaTyfyEWBdKcGdPxPtLFBXuHR8XHb33YNYaP+lLbmSvBTsnoesCNJEsQ==}
-    engines: {node: '>=14'}
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
 
   jsesc@3.1.0:
     resolution: {integrity: sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA==}
@@ -8220,9 +8160,6 @@ packages:
   nth-check@2.1.1:
     resolution: {integrity: sha512-lqjrjmaOoAnWfMmBPL+XNnynZh2+swxiX3WUE0s4yEHI6m+AwrK2UZOimIRl3X/4QctVqS8AiZjFqyOGrMXb/w==}
 
-  nwsapi@2.2.23:
-    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
-
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -8836,9 +8773,6 @@ packages:
   proxy-from-env@1.1.0:
     resolution: {integrity: sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg==}
 
-  psl@1.15.0:
-    resolution: {integrity: sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==}
-
   public-encrypt@4.0.3:
     resolution: {integrity: sha512-zVpa8oKZSz5bTMTFClc1fQOnyyEzpl5ozpi1B5YcvBrdohMjH2rfsBtyXcuNuwjsDIXmBYlF2N5FlJYhR29t8Q==}
 
@@ -8873,9 +8807,6 @@ packages:
   querystring-es3@0.2.1:
     resolution: {integrity: sha512-773xhDQnZBMFobEiztv8LIl70ch5MSF/jUQVlhwFyBILqq96anmoctVIYz+ZRp0qbCKATTn6ev02M3r7Ga5vqA==}
     engines: {node: '>=0.4.x'}
-
-  querystringify@2.2.0:
-    resolution: {integrity: sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==}
 
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
@@ -9220,9 +9151,6 @@ packages:
     resolution: {integrity: sha512-LBnkqsDE7BZKvqylbmn7lTIVdpx4K/QCduRATpO5R+wtPmky/a8pN1bO2D6wXppn1497AJF9mNjqAXr6bdl9jg==}
     engines: {node: '>=0.10.5'}
 
-  requires-port@1.0.0:
-    resolution: {integrity: sha512-KigOCHcocU3XODJxsu8i/j8T9tzT4adHiecwORRQ0ZZFcp7ahwXuRU1m+yuO90C5ZUyGeGfocHDI14M3L3yDAQ==}
-
   resedit@1.7.2:
     resolution: {integrity: sha512-vHjcY2MlAITJhC0eRD/Vv8Vlgmu9Sd3LX9zZvtGzU5ZImdTN3+d6e/4mnTyV8vEbyf1sgNIrWxhWlrys52OkEA==}
     engines: {node: '>=12', npm: '>=6'}
@@ -9374,10 +9302,6 @@ packages:
 
   sax@1.4.1:
     resolution: {integrity: sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==}
-
-  saxes@6.0.0:
-    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
-    engines: {node: '>=v12.22.7'}
 
   scale-ts@1.6.1:
     resolution: {integrity: sha512-PBMc2AWc6wSEqJYBDPcyCLUj9/tMKnLX70jLOSndMtcUoLQucP/DM0vnQo1wJAYjTrQiq8iG9rD0q6wFzgjH7g==}
@@ -9830,9 +9754,6 @@ packages:
     resolution: {integrity: sha512-b19dMThMV4HVFynSAM1++gBHAbk2Tc/osgLIBZMKsyqh34jb2e8Os7T6ZW/Bt3pJFdBTd2JwAnAAEQV7rSNvcQ==}
     engines: {node: '>=0.10'}
 
-  symbol-tree@3.2.4:
-    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
-
   symlink-or-copy@1.3.1:
     resolution: {integrity: sha512-0K91MEXFpBUaywiwSSkmKjnGcasG/rVBXFLJz5DrgGabpYD6N+3yZrfD6uUIfpuTu65DZLHi7N8CizHc07BPZA==}
 
@@ -9861,10 +9782,12 @@ packages:
   tar@6.2.1:
     resolution: {integrity: sha512-DZ4yORTwrbTj/7MZYq2w+/ZFdI6OZ/f9SFHR+71gIVUZhOQPHzVCLpvRnPgyaMpfWxxk/4ONva3GQSyNIKRv6A==}
     engines: {node: '>=10'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   tar@7.4.3:
     resolution: {integrity: sha512-5S7Va8hKfV7W5U6g3aYxXmlPoZVAwUMy9AOKyF2fVuZa2UD3qZjg578OrLRt8PcNN1PleVaL/5/yYATNL0ICUw==}
     engines: {node: '>=18'}
+    deprecated: Old versions of tar are not supported, and contain widely publicized security vulnerabilities, which have been fixed in the current version. Please update. Support for old versions may be purchased (at exorbitant rates) by contacting i@izs.me
 
   teex@1.0.1:
     resolution: {integrity: sha512-eYE6iEI62Ni1H8oIa7KlDU6uQBtqr4Eajni3wX7rpfXD8ysFx8z0+dri+KWEPWpBsxXfxu58x/0jvTVT1ekOSg==}
@@ -9875,11 +9798,6 @@ packages:
   temp@0.9.4:
     resolution: {integrity: sha512-yYrrsWnrXMcdsnu/7YMYAofM1ktpL5By7vZhf15CrXijWWrEYZks5AXBudalfSWJLlnen/QUJUB5aoB0kqZUGA==}
     engines: {node: '>=6.0.0'}
-
-  terser@5.37.0:
-    resolution: {integrity: sha512-B8wRRkmre4ERucLM/uXx4MOV5cbnOlVAqUst+1+iLKPI0dOgFO28f84ptoQt9HEI537PMzfYa/d+GEPKTRXmYA==}
-    engines: {node: '>=10'}
-    hasBin: true
 
   text-decoder@1.2.3:
     resolution: {integrity: sha512-3/o9z3X0X0fTupwsYvR03pJ/DjWuqqrfwBgTQzdWDiQSm9KitAyz/9WqsT2JQW7KV2m+bC2ol/zqpW37NHxLaA==}
@@ -9975,19 +9893,11 @@ packages:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
 
-  tough-cookie@4.1.4:
-    resolution: {integrity: sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==}
-    engines: {node: '>=6'}
-
   tr46@0.0.3:
     resolution: {integrity: sha512-N3WMsuqV66lT30CrXNbEjx4GEwlow3v6rr4mCcv6prnfwhS01rkgyFdjPNBYd9br7LpXV1+Emh01fHnq2Gdgrw==}
 
   tr46@1.0.1:
     resolution: {integrity: sha512-dTpowEjclQ7Kgx5SdBkqRzVhERQXov8/l9Ft9dVM9fmg0W0KQSVaXX9T4i6twCPNtYiZM53lpSSUAwJbFPOHxA==}
-
-  tr46@3.0.0:
-    resolution: {integrity: sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==}
-    engines: {node: '>=12'}
 
   tree-kill@1.2.2:
     resolution: {integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==}
@@ -10264,10 +10174,6 @@ packages:
     resolution: {integrity: sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==}
     engines: {node: '>= 4.0.0'}
 
-  universalify@0.2.0:
-    resolution: {integrity: sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==}
-    engines: {node: '>= 4.0.0'}
-
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
     engines: {node: '>= 10.0.0'}
@@ -10353,9 +10259,6 @@ packages:
 
   uri-js@4.4.1:
     resolution: {integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==}
-
-  url-parse@1.5.10:
-    resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
   url@0.11.4:
     resolution: {integrity: sha512-oCwdVC7mTuWiPyjLUz/COz5TLk6wgp0RCsN+wHZ2Ekneac9w8uuV0njcbbie2ME+Vs+d6duwmYuR3HgQXs1fOg==}
@@ -10606,10 +10509,6 @@ packages:
     resolution: {integrity: sha512-Dhxzh5HZuiHQhbvTW9AMetFfBHDMYpo23Uo9btPXgdYP+3T5S+p+jgNy7spra+veYhBP2dCSgxR/i2Y02h5/6w==}
     engines: {node: '>=0.10.0'}
 
-  w3c-xmlserializer@4.0.0:
-    resolution: {integrity: sha512-d+BFHzbiCx6zGfz0HyQ6Rg69w9k19nviJspaj4yNscGjrHu94sVP+aRm75yEbCh+r2/yR+7q6hux9LVtbuTGBw==}
-    engines: {node: '>=14'}
-
   walk-sync@2.2.0:
     resolution: {integrity: sha512-IC8sL7aB4/ZgFcGI2T1LczZeFWZ06b3zoHH7jBPyHxOtIIz1jppWHjjEXkOFvFojBVAK9pV7g47xOZ4LW3QLfg==}
     engines: {node: 8.* || >= 10.*}
@@ -10634,21 +10533,13 @@ packages:
   webidl-conversions@4.0.2:
     resolution: {integrity: sha512-YQ+BmxuTgd6UXZW3+ICGfyqRyHXVlD5GtQr5+qjiNW7bF0cqrzX500HVXPBOvgXb5YnzDd+h0zqyv61KUD7+Sg==}
 
-  webidl-conversions@7.0.0:
-    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
-    engines: {node: '>=12'}
-
   webpack-virtual-modules@0.6.2:
     resolution: {integrity: sha512-66/V2i5hQanC51vBQKPH4aI8NMAcBW59FVBs+rC7eGHupMyfn34q7rZIE+ETlJ+XTevqfUhVVBgSUNSW2flEUQ==}
-
-  whatwg-encoding@2.0.0:
-    resolution: {integrity: sha512-p41ogyeMUrw3jWclHWTQg1k05DSVXPLcVxRTYsXUk+ZooOCZLcoYgPZ/HL/D/N+uQPOtcp1me1WhBEaX02mhWg==}
-    engines: {node: '>=12'}
-    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-encoding@3.1.1:
     resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
     engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
 
   whatwg-mimetype@3.0.0:
     resolution: {integrity: sha512-nt+N2dzIutVRxARx1nghPKGv1xHikU7HKdfafKkLNLindmPU/ch3U31NOCGGA/dmPcmb1VlofO0vnKAcsm0o/Q==}
@@ -10657,10 +10548,6 @@ packages:
   whatwg-mimetype@4.0.0:
     resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
     engines: {node: '>=18'}
-
-  whatwg-url@11.0.0:
-    resolution: {integrity: sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==}
-    engines: {node: '>=12'}
 
   whatwg-url@5.0.0:
     resolution: {integrity: sha512-saE57nupxk6v3HY35+jzBwYa0rKSy0XR8JSxZPwgLr7ys0IBzhGviA1/TUGJLmSVqs8pb9AnvICXEuOHLprYTw==}
@@ -10785,10 +10672,6 @@ packages:
       utf-8-validate:
         optional: true
 
-  xml-name-validator@4.0.0:
-    resolution: {integrity: sha512-ICP2e+jsHvAj2E2lIHxa5tjXRlKDJo4IdvPvCXbXQGdzSfmSpNVyIKMvoZHjDY9DP0zV17iI85o90vRFXNccRw==}
-    engines: {node: '>=12'}
-
   xml2js@0.6.2:
     resolution: {integrity: sha512-T4rieHaC1EXcES0Kxxj4JWgaUQHDk+qwHcYOCFHfiwKz7tOVPLq7Hjq9dM1WCMhylqMEfP7hMcOIChvotiZegA==}
     engines: {node: '>=4.0.0'}
@@ -10800,9 +10683,6 @@ packages:
   xmlbuilder@15.1.1:
     resolution: {integrity: sha512-yMqGBqtXyeN1e3TGYvgNgDVZ3j84W4cwkOXQswghol6APgZWaff9lnbvN7MHYJOiXsvGPXtjTYJEiC9J2wv9Eg==}
     engines: {node: '>=8.0'}
-
-  xmlchars@2.2.0:
-    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
 
   xtend@4.0.2:
     resolution: {integrity: sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==}
@@ -11002,12 +10882,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
+  '@astrojs/mdx@4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.5
       '@mdx-js/mdx': 3.1.0(acorn@8.15.0)
       acorn: 8.15.0
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       es-module-lexer: 1.7.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -11031,17 +10911,17 @@ snapshots:
       stream-replace-string: 2.0.0
       zod: 3.25.76
 
-  '@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
+  '@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))':
     dependencies:
       '@astrojs/markdown-remark': 6.3.5
-      '@astrojs/mdx': 4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      '@astrojs/mdx': 4.3.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       '@astrojs/sitemap': 3.4.2
       '@pagefind/default-ui': 1.3.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
-      astro-expressive-code: 0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro-expressive-code: 0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -12167,12 +12047,12 @@ snapshots:
 
   '@jonasgeiler/tsc-files@2.3.1': {}
 
-  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@joshwooding/vite-plugin-react-docgen-typescript@0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       glob: 10.4.5
       magic-string: 0.30.17
       react-docgen-typescript: 2.4.0(typescript@5.9.2)
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     optionalDependencies:
       typescript: 5.9.2
 
@@ -12192,12 +12072,6 @@ snapshots:
       '@jridgewell/trace-mapping': 0.3.29
 
   '@jridgewell/resolve-uri@3.1.2': {}
-
-  '@jridgewell/source-map@0.3.11':
-    dependencies:
-      '@jridgewell/gen-mapping': 0.3.13
-      '@jridgewell/trace-mapping': 0.3.31
-    optional: true
 
   '@jridgewell/sourcemap-codec@1.5.5': {}
 
@@ -12484,10 +12358,10 @@ snapshots:
     dependencies:
       zod: 4.2.1
 
-  '@peterek/vite-plugin-favicons@2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@peterek/vite-plugin-favicons@2.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       favicons: 7.2.0
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
 
   '@pivanov/utils@0.0.2(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
@@ -13963,42 +13837,42 @@ snapshots:
 
   '@standard-schema/utils@0.3.0': {}
 
-  '@storybook/addon-a11y@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-a11y@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@storybook/global': 5.0.0
       axe-core: 4.10.3
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
 
-  '@storybook/addon-docs@9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-docs@9.1.12(@types/react@19.2.2)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@mdx-js/react': 3.1.0(@types/react@19.2.2)(react@19.2.0)
-      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       '@storybook/icons': 1.4.0(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
-      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       ts-dedent: 2.2.0
     transitivePeerDependencies:
       - '@types/react'
 
-  '@storybook/addon-links@9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/addon-links@9.1.12(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       '@storybook/global': 5.0.0
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
     optionalDependencies:
       react: 19.2.0
 
-  '@storybook/builder-vite@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@storybook/builder-vite@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@storybook/csf-plugin': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       ts-dedent: 2.2.0
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
 
-  '@storybook/csf-plugin@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/csf-plugin@9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       unplugin: 1.16.1
 
   '@storybook/global@5.0.0': {}
@@ -14008,39 +13882,39 @@ snapshots:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
 
-  '@storybook/react-dom-shim@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))':
+  '@storybook/react-dom-shim@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))':
     dependencies:
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
 
-  '@storybook/react-vite@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@storybook/react-vite@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(rollup@4.52.5)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
-      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@joshwooding/vite-plugin-react-docgen-typescript': 0.6.1(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@rollup/pluginutils': 5.2.0(rollup@4.52.5)
-      '@storybook/builder-vite': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
-      '@storybook/react': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)
+      '@storybook/builder-vite': 9.1.12(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
+      '@storybook/react': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)
       find-up: 7.0.0
       magic-string: 0.30.17
       react: 19.2.0
       react-docgen: 8.0.0
       react-dom: 19.2.0(react@19.2.0)
       resolve: 1.22.10
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       tsconfig-paths: 4.2.0
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
       - typescript
 
-  '@storybook/react@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)':
+  '@storybook/react@9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))(typescript@5.9.2)':
     dependencies:
       '@storybook/global': 5.0.0
-      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)))
+      '@storybook/react-dom-shim': 9.1.12(react-dom@19.2.0(react@19.2.0))(react@19.2.0)(storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)))
       react: 19.2.0
       react-dom: 19.2.0(react@19.2.0)
-      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      storybook: 9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
     optionalDependencies:
       typescript: 5.9.2
 
@@ -14295,12 +14169,12 @@ snapshots:
       '@tailwindcss/oxide-win32-arm64-msvc': 4.1.12
       '@tailwindcss/oxide-win32-x64-msvc': 4.1.12
 
-  '@tailwindcss/vite@4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@tailwindcss/vite@4.1.12(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@tailwindcss/node': 4.1.12
       '@tailwindcss/oxide': 4.1.12
       tailwindcss: 4.1.12
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
 
   '@talismn/connect-wallets@1.2.8(@polkadot/api@16.4.8)(@polkadot/extension-inject@0.58.1(@polkadot/api@16.4.8)(@polkadot/util@13.5.6))':
     dependencies:
@@ -14460,12 +14334,6 @@ snapshots:
   '@types/deep-eql@4.0.2': {}
 
   '@types/doctrine@0.0.9': {}
-
-  '@types/eslint@9.6.1':
-    dependencies:
-      '@types/estree': 1.0.8
-      '@types/json-schema': 7.0.15
-    optional: true
 
   '@types/estree-jsx@1.0.5':
     dependencies:
@@ -14862,11 +14730,11 @@ snapshots:
   '@unrs/resolver-binding-win32-x64-msvc@1.11.1':
     optional: true
 
-  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@vitejs/plugin-react-swc@4.3.0(@swc/helpers@0.5.17)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@rolldown/pluginutils': 1.0.0-rc.7
       '@swc/core': 1.15.11(@swc/helpers@0.5.17)
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - '@swc/helpers'
 
@@ -14882,7 +14750,7 @@ snapshots:
       obug: 2.1.1
       std-env: 4.0.0
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
 
   '@vitest/expect@3.2.4':
     dependencies:
@@ -14901,21 +14769,21 @@ snapshots:
       chai: 6.2.2
       tinyrainbow: 3.1.0
 
-  '@vitest/mocker@3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@vitest/mocker@3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 3.2.4
       estree-walker: 3.0.3
       magic-string: 0.30.17
     optionalDependencies:
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
 
-  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))':
+  '@vitest/mocker@4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))':
     dependencies:
       '@vitest/spy': 4.1.0
       estree-walker: 3.0.3
       magic-string: 0.30.21
     optionalDependencies:
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
 
   '@vitest/pretty-format@3.2.4':
     dependencies:
@@ -14952,7 +14820,7 @@ snapshots:
       sirv: 3.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
 
   '@vitest/utils@3.2.4':
     dependencies:
@@ -15277,9 +15145,6 @@ snapshots:
       jsonparse: 1.3.1
       through: 2.3.8
 
-  abab@2.0.6:
-    optional: true
-
   abbrev@1.1.1: {}
 
   abitype@1.1.0(typescript@5.9.2)(zod@4.0.14):
@@ -15292,12 +15157,6 @@ snapshots:
       typescript: 5.9.2
       zod: 4.0.14
 
-  acorn-globals@7.0.1:
-    dependencies:
-      acorn: 8.16.0
-      acorn-walk: 8.3.5
-    optional: true
-
   acorn-jsx@5.3.2(acorn@8.15.0):
     dependencies:
       acorn: 8.15.0
@@ -15306,15 +15165,7 @@ snapshots:
     dependencies:
       acorn: 8.15.0
 
-  acorn-walk@8.3.5:
-    dependencies:
-      acorn: 8.16.0
-    optional: true
-
   acorn@8.15.0: {}
-
-  acorn@8.16.0:
-    optional: true
 
   aes-js@4.0.0-beta.5: {}
 
@@ -15372,7 +15223,7 @@ snapshots:
     dependencies:
       '@vitest/runner': 4.1.0
       allure-js-commons: 3.7.0(allure-playwright@3.7.0(@playwright/test@1.58.0))
-      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      vitest: 4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
     transitivePeerDependencies:
       - allure-playwright
 
@@ -15563,12 +15414,12 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)):
+  astro-expressive-code@0.41.3(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)):
     dependencies:
-      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
+      astro: 5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)
       rehype-expressive-code: 0.41.3
 
-  astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1):
+  astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1):
     dependencies:
       '@astrojs/compiler': 2.12.2
       '@astrojs/internal-helpers': 0.7.1
@@ -15624,8 +15475,8 @@ snapshots:
       unist-util-visit: 5.0.0
       unstorage: 1.16.1(idb-keyval@6.2.1)
       vfile: 6.0.3
-      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
-      vitefu: 1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1)
+      vitefu: 1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1))
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
@@ -16176,9 +16027,6 @@ snapshots:
 
   commander@14.0.1: {}
 
-  commander@2.20.3:
-    optional: true
-
   commander@4.1.1: {}
 
   commander@5.1.0: {}
@@ -16418,17 +16266,6 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
-  cssom@0.3.8:
-    optional: true
-
-  cssom@0.5.0:
-    optional: true
-
-  cssstyle@2.3.0:
-    dependencies:
-      cssom: 0.3.8
-    optional: true
-
   csstype@3.1.3: {}
 
   csv-parse@6.1.0: {}
@@ -16500,13 +16337,6 @@ snapshots:
   dargs@8.1.0: {}
 
   data-uri-to-buffer@4.0.1: {}
-
-  data-urls@3.0.2:
-    dependencies:
-      abab: 2.0.6
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-    optional: true
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -16711,11 +16541,6 @@ snapshots:
   domain-browser@4.22.0: {}
 
   domelementtype@2.3.0: {}
-
-  domexception@4.0.0:
-    dependencies:
-      webidl-conversions: 7.0.0
-    optional: true
 
   domhandler@5.0.3:
     dependencies:
@@ -17155,15 +16980,6 @@ snapshots:
 
   escape-string-regexp@5.0.0: {}
 
-  escodegen@2.1.0:
-    dependencies:
-      esprima: 4.0.1
-      estraverse: 5.3.0
-      esutils: 2.0.3
-    optionalDependencies:
-      source-map: 0.6.1
-    optional: true
-
   eslint-import-context@0.1.9(unrs-resolver@1.11.1):
     dependencies:
       get-tsconfig: 4.10.1
@@ -17279,14 +17095,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-prettier@5.5.3(@types/eslint@9.6.1)(eslint@9.39.2(jiti@2.5.1))(prettier@3.6.2):
+  eslint-plugin-prettier@5.5.3(eslint@9.39.2(jiti@2.5.1))(prettier@3.6.2):
     dependencies:
       eslint: 9.39.2(jiti@2.5.1)
       prettier: 3.6.2
       prettier-linter-helpers: 1.0.0
       synckit: 0.11.11
-    optionalDependencies:
-      '@types/eslint': 9.6.1
 
   eslint-plugin-react@7.37.5(eslint@9.39.2(jiti@2.5.1)):
     dependencies:
@@ -17639,15 +17453,6 @@ snapshots:
       es-set-tostringtag: 2.1.0
       hasown: 2.0.2
       mime-types: 2.1.35
-
-  form-data@4.0.5:
-    dependencies:
-      asynckit: 0.4.0
-      combined-stream: 1.0.8
-      es-set-tostringtag: 2.1.0
-      hasown: 2.0.2
-      mime-types: 2.1.35
-    optional: true
 
   formatly@0.2.4:
     dependencies:
@@ -18236,11 +18041,6 @@ snapshots:
     dependencies:
       lru-cache: 10.4.3
 
-  html-encoding-sniffer@3.0.0:
-    dependencies:
-      whatwg-encoding: 2.0.0
-    optional: true
-
   html-escaper@2.0.2: {}
 
   html-escaper@3.0.3: {}
@@ -18543,9 +18343,6 @@ snapshots:
 
   is-plain-obj@4.1.0: {}
 
-  is-potential-custom-element-name@1.0.1:
-    optional: true
-
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -18727,40 +18524,6 @@ snapshots:
   js-yaml@4.1.1:
     dependencies:
       argparse: 2.0.1
-
-  jsdom@20.0.3:
-    dependencies:
-      abab: 2.0.6
-      acorn: 8.16.0
-      acorn-globals: 7.0.1
-      cssom: 0.5.0
-      cssstyle: 2.3.0
-      data-urls: 3.0.2
-      decimal.js: 10.6.0
-      domexception: 4.0.0
-      escodegen: 2.1.0
-      form-data: 4.0.5
-      html-encoding-sniffer: 3.0.0
-      http-proxy-agent: 5.0.0
-      https-proxy-agent: 5.0.1
-      is-potential-custom-element-name: 1.0.1
-      nwsapi: 2.2.23
-      parse5: 7.3.0
-      saxes: 6.0.0
-      symbol-tree: 3.2.4
-      tough-cookie: 4.1.4
-      w3c-xmlserializer: 4.0.0
-      webidl-conversions: 7.0.0
-      whatwg-encoding: 2.0.0
-      whatwg-mimetype: 3.0.0
-      whatwg-url: 11.0.0
-      ws: 8.19.0
-      xml-name-validator: 4.0.0
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-    optional: true
 
   jsesc@3.1.0: {}
 
@@ -19983,9 +19746,6 @@ snapshots:
     dependencies:
       boolbase: 1.0.0
 
-  nwsapi@2.2.23:
-    optional: true
-
   object-assign@4.1.1: {}
 
   object-inspect@1.13.4: {}
@@ -20623,11 +20383,6 @@ snapshots:
 
   proxy-from-env@1.1.0: {}
 
-  psl@1.15.0:
-    dependencies:
-      punycode: 2.3.1
-    optional: true
-
   public-encrypt@4.0.3:
     dependencies:
       bn.js: 4.12.1
@@ -20661,9 +20416,6 @@ snapshots:
       side-channel: 1.1.0
 
   querystring-es3@0.2.1: {}
-
-  querystringify@2.2.0:
-    optional: true
 
   queue-microtask@1.2.3: {}
 
@@ -21121,9 +20873,6 @@ snapshots:
 
   requireindex@1.1.0: {}
 
-  requires-port@1.0.0:
-    optional: true
-
   resedit@1.7.2:
     dependencies:
       pe-library: 0.4.1
@@ -21326,11 +21075,6 @@ snapshots:
       truncate-utf8-bytes: 1.0.2
 
   sax@1.4.1: {}
-
-  saxes@6.0.0:
-    dependencies:
-      xmlchars: 2.2.0
-    optional: true
 
   scale-ts@1.6.1: {}
 
@@ -21651,9 +21395,9 @@ snapshots:
 
   stackback@0.0.2: {}
 
-  starlight-typedoc@0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2)):
+  starlight-typedoc@0.21.3(@astrojs/starlight@0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1)))(typedoc-plugin-markdown@4.4.1(typedoc@0.27.6(typescript@5.9.2)))(typedoc@0.27.6(typescript@5.9.2)):
     dependencies:
-      '@astrojs/starlight': 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(terser@5.37.0)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
+      '@astrojs/starlight': 0.35.2(astro@5.13.1(@types/node@22.17.0)(encoding@0.1.13)(idb-keyval@6.2.1)(jiti@2.5.1)(lightningcss@1.32.0)(rollup@4.52.5)(tsx@4.20.3)(typescript@5.9.2)(yaml@2.7.1))
       github-slugger: 2.0.0
       typedoc: 0.27.6(typescript@5.9.2)
       typedoc-plugin-markdown: 4.4.1(typedoc@0.27.6(typescript@5.9.2))
@@ -21671,13 +21415,13 @@ snapshots:
 
   store@2.0.12: {}
 
-  storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  storybook@9.1.12(@testing-library/dom@10.4.0)(prettier@3.6.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@storybook/global': 5.0.0
       '@testing-library/jest-dom': 6.6.4
       '@testing-library/user-event': 14.6.1(@testing-library/dom@10.4.0)
       '@vitest/expect': 3.2.4
-      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@vitest/mocker': 3.2.4(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@vitest/spy': 3.2.4
       better-opn: 3.0.2
       esbuild: 0.25.9
@@ -21909,9 +21653,6 @@ snapshots:
 
   symbol-observable@4.0.0: {}
 
-  symbol-tree@3.2.4:
-    optional: true
-
   symlink-or-copy@1.3.1: {}
 
   synckit@0.11.11:
@@ -21961,14 +21702,6 @@ snapshots:
     dependencies:
       mkdirp: 0.5.6
       rimraf: 2.6.3
-
-  terser@5.37.0:
-    dependencies:
-      '@jridgewell/source-map': 0.3.11
-      acorn: 8.16.0
-      commander: 2.20.3
-      source-map-support: 0.5.21
-    optional: true
 
   text-decoder@1.2.3:
     dependencies:
@@ -22051,24 +21784,11 @@ snapshots:
 
   totalist@3.0.1: {}
 
-  tough-cookie@4.1.4:
-    dependencies:
-      psl: 1.15.0
-      punycode: 2.3.1
-      universalify: 0.2.0
-      url-parse: 1.5.10
-    optional: true
-
   tr46@0.0.3: {}
 
   tr46@1.0.1:
     dependencies:
       punycode: 2.3.1
-
-  tr46@3.0.0:
-    dependencies:
-      punycode: 2.3.1
-    optional: true
 
   tree-kill@1.2.2: {}
 
@@ -22373,9 +22093,6 @@ snapshots:
 
   universalify@0.1.2: {}
 
-  universalify@0.2.0:
-    optional: true
-
   universalify@2.0.1: {}
 
   unplugin@1.16.1:
@@ -22441,12 +22158,6 @@ snapshots:
   uri-js@4.4.1:
     dependencies:
       punycode: 2.3.1
-
-  url-parse@1.5.10:
-    dependencies:
-      querystringify: 2.2.0
-      requires-port: 1.0.0
-    optional: true
 
   url@0.11.4:
     dependencies:
@@ -22601,29 +22312,29 @@ snapshots:
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-mkcert@1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-mkcert@1.17.8(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       axios: 1.11.0(debug@4.4.1)
       debug: 4.4.1
       picocolors: 1.1.1
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - supports-color
 
-  vite-plugin-node-polyfills@0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-node-polyfills@0.24.0(rollup@4.52.5)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@rollup/plugin-inject': 5.0.5(rollup@4.52.5)
       node-stdlib-browser: 1.3.1
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
 
-  vite-plugin-svgr@4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vite-plugin-svgr@4.5.0(rollup@4.52.5)(typescript@5.9.2)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@rollup/pluginutils': 5.2.0(rollup@4.52.5)
       '@svgr/core': 8.1.0(typescript@5.9.2)
       '@svgr/plugin-jsx': 8.1.0(@svgr/core@8.1.0(typescript@5.9.2))
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
     transitivePeerDependencies:
       - rollup
       - supports-color
@@ -22633,7 +22344,7 @@ snapshots:
     dependencies:
       lib-esm: 0.3.0
 
-  vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
+  vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:
       esbuild: 0.25.9
       fdir: 6.5.0(picomatch@4.0.3)
@@ -22646,11 +22357,10 @@ snapshots:
       fsevents: 2.3.3
       jiti: 2.5.1
       lightningcss: 1.32.0
-      terser: 5.37.0
       tsx: 4.20.3
       yaml: 2.7.1
 
-  vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1):
+  vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1):
     dependencies:
       '@oxc-project/runtime': 0.115.0
       lightningcss: 1.32.0
@@ -22663,18 +22373,17 @@ snapshots:
       esbuild: 0.25.11
       fsevents: 2.3.3
       jiti: 2.5.1
-      terser: 5.37.0
       tsx: 4.20.3
       yaml: 2.7.1
 
-  vitefu@1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vitefu@1.1.1(vite@6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1)):
     optionalDependencies:
-      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 6.4.1(@types/node@22.17.0)(jiti@2.5.1)(lightningcss@1.32.0)(tsx@4.20.3)(yaml@2.7.1)
 
-  vitest@4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(jsdom@20.0.3)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)):
+  vitest@4.1.0(@types/node@22.17.0)(@vitest/ui@4.1.0)(happy-dom@18.0.1)(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)):
     dependencies:
       '@vitest/expect': 4.1.0
-      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1))
+      '@vitest/mocker': 4.1.0(vite@8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1))
       '@vitest/pretty-format': 4.1.0
       '@vitest/runner': 4.1.0
       '@vitest/snapshot': 4.1.0
@@ -22691,24 +22400,18 @@ snapshots:
       tinyexec: 1.0.2
       tinyglobby: 0.2.15
       tinyrainbow: 3.1.0
-      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(terser@5.37.0)(tsx@4.20.3)(yaml@2.7.1)
+      vite: 8.0.0(@types/node@22.17.0)(esbuild@0.25.11)(jiti@2.5.1)(tsx@4.20.3)(yaml@2.7.1)
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.17.0
       '@vitest/ui': 4.1.0(vitest@4.1.0)
       happy-dom: 18.0.1
-      jsdom: 20.0.3
     transitivePeerDependencies:
       - msw
 
   vm-browserify@1.1.2: {}
 
   void-elements@3.1.0: {}
-
-  w3c-xmlserializer@4.0.0:
-    dependencies:
-      xml-name-validator: 4.0.0
-    optional: true
 
   walk-sync@2.2.0:
     dependencies:
@@ -22731,15 +22434,7 @@ snapshots:
 
   webidl-conversions@4.0.2: {}
 
-  webidl-conversions@7.0.0:
-    optional: true
-
   webpack-virtual-modules@0.6.2: {}
-
-  whatwg-encoding@2.0.0:
-    dependencies:
-      iconv-lite: 0.6.3
-    optional: true
 
   whatwg-encoding@3.1.1:
     dependencies:
@@ -22748,12 +22443,6 @@ snapshots:
   whatwg-mimetype@3.0.0: {}
 
   whatwg-mimetype@4.0.0: {}
-
-  whatwg-url@11.0.0:
-    dependencies:
-      tr46: 3.0.0
-      webidl-conversions: 7.0.0
-    optional: true
 
   whatwg-url@5.0.0:
     dependencies:
@@ -22876,9 +22565,6 @@ snapshots:
 
   ws@8.19.0: {}
 
-  xml-name-validator@4.0.0:
-    optional: true
-
   xml2js@0.6.2:
     dependencies:
       sax: 1.4.1
@@ -22887,9 +22573,6 @@ snapshots:
   xmlbuilder@11.0.1: {}
 
   xmlbuilder@15.1.1: {}
-
-  xmlchars@2.2.0:
-    optional: true
 
   xtend@4.0.2: {}
 

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,20 @@
+packages:
+  - .
+
+savePrefix: ''
+minimumReleaseAge: 4320
+blockExoticSubdeps: false
+
+peerDependencyRules:
+  allowedVersions:
+    vite: '8'
+
+allowBuilds:
+  '@swc/core': true
+  '@tailwindcss/oxide': true
+  electron: true
+  electron-winstaller: true
+  esbuild: true
+  oxc-resolver: true
+  sharp: true
+  unrs-resolver: true


### PR DESCRIPTION
## Description
- Upgrade project tooling to pnpm@11.4.0
- Move pnpm settings from package.json / .npmrc into pnpm-workspace.yaml
- Replace removed onlyBuiltDependencies config with v11 allowBuilds
- Allow Electron’s git-hosted transitive @electron/node-gyp dependency via blockExoticSubdeps: false
- Update CI, Docker, and devcontainer pnpm setup to use the same pinned pnpm version
- Refresh pnpm-lock.yaml with pnpm v11 metadata normalization

## Related Issues
<!-- List the issues this PR closes or relates to using GitHub keywords like "Closes #123" or "Related to #456" -->

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
