### PR TITLE
fix: multisig operations verify proxy memo

### DIFF
--- a/src/renderer/features/multisig-operations/lib/verify-proxy-op.test.ts
+++ b/src/renderer/features/multisig-operations/lib/verify-proxy-op.test.ts
@@ -36,6 +36,13 @@ const proxyWrap = (inner: DecodedTransaction) =>
     args: { real: pureProxy, forceProxyType: 'Any', transaction: inner },
   });
 
+const batchAll = (transactions: DecodedTransaction[]) =>
+  tx({
+    section: 'utility',
+    method: 'batchAll',
+    args: { transactions },
+  });
+
 const operation = (transaction: DecodedTransaction | null): MultisigOperation =>
   ({
     id: 'op-1',
@@ -130,6 +137,22 @@ describe('parseVerifyProxyOperation', () => {
       memo: 'Q1 audit sign-off',
     });
     const op = operation(proxyWrap(remarkWithEvent(payloadWithMemo)));
+    expect(parseVerifyProxyOperation(op)).toEqual({
+      delegateAccountId: delegate,
+      pureProxyAccountId: pureProxy,
+      memo: 'Q1 audit sign-off',
+    });
+  });
+
+  test('returns memo when verify-proxy call is nested in a batch', () => {
+    const payloadWithMemo = JSON.stringify({
+      kind: VERIFY_PROXY_REMARK_KIND,
+      delegateAccountId: delegate,
+      pureProxyAccountId: pureProxy,
+      memo: 'Q1 audit sign-off',
+    });
+    const op = operation(batchAll([proxyWrap(remarkWithEvent(payloadWithMemo))]));
+
     expect(parseVerifyProxyOperation(op)).toEqual({
       delegateAccountId: delegate,
       pureProxyAccountId: pureProxy,

--- a/src/renderer/features/multisig-operations/lib/verify-proxy-op.ts
+++ b/src/renderer/features/multisig-operations/lib/verify-proxy-op.ts
@@ -13,13 +13,33 @@ export type VerifyProxyOpInfo = {
 };
 
 const isProxyWrap = (tx: DecodedTransaction): boolean => tx.section === 'proxy' && tx.method === 'proxy';
+const BATCH_METHODS = new Set(['batch', 'batchAll', 'forceBatch']);
 
-const unwrapProxyOrNull = (tx: DecodedTransaction | null): DecodedTransaction | null => {
-  if (nullable(tx) || !isProxyWrap(tx)) return null;
-  const inner = (tx.args['transaction'] as DecodedTransaction | null) ?? null;
-  if (nullable(inner)) return null;
-  // Tolerate nested proxy.proxy wrappers (defensive — real ops shouldn't nest).
-  return isProxyWrap(inner) ? unwrapProxyOrNull(inner) : inner;
+const findVerifyProxyRemark = (tx: DecodedTransaction | null): DecodedTransaction | null => {
+  if (nullable(tx)) return null;
+
+  if (isProxyWrap(tx)) {
+    const inner = (tx.args['transaction'] as DecodedTransaction | null) ?? null;
+    if (nullable(inner)) return null;
+
+    if (inner.section === 'system' && inner.method === 'remarkWithEvent') {
+      return inner;
+    }
+
+    return findVerifyProxyRemark(inner);
+  }
+
+  if (tx.section === 'utility' && BATCH_METHODS.has(tx.method)) {
+    const transactions = tx.args['transactions'];
+    if (!Array.isArray(transactions)) return null;
+
+    for (const child of transactions as DecodedTransaction[]) {
+      const found = findVerifyProxyRemark(child);
+      if (found) return found;
+    }
+  }
+
+  return null;
 };
 
 // Verify-proxy ping shape: `proxy.proxy(real=pure, call=system.remarkWithEvent(<verify-proxy marker>))`.
@@ -27,9 +47,8 @@ const unwrapProxyOrNull = (tx: DecodedTransaction | null): DecodedTransaction | 
 // `features/proxy-verify/lib/build-verify-proxy.ts`), and additionally require the marker payload
 // so incidental proxy.remarkWithEvent ops don't render here.
 export const parseVerifyProxyOperation = (operation: MultisigOperation): VerifyProxyOpInfo | null => {
-  const inner = unwrapProxyOrNull(operation.transaction);
+  const inner = findVerifyProxyRemark(operation.transaction);
   if (nullable(inner)) return null;
-  if (inner.section !== 'system' || inner.method !== 'remarkWithEvent') return null;
   const remark = inner.args['remark'];
   if (typeof remark !== 'string') return null;
   const payload = parseVerifyProxyMarker(remark);


### PR DESCRIPTION
## Description
Fix Verify Proxy multisig operation details so memo is shown when the verify remark is nested inside wrapper calls.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-600

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="527" height="380" alt="Screenshot 2026-05-28 at 12 09 31 PM" src="https://github.com/user-attachments/assets/23275e80-96d6-4ae3-9ffb-df515264848e" />
<img width="508" height="456" alt="Screenshot 2026-05-28 at 12 09 45 PM" src="https://github.com/user-attachments/assets/a40d377d-fb7a-4786-81f9-fe8d7575e9ad" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
