### PR TITLE
fix: filter flexible multisig replacement candidates by chain family

### DIFF
--- a/src/renderer/features/flexible-change-signatories/ui/components/UnifiedPicker.test.ts
+++ b/src/renderer/features/flexible-change-signatories/ui/components/UnifiedPicker.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest';
+
+import { type Chain, ChainOptions } from '@/shared/core';
+import { createAccountId } from '@/shared/mocks';
+import { type MultisigCandidate } from '@/aggregates/multisig-candidates';
+
+import { filterCandidatesByChainFamily } from './UnifiedPicker';
+
+const substrateChain = {
+  options: [],
+} as unknown as Chain;
+
+const ethereumChain = {
+  options: [ChainOptions.ETHEREUM_BASED],
+} as unknown as Chain;
+
+const substrateCandidate = {
+  source: 'wallet',
+  walletId: 1,
+  name: 'Substrate multisig',
+  accountId: createAccountId('substrate-multisig'),
+  address: '5Substrate' as never,
+  signatories: [createAccountId('substrate-signatory')],
+  threshold: 1,
+} satisfies MultisigCandidate;
+
+const ethereumCandidate = {
+  source: 'wallet',
+  walletId: 2,
+  name: 'Ethereum multisig',
+  accountId: '0x1111111111111111111111111111111111111111' as never,
+  address: '0x1111111111111111111111111111111111111111' as never,
+  signatories: ['0x2222222222222222222222222222222222222222' as never],
+  threshold: 1,
+} satisfies MultisigCandidate;
+
+describe('filterCandidatesByChainFamily', () => {
+  it('keeps only substrate multisigs for substrate chains', () => {
+    expect(filterCandidatesByChainFamily([substrateCandidate, ethereumCandidate], substrateChain)).toEqual([
+      substrateCandidate,
+    ]);
+  });
+
+  it('keeps only EVM multisigs for EVM chains', () => {
+    expect(filterCandidatesByChainFamily([substrateCandidate, ethereumCandidate], ethereumChain)).toEqual([
+      ethereumCandidate,
+    ]);
+  });
+});

--- a/src/renderer/features/flexible-change-signatories/ui/components/UnifiedPicker.tsx
+++ b/src/renderer/features/flexible-change-signatories/ui/components/UnifiedPicker.tsx
@@ -3,14 +3,20 @@ import { useCallback, useMemo, useState } from 'react';
 
 import { type Address, type Chain } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
-import { performSearch, toAddress, toShortAddress } from '@/shared/lib/utils';
+import {
+  isEthereumAccountId,
+  isSubstrateAccountId,
+  performSearch,
+  toAddress,
+  toShortAddress,
+} from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HelpText } from '@/shared/ui';
 import { AccountExplorers, Address as AddressDisplay, Identicon } from '@/shared/ui-entities';
 import { Field, Select, Tabs } from '@/shared/ui-kit';
 import { accountService, accounts as accountsStore, identity, useAccountName } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
-import { networkModel } from '@/entities/network';
+import { networkModel, networkUtils } from '@/entities/network';
 import {
   type ContactCandidate,
   type MultisigCandidate,
@@ -29,6 +35,14 @@ type Props = {
 };
 
 type Mode = 'modify' | 'replace';
+
+export const filterCandidatesByChainFamily = (candidates: MultisigCandidate[], chain: Chain): MultisigCandidate[] => {
+  const isEthereumChain = networkUtils.isEthereumBased(chain.options);
+
+  return candidates.filter((candidate) =>
+    isEthereumChain ? isEthereumAccountId(candidate.accountId) : isSubstrateAccountId(candidate.accountId),
+  );
+};
 
 export const UnifiedPicker = ({ chain, currentControllerAddress, currentThreshold }: Props) => {
   const { t } = useI18n();
@@ -56,7 +70,7 @@ export const UnifiedPicker = ({ chain, currentControllerAddress, currentThreshol
 
   const selectableCandidates = useMemo(
     () =>
-      candidates
+      filterCandidatesByChainFamily(candidates, chain)
         .filter((c) => c.address !== currentControllerAddress)
         .map((c) => {
           const resolved = accountService.resolveAccountName({
@@ -69,7 +83,7 @@ export const UnifiedPicker = ({ chain, currentControllerAddress, currentThreshol
           });
           return { ...c, name: resolved === shortAddressFor(c.accountId) ? c.name : resolved };
         }),
-    [candidates, currentControllerAddress, chain, allAccounts, allContacts, allIdentities, allChains, shortAddressFor],
+    [candidates, chain, currentControllerAddress, allAccounts, allContacts, allIdentities, allChains, shortAddressFor],
   );
 
   const filtered = useMemo(


### PR DESCRIPTION
## Description
Filter flexible multisig “Replace with existing” candidates by chain family, so EVM wallets only show EVM multisigs and Substrate wallets only show Substrate multisigs.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-601

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings

https://github.com/user-attachments/assets/9e438ffd-bf41-4372-80d4-d554b4097e3a



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
