### PR TITLE
fix: show signer accounts in multisig operations

### DIFF
--- a/src/renderer/features/multisig-operations/components/Details.test.tsx
+++ b/src/renderer/features/multisig-operations/components/Details.test.tsx
@@ -1,0 +1,162 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type Chain, type Wallet } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type AnyAccount, type MultisigOperation } from '@/domains/network';
+
+import { Details } from './Details';
+
+const stores = vi.hoisted(() => ({
+  walletsStore: Symbol('wallets'),
+  chainsStore: Symbol('chains'),
+}));
+
+vi.mock('effector-react', () => ({
+  useStoreMap: () => ({}),
+  useUnit: (store: symbol) => {
+    if (store === stores.walletsStore) return testWallets;
+    if (store === stores.chainsStore) return {};
+    return undefined;
+  },
+}));
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      if (key === 'operation.details.signerAccount') return 'Signer Account';
+      if (key === 'transfer.signatoryLabel') return 'Signatory';
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/shared/ui', () => ({
+  CaptionText: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  DetailRow: ({ label, children }: { label: string; children: ReactNode }) => (
+    <div>
+      <dt>{label}</dt>
+      <dd>{children}</dd>
+    </div>
+  ),
+  FootnoteText: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Icon: () => null,
+}));
+
+vi.mock('@/shared/ui-entities', () => ({
+  AccountExplorers: () => null,
+  AssetBalance: () => null,
+  WalletIcon: () => null,
+}));
+
+vi.mock('@/shared/ui-kit', () => ({
+  Box: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  Skeleton: () => null,
+}));
+
+vi.mock('@/domains/network', () => ({
+  identity: { $list: null },
+}));
+
+vi.mock('@/domains/staking', () => ({
+  useActiveEra: () => ({ data: null }),
+  useValidators: () => ({ data: {} }),
+}));
+
+vi.mock('@/entities/network', () => ({
+  networkModel: { $chains: stores.chainsStore },
+}));
+
+vi.mock('@/entities/chain', () => ({
+  ChainTitle: () => null,
+}));
+
+vi.mock('@/entities/governance', () => ({
+  TracksDetails: () => null,
+  voteTransactionService: {
+    getAccountVote: () => null,
+    getConviction: () => null,
+  },
+}));
+
+vi.mock('@/entities/operations', () => ({
+  operationDetailsUtils: {
+    getDelegate: () => null,
+    getDelegationTarget: () => null,
+    getDelegationTracks: () => [],
+    getDelegationVotes: () => null,
+    getDestination: () => null,
+    getDestinationAccountId: () => null,
+    getDestinationChain: () => null,
+    getPayee: () => undefined,
+    getProxyType: () => null,
+    getReferendumId: () => null,
+    getSpawner: () => null,
+    getUndelegationData: () => Promise.resolve({ votes: undefined, target: undefined }),
+    getVote: () => null,
+  },
+}));
+
+vi.mock('@/entities/staking', () => ({
+  SelectedValidatorsModal: () => null,
+}));
+
+vi.mock('@/entities/transaction', () => ({
+  isAddProxyTransaction: () => false,
+  isManageProxyTransaction: () => false,
+  isProxyTransaction: () => false,
+  isRemoveProxyTransaction: () => false,
+  isRemovePureProxyTransaction: () => false,
+  isTransferTransaction: () => false,
+  isUndelegateTransaction: () => false,
+  isXcmTransaction: () => false,
+}));
+
+vi.mock('@/entities/wallet', () => ({
+  walletModel: { $wallets: stores.walletsStore },
+}));
+
+vi.mock('@/widgets/NameResolver', () => ({
+  NamedAccount: ({ title, accountId }: { title?: string; accountId: AccountId }) => <span>{title ?? accountId}</span>,
+  WalletName: ({ wallet }: { wallet: Wallet }) => <span>{wallet.name}</span>,
+}));
+
+const signerAccountId = '0x01' as AccountId;
+const signerWalletId = 1;
+const testWallets = [
+  {
+    id: signerWalletId,
+    name: 'Signer Wallet',
+    accounts: [],
+    type: 'polkadot_vault',
+  },
+] as unknown as Wallet[];
+
+const chain = {
+  chainId: '0x00',
+  assets: [],
+} as unknown as Chain;
+
+const operation = {
+  id: 'operation-id',
+  chainId: chain.chainId,
+  transaction: null,
+} as unknown as MultisigOperation;
+
+const signer = {
+  id: 'signer-account',
+  name: 'Alice Signer',
+  walletId: signerWalletId,
+  accountId: signerAccountId,
+} as unknown as AnyAccount;
+
+describe('Details', () => {
+  it('shows signer account instead of signer wallet for multisig operation signatory', () => {
+    render(<Details api={{} as never} operation={operation} chain={chain} signatory={signer} />);
+
+    expect(screen.getByText('Signer Account')).toBeInTheDocument();
+    expect(screen.getByText('Alice Signer')).toBeInTheDocument();
+    expect(screen.queryByText('Signer Wallet')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/multisig-operations/components/Details.tsx
+++ b/src/renderer/features/multisig-operations/components/Details.tsx
@@ -195,13 +195,15 @@ export const Details = ({ api, operation, account, multisigAccount, chain, signa
       )}
 
       {signatory && signatoryWallet && (
-        <DetailRow label={t('transfer.signatoryLabel')} className="text-text-secondary">
+        <DetailRow label={t('operation.details.signerAccount')} className="text-text-secondary">
           <Box direction="row" gap={2}>
-            <WalletIcon type={signatoryWallet.type} size={16} />
-            <span>
-              <WalletName wallet={signatoryWallet} />
-            </span>
-            {chain ? <AccountExplorers accountId={signatory.accountId} chain={chain} /> : null}
+            <NamedAccount
+              chain={chain}
+              accountId={signatory.accountId}
+              title={signatory.name}
+              wallet={signatoryWallet}
+              variant="short"
+            />
           </Box>
         </DetailRow>
       )}

--- a/src/renderer/features/multisig-operations/components/OperationSignatories.test.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationSignatories.test.tsx
@@ -1,0 +1,145 @@
+import { render, screen } from '@testing-library/react';
+import { type ReactNode } from 'react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type MultisigAccount, type Wallet } from '@/shared/core';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type AnyAccount, type MultisigOperation } from '@/domains/network';
+
+import { OperationSignatories } from './OperationSignatories';
+
+const stores = vi.hoisted(() => ({
+  walletsStore: Symbol('wallets'),
+  accountsStore: Symbol('accounts'),
+}));
+
+vi.mock('effector-react', () => ({
+  useUnit: (store: symbol) => {
+    if (store === stores.walletsStore) return testWallets;
+    if (store === stores.accountsStore) return testAccounts;
+    return undefined;
+  },
+}));
+
+vi.mock('@/shared/di', () => ({
+  createSlot: () => Symbol('slot'),
+  Slot: ({ props }: { props?: { trigger?: ReactNode } }) => props?.trigger ?? null,
+}));
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: () => ({
+    t: (key: string) => {
+      if (key === 'operation.walletSignatoriesTitle') return 'Your accounts';
+      if (key === 'operation.contactSignatoriesTitle') return 'Contacts';
+      if (key === 'operation.signatoriesTitle') return 'Signatories';
+      if (key === 'operation.logButton') return 'Log';
+      if (key === 'operation.openOverviewButton') return 'Open overview';
+      return key;
+    },
+  }),
+}));
+
+vi.mock('@/shared/lib/utils', () => ({
+  nonNullable: <T,>(value: T | null | undefined): value is T => value !== null && value !== undefined,
+  toAddress: (accountId: AccountId) => accountId,
+}));
+
+vi.mock('@/shared/ui', () => ({
+  BodyText: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({ children }: { children: ReactNode }) => <button>{children}</button>,
+  CaptionText: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  FootnoteText: ({ children }: { children: ReactNode }) => <h4>{children}</h4>,
+  Icon: () => null,
+  SmallTitleText: ({ children }: { children: ReactNode }) => <h3>{children}</h3>,
+}));
+
+vi.mock('@/shared/ui-entities', () => ({
+  Address: ({ title, address }: { title?: string; address: string }) => <span>{title ?? address}</span>,
+  WalletIcon: () => null,
+}));
+
+vi.mock('@/domains/network', () => ({
+  accounts: { $list: stores.accountsStore },
+  isContactMultisigAccount: () => false,
+  multisigOperationService: {
+    getApprovals: () => [],
+  },
+  useAccountName: ({ accountId }: { accountId: AccountId }) => accountId,
+}));
+
+vi.mock('@/entities/network', () => ({
+  useChain: () => ({ chainId: '0x00', addressPrefix: 0 }),
+}));
+
+vi.mock('@/entities/operations', () => ({
+  operationDetailsUtils: {
+    getSignatoryStatus: () => 'pending',
+  },
+}));
+
+vi.mock('@/entities/signatory', () => ({
+  SignatoryCard: ({ children }: { children: ReactNode }) => <li>{children}</li>,
+}));
+
+vi.mock('@/entities/wallet', () => ({
+  accountUtils: {
+    isFlexibleMultisigAccount: () => false,
+  },
+  walletModel: { $wallets: stores.walletsStore },
+}));
+
+vi.mock('@/widgets/NameResolver', () => ({
+  NamedAccount: ({ title, accountId }: { title?: string; accountId: AccountId }) => <span>{title ?? accountId}</span>,
+  WalletName: ({ wallet }: { wallet: Wallet }) => <span>{wallet.name}</span>,
+}));
+
+vi.mock('./LogModal', () => ({
+  default: () => null,
+}));
+
+const ownedSignatoryId = '0x01' as AccountId;
+const contactSignatoryId = '0x02' as AccountId;
+const signerWalletId = 1;
+
+const testWallets = [
+  {
+    id: signerWalletId,
+    name: 'Signer Wallet',
+    accounts: [],
+    type: 'polkadot_vault',
+  },
+] as unknown as Wallet[];
+
+const testAccounts = [
+  {
+    id: 'owned-signatory',
+    name: 'Alice Signer',
+    walletId: signerWalletId,
+    accountId: ownedSignatoryId,
+  },
+] as unknown as AnyAccount[];
+
+const operation = {
+  id: 'operation-id',
+  chainId: '0x00',
+  events: [],
+  transaction: null,
+} as unknown as MultisigOperation;
+
+const multisigAccount = {
+  id: 'multisig',
+  accountId: '0x03',
+  walletId: 2,
+  signatories: [{ accountId: ownedSignatoryId }, { accountId: contactSignatoryId }],
+} as unknown as MultisigAccount;
+
+describe('OperationSignatories', () => {
+  it('renders owned signatories as accounts instead of wallets', () => {
+    render(<OperationSignatories operation={operation} account={multisigAccount} />);
+
+    expect(screen.getByText('Your accounts')).toBeInTheDocument();
+    expect(screen.getByText('Alice Signer')).toBeInTheDocument();
+    expect(screen.queryByText('Your wallets')).not.toBeInTheDocument();
+    expect(screen.queryByText('Signer Wallet')).not.toBeInTheDocument();
+  });
+});

--- a/src/renderer/features/multisig-operations/components/OperationSignatories.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationSignatories.tsx
@@ -8,14 +8,15 @@ import {
   type ProxyType,
   type Signatory,
   type Wallet,
+  ProxyTypes,
   TransactionType,
 } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
 import { nonNullable, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { BodyText, Button, CaptionText, FootnoteText, Icon, SmallTitleText } from '@/shared/ui';
-import { Address, WalletIcon } from '@/shared/ui-entities';
+import { Button, CaptionText, FootnoteText, Icon, SmallTitleText } from '@/shared/ui';
+import { Address } from '@/shared/ui-entities';
 import {
   type AnyAccount,
   type MultisigOperation,
@@ -28,7 +29,7 @@ import { useChain } from '@/entities/network';
 import { operationDetailsUtils } from '@/entities/operations';
 import { SignatoryCard } from '@/entities/signatory';
 import { accountUtils, walletModel } from '@/entities/wallet';
-import { WalletName } from '@/widgets/NameResolver';
+import { NamedAccount } from '@/widgets/NameResolver';
 
 import LogModal from './LogModal';
 
@@ -54,7 +55,7 @@ const SignatoryAddress = ({ accountId, chain }: SignatoryAddressProps) => {
 const getOperationProxyType = (operation: MultisigOperation): ProxyType | null => {
   if (operation.transaction?.type !== TransactionType.PROXY) return null;
 
-  return operation.transaction.args.forceProxyType as ProxyType;
+  return Object.values(ProxyTypes).find(proxyType => proxyType === operation.transaction?.args.forceProxyType) ?? null;
 };
 
 export const operationOverviewSlot = createSlot<{
@@ -64,7 +65,7 @@ export const operationOverviewSlot = createSlot<{
   exclusive?: boolean;
 }>();
 
-type WalletSignatory = Signatory & { wallet: Wallet };
+type WalletSignatory = Signatory & { account: AnyAccount; wallet: Wallet };
 
 type Props = {
   operation: MultisigOperation;
@@ -105,9 +106,10 @@ export const OperationSignatories = ({ operation, account }: Props) => {
   const walletSignatories: WalletSignatory[] = signatoriesList.reduce((acc: WalletSignatory[], signatory) => {
     const signatoryAccounts = accountsList.filter(account => account.accountId === signatory.accountId);
     const signatoryWallet = wallets.find(w => signatoryAccounts.some(account => account.walletId === w.id));
+    const signatoryAccount = signatoryAccounts.find(account => account.walletId === signatoryWallet?.id);
 
-    if (signatoryWallet) {
-      acc.push({ ...signatory, wallet: signatoryWallet });
+    if (signatoryAccount && signatoryWallet) {
+      acc.push({ ...signatory, account: signatoryAccount, wallet: signatoryWallet });
     }
 
     return acc;
@@ -195,10 +197,14 @@ export const OperationSignatories = ({ operation, account }: Props) => {
                   key={signatory.accountId}
                   status={operationDetailsUtils.getSignatoryStatus(operation.events, signatory.accountId)}
                 >
-                  <WalletIcon type={signatory.wallet.type} size={20} />
-                  <BodyText className="mr-auto truncate text-inherit">
-                    <WalletName wallet={signatory.wallet} />
-                  </BodyText>
+                  <NamedAccount
+                    accountId={signatory.account.accountId}
+                    chain={chain ?? undefined}
+                    title={signatory.account.name}
+                    wallet={signatory.wallet}
+                    variant="short"
+                    iconSize={20}
+                  />
                 </SignatoryCard>
               ))}
             </ul>

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -2491,6 +2491,7 @@
       "sender": "Sender",
       "senderAccount": "Sender account",
       "senderProxiedWallet": "Sender proxied wallet",
+      "signerAccount": "Signer Account",
       "timePoint": "Time Point",
       "toNetwork": "To network",
       "validators": "Validators",
@@ -2601,7 +2602,7 @@
       "signTitle_other": "Confirm { count } operations on your { walletName } app",
       "tryAgainButton": "Try again"
     },
-    "walletSignatoriesTitle": "Your wallets",
+    "walletSignatoriesTitle": "Your accounts",
     "xcmFee": "Cross-chain fee"
   },
   "operations": {


### PR DESCRIPTION
## Description
Multisig operations. Show “Signer Account” not “Signer Wallet” in signatories

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-603

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="468" height="524" alt="Screenshot 2026-05-29 at 10 52 15 AM" src="https://github.com/user-attachments/assets/9c18f25c-7312-4dec-bb60-87d0c3457b68" />
<img width="1475" height="702" alt="Screenshot 2026-05-29 at 10 52 33 AM" src="https://github.com/user-attachments/assets/714a70b7-0578-40c2-9e62-23af4278cea8" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#56