### PR TITLE
refactor(presets): streamline manage presets. SPEK-613

### DIFF
--- a/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/CustomAccountSelector.tsx
@@ -4,21 +4,19 @@ import { useI18n } from '@/shared/i18n';
 import { cnTw, includesMultiple, toShortAddress } from '@/shared/lib/utils';
 import { CaptionText, FootnoteText } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
-import { Checkbox, Input, SearchInput } from '@/shared/ui-kit';
+import { Checkbox, SearchInput } from '@/shared/ui-kit';
 import { type AccountEntry } from '@/aggregates/account-presets';
 
 import { AccountEntryRowBadges } from './AccountEntryRowBadges';
 import { VirtualAccountList } from './VirtualAccountList';
 
 type Props = {
-  name: string;
   allEntries: AccountEntry[];
   selectedIds: string[];
-  onNameChange: (name: string) => void;
   onSelectedIdsChange: (ids: string[]) => void;
 };
 
-export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameChange, onSelectedIdsChange }: Props) => {
+export const CustomAccountSelector = ({ allEntries, selectedIds, onSelectedIdsChange }: Props) => {
   const { t } = useI18n();
   const [search, setSearch] = useState('');
 
@@ -56,21 +54,6 @@ export const CustomAccountSelector = ({ name, allEntries, selectedIds, onNameCha
 
   return (
     <div className="flex flex-col gap-y-3">
-      <div className="flex flex-col gap-y-1">
-        <label className="text-footnote text-text-tertiary">{t('dashboard.presets.modal.name')}</label>
-        <Input
-          value={name}
-          placeholder={t('dashboard.presets.modal.namePlaceholder')}
-          maxLength={30}
-          width="full"
-          onChange={onNameChange}
-        />
-      </div>
-
-      <FootnoteText className="text-text-tertiary">
-        {t('dashboard.presets.modal.selectedCount', { count: selectedIds.length })}
-      </FootnoteText>
-
       <SearchInput value={search} placeholder={t('dashboard.presets.modal.searchAccounts')} onChange={setSearch} />
 
       <div className="rounded-sm px-2 py-1">

--- a/src/renderer/widgets/PresetManagementModal/ui/PresetFilterEditor.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/PresetFilterEditor.tsx
@@ -4,14 +4,11 @@ import { useMemo } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
 import { MultiSelect } from '@/shared/ui';
-import { Input } from '@/shared/ui-kit';
 import { contactModel } from '@/entities/contact';
 import { type AccountSource, type PresetFilterCriteria } from '@/aggregates/account-presets';
 
 type Props = {
-  name: string;
   filters: PresetFilterCriteria;
-  onNameChange: (name: string) => void;
   onFiltersChange: (filters: PresetFilterCriteria) => void;
 };
 
@@ -26,7 +23,7 @@ const SOURCE_OPTIONS: SourceOption[] = [
   { id: 'backend-contact', label: 'dashboard.presets.sources.backendContact' },
 ];
 
-export const PresetFilterEditor = ({ name, filters, onNameChange, onFiltersChange }: Props) => {
+export const PresetFilterEditor = ({ filters, onFiltersChange }: Props) => {
   const { t } = useI18n();
   const backendContacts = useUnit(contactModel.$backendContacts);
 
@@ -86,17 +83,6 @@ export const PresetFilterEditor = ({ name, filters, onNameChange, onFiltersChang
 
   return (
     <div className="flex flex-col gap-y-3">
-      <div className="flex flex-col gap-y-1">
-        <label className="text-footnote text-text-tertiary">{t('dashboard.presets.modal.name')}</label>
-        <Input
-          value={name}
-          placeholder={t('dashboard.presets.modal.namePlaceholder')}
-          maxLength={30}
-          width="full"
-          onChange={onNameChange}
-        />
-      </div>
-
       <div className="flex flex-col gap-y-1">
         <span className="text-footnote text-text-tertiary">{t('dashboard.presets.modal.sourceType')}</span>
         <div className="flex flex-wrap gap-2">

--- a/src/renderer/widgets/PresetManagementModal/ui/PresetManagementModal.tsx
+++ b/src/renderer/widgets/PresetManagementModal/ui/PresetManagementModal.tsx
@@ -7,7 +7,7 @@ import { type ComponentProps, useCallback, useEffect, useMemo, useRef, useState 
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
 import { Button, FootnoteText, Icon } from '@/shared/ui';
-import { Modal, useNotification } from '@/shared/ui-kit';
+import { Input, Modal, useNotification } from '@/shared/ui-kit';
 import {
   type PresetFilterCriteria,
   type PresetType,
@@ -220,24 +220,28 @@ export const PresetManagementModal = ({ isOpen, onClose }: Props) => {
               />
             </div>
 
+            <div className="flex flex-col gap-y-1">
+              <label className="text-footnote text-text-tertiary">{t('dashboard.presets.modal.name')}</label>
+              <Input
+                value={editName}
+                placeholder={t('dashboard.presets.modal.namePlaceholder')}
+                maxLength={30}
+                width="full"
+                onChange={setEditName}
+              />
+            </div>
+
             <SourceBreakdownBar entries={matchedEntries} total={allEntries.length} tone="light" />
 
             {editType === 'filter' ? (
               <>
-                <PresetFilterEditor
-                  name={editName}
-                  filters={editFilters}
-                  onNameChange={setEditName}
-                  onFiltersChange={setEditFilters}
-                />
+                <PresetFilterEditor filters={editFilters} onFiltersChange={setEditFilters} />
                 <MatchedAccountsPreview matched={matchedEntries} totalEntries={allEntries.length} />
               </>
             ) : (
               <CustomAccountSelector
-                name={editName}
                 allEntries={allEntries}
                 selectedIds={editSelectedIds}
-                onNameChange={setEditName}
                 onSelectedIdsChange={setEditSelectedIds}
               />
             )}


### PR DESCRIPTION
## What

Tidies up the **Manage Presets** modal layout:

- **Lift the `Name` field into the preset panel**, directly above the source-breakdown bar — shared by both *Custom Selection* and *Smart Filter* modes.
- **Remove the duplicate `Name` inputs** that lived inside `CustomAccountSelector` and `PresetFilterEditor`.
- **Remove the redundant `N selected` line** in custom mode — the breakdown bar header (`3 of 137 accounts`) already reports the count.

## Why

The `Name` input was duplicated across both editors and the count was shown twice. Centralizing the name + breakdown bar gives a single, consistent header for both modes and removes ~27 net lines.



https://github.com/user-attachments/assets/3c3d9f43-a63e-4ab1-af4d-f5b5128c0ecd


Fixes novasamatech/nova-spektr-tracker#58