### PR TITLE
fix: prefetch draft submit validation balances

### DIFF
--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -33,11 +33,12 @@ import {
   multisigOperationService,
   transactionService,
 } from '@/domains/network';
-import { balanceModel } from '@/entities/balance';
+import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
-import { walletModel } from '@/entities/wallet';
+import { accountUtils, walletModel } from '@/entities/wallet';
 import { backendConfigurationModel } from '@/aggregates/backend';
 import { multisigOperationDescription } from '@/aggregates/multisig-operation-description';
+import { balanceSubModel } from '@/features/assets-balances';
 import { type TransactionSigningPayload, signModel } from '@/features/operations/OperationSign';
 import { type SuccessResult, ExtrinsicResult, submitModel } from '@/features/operations/OperationSubmit';
 import { createPathRouteStore } from '@/features/signing-path';
@@ -316,6 +317,54 @@ const $signatories = combine($graphSignatories, $savedPathSignatory, (graphSigna
 
 const $asset = $chain.map((chain) => (chain ? getNativeAsset(chain.assets) : null));
 
+const getDraftSubmitBalanceAccounts = (route: AnyAccount[]): AnyAccount[] => {
+  const accountsById = new Map<string, AnyAccount>();
+
+  const addAccount = (account: AnyAccount | null) => {
+    if (nullable(account) || accountsById.has(account.accountId)) return;
+    accountsById.set(account.accountId, account);
+  };
+
+  for (const account of route) {
+    if (accountUtils.isAnyMultisigAccount(account)) {
+      addAccount(accountService.findNextAccount(route, account));
+    }
+  }
+
+  addAccount(accountService.findSignatory(route));
+
+  return Array.from(accountsById.values());
+};
+
+const $validationBalanceRequests = combine({ route: $route, chain: $chain }, ({ route, chain }) => {
+  if (nullable(chain)) return [];
+
+  return getDraftSubmitBalanceAccounts(route).map((account) => ({
+    accountId: account.accountId,
+    chain,
+  }));
+});
+
+sample({
+  clock: $validationBalanceRequests,
+  filter: (requests) => requests.length > 0,
+  target: balanceSubModel.fetchAccountIds,
+});
+
+const $validationBalances = combine(
+  { balances: balanceModel.$balanceMap, requests: $validationBalanceRequests, asset: $asset },
+  ({ balances, requests, asset }) => {
+    if (nullable(asset) || requests.length === 0) return null;
+
+    const hasRequiredBalances = requests.every(({ accountId, chain }) => {
+      const balanceId = balanceUtils.constructBalanceId(accountId, chain.chainId, asset.assetId);
+      return nonNullable(balances[balanceId]);
+    });
+
+    return hasRequiredBalances ? balances : null;
+  },
+);
+
 const draftSubmitValidator = createTxValidator();
 
 const {
@@ -328,7 +377,7 @@ const {
   params: {
     api: $api,
     asset: $asset,
-    balances: balanceModel.$balanceMap,
+    balances: $validationBalances,
     route: $route,
     transaction: $wrappedTx,
   },

--- a/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
+++ b/tests/integrations/cases/drafts/draft-signing-path.integration.test.ts
@@ -1,4 +1,4 @@
-import { type Scope, allSettled } from 'effector';
+import { type Event, type Scope, allSettled, createStore } from 'effector';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 
 import {
@@ -15,6 +15,7 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type Draft, type PathNode } from '@/domains/backend';
 import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { walletModel } from '@/entities/wallet';
+import { balanceSubModel } from '@/features/assets-balances';
 import { submitDraftModel } from '@/features/drafts/model/submit-draft-model';
 import { polkadotChain, polkadotChainId, vaultWallet } from '../../fixtures/index';
 import { type FeatureTestEnvironment, FeatureTestBuilder, allureMetadata } from '../../utils/index';
@@ -139,6 +140,11 @@ const setupAccountHandlers = async (scope: Scope) => {
     },
   });
 };
+
+// `.watch` is blocked by `effector/no-watch`; collect payloads in a store instead.
+const payloadsStore = <T>(event: Event<T>) => createStore<T[]>([]).on(event, (s, p) => [...s, p]);
+
+const $balanceFetchPayloads = payloadsStore(balanceSubModel.fetchAccountIds);
 
 const buildEnv = async (testAccounts: AnyAccount[]): Promise<FeatureTestEnvironment> => {
   // `autoPopulate: false` + direct `withStoreValue` — the test storage uses a
@@ -346,6 +352,40 @@ describe('Submit Draft — signing path drives the route', () => {
       expect(route.map((a) => a.accountId)).toEqual([MULTISIG_TOP_ID, MULTISIG_MID_ID, SIGNER_ID]);
       expect(route).toHaveLength(3);
       expect(route.every((a) => a.accountId !== SIGNER_2_ID)).toBe(true);
+    });
+  });
+
+  describe('balance prefetch for validation', () => {
+    beforeEach(async () => {
+      await allureMetadata({
+        epic: 'Drafts',
+        feature: 'Submit Draft',
+        story: 'Submit prefetches fee and multisig-deposit payer balances',
+      });
+    });
+
+    it('requests balances for nested multisig deposit payers on flow start', async () => {
+      env = await buildEnv([multisigTop, multisigMid, signerAccount]);
+
+      const draft = makeDraft(
+        [
+          { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+          { kind: 'multisig', accountId: MULTISIG_MID_ID },
+          { kind: 'signer', accountId: SIGNER_ID },
+        ],
+        { multisigAccountId: MULTISIG_MID_ID, initiatorAccountId: SIGNER_ID },
+      );
+
+      await allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigMid, chain: polkadotChain },
+      });
+
+      const calls = env.getState($balanceFetchPayloads);
+      const lastCall = calls.at(-1);
+      expect(lastCall?.map(({ accountId }) => accountId)).toEqual([MULTISIG_MID_ID, SIGNER_ID]);
+      expect(lastCall?.map(({ chain }) => chain.chainId)).toEqual([polkadotChainId, polkadotChainId]);
+      expect(env.getState(submitDraftModel.$validationValid)).toBe(false);
     });
   });
 


### PR DESCRIPTION
## Description
Submit draft reused generic transaction validation but assumed needed balances were already present in `balanceModel.$balanceMap`. For nested multisig routes, an intermediate multisig can pay a multisig deposit, and that balance was not always loaded before validation. This could let users reach submission and then receive a chain `Funds Unavailable` failure.

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-599

## Changes Made
- Prefetch native balances for submit-draft route validation payers.
- Gate submit-draft transaction validation until required route payer balances are available.
- Add regression coverage for nested multisig draft submission balance prefetching.


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
