### PR TITLE
docs: add feature spec README convention for features and aggregates

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,6 +11,7 @@ Project documentation:
 - @docs/content/docs/onboarding/links.mdx
 - @docs/content/docs/code/style/naming.md
 - @docs/content/docs/code/style/effector.md
+- @docs/content/docs/code/style/feature-specs.md
 
 ## Workflow Orchestration
 
@@ -56,6 +57,24 @@ Project documentation:
 4. Explain Changes: High-level summary at each step
 5. Document Results: Add review to 'tasks/todo.md'
 6. Capture Lessons: Update 'tasks/lessons.md' after corrections
+
+## Feature Spec READMEs
+
+Non-trivial features and aggregates carry a colocated `README.md` — a **product
+spec** of what the code does and why (states, scenarios, lifecycle), not how it is
+wired. Full convention and template: @docs/content/docs/code/style/feature-specs.md.
+Worked example: `src/renderer/aggregates/multisig-operation-description/README.md`.
+
+- **Before changing a feature**: look for its `README.md` and read it first — it is
+  the source of product truth. If the code you touch contradicts it, surface that.
+- **When adding a feature or materially changing behavior**: draft or update the
+  `README.md` as part of the change, then get the author's approval on it before
+  finalizing — treat the spec as a deliverable alongside the code, never an
+  afterthought.
+- **Keep it in sync**: update the README in the same change that alters behavior;
+  never let it drift. Product-level English, mermaid diagrams where they help.
+- **Scope**: one README per feature/aggregate folder. Skip it for trivial,
+  presentation-only, or purely mechanical modules.
 
 ## Core Principles
 - Simplicity First: Make every change as simple as possible. Impact minimal code.

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -1,0 +1,108 @@
+---
+title: Feature specs
+sidebar:
+  order: 2
+---
+
+Non-trivial features and aggregates carry a **product spec** as a colocated
+`README.md`. It describes _what_ the code does and _why_ — the behaviour a product
+owner or a new contributor needs to understand — and deliberately leaves out _how_
+it is wired (store names, samples, file maps). The spec is the single source of
+product truth, kept in the repo so both people and AI agents find it the moment
+they open the folder.
+
+## Why specs live next to the code
+
+- **Discoverable.** A `README.md` in the feature folder is the first thing read on
+  navigation — by a reviewer, a new teammate, or an AI agent about to change the
+  code. No wiki to hunt through.
+- **Reviewed with the change.** When the spec ships in the same PR as the code,
+  reviewers approve behaviour and implementation together, and the spec cannot
+  silently drift from reality.
+- **A shared contract.** The spec is what the author and the implementer (human or
+  AI) agree on before the code is final. It captures intent that the code alone
+  cannot.
+
+## Where it lives
+
+One `README.md` per feature or aggregate folder, colocated with the code:
+
+```
+src/renderer/aggregates/<name>/README.md
+src/renderer/features/<name>/README.md
+```
+
+Worked example: `src/renderer/aggregates/multisig-operation-description/README.md`.
+
+## When to write or update one
+
+- **New feature / aggregate** with user-visible behaviour or non-obvious rules →
+  write a spec.
+- **Materially changing behaviour** of an existing one (new states, new gating, a
+  changed flow) → update its spec in the same change.
+- **Skip** for trivial, presentation-only, or purely mechanical modules (a styled
+  wrapper, a pure formatter, a rename). When in doubt, a short spec beats none.
+
+## The workflow (author ↔ implementer)
+
+The spec is a deliverable, not an afterthought. For AI-assisted work the loop is:
+
+1. **Draft first.** Before or alongside the implementation, draft the spec from the
+   agreed requirements — states, scenarios, lifecycle.
+2. **Get approval.** Present the draft to the person who owns the feature and
+   confirm it matches intent _before_ finalizing the code. Disagreements are
+   cheaper to resolve in prose than in code.
+3. **Ship together.** Commit the spec with the code change it describes. A behaviour
+   change without a spec update is an incomplete change.
+4. **Re-read on touch.** When later modifying the feature, read its spec first and
+   reconcile any contradiction between spec and code before proceeding.
+
+## What goes in (and what stays out)
+
+**In** — product-level, English, concise:
+
+- **Overview** — what the feature is and the problem it solves.
+- **Who / when** — preconditions, permissions, the audience.
+- **States & scenarios** — every visible state and the rule that produces it.
+- **Lifecycle** — the happy path from entry to outcome, and notable failures.
+- **Related** — adjacent flows or backend contracts that shape behaviour.
+- **Diagrams** — `mermaid` flowcharts / sequence diagrams render on GitHub and the
+  docs site; use them when a picture beats a paragraph.
+
+**Out** — implementation detail that the code already documents: Effector store
+names, `sample` graphs, file-by-file maps, import-cycle notes, internal helper
+signatures. Those belong in code comments, not the spec.
+
+## Template
+
+````markdown
+# <Feature name>
+
+## Overview
+What this feature is, the problem it solves, and the one-line behaviour summary.
+
+## Who can use it / when it applies
+Preconditions, permissions, audience.
+
+## States / scenarios
+Each visible state and the rule that triggers it. A decision diagram helps:
+
+```mermaid
+flowchart TD
+    START["Entry point"] --> Q1{"Condition?"}
+    Q1 -- "yes" --> A["State A"]
+    Q1 -- "no" --> B["State B"]
+```
+
+| State | When it appears | What the user sees |
+| --- | --- | --- |
+| ... | ... | ... |
+
+## Lifecycle
+The happy path from entry to outcome; notable failure handling.
+
+## Related
+Adjacent flows, backend contracts, or constraints that shape the behaviour.
+````
+
+Match the depth to the feature — a small feature needs only Overview + States.

--- a/docs/content/docs/onboarding/project-structure.mdx
+++ b/docs/content/docs/onboarding/project-structure.mdx
@@ -141,6 +141,7 @@ For example, a selected wallet or network for working within a specific feature.
     - model.ts
     - hooks.ts (optional) effector-react bindings
     - service.ts (optional)
+    - README.md product spec — see [Feature specs](/code/style/feature-specs)
     - index.ts
 </FileTree>
 
@@ -169,5 +170,10 @@ Feature **must not**:
     - hooks/ custom React hooks
     - model/ effector stores, events, and effects
     - feature.ts feature identifier created with `createFeature` + `feature.inject(...)` integrations
+    - README.md product spec — see [Feature specs](/code/style/feature-specs)
     - index.ts (or index.tsx) public exports
 </FileTree>
+
+A non-trivial feature carries a colocated `README.md` product spec describing its
+behaviour (states, scenarios, lifecycle). Draft it with the feature author and ship
+it in the same change — see [Feature specs](/code/style/feature-specs).


### PR DESCRIPTION
## Description

Introduces a lightweight convention: **non-trivial features and aggregates carry a
colocated `README.md` product spec** — a description of _what_ the code does and
_why_ (states, scenarios, lifecycle), not _how_ it is wired.

The goal is that the spec is **discoverable and kept in sync** by both people and AI
agents: an agent reads a feature's README before changing it, drafts/updates it as
part of the change, and confirms it with the feature author before the code is final.

This PR only documents the convention — no runtime code changes.

## Related Issues

<!-- Related to the multisig-operation-description feature PR -->

## Changes Made

- **`CLAUDE.md`** — new "Feature Spec READMEs" section (read the README before
  touching a feature, draft/update it with the change, get author approval, keep it
  in sync) and a reference include of the new doc so it loads into agent context.
- **`docs/content/docs/code/style/feature-specs.md`** (new) — the full convention:
  why specs live next to the code, where they live, when to write/update, the
  author↔implementer approval workflow, what goes in/out, and a copy-paste template.
  Appears in the docs sidebar under "Code style".
- **`docs/content/docs/onboarding/project-structure.mdx`** — `README.md` added to the
  feature and aggregate folder trees, with a short note linking to the convention.

Worked example referenced throughout:
[`src/renderer/aggregates/multisig-operation-description/README.md`](https://github.com/novasamatech/nova-spektr/pull/5906/changes#diff-b919328a9d8ac4b7d2b3a64c3329cab10ec8999bf8da511e5a9b3bcc41eeb491).

## Screenshots/Recordings

<!-- n/a — documentation only -->

## Notes for reviewers

- Docs in this repo are hand-formatted; Prettier is intentionally not run over
  `.md`/`.mdx` (the existing pages don't pass it either), so the additions match the
  surrounding manual style rather than a formatter.
- The new page sits under `code/style/` because the docs sidebar auto-generates only
  from `onboarding` and `code/style`; that placement makes it visible in navigation.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
