### PR TITLE
feat: collapse orphaned derived wallets on local source removal

### DIFF
--- a/src/renderer/domains/network/account/service.test.ts
+++ b/src/renderer/domains/network/account/service.test.ts
@@ -1,6 +1,14 @@
 import { afterEach, describe, expect, it } from 'vitest';
 
-import { type BackendContact, type Chain, type Contact, AccountNameType, CryptoType, SigningType } from '@/shared/core';
+import {
+  type BackendContact,
+  type Chain,
+  type Contact,
+  AccountNameType,
+  AccountType,
+  CryptoType,
+  SigningType,
+} from '@/shared/core';
 import { toAddress } from '@/shared/lib/utils';
 import {
   createAccountId,
@@ -357,6 +365,163 @@ describe('account service', () => {
       });
 
       expect(accountService.findInitiators(accounts, polkadotChain)).toEqual([proxy]);
+    });
+  });
+
+  describe('findAccountsWithoutSigners', () => {
+    interface TestProxied extends ChainAccount {
+      accountType: AccountType.PROXIED;
+      connections: { proxyAccountId: AccountId }[];
+    }
+
+    interface TestMultisig extends UniversalAccount {
+      accountType: AccountType.MULTISIG;
+      signatories: { accountId: AccountId }[];
+    }
+
+    const isTestProxied = (account: AnyAccount): account is TestProxied =>
+      'accountType' in account && account.accountType === AccountType.PROXIED;
+
+    const isTestMultisig = (account: AnyAccount): account is TestMultisig =>
+      'accountType' in account && account.accountType === AccountType.MULTISIG;
+
+    const chains: Record<string, Chain> = {
+      [polkadotChainId]: polkadotChain,
+      [kusamaChainId]: kusamaChain,
+    };
+
+    const registerHandlers = () => {
+      accountService.accountAvailabilityOnChainAnyOf.registerHandler({
+        body: ({ account, chain }) =>
+          accountService.isChainAccount(account) ? account.chainId === chain.chainId : true,
+        available: () => true,
+      });
+      // a "signable" leaf is a Polkadot Vault key; derived accounts are watch-only
+      accountService.accountActionPermissionAnyOf.registerHandler({
+        body: ({ account }) => account.signingType === SigningType.POLKADOT_VAULT,
+        available: () => true,
+      });
+      accountService.accountCollectChildrenPipeline.registerHandler({
+        body(children, { account, accounts }) {
+          if (isTestProxied(account)) {
+            return accounts
+              .filter(a => account.connections.some(c => c.proxyAccountId === a.accountId))
+              .concat(children);
+          }
+          if (isTestMultisig(account)) {
+            return accounts.filter(a => account.signatories.some(s => s.accountId === a.accountId)).concat(children);
+          }
+          return children;
+        },
+        available: () => true,
+      });
+    };
+
+    const signerKey: ChainAccount = {
+      id: 'signer',
+      type: 'chain',
+      name: 'signer',
+      walletId: 1,
+      chainId: polkadotChainId,
+      accountId: createAccountId('signer'),
+      cryptoType: CryptoType.SR25519,
+      signingType: SigningType.POLKADOT_VAULT,
+      createdAt: Date.now(),
+    };
+
+    const proxied: TestProxied = {
+      id: 'proxied',
+      type: 'chain',
+      accountType: AccountType.PROXIED,
+      name: 'proxied',
+      walletId: 2,
+      chainId: polkadotChainId,
+      accountId: createAccountId('proxied'),
+      cryptoType: CryptoType.SR25519,
+      signingType: SigningType.WATCH_ONLY,
+      createdAt: Date.now(),
+      connections: [{ proxyAccountId: signerKey.accountId }],
+    };
+
+    const multisig: TestMultisig = {
+      id: 'multisig',
+      type: 'universal',
+      accountType: AccountType.MULTISIG,
+      name: 'multisig',
+      walletId: 3,
+      accountId: createAccountId('multisig'),
+      cryptoType: CryptoType.SR25519,
+      signingType: SigningType.WATCH_ONLY,
+      createdAt: Date.now(),
+      signatories: [{ accountId: signerKey.accountId }],
+    };
+
+    it('keeps a proxied while its delegate is a signable local account', () => {
+      registerHandlers();
+
+      expect(accountService.findAccountsWithoutSigners([signerKey, proxied], chains)).toEqual([]);
+    });
+
+    it('orphans a proxied once its last signable delegate is gone', () => {
+      registerHandlers();
+
+      expect(accountService.findAccountsWithoutSigners([proxied], chains)).toEqual([proxied]);
+    });
+
+    it('orphans a multisig once its last signatory is gone', () => {
+      registerHandlers();
+
+      expect(accountService.findAccountsWithoutSigners([signerKey, multisig], chains)).toEqual([]);
+      expect(accountService.findAccountsWithoutSigners([multisig], chains)).toEqual([multisig]);
+    });
+
+    it('collapses a whole chain at once (proxied of a multisig of a removed key)', () => {
+      registerHandlers();
+
+      const proxiedOfMultisig: TestProxied = {
+        ...proxied,
+        id: 'proxied-of-multisig',
+        walletId: 4,
+        accountId: createAccountId('proxied-of-multisig'),
+        connections: [{ proxyAccountId: multisig.accountId }],
+      };
+
+      const all = [signerKey, multisig, proxiedOfMultisig];
+
+      expect(accountService.findAccountsWithoutSigners(all, chains)).toEqual([]);
+
+      // remove the only signable key: both the multisig and the proxied above it collapse
+      const orphans = accountService.findAccountsWithoutSigners([multisig, proxiedOfMultisig], chains);
+      expect(orphans).toEqual(expect.arrayContaining([multisig, proxiedOfMultisig]));
+      expect(orphans).toHaveLength(2);
+    });
+
+    it('keeps a universal multisig while it is signable on any one chain', () => {
+      registerHandlers();
+
+      const kusamaSigner: ChainAccount = {
+        ...signerKey,
+        id: 'kusama-signer',
+        walletId: 5,
+        chainId: kusamaChainId,
+        accountId: createAccountId('kusama-signer'),
+      };
+      const kusamaMultisig: TestMultisig = {
+        ...multisig,
+        signatories: [{ accountId: kusamaSigner.accountId }],
+      };
+
+      // signable only on kusama, but the cross-chain pass keeps it
+      expect(accountService.findAccountsWithoutSigners([kusamaSigner, kusamaMultisig], chains)).toEqual([]);
+      // signer gone everywhere → orphaned
+      expect(accountService.findAccountsWithoutSigners([kusamaMultisig], chains)).toEqual([kusamaMultisig]);
+    });
+
+    it('keeps a derived account it cannot evaluate on any provided chain', () => {
+      registerHandlers();
+
+      // no chains to build a graph on → nothing is evaluated, so nothing is deleted
+      expect(accountService.findAccountsWithoutSigners([proxied], {})).toEqual([]);
     });
   });
 

--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -10,6 +10,7 @@ import {
   type Contact,
   type Wallet,
   AccountNameType,
+  AccountType,
   WalletType,
   isBackendContact,
   isLocalContact,
@@ -430,6 +431,70 @@ function findSignatories(account: AnyAccount, accounts: AnyAccount[], chain: Cha
 }
 
 /**
+ * Derived accounts (multisig, flexible multisig, proxied) exist locally only
+ * because a signable local account sits behind them as a signatory or
+ * delegate.
+ */
+function isDerivedAccount(account: AnyAccount): boolean {
+  if (!('accountType' in account)) return false;
+
+  const { accountType } = account;
+
+  return (
+    accountType === AccountType.MULTISIG ||
+    accountType === AccountType.FLEX_MULTISIG ||
+    accountType === AccountType.PROXIED
+  );
+}
+
+/**
+ * Find derived accounts that no longer reach a signable local account on any
+ * chain they are available on. Such an account is orphaned — its last local
+ * signer is gone — so it can be removed from local state alone, without
+ * consulting the indexer or the chain. The dependency graph is followed
+ * recursively, so a chain of derived accounts (a proxied of a multisig of a
+ * removed key) collapses in a single evaluation.
+ *
+ * An account is only considered when it could actually be placed in a graph on
+ * at least one of the given chains; an account we cannot evaluate is kept.
+ */
+function findAccountsWithoutSigners(accounts: AnyAccount[], chains: Record<ChainId, Chain>): AnyAccount[] {
+  const derivedAccounts = accounts.filter(isDerivedAccount);
+  if (derivedAccounts.length === 0) {
+    return [];
+  }
+
+  const evaluatedAccounts = new Set<AnyAccount>();
+  const accountsWithSigner = new Set<AnyAccount>();
+
+  for (const chain of Object.values(chains)) {
+    const graphs = createAccountGraphs(accounts, chain);
+
+    for (const [account, node] of graphs) {
+      evaluatedAccounts.add(account);
+      if (accountsWithSigner.has(account)) continue;
+
+      let hasSigner = false;
+      traverseGraph(node, {
+        enter(current) {
+          if (current.children.length === 0 && hasPermissionToMakeActions(current.account)) {
+            hasSigner = true;
+            // stop the traversal: one signable leaf is enough to keep the account
+            return false;
+          }
+        },
+      });
+
+      if (hasSigner) {
+        accountsWithSigner.add(account);
+      }
+    }
+  }
+
+  return derivedAccounts.filter(account => evaluatedAccounts.has(account) && !accountsWithSigner.has(account));
+}
+
+/**
  * Find graphs roots.
  */
 function findInitiators(accounts: AnyAccount[], chain: Chain): AnyAccount[] {
@@ -626,6 +691,7 @@ export const accountService = {
   createAccountGraphs: createAccountGraphs,
   findLeafs,
   findSignatories,
+  findAccountsWithoutSigners,
   findInitiators,
   findRoute,
   findInitiator,

--- a/src/renderer/features/account-sync/README.md
+++ b/src/renderer/features/account-sync/README.md
@@ -84,30 +84,46 @@ sequenceDiagram
     Seeds->>Identity: request names for every discovered account
     Note over Wallets: once accounts + identities are in
     Wallets->>Wallets: create new, update changed, reconcile proxy links
-    Note over Wallets: deletions pass the safety checks below
+    Note over Wallets: deletions follow the two rules below
     Wallets-->>Seeds: if anything was deleted, cascade another pass
 ```
 
 A pass discovers accounts, fetches each chain's last-indexed block and the identities
 used to name new wallets, then reconciles the wallet store: create what's new, update
-what changed, and delete what's gone — under strict guards.
+what changed, and delete what's gone.
 
-### Deletion safety rules
+### When a derived wallet is deleted
 
-Sync must never delete a real wallet just because the indexer is behind. So a derived
-wallet is removed **only** when:
+A derived wallet is removed for one of two distinct reasons, decided differently. The
+distinction matters: confusing them is what used to leave orphaned wallets behind.
 
-- its chain was actually part of this sync pass, **and**
-- the indexer reports a last-processed block for that chain (un-indexed chains never
-  trigger deletes), **and**
-- that last-processed block is **at or past** the block the account was created at —
-  so an account created after the indexer's checkpoint is kept until the indexer
-  catches up.
+**1. Its local source is gone — immediate, local, no source needed.** A derived wallet
+is only _yours_ because one of your **signable** accounts sits behind it as a signatory
+or delegate — possibly through a chain of other derived wallets. The moment that last
+signable account disappears (you removed the wallet, or an upstream derived wallet was
+itself removed), the dependent wallet is provably orphaned and is deleted **right away,
+from local data alone** — no indexer, no chain call. Because the dependency is followed
+recursively, a single pass collapses a whole chain at once (a proxied of a multisig of a
+removed key). This check runs both when you remove a wallet **and** as the first step of
+every sync pass, so a derived wallet never lingers waiting for a source to respond.
 
-For **proxied** wallets there is an extra on-chain check before deletion: the wallet
-is kept if **any** of its delegates is still a local account, verified against live
-chain state. Chains that can't be reached are left untouched. A wrongful removal, if
-it ever happened, heals on the next pass.
+```mermaid
+flowchart TD
+    START["Wallet removed / sync pass starts"] --> Q{"Does the derived wallet still reach<br/>a signable local account?"}
+    Q -- "no" --> DEL["Delete now — provably orphaned<br/>(works offline)"]
+    Q -- "yes" --> KEEP["Keep — only an on-chain change<br/>could remove it (rule 2)"]
+    style DEL fill:#b71c1c,color:#fff
+    style KEEP fill:#1b5e20,color:#fff
+```
+
+**2. The on-chain relationship was revoked — confirmed against sources.** The wallet
+still has a local signer, but the proxy was revoked or the multisig dissolved on-chain.
+This needs external confirmation and the indexer can lag, so deletion stays guarded: the
+chain must have been part of the pass, the indexer must report a last-processed block for
+it, and that block must be **at or past** the account's creation block (accounts newer
+than the indexer's checkpoint are kept until it catches up). Proxied wallets get an extra
+on-chain check — kept if any delegate is still valid on live chain state; unreachable
+chains are left untouched. A wrongful removal here heals on the next pass.
 
 ## Related
 

--- a/src/renderer/features/account-sync/README.md
+++ b/src/renderer/features/account-sync/README.md
@@ -1,0 +1,122 @@
+# Account Sync
+
+## Overview
+
+**Account sync** keeps the user's _derived_ wallets in step with on-chain reality.
+The user only ever adds a **signing wallet** (a Vault, a key, a watch-only address);
+the multisig, flexible-multisig, and delegated-authority (proxy) wallets that depend
+on it are never added by hand — the sync service discovers them, creates them as
+watch-only wallets, keeps their details current, and removes them once they no longer
+exist on-chain.
+
+It runs in the background and is mostly invisible: the only direct UI is a refresh
+control in the wallet panel. Everything else surfaces as wallets appearing or
+disappearing and as "wallet added" notifications.
+
+## What it discovers
+
+Starting from the user's own accounts as seeds, sync asks the indexer (and verifies
+against the live chains) for three kinds of derived account, then keeps expanding:
+
+- **Multisig** — a multisig account the user is a signatory of. The account id is
+  re-derived from the returned signatories + threshold and only accepted if it
+  matches, so an indexer can't fabricate a membership.
+- **Delegated authority (proxy)** — an account that has delegated a proxy to one of
+  the user's accounts. Only **immediate** proxies are tracked (delay `0`); delayed
+  proxies are ignored.
+- **Flexible multisig** — a pure proxy whose delegate is a discovered multisig
+  account (a multisig that controls a pure-proxy account).
+
+Discovery is **recursive**: every newly found account becomes a seed for the next
+round, so chains of relationships (a proxy of a multisig of a proxy …) are walked to
+their end. Only accounts the user has **permission to act with** are used as the
+initial seeds.
+
+## When it runs
+
+```mermaid
+flowchart TD
+    START["Trigger"] --> RUN["Run a sync pass"]
+
+    T1["App start — once every supported network is connected"] --> START
+    T2["A wallet is created"] --> START
+    T3["A wallet is removed"] --> START
+    T4["Manual refresh button in the wallet panel"] --> START
+    T5["A pass removed wallets → re-run to collapse downstream orphans"] --> START
+
+    RUN --> ONLYLAST["Only the latest trigger wins<br/>(overlapping runs collapse to one)"]
+```
+
+- **First run** waits until *all* chains that support proxies/multisigs are
+  connected — syncing against a half-connected node set would produce false deletes.
+- **Cascade re-run.** When a pass actually deletes wallets, it kicks another pass so
+  that wallets which only existed *because of* the now-deleted ones (a proxied of a
+  removed multisig, and so on) collapse too. It terminates as soon as a pass deletes
+  nothing.
+- Concurrent triggers don't stack — only the most recent run is kept.
+
+## States the user sees
+
+The sync service has a single visible control — a button in the wallet-select panel:
+
+| State | When it appears | What the user sees |
+| --- | --- | --- |
+| **Idle** | No sync in progress | A refresh icon; clicking it starts a manual sync |
+| **Syncing** | A sync pass is running | A spinner with a "Syncing accounts…" tooltip |
+
+Indirectly, a sync pass may: add watch-only wallets (multisig / flexible multisig /
+delegated authority), update an existing proxied wallet's connections and deposit,
+remove wallets that no longer exist on-chain, and raise a "wallet added"
+notification for each newly created wallet.
+
+## Lifecycle
+
+```mermaid
+sequenceDiagram
+    participant Seeds as User accounts
+    participant Indexer as Indexer + live chains
+    participant Identity as Identity lookup
+    participant Wallets as Wallet store
+
+    Seeds->>Indexer: find multisigs / proxies / flexible multisigs
+    Indexer-->>Seeds: discovered accounts (expand & repeat until none new)
+    Indexer-->>Wallets: last indexed block per chain
+    Seeds->>Identity: request names for every discovered account
+    Note over Wallets: once accounts + identities are in
+    Wallets->>Wallets: create new, update changed, reconcile proxy links
+    Note over Wallets: deletions pass the safety checks below
+    Wallets-->>Seeds: if anything was deleted, cascade another pass
+```
+
+A pass discovers accounts, fetches each chain's last-indexed block and the identities
+used to name new wallets, then reconciles the wallet store: create what's new, update
+what changed, and delete what's gone — under strict guards.
+
+### Deletion safety rules
+
+Sync must never delete a real wallet just because the indexer is behind. So a derived
+wallet is removed **only** when:
+
+- its chain was actually part of this sync pass, **and**
+- the indexer reports a last-processed block for that chain (un-indexed chains never
+  trigger deletes), **and**
+- that last-processed block is **at or past** the block the account was created at —
+  so an account created after the indexer's checkpoint is kept until the indexer
+  catches up.
+
+For **proxied** wallets there is an extra on-chain check before deletion: the wallet
+is kept if **any** of its delegates is still a local account, verified against live
+chain state. Chains that can't be reached are left untouched. A wrongful removal, if
+it ever happened, heals on the next pass.
+
+## Related
+
+- **`domains/network/account-sync`** — the discovery engine and the indexer/on-chain
+  providers (proxy, multisig, indexed-blocks). This feature orchestrates those
+  results into wallet create/update/delete, identity naming, proxy-store
+  reconciliation, and notifications.
+- **Identity, proxy, notification, and wallet** domains/entities consume the output
+  of each pass.
+- The discovery providers read from the accounts SubQuery indexer and cross-check
+  against connected chain APIs; indexer lag is the reason for the block-number and
+  on-chain deletion guards above.

--- a/src/renderer/features/account-sync/model/sync.ts
+++ b/src/renderer/features/account-sync/model/sync.ts
@@ -3,6 +3,7 @@ import { attach, createEffect, createStore, sample } from 'effector';
 import { combineEvents, spread } from 'patronum';
 
 import {
+  type Chain,
   type ChainId,
   type CreateFlexibleMultisigOperationParams,
   type CreateMultisigCreatedParams,
@@ -43,6 +44,7 @@ import {
   type AccountIdentity,
   type AnyAccount,
   type SyncedAccount,
+  accountService,
   accountSync,
   accountSyncService,
   accounts,
@@ -94,6 +96,44 @@ sample({
   clock: walletModel.walletsRemoved.doneData,
   filter: (removed) => Array.isArray(removed) && removed.length > 0,
   target: accountSync.syncAccounts,
+});
+
+// Local orphan-collapse. A derived wallet (multisig / flexible multisig /
+// proxied) exists only because a signable local account sits behind it. When
+// that last signer is gone — the user removed it, or an upstream derived wallet
+// was itself removed — the dependent wallet is provably orphaned and is removed
+// immediately from local state, with no indexer or on-chain call. The dependency
+// graph is followed recursively, so a whole chain collapses in one pass.
+//
+// Runs on wallet removal and as the first step of every sync pass, so a derived
+// wallet never lingers waiting for an external source to confirm its absence.
+// The remaining indexer/on-chain delete path then only handles the other cause:
+// an on-chain relationship revoked while a local signer is still present.
+const collapseOrphanedWalletsFx = createEffect(
+  ({ allAccounts, chains }: { allAccounts: AnyAccount[]; chains: Record<ChainId, Chain> }): number[] => {
+    const orphanedAccounts = accountService.findAccountsWithoutSigners(allAccounts, chains);
+
+    return Array.from(new Set(orphanedAccounts.map((account) => account.walletId)));
+  },
+);
+
+sample({
+  clock: [walletModel.events.walletRemovedSuccess, accountSync.syncAccounts],
+  source: {
+    allAccounts: accounts.$list,
+    chains: networkModel.$chains,
+  },
+  target: collapseOrphanedWalletsFx,
+});
+
+// walletsRemoved is the batch effect — it never re-fires walletRemovedSuccess
+// (a single-wallet signal), so this can't loop. A follow-up sync pass re-runs the
+// collapse, which is idempotent: the recursive first pass already removed the
+// whole orphan chain, so the next pass finds nothing.
+sample({
+  clock: collapseOrphanedWalletsFx.doneData,
+  filter: (walletIds) => walletIds.length > 0,
+  target: walletModel.walletsRemoved,
 });
 
 // TODO


### PR DESCRIPTION
## Description

Derived wallets (multisig, flexible multisig, and delegated-authority / proxied) used
to be deleted **only** by a sync pass that pulls from the indexer + on-chain storage,
behind block-number and on-chain-delegate guards. Those guards exist to tolerate
indexer lag — but they were applied to **every** deletion, including the case where the
user removed the only local signer. As a result, when a source was slow or unreachable,
the dependent multisig/proxied wallets lingered as orphans the user could no longer
sign with, waiting for an external source to confirm their absence.

This PR adds a **local, source-independent orphan-collapse**. "The user removed the
local source" is a deterministic local fact that never needs external confirmation, so
we no longer wait on the indexer for it:

- A derived wallet is _yours_ only because a **signable** local account sits behind it
  as a signatory or delegate (possibly through a chain of other derived wallets). When
  that last signable account is gone, the dependent wallet is provably orphaned and is
  removed **immediately from local state alone** — no indexer, no chain call.
- The dependency graph is followed recursively, so a whole chain (a proxied of a
  multisig of a removed key) collapses in a single evaluation.
- The collapse runs both on wallet removal and as the first step of every sync pass, so
  a derived wallet never lingers waiting for a source to respond.

The existing indexer/on-chain delete path stays in place and now only handles the other
cause of deletion: an on-chain relationship that was **revoked** while a local signer is
still present (proxy revoked, multisig dissolved) — the case the lag-tolerant guards
were actually designed for.

This PR also adds a colocated **feature spec README** for the account-sync feature,
following the feature-spec convention (#5916), and documents the new two-cause deletion
model there.

## Related Issues

<!-- Builds on the feature-spec README convention (#5916). -->

## Changes Made

- **`domains/network/account/service.ts`** — new `accountService.findAccountsWithoutSigners(accounts, chains)`.
  Reusing the existing recursive account graph, it returns derived accounts (multisig /
  flexible multisig / proxied) that no longer reach a signable local account on any
  chain they are available on. An account that cannot be evaluated on any provided chain
  is kept (conservative).
- **`features/account-sync/model/sync.ts`** — `collapseOrphanedWalletsFx` wired on
  `walletRemovedSuccess` and `accountSync.syncAccounts`, deleting orphaned wallets via
  `walletModel.walletsRemoved`. The batch removal never re-fires the single-wallet
  signal, and the collapse is idempotent, so it cannot loop.
- **`features/account-sync/README.md`** (new) — product spec for the sync feature: what
  it discovers, when it runs, the visible states, the lifecycle, and the two-cause
  deletion model.
- **`domains/network/account/service.test.ts`** — unit tests for the orphan detector
  (proxied/multisig kept-vs-orphaned, recursive chain collapse, cross-chain "signable on
  any one chain", and the cannot-evaluate guard).

## Screenshots/Recordings

<!-- n/a — no visible UI changes; the only surface is the existing wallet-panel sync button. -->

## Notes for reviewers

- The change is split into reviewable commits: (1) feature spec, (2) spec update for the
  new deletion model, (3) the logic, (4) tests.
- Load-bearing assumption: the on-removal collapse reads `accounts.$list` on
  `walletRemovedSuccess`. This is post-removal because `removeWalletFx` _awaits_
  `accounts.deleteAccounts(...)` and Effector runs the `$accounts` update synchronously
  before `removeWalletFx.done` fires — the same ordering the existing
  `walletRemovedSuccess → syncAccounts` sample already relies on.
- The deletion decision trusts the account graph's `collectChildren` handlers (registered
  by `multisig-wallet` / `proxied-wallet`). All current derived types are covered; a
  future derived `AccountType` must register a handler before being added to
  `isDerivedAccount`.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
