### PR TITLE
fix: unify proxy status badge color

### DIFF
--- a/src/renderer/features/wallet-details/ui/components/proxies/ProxyStatusBadge.tsx
+++ b/src/renderer/features/wallet-details/ui/components/proxies/ProxyStatusBadge.tsx
@@ -8,7 +8,7 @@ const STATUS_TO_LABEL_VARIANT: Record<WalletProxyStatus, LabelVariant> = {
   not_verified: 'orange',
   pending_verification: 'blue',
   pending_addition: 'lightBlue',
-  not_verified_no_wallet: 'gray',
+  not_verified_no_wallet: 'orange',
 };
 
 const STATUS_I18N_KEYS: Record<WalletProxyStatus, string> = {


### PR DESCRIPTION
## Description
Fix proxy status badges for not verified state same color for different account types. 

## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-617

## Changes Made
<!-- Briefly describe the key changes, e.g.: 
- Added feature X
- Fixed bug in component Y
- Refactored module Z
-->

## Screenshots/Recordings
<img width="823" height="790" alt="Screenshot 2026-06-01 at 12 16 57 PM" src="https://github.com/user-attachments/assets/cfb9ee19-c716-43fc-8e83-b7d35d5f5a9b" />


## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
