### PR TITLE
fix: avoid hook-order crash in nominator rows

### DIFF
--- a/src/renderer/pages/Staking/ui/NominatorsList.test.tsx
+++ b/src/renderer/pages/Staking/ui/NominatorsList.test.tsx
@@ -1,0 +1,61 @@
+import { render } from '@testing-library/react';
+import { vi } from 'vitest';
+
+import { CryptoType, SigningType } from '@/shared/core';
+import { TEST_ACCOUNTS } from '@/shared/lib/utils';
+import { polkadotAssetHubChain } from '@/shared/mocks';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type ChainAccount } from '@/domains/network';
+import { type NominatorInfo } from '../lib/types';
+
+import { NominatorsList } from './NominatorsList';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: vi.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+const createAccount = (index: number): ChainAccount => ({
+  id: `account-${index}`,
+  type: 'chain',
+  walletId: 1,
+  name: `Account ${index}`,
+  accountId: TEST_ACCOUNTS[index]!,
+  chainId: polkadotAssetHubChain.chainId,
+  signingType: SigningType.WATCH_ONLY,
+  cryptoType: CryptoType.SR25519,
+  createdAt: 0,
+});
+
+const createNominator = (index: number): NominatorInfo<ChainAccount> => ({
+  account: createAccount(index),
+  isSelected: index === 0,
+  stash: TEST_ACCOUNTS[index] as AccountId,
+  totalStake: '0',
+  totalReward: '0',
+  unlocking: [],
+});
+
+const defaultProps = {
+  api: null,
+  timelineApi: null,
+  chain: polkadotAssetHubChain,
+  asset: polkadotAssetHubChain.assets[0],
+  era: 1,
+  isStakingLoading: false,
+  onCheckValidators: vi.fn(),
+  onToggleNominator: vi.fn(),
+};
+
+describe('pages/Staking/ui/NominatorsList', () => {
+  test('does not break hook order when wallet switch changes account row count', () => {
+    const { rerender } = render(
+      <NominatorsList {...defaultProps} nominators={[createNominator(0), createNominator(1), createNominator(2)]} />,
+    );
+
+    expect(() => {
+      rerender(<NominatorsList {...defaultProps} nominators={[createNominator(0)]} />);
+    }).not.toThrow();
+  });
+});

--- a/src/renderer/pages/Staking/ui/NominatorsList.tsx
+++ b/src/renderer/pages/Staking/ui/NominatorsList.tsx
@@ -2,7 +2,7 @@ import { type ApiPromise } from '@polkadot/api';
 import { type ReactNode } from 'react';
 import { Trans } from 'react-i18next';
 
-import { type Asset, type Chain, type VaultBaseAccount, type VaultShardAccount } from '@/shared/core';
+import { type Asset, type Chain, type VaultShardAccount } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { cnTw, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
@@ -18,7 +18,7 @@ import { ShardedList } from './ShardedList';
 import { TimeToEra } from './TimeToEra';
 
 type Props = {
-  nominators: (NominatorInfo<VaultBaseAccount> | NominatorInfo<VaultShardAccount>[])[];
+  nominators: (NominatorInfo<AnyAccount> | NominatorInfo<VaultShardAccount>[])[];
   isStakingLoading: boolean;
   api: ApiPromise | null;
   timelineApi: ApiPromise | null;
@@ -27,6 +27,29 @@ type Props = {
   chain: Chain;
   onCheckValidators: (stash?: AccountId) => void;
   onToggleNominator: (nominator: AccountId, value?: boolean) => void;
+};
+
+type NominatorContentProps = {
+  stake: NominatorInfo<AnyAccount>;
+  chain: Chain;
+  badge?: ReactNode;
+};
+
+const NominatorContent = ({ stake, chain, badge }: NominatorContentProps) => {
+  const accountName = useAccountName({ accountId: stake.account.accountId, chain });
+
+  return (
+    <>
+      <Address
+        title={accountName}
+        variant="truncate"
+        address={toAddress(stake.account.accountId, { prefix: chain.addressPrefix })}
+        showIcon
+        iconSize={20}
+      />
+      <div className="ml-auto">{badge}</div>
+    </>
+  );
 };
 
 export const NominatorsList = ({
@@ -83,19 +106,7 @@ export const NominatorsList = ({
   };
 
   const getContent = (stake: NominatorInfo<AnyAccount>): ReactNode => {
-    const accountName = useAccountName({ accountId: stake.account.accountId, chain });
-    return (
-      <>
-        <Address
-          title={accountName}
-          variant="truncate"
-          address={toAddress(stake.account.accountId, { prefix: chain.addressPrefix })}
-          showIcon
-          iconSize={20}
-        />
-        <div className="ml-auto">{getUnstakeBadge(stake) || getRedeemBadge(stake)}</div>
-      </>
-    );
+    return <NominatorContent stake={stake} chain={chain} badge={getUnstakeBadge(stake) || getRedeemBadge(stake)} />;
   };
 
   const hasShards = nominators.some(Array.isArray);


### PR DESCRIPTION
## Description
Changing the selected wallet from Vault to Proxied can change the number of rendered nominator rows. `NominatorsList` previously called `useAccountName()` from a helper invoked inside row loops, which could violate React hook ordering and throw:

`Rendered fewer hooks than expected`


## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-614

## Changes Made
- Move `useAccountName` out of the variable-length `NominatorsList` render helper into a stable row content component
- Add a regression test for switching staking rows from multi-account Vault-style data to a single Proxied account row


## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#66