### PR TITLE
fix: separator overlap and form overflow in build operation modal

### DIFF
--- a/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
+++ b/src/renderer/features/call-data-execute/ui/CallDataForm.tsx
@@ -50,28 +50,28 @@ export const CallDataForm = () => {
 
   return (
     <>
-      <ScrollArea>
-        <div className="flex flex-col gap-y-4 px-5 pb-4">
-          <DraftModeCard isOn={isDraftMode} onToggle={formModel.events.toggleDraftMode} />
-          {isDraftMode && (
-            <DraftSigningPath
-              chainId={chain?.chainId ?? null}
-              asset={chain ? getNativeAsset(chain.assets) : null}
-              $draftPath={formModel.$draftSigningPath}
-              draftPathCommitted={formModel.events.draftPathCommitted}
-              draftPathEditStarted={formModel.events.draftPathEditStarted}
-              draftPathEditEnded={formModel.events.draftPathEditEnded}
-            />
-          )}
-          <DraftFormBody $isDraftMode={formModel.$isDraftMode} $isDraftPathComplete={formModel.$isDraftPathComplete}>
-            <div className="flex flex-col gap-y-4">
-              {!isDraftMode && <TransactionValidationError errors={errors} wallets={wallets} />}
-              <form id="call-data-form" className="flex flex-col gap-y-4" onSubmit={submitForm}>
-                <NetworkSelect />
-                {!isDraftMode && <InitiatorSelect />}
-                {!isDraftMode && showSignatories && <SignatorySelect />}
+      <div className="flex min-h-0 flex-1 flex-col">
+        <ScrollArea>
+          <div className="flex flex-col gap-y-4 px-5 pb-4">
+            <DraftModeCard isOn={isDraftMode} onToggle={formModel.events.toggleDraftMode} />
+            {isDraftMode && (
+              <DraftSigningPath
+                chainId={chain?.chainId ?? null}
+                asset={chain ? getNativeAsset(chain.assets) : null}
+                $draftPath={formModel.$draftSigningPath}
+                draftPathCommitted={formModel.events.draftPathCommitted}
+                draftPathEditStarted={formModel.events.draftPathEditStarted}
+                draftPathEditEnded={formModel.events.draftPathEditEnded}
+              />
+            )}
+            <DraftFormBody $isDraftMode={formModel.$isDraftMode} $isDraftPathComplete={formModel.$isDraftPathComplete}>
+              <div className="flex flex-col gap-y-4">
+                {!isDraftMode && <TransactionValidationError errors={errors} wallets={wallets} />}
+                <form id="call-data-form" className="flex flex-col gap-y-4" onSubmit={submitForm}>
+                  <NetworkSelect />
+                  {!isDraftMode && <InitiatorSelect />}
+                  {!isDraftMode && showSignatories && <SignatorySelect />}
 
-                <div className="-mb-2">
                   <Tabs value={inputMode} onChange={(value) => inputModeChanged(value as InputMode)}>
                     <Tabs.List>
                       <Tabs.Trigger value={InputMode.PASTE}>{t('callData.mode.paste')}</Tabs.Trigger>
@@ -88,41 +88,41 @@ export const CallDataForm = () => {
                       />
                     </Tabs.Content>
                   </Tabs>
-                </div>
-              </form>
-            </div>
-          </DraftFormBody>
-        </div>
+                </form>
+              </div>
+            </DraftFormBody>
+          </div>
 
-        {nonNullable(chain) && (
-          <OperationTemplatesToolbar
-            api={api}
-            chainId={chain.chainId}
-            callData={callDataValue}
-            specVersion={specVersion}
-            modalWidth="37rem"
-            onApply={templateApplied}
-          />
-        )}
-
-        <Separator />
-
-        <Box padding={[4, 5]}>
-          {nonNullable(args) && (
-            <div className="flex flex-col gap-y-3">
-              <SmallTitleText>{t('callData.isCorrect')}</SmallTitleText>
-              <JsonArgs value={args} />
-            </div>
+          {nonNullable(chain) && (
+            <OperationTemplatesToolbar
+              api={api}
+              chainId={chain.chainId}
+              callData={callDataValue}
+              specVersion={specVersion}
+              modalWidth="37rem"
+              onApply={templateApplied}
+            />
           )}
-          {nullable(args) && (
-            <div className="flex flex-col items-center gap-y-2 px-10 py-20">
-              <Icon size={64} name="empty" className="mb-4" />
-              <SmallTitleText>{t('callData.noDecodedTxTitle')}</SmallTitleText>
-              <FootnoteText className="text-text-tertiary">{t('callData.noDecodedTxDescription')}</FootnoteText>
-            </div>
-          )}
-        </Box>
-      </ScrollArea>
+
+          <Separator />
+
+          <Box padding={[4, 5]}>
+            {nonNullable(args) && (
+              <div className="flex flex-col gap-y-3">
+                <SmallTitleText>{t('callData.isCorrect')}</SmallTitleText>
+                <JsonArgs value={args} />
+              </div>
+            )}
+            {nullable(args) && (
+              <div className="flex flex-col items-center gap-y-2 px-10 py-20">
+                <Icon size={64} name="empty" className="mb-4" />
+                <SmallTitleText>{t('callData.noDecodedTxTitle')}</SmallTitleText>
+                <FootnoteText className="text-text-tertiary">{t('callData.noDecodedTxDescription')}</FootnoteText>
+              </div>
+            )}
+          </Box>
+        </ScrollArea>
+      </div>
 
       <ActionsSection />
     </>


### PR DESCRIPTION
## Problem

The **Build an operation** modal (`features/call-data-execute` → `CallDataForm`) had two layout bugs:

1. With tall content in **Build** mode (extrinsic builder + decoded JSON preview), the form section grew past the modal and **overlapped** the footer / decoded section instead of scrolling.
2. In **Paste** mode, when the call-data error hint wrapped to two lines, the `<Separator />` rendered **through** the error text (clipping it).

## Root cause

1. `CallDataForm` provides its own `<ScrollArea>` inside `<Modal.Content disableScroll>`. The ScrollArea was a direct flex child with only `h-full` (no `flex-1 min-h-0`), so with tall content `min-height: auto` prevented it from shrinking — it overflowed the flex column and overlapped the fixed footer.
2. A `-mb-2` (−8px) on the `Tabs` wrapper pushed the form content past its box. `DraftFormBody`'s `overflow-hidden` (used for the draft collapse animation) then clipped the overflowing pixels — the bottom half of the wrapping error hint — and the `Separator`, positioned by the clipped height, landed through the text.

## Fix

- Wrap the `ScrollArea` in a `flex min-h-0 flex-1 flex-col` container so it bounds and scrolls — mirroring what the non-`disableScroll` `Modal.Content` does internally.
- Remove the `-mb-2` hack and rely on the form container's existing `pb-4` spacing before the separator.

Single-file change; no behavior/logic changes.

Before:

<img width="703" height="795" alt="Screenshot 2026-06-02 at 18 00 27" src="https://github.com/user-attachments/assets/ce327a24-863f-477d-9844-d791713b834c" />

After:

<img width="1484" height="912" alt="Screenshot 2026-06-03 at 12 29 09" src="https://github.com/user-attachments/assets/6c05e9f9-6604-4828-be4a-a181fc188c9b" />
<img width="1484" height="912" alt="Screenshot 2026-06-03 at 12 28 47" src="https://github.com/user-attachments/assets/36f2cac9-0299-4e26-b8a3-6cf6590e3b59" />

