### PR TITLE
fix: portfolio page loading lag and indicator

### DIFF
--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -1,4 +1,5 @@
 import { type ApiPromise } from '@polkadot/api';
+import { createStore, sample } from 'effector';
 
 import {
   type Asset,
@@ -41,6 +42,15 @@ const accountAvailabilityOnChainAnyOf = createAnyOf<{ account: AnyAccount; chain
 const accountActionPermissionAnyOf = createAnyOf<{ account: AnyAccount }>();
 const accountCanSignMultipleAnyOf = createAnyOf<{ account: AnyAccount }>();
 const accountCollectChildrenPipeline = createPipeline<AnyAccount[], { account: AnyAccount; accounts: AnyAccount[] }>();
+const $accountAvailabilityRevision = createStore(0);
+
+sample({
+  clock: accountAvailabilityOnChainAnyOf.updateHandlers,
+  source: $accountAvailabilityRevision,
+  fn: revision => revision + 1,
+  target: $accountAvailabilityRevision,
+});
+
 const validateRouteBalancesTransformer = createTransformer<
   {
     api: ApiPromise;
@@ -660,6 +670,7 @@ function hasTransactionValidationErrors(
 
 export const accountService = {
   accountAvailabilityOnChainAnyOf,
+  $accountAvailabilityRevision,
   accountActionPermissionAnyOf,
   accountCanSignMultipleAnyOf,
   accountCollectChildrenPipeline,

--- a/src/renderer/entities/balance/model/balance-model.ts
+++ b/src/renderer/entities/balance/model/balance-model.ts
@@ -4,7 +4,7 @@ import { readonly, spread } from 'patronum';
 
 import { balanceMapper, storageService } from '@/shared/api/storage';
 import { type Balance, type BalanceDraft, type BalanceMap } from '@/shared/core';
-import { createBuffer, createQueuedEffect } from '@/shared/effector';
+import { createBuffer, createQueuedEffect, populated } from '@/shared/effector';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { balanceUtils } from '../lib/balance-utils';
 
@@ -37,6 +37,7 @@ const removeBalancesFx = createQueuedEffect(async (balances: Balance[]) => {
 const populateFx = createQueuedEffect(async (): Promise<Balance[]> => {
   return storageService.balances.readAll().then((balances) => balances.map(balanceMapper.fromDB));
 });
+const $populated = populated(populateFx);
 
 sample({
   clock: bufferedUpdate,
@@ -105,6 +106,7 @@ sample({
 export const balanceModel = {
   $balances,
   $balanceMap: readonly($balanceMap),
+  $populated,
 
   populate: populateFx,
 
@@ -114,6 +116,7 @@ export const balanceModel = {
 
   __test: {
     $balanceMap,
+    $populated,
     removeBalancesFx,
   },
 };

--- a/src/renderer/features/assets/AssetsChainView/ui/AssetsChainView.test.tsx
+++ b/src/renderer/features/assets/AssetsChainView/ui/AssetsChainView.test.tsx
@@ -1,0 +1,100 @@
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { allSettled, fork } from 'effector';
+import { Provider } from 'effector-react';
+import { afterEach, vi } from 'vitest';
+
+import { type Connection, type Wallet, ConnectionType, CryptoType, SigningType, WalletType } from '@/shared/core';
+import { createAccountId, polkadotChain } from '@/shared/mocks';
+import { type AnyAccount, accountService, accounts } from '@/domains/network';
+import { balanceModel } from '@/entities/balance';
+import { networkModel } from '@/entities/network';
+import { walletModel } from '@/entities/wallet';
+import { walletSelect } from '@/aggregates/wallet-select';
+
+import { AssetsChainView } from './AssetsChainView';
+
+vi.mock('@/domains/price', async (importOriginal) => ({
+  ...(await importOriginal()),
+  useAssetsPrices: () => ({ data: null }),
+}));
+
+vi.mock('./NetworkAssets/NetworkAssets', () => ({
+  NetworkAssets: ({ chain }: { chain: typeof polkadotChain }) => <div data-testid="NetworkAssets">{chain.name}</div>,
+}));
+
+const mockAccount: AnyAccount = {
+  id: '1',
+  walletId: 1,
+  name: 'My base account',
+  type: 'universal',
+  accountId: createAccountId('1'),
+  signingType: SigningType.POLKADOT_VAULT,
+  cryptoType: CryptoType.SR25519,
+  createdAt: Date.now(),
+};
+
+const mockWallet: Wallet = {
+  id: 1,
+  name: 'My first wallet',
+  type: WalletType.POLKADOT_VAULT,
+  accounts: [mockAccount],
+};
+
+const mockConnection = {
+  id: 1,
+  chainId: polkadotChain.chainId,
+  connectionType: ConnectionType.AUTO_BALANCE,
+  customNodes: [],
+} as Connection;
+
+describe('features/AssetsChainView/ui/AssetsChainView', () => {
+  afterEach(() => {
+    accountService.accountAvailabilityOnChainAnyOf.resetHandlers();
+  });
+
+  test('should render loader instead of null while visible accounts are not populated', async () => {
+    const scope = fork();
+
+    await act(async () => {
+      render(
+        <Provider value={scope}>
+          <AssetsChainView query="" visibleAccounts={[]} hideZeroBalances={false} />
+        </Provider>,
+      );
+    });
+
+    expect(screen.getByTestId('Icon:loader')).toBeInTheDocument();
+  });
+
+  test('should recompute chains when account availability handlers are registered after startup', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(accounts.__test.$populated, true)
+        .set(accounts.__test.$list, [mockAccount])
+        .set(walletSelect.__test.$selectedWalletId, mockWallet.id)
+        .set(networkModel.$chains, { [polkadotChain.chainId]: polkadotChain })
+        .set(networkModel.$connections, { [polkadotChain.chainId]: mockConnection })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    await allSettled(walletModel.__test.$rawWallets, { scope, params: [mockWallet] });
+
+    await act(async () => {
+      render(
+        <Provider value={scope}>
+          <AssetsChainView query="" visibleAccounts={[mockAccount]} hideZeroBalances={false} />
+        </Provider>,
+      );
+    });
+
+    expect(screen.queryByTestId('NetworkAssets')).not.toBeInTheDocument();
+
+    accountService.accountAvailabilityOnChainAnyOf.registerHandler({ body: () => true, available: () => true });
+
+    await act(async () => {
+      await allSettled(accountService.accountAvailabilityOnChainAnyOf.updateHandlers, { scope });
+    });
+
+    await waitFor(() => expect(screen.getByTestId('NetworkAssets')).toBeInTheDocument());
+  });
+});

--- a/src/renderer/features/assets/AssetsChainView/ui/AssetsChainView.tsx
+++ b/src/renderer/features/assets/AssetsChainView/ui/AssetsChainView.tsx
@@ -1,5 +1,5 @@
 import { useUnit } from 'effector-react';
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
 import { chainsService } from '@/shared/api/network';
 import { type Asset, type Chain } from '@/shared/core';
@@ -7,11 +7,12 @@ import { useDeferredList } from '@/shared/lib/hooks';
 import { includesMultiple, nullable } from '@/shared/lib/utils';
 import { Loader } from '@/shared/ui';
 import { Box } from '@/shared/ui-kit';
-import { type AnyAccount, accountService } from '@/domains/network';
+import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { useAssetsPrices } from '@/domains/price';
 import { EmptyAssetsState } from '@/entities/asset';
 import { balanceModel } from '@/entities/balance';
 import { networkModel, networkUtils } from '@/entities/network';
+import { walletModel } from '@/entities/wallet';
 import { currencySelect } from '@/aggregates/currency-select';
 import { walletSelect } from '@/aggregates/wallet-select';
 
@@ -24,8 +25,13 @@ type Props = {
 };
 export const AssetsChainView = ({ query, visibleAccounts, hideZeroBalances }: Props) => {
   const activeWallet = useUnit(walletSelect.$selectedWallet);
+  const wallets = useUnit(walletModel.$wallets);
+  const isLoadingWallets = useUnit(walletModel.$isLoadingWallets);
   const activeWalletAccounts = useUnit(walletSelect.$selectedAccounts);
+  const accountsPopulated = useUnit(accounts.$populated);
+  const accountAvailabilityRevision = useUnit(accountService.$accountAvailabilityRevision);
   const balances = useUnit(balanceModel.$balanceMap);
+  const balancesPopulated = useUnit(balanceModel.$populated);
 
   const fiatFlag = useUnit(currencySelect.$fiatFlag);
   const currency = useUnit(currencySelect.$activeCurrency);
@@ -37,12 +43,23 @@ export const AssetsChainView = ({ query, visibleAccounts, hideZeroBalances }: Pr
   const [sortedChains, setSortedChains] = useState<Chain[]>([]);
   const [filteredChains, setFilteredChains] = useState<Chain[]>([]);
 
-  const { list, isLoading } = useDeferredList({ list: filteredChains, forceFirstRender: true });
+  const visibleAccountIds = useMemo(() => new Set(visibleAccounts.map((a) => a.accountId)), [visibleAccounts]);
+  const networkDataPopulated = Object.keys(chains).length > 0 && Object.keys(connections).length > 0;
+  const visibleAccountsPopulated =
+    accountsPopulated && !isLoadingWallets && (wallets.length === 0 || activeWallet !== null);
+  const chainViewLoading = !balancesPopulated || !networkDataPopulated || !visibleAccountsPopulated;
+  const emptyStateAvailable = Boolean(query) || hideZeroBalances;
+
+  const { list, isLoading } = useDeferredList({
+    list: filteredChains,
+    isLoading: chainViewLoading,
+    forceFirstRender: true,
+  });
+  const shouldShowLoader = isLoading && list.length === 0;
+  const shouldShowEmptyState = emptyStateAvailable && list.length === 0 && !isLoading;
 
   useEffect(() => {
     if (!visibleAccounts.length) return;
-
-    const visibleAccountIds = new Set(visibleAccounts.map((a) => a.accountId));
 
     const filteredChains = Object.values(chains).filter((chain) => {
       const connection = connections[chain.chainId];
@@ -66,7 +83,17 @@ export const AssetsChainView = ({ query, visibleAccounts, hideZeroBalances }: Pr
     );
 
     setSortedChains(sortedChains);
-  }, [activeWalletAccounts, balances, assetsPrices, connections, visibleAccounts]);
+  }, [
+    activeWalletAccounts,
+    balances,
+    assetsPrices,
+    chains,
+    connections,
+    currency,
+    fiatFlag,
+    visibleAccountIds,
+    accountAvailabilityRevision,
+  ]);
 
   useEffect(() => {
     let filteredChains: Chain[] = [];
@@ -105,14 +132,14 @@ export const AssetsChainView = ({ query, visibleAccounts, hideZeroBalances }: Pr
     }
   }, [sortedChains, query]);
 
-  if (!visibleAccounts.length) {
+  if (!visibleAccounts.length && !chainViewLoading) {
     return null;
   }
 
   return (
     <div className="flex h-full w-full flex-col gap-y-4 overflow-y-scroll">
       <div className="flex min-h-full w-full flex-col items-center gap-y-4 py-4">
-        {isLoading && (
+        {shouldShowLoader && (
           <Box fillContainer verticalAlign="center" horizontalAlign="center">
             <Loader color="primary" size={32} />
           </Box>
@@ -128,7 +155,7 @@ export const AssetsChainView = ({ query, visibleAccounts, hideZeroBalances }: Pr
             wallet={activeWallet}
           />
         ))}
-        <EmptyAssetsState />
+        {shouldShowEmptyState && <EmptyAssetsState />}
       </div>
     </div>
   );

--- a/src/renderer/features/assets/AssetsPortfolioView/model/__tests__/portfolio-model.test.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/__tests__/portfolio-model.test.ts
@@ -1,8 +1,26 @@
 import { BN_ZERO } from '@polkadot/util';
 import { allSettled, fork } from 'effector';
 
-import { type AssetByChains, type AssetId } from '@/shared/core';
+import {
+  type AssetByChains,
+  type AssetId,
+  type Chain,
+  type ChainId,
+  type Connection,
+  type Wallet,
+  ConnectionStatus,
+  ConnectionType,
+  CryptoType,
+  SigningType,
+  WalletType,
+} from '@/shared/core';
+import { createAccountId } from '@/shared/mocks';
+import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { AssetsListView } from '@/entities/asset';
+import { balanceModel } from '@/entities/balance';
+import { networkModel } from '@/entities/network';
+import { walletModel } from '@/entities/wallet';
+import { walletSelect } from '@/aggregates/wallet-select';
 import { portfolioModel } from '../portfolio-model';
 
 const mockTokens: AssetByChains[] = [
@@ -60,10 +78,51 @@ const mockTokens: AssetByChains[] = [
   },
 ];
 
+const walletsWithoutAccounts: Wallet[] = [
+  {
+    id: 1,
+    type: WalletType.POLKADOT_VAULT,
+    name: 'My wallet',
+    accounts: [],
+  },
+];
+const mockWalletAccounts: AnyAccount[] = [
+  {
+    id: '1',
+    walletId: 1,
+    name: 'My base account',
+    type: 'universal',
+    accountId: createAccountId('1'),
+    signingType: SigningType.POLKADOT_VAULT,
+    cryptoType: CryptoType.SR25519,
+    createdAt: Date.now(),
+  },
+];
+const mockWallets: Wallet[] = [
+  {
+    id: 1,
+    name: 'My first wallet',
+    type: WalletType.POLKADOT_VAULT,
+    accounts: mockWalletAccounts,
+  },
+];
+const mockChainId = mockTokens[0]!.chains[0]!.chainId;
+const mockChain = { chainId: mockChainId, name: 'Polkadot', assets: [], options: [] } as unknown as Chain;
+const mockConnection = {
+  id: 1,
+  chainId: mockChainId,
+  connectionType: ConnectionType.AUTO_BALANCE,
+  customNodes: [],
+} as Connection;
+
 // TODO: input data is a bit complex and after refactoring of internal model, chains wallet and etc should be presented.
 // For now it's simpler to turn off some of the test and think about simplifying external dependencies.
 
 describe('Portfolio model', () => {
+  afterEach(() => {
+    accountService.accountAvailabilityOnChainAnyOf.resetHandlers();
+  });
+
   test('should handle activeViewChanged event', async () => {
     const scope = fork({
       values: new Map().set(portfolioModel.$activeView, AssetsListView.CHAIN_CENTRIC),
@@ -71,6 +130,153 @@ describe('Portfolio model', () => {
 
     await allSettled(portfolioModel.events.activeViewChanged, { scope, params: AssetsListView.TOKEN_CENTRIC });
     expect(scope.getState(portfolioModel.$activeView)).toEqual(AssetsListView.TOKEN_CENTRIC);
+  });
+
+  test('should keep tokens loading while token catalog is not populated', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(accounts.__test.$populated, true)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    await allSettled(walletModel.__test.$rawWallets, { scope, params: [] });
+    await allSettled(portfolioModel.events.queryChanged, { scope, params: 'DOT' });
+
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(false);
+
+    await allSettled(portfolioModel._test.$defaultTokens, { scope, params: mockTokens });
+
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(true);
+  });
+
+  test('should keep tokens loading while wallets are not populated', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(portfolioModel._test.$defaultTokens, mockTokens)
+        .set(accounts.__test.$populated, true)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    expect(scope.getState(walletModel.$isLoadingWallets)).toEqual(true);
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(false);
+  });
+
+  test('should keep tokens loading while selected wallet accounts are not populated', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(portfolioModel._test.$defaultTokens, mockTokens)
+        .set(accounts.__test.$populated, true)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    await allSettled(walletModel.__test.$rawWallets, { scope, params: walletsWithoutAccounts });
+
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(false);
+  });
+
+  test('should allow empty state only when portfolio filtering is active', async () => {
+    const scope = fork();
+
+    expect(scope.getState(portfolioModel.$emptyStateAvailable)).toEqual(false);
+
+    await allSettled(portfolioModel.events.queryChanged, { scope, params: 'DOT' });
+    expect(scope.getState(portfolioModel.$emptyStateAvailable)).toEqual(true);
+
+    await allSettled(portfolioModel.events.queryChanged, { scope, params: '' });
+    expect(scope.getState(portfolioModel.$emptyStateAvailable)).toEqual(false);
+
+    await allSettled(portfolioModel.events.hideZeroBalancesChanged, { scope, params: true });
+    expect(scope.getState(portfolioModel.$emptyStateAvailable)).toEqual(true);
+  });
+
+  test('should treat local network data as populated without waiting for network batch', async () => {
+    accountService.accountAvailabilityOnChainAnyOf.registerHandler({ body: () => true, available: () => true });
+
+    const scope = fork({
+      handlers: [[walletModel.populate, () => mockWallets]],
+      values: new Map()
+        .set(portfolioModel._test.$defaultTokens, mockTokens)
+        .set(accounts.__test.$populated, true)
+        .set(accounts.__test.$list, mockWalletAccounts)
+        .set(walletSelect.__test.$selectedWalletId, mockWallets[0]!.id)
+        .set(networkModel.$populated, false)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(networkModel.$connectionStatuses, { [mockChainId]: ConnectionStatus.CONNECTING })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    await allSettled(walletModel.populate, { scope });
+    await allSettled(networkModel.$connectionStatuses, {
+      scope,
+      params: { [mockChainId]: ConnectionStatus.CONNECTING },
+    });
+    await allSettled(networkModel.$chains, {
+      scope,
+      params: { [mockChainId]: mockChain } as Record<ChainId, Chain>,
+    });
+
+    expect(scope.getState(portfolioModel._test.$networkDataPopulated)).toEqual(true);
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(true);
+  });
+
+  test('should recompute token rows when account availability handlers are registered after startup', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(portfolioModel._test.$defaultTokens, mockTokens)
+        .set(accounts.__test.$populated, true)
+        .set(accounts.__test.$list, mockWalletAccounts)
+        .set(walletModel.__test.$rawWallets, mockWallets)
+        .set(walletSelect.__test.$selectedWalletId, mockWallets[0]!.id)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    expect(scope.getState(walletSelect.$selectedAccounts).length).toBeGreaterThan(0);
+    expect(scope.getState(portfolioModel.$accounts)).toEqual([]);
+    expect(scope.getState(portfolioModel.$sortedTokens)).toEqual([]);
+
+    await allSettled(accountService.accountAvailabilityOnChainAnyOf.registerHandler, {
+      scope,
+      params: { body: () => true, available: () => true },
+    });
+
+    expect(scope.getState(accountService.$accountAvailabilityRevision)).toBeGreaterThan(0);
+    expect(scope.getState(portfolioModel.$accounts).length).toBeGreaterThan(0);
+    expect(scope.getState(portfolioModel.$sortedTokens).length).toBeGreaterThan(0);
+  });
+
+  test('should keep portfolio loading while networks are connecting and no tokens are rendered', async () => {
+    const scope = fork({
+      values: new Map()
+        .set(portfolioModel._test.$defaultTokens, mockTokens)
+        .set(accounts.__test.$populated, true)
+        .set(networkModel.$chains, { [mockChainId]: mockChain } as Record<ChainId, Chain>)
+        .set(networkModel.$connections, { [mockChainId]: mockConnection })
+        .set(networkModel.$connectionStatuses, { [mockChainId]: ConnectionStatus.CONNECTING })
+        .set(balanceModel.__test.$populated, true),
+    });
+
+    await allSettled(walletModel.__test.$rawWallets, { scope, params: [] });
+
+    expect(scope.getState(portfolioModel.$tokensPopulated)).toEqual(true);
+    expect(scope.getState(portfolioModel._test.$networksLoading)).toEqual(true);
+    expect(scope.getState(portfolioModel.$sortedTokens)).toEqual([]);
+    expect(scope.getState(portfolioModel.$isLoading)).toEqual(true);
+
+    await allSettled(networkModel.$connectionStatuses, {
+      scope,
+      params: { [mockChainId]: ConnectionStatus.CONNECTED },
+    });
+    expect(scope.getState(portfolioModel._test.$networksLoading)).toEqual(false);
+    expect(scope.getState(portfolioModel.$isLoading)).toEqual(false);
   });
 
   test.skip('should update $filteredTokens and $query stores on queryChanged event', async () => {

--- a/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
+++ b/src/renderer/features/assets/AssetsPortfolioView/model/portfolio-model.ts
@@ -1,13 +1,14 @@
 import { combine, createEffect, createEvent, createStore, restore, sample } from 'effector';
 import { persist } from 'effector-storage/local';
-import { once } from 'patronum';
+import { and } from 'patronum';
 
 import { type AssetByChains } from '@/shared/core';
 import { includesMultiple, nonNullable, nullable } from '@/shared/lib/utils';
-import { type AnyAccount, accountService } from '@/domains/network';
+import { type AnyAccount, accountService, accounts } from '@/domains/network';
 import { AssetsListView } from '@/entities/asset';
 import { balanceModel } from '@/entities/balance';
 import { networkModel, networkUtils } from '@/entities/network';
+import { walletModel } from '@/entities/wallet';
 import { currencySelect } from '@/aggregates/currency-select';
 import { walletSelect } from '@/aggregates/wallet-select';
 import { shardsModel, shardsUtils } from '@/features/wallets';
@@ -60,8 +61,9 @@ const $allInitiators = combine(
   {
     accounts: walletSelect.$selectedAccounts,
     chains: networkModel.$chains,
+    accountAvailabilityRevision: accountService.$accountAvailabilityRevision,
   },
-  ({ accounts, chains }) => {
+  ({ accounts, chains, accountAvailabilityRevision: _accountAvailabilityRevision }) => {
     if (nullable(accounts) || Object.keys(chains).length === 0) return [];
     const result = new Set<AnyAccount>();
 
@@ -232,13 +234,71 @@ const $sortedTokens = combine(
   },
 );
 
-const $tokensPopulated = createStore(false).on(once($sortedTokens.updates), () => true);
+const $emptyStateAvailable = combine(
+  {
+    query: $query,
+    hideZeroBalances: $hideZeroBalances,
+  },
+  ({ query, hideZeroBalances }) => Boolean(query) || hideZeroBalances,
+);
+
+const $walletsPopulated = combine(
+  {
+    isLoadingWallets: walletModel.$isLoadingWallets,
+    wallets: walletModel.$wallets,
+    selectedWallet: walletSelect.$selectedWallet,
+  },
+  ({ isLoadingWallets, wallets, selectedWallet }) => {
+    if (isLoadingWallets) return false;
+    if (wallets.length === 0) return true;
+
+    return nonNullable(selectedWallet) && selectedWallet.accounts.length > 0;
+  },
+);
+
+const $networkDataPopulated = combine(
+  {
+    chains: networkModel.$chains,
+    connections: networkModel.$connections,
+  },
+  ({ chains, connections }) => Object.keys(chains).length > 0 && Object.keys(connections).length > 0,
+);
+
+const $tokensPopulated = and(
+  $defaultTokens.map((tokens) => nonNullable(tokens)),
+  accounts.$populated,
+  $networkDataPopulated,
+  balanceModel.$populated,
+  $walletsPopulated,
+);
+
+const $networksLoading = combine(networkModel.$connectionStatuses, (statuses) =>
+  Object.values(statuses).some(networkUtils.isConnectingStatus),
+);
+
+const $isLoading = combine(
+  {
+    tokensPopulated: $tokensPopulated,
+    sortedTokens: $sortedTokens,
+    emptyStateAvailable: $emptyStateAvailable,
+    networksLoading: $networksLoading,
+  },
+  ({ tokensPopulated, sortedTokens, emptyStateAvailable, networksLoading }) => {
+    if (!tokensPopulated) return true;
+    if (sortedTokens.length > 0) return false;
+    if (emptyStateAvailable) return false;
+
+    return networksLoading;
+  },
+);
 
 export const portfolioModel = {
   $activeView,
   $accounts: $allInitiators,
   $sortedTokens,
   $tokensPopulated,
+  $isLoading,
+  $emptyStateAvailable,
 
   populate: populateFx,
 
@@ -253,5 +313,7 @@ export const portfolioModel = {
   _test: {
     $defaultTokens,
     $query,
+    $networksLoading,
+    $networkDataPopulated,
   },
 };

--- a/src/renderer/features/assets/AssetsPortfolioView/ui/AssetsPortfolioView.tsx
+++ b/src/renderer/features/assets/AssetsPortfolioView/ui/AssetsPortfolioView.tsx
@@ -30,15 +30,17 @@ export const AssetsPortfolioView = () => {
   const { t } = useI18n();
 
   const sortedTokens = useUnit(portfolioModel.$sortedTokens);
-  const tokensPopulated = useUnit(portfolioModel.$tokensPopulated);
+  const portfolioLoading = useUnit(portfolioModel.$isLoading);
+  const emptyStateAvailable = useUnit(portfolioModel.$emptyStateAvailable);
   const fiatFlag = useUnit(currencySelect.$fiatFlag);
   const wallet = useUnit(walletSelect.$selectedWallet);
 
   const { list, isLoading } = useDeferredList({
     list: sortedTokens,
-    isLoading: !tokensPopulated,
+    isLoading: portfolioLoading,
     forceFirstRender: true,
   });
+  const shouldShowEmptyState = emptyStateAvailable && list.length === 0 && !isLoading;
 
   return (
     <div className="flex min-h-full w-full flex-col items-center gap-y-2 py-4">
@@ -70,7 +72,7 @@ export const AssetsPortfolioView = () => {
           </Box>
         )}
 
-        <EmptyAssetsState />
+        {shouldShowEmptyState && <EmptyAssetsState />}
       </ul>
     </div>
   );

--- a/src/renderer/pages/Assets/Assets/Assets.tsx
+++ b/src/renderer/pages/Assets/Assets/Assets.tsx
@@ -4,6 +4,7 @@ import { Outlet } from 'react-router-dom';
 
 import { useI18n } from '@/shared/i18n';
 import { Header, Loader } from '@/shared/ui';
+import { Box } from '@/shared/ui-kit';
 import { AssetsListView } from '@/entities/asset';
 import { AssetsSearch, AssetsSettings, assetsSearchModel, assetsSettingsModel } from '@/features/assets';
 import { AssetTransactionModal } from '@/features/assets-transaction';
@@ -17,6 +18,12 @@ const AssetsChainView = lazy(() =>
 );
 
 import { assetsModel } from './model/assets-model';
+
+const assetsFallback = (
+  <Box fillContainer verticalAlign="center" horizontalAlign="center">
+    <Loader color="primary" size={32} />
+  </Box>
+);
 
 export const Assets = () => {
   const { t } = useI18n();
@@ -38,12 +45,12 @@ export const Assets = () => {
         <ShardSelectorButton />
         <div className="flex h-full w-full flex-col gap-y-4 overflow-y-scroll">
           {assetsView === AssetsListView.TOKEN_CENTRIC && (
-            <Suspense fallback={<Loader color="primary" className="m-auto" />}>
+            <Suspense fallback={assetsFallback}>
               <AssetsPortfolioView />
             </Suspense>
           )}
           {assetsView === AssetsListView.CHAIN_CENTRIC && (
-            <Suspense fallback={<Loader color="primary" className="m-auto" />}>
+            <Suspense fallback={assetsFallback}>
               <AssetsChainView query={query} visibleAccounts={visibleAccounts} hideZeroBalances={hideZeroBalances} />
             </Suspense>
           )}


### PR DESCRIPTION
## Description
Fix Assets portfolio cold-start loading so unfiltered token-centric and chain-centric views no longer show an incorrect “Nothing was found” state or blank area while local prerequisites are still initializing.


## Related Issues
Closes https://novasama-technologies.atlassian.net/browse/SPEK-133

## Changes Made
- Added balance cache population state via `balanceModel.$populated`.
- Added account availability revision tracking so portfolio derivations recompute when wallet feature availability handlers register.
- Reworked token-centric loading state to distinguish:
  - real bootstrap/loading state
  - rendered portfolio rows
  - search/hide-zero empty results
- Updated chain-centric view to:
  - listen for account availability handler updates
  - show loader while accounts/wallet/network/balance prerequisites are loading
  - only show empty state when filtering is active
- Centered the Assets route Suspense fallback using a parent `Box`, without changing shared `Loader` behavior.
- Added regression coverage for token-centric and chain-centric cold-start behavior.


## Screenshots/Recordings

https://github.com/user-attachments/assets/7c8b8af9-db04-4ba4-826e-43d1e38a8499



## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [X] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
