### PR TITLE
fix: extrinsic builder - address suggestions, click area, template apply

### DIFF
--- a/src/renderer/features/call-data-execute/model/form.ts
+++ b/src/renderer/features/call-data-execute/model/form.ts
@@ -330,6 +330,13 @@ sample({
   target: form.fields.callData.change,
 });
 
+// jump straight to the builder — the user's next step is tweaking the arguments
+sample({
+  clock: templateApplied,
+  fn: () => InputMode.BUILD,
+  target: inputModeChanged,
+});
+
 // flow setup
 
 // Preselect initiator on form open

--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -153,6 +153,8 @@ export const CreateDraftModal = () => {
 
   const handleTemplateApply = (templateCallData: string) => {
     createDraftModel.callDataChanged(templateCallData);
+    // jump straight to the builder — the user's next step is tweaking the arguments
+    createDraftModel.inputModeChanged('build');
   };
 
   const handleToggle = (open: boolean) => {

--- a/src/renderer/features/extrinsic-builder/ui/CallSelect.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/CallSelect.tsx
@@ -20,7 +20,7 @@ export const CallSelect = memo(({ options, value, disabled, onChange }: Props) =
   );
 
   return (
-    <Field text={t('extrinsicBuilder.call')}>
+    <Field text={t('extrinsicBuilder.call')} clickableLabel={false}>
       <Combobox
         placeholder={t('extrinsicBuilder.callPlaceholder')}
         value={displayValue}

--- a/src/renderer/features/extrinsic-builder/ui/PalletSelect.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/PalletSelect.tsx
@@ -19,7 +19,7 @@ export const PalletSelect = memo(({ options, value, onChange }: Props) => {
   );
 
   return (
-    <Field text={t('extrinsicBuilder.pallet')}>
+    <Field text={t('extrinsicBuilder.pallet')} clickableLabel={false}>
       <Combobox
         placeholder={t('extrinsicBuilder.palletPlaceholder')}
         value={displayValue}

--- a/src/renderer/features/extrinsic-builder/ui/ParameterField.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/ParameterField.tsx
@@ -55,7 +55,7 @@ export const ParameterField = memo(({ name, typeDef, value, onChange, depth, api
   const label = `${name}: ${typeDef.typeName}${kindHint}`;
 
   return (
-    <Field text={<FootnoteText className="text-text-secondary">{label}</FootnoteText>}>
+    <Field text={<FootnoteText className="text-text-secondary">{label}</FootnoteText>} clickableLabel={false}>
       <ParameterInput typeDef={typeDef} value={value} depth={depth} api={api} onChange={onChange} />
     </Field>
   );

--- a/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
@@ -4,7 +4,14 @@ import { uniqBy } from 'lodash';
 import { memo, useCallback, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { includesMultiple, performSearch, toAddress, validateAddress } from '@/shared/lib/utils';
+import {
+  includesMultiple,
+  isCorrectAccountId,
+  performSearch,
+  toAccountId,
+  toAddress,
+  validateAddress,
+} from '@/shared/lib/utils';
 import { CaptionText } from '@/shared/ui';
 import { Address, Identicon } from '@/shared/ui-entities';
 import { Combobox } from '@/shared/ui-kit';
@@ -36,52 +43,45 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
   const uniqueAccountsList = useMemo(() => uniqBy(accountsList, 'accountId'), [accountsList]);
   const resolvedAccounts = useAccountsNames(uniqueAccountsList, null);
 
-  // Collect all known addresses for selection detection
-  const knownAddresses = useMemo(() => {
-    if (!chain) return new Set<string>();
-    const addresses = new Set<string>();
-    for (const account of resolvedAccounts) {
-      addresses.add(toAddress(account.accountId, { prefix: chain.prefix }));
-    }
-    for (const contact of contacts) {
-      addresses.add(toAddress(contact.accountId, { prefix: chain.prefix }));
-    }
-
-    return addresses;
-  }, [chain, resolvedAccounts, contacts]);
-
   const searchQuery = isEditing ? inputText : '';
+
+  // A full address typed in any ss58 prefix matches by accountId;
+  // toAccountId falls back to '0x00' for undecodable values (e.g. EVM)
+  const queryAccountId = useMemo(() => {
+    if (!searchQuery || !validateAddress(searchQuery)) return null;
+    const accountId = toAccountId(searchQuery);
+
+    return isCorrectAccountId(accountId) ? accountId : null;
+  }, [searchQuery]);
 
   const accountOptions = useMemo(() => {
     if (!chain) return [];
 
     return resolvedAccounts
+      .map((account) => ({
+        accountId: account.accountId,
+        name: account.name,
+        address: toAddress(account.accountId, { prefix: chain.prefix }),
+      }))
       .filter((account) => {
-        const address = toAddress(account.accountId, { prefix: chain.prefix });
+        if (queryAccountId) return account.accountId === queryAccountId;
 
-        return !searchQuery || includesMultiple([account.name, address], searchQuery);
-      })
-      .slice(0, 20)
-      .map((account) => {
-        const address = toAddress(account.accountId, { prefix: chain.prefix });
-
-        return { id: address, name: account.name, address };
+        return !searchQuery || includesMultiple([account.name, account.address], searchQuery);
       });
-  }, [searchQuery, chain, resolvedAccounts]);
+  }, [searchQuery, queryAccountId, chain, resolvedAccounts]);
 
   const contactOptions = useMemo(() => {
-    if (searchQuery && validateAddress(searchQuery)) return [];
+    const filtered = queryAccountId
+      ? contacts.filter((contact) => contact.accountId === queryAccountId)
+      : searchQuery
+        ? performSearch({ query: searchQuery, records: contacts, weights: { name: 1, address: 0.5 } })
+        : contacts;
 
-    const filtered = searchQuery
-      ? performSearch({ query: searchQuery, records: contacts, weights: { name: 1, address: 0.5 } })
-      : contacts;
-
-    return filtered.slice(0, 10).map((contact) => {
-      const address = toAddress(contact.accountId, { prefix: chain?.prefix });
-
-      return { id: contact.name, name: contact.name, address };
-    });
-  }, [searchQuery, contacts, chain]);
+    return filtered.map((contact) => ({
+      name: contact.name,
+      address: toAddress(contact.accountId, { prefix: chain?.prefix }),
+    }));
+  }, [searchQuery, queryAccountId, contacts, chain]);
 
   const displayValue = isEditing ? inputText : value;
 
@@ -89,23 +89,18 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
     <Identicon size={20} address={toAddress(value, { prefix: chain?.prefix })} background={false} />
   ) : undefined;
 
-  const handleChange = useCallback(
+  const handleSelect = useCallback(
     (val: string) => {
-      if (knownAddresses.has(val)) {
-        // Selected from list
-        onChange(val);
-        setIsEditing(false);
-        setInputText('');
-      } else {
-        setInputText(val);
-      }
+      onChange(val);
+      setIsEditing(false);
+      setInputText('');
     },
-    [knownAddresses, onChange],
+    [onChange],
   );
 
   const handleBlur = useCallback(() => {
-    // Commit whatever was typed as the value
-    if (isEditing && inputText) {
+    // Commit whatever was typed as the value; an empty commit clears it
+    if (isEditing) {
       onChange(inputText);
     }
     setIsEditing(false);
@@ -119,7 +114,8 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
       prefixElement={prefixElement}
       height="sm"
       onBlur={handleBlur}
-      onChange={handleChange}
+      onChange={setInputText}
+      onSelect={handleSelect}
       onInput={(v) => {
         setIsEditing(true);
         setInputText(v);
@@ -134,7 +130,7 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
           }
         >
           {accountOptions.map((opt) => (
-            <Combobox.Item key={opt.id} value={opt.address}>
+            <Combobox.Item key={opt.address} value={opt.address}>
               <Address showIcon title={opt.name} address={opt.address} />
             </Combobox.Item>
           ))}
@@ -149,7 +145,7 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
           }
         >
           {contactOptions.map((opt) => (
-            <Combobox.Item key={`contact-${opt.id}`} value={opt.address}>
+            <Combobox.Item key={`contact-${opt.name}`} value={opt.address}>
               <Address showIcon title={opt.name} address={opt.address} />
             </Combobox.Item>
           ))}

--- a/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
+++ b/src/renderer/features/extrinsic-builder/ui/parameterInputs/AccountParamInput.tsx
@@ -43,7 +43,10 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
   const uniqueAccountsList = useMemo(() => uniqBy(accountsList, 'accountId'), [accountsList]);
   const resolvedAccounts = useAccountsNames(uniqueAccountsList, null);
 
-  const searchQuery = isEditing ? inputText : '';
+  const displayValue = isEditing ? inputText : value;
+  // Suggestions always filter by what the input shows, so re-focusing a filled
+  // field lists the matching entries instead of the full address book
+  const searchQuery = displayValue;
 
   // A full address typed in any ss58 prefix matches by accountId;
   // toAccountId falls back to '0x00' for undecodable values (e.g. EVM)
@@ -82,8 +85,6 @@ export const AccountParamInput = memo(({ value, api, onChange }: Props) => {
       address: toAddress(contact.accountId, { prefix: chain?.prefix }),
     }));
   }, [searchQuery, queryAccountId, contacts, chain]);
-
-  const displayValue = isEditing ? inputText : value;
 
   const prefixElement = value ? (
     <Identicon size={20} address={toAddress(value, { prefix: chain?.prefix })} background={false} />

--- a/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
+++ b/src/renderer/shared/ui-kit/Combobox/Combobox.tsx
@@ -45,11 +45,17 @@ type ControlledPopoverProps = {
   value: string;
   onChange: (value: string) => void;
   onInput: (value: string) => void;
+  /**
+   * Fired only when the user picks an item from the list. Without it item
+   * selection falls back to `onChange`, which is also fired on typing — pass
+   * `onSelect` when the consumer needs to tell the two apart.
+   */
+  onSelect?: (value: string) => void;
 };
 
 type RootProps = PropsWithChildren<ControlledPopoverProps & ContextProps & InputProps>;
 
-const Root = ({ testId = 'Combobox', value, onChange, onInput, children, ...inputProps }: RootProps) => {
+const Root = ({ testId = 'Combobox', value, onChange, onInput, onSelect, children, ...inputProps }: RootProps) => {
   const comboboxRef = useRef<HTMLInputElement | null>(null);
   const listboxRef = useRef<HTMLDivElement | null>(null);
   const anchorRef = useRef<HTMLDivElement | null>(null);
@@ -69,7 +75,7 @@ const Root = ({ testId = 'Combobox', value, onChange, onInput, children, ...inpu
             defaultSelectedValue={value}
             value={value}
             selectedValue={value}
-            setSelectedValue={onChange}
+            setSelectedValue={onSelect ?? onChange}
             setValue={value => startTransition(() => onChange(value.trim()))}
           >
             <Trigger {...inputProps} onChange={onInput} />

--- a/src/renderer/shared/ui-kit/Field/Field.tsx
+++ b/src/renderer/shared/ui-kit/Field/Field.tsx
@@ -8,16 +8,22 @@ type Props = {
    * opens an editor for the selected value).
    */
   action?: ReactNode;
+  /**
+   * Whether clicking the field text focuses the wrapped control. Disable for
+   * controls that open a dropdown on focus (e.g. Combobox) so the clickable
+   * area stays limited to the visible input box.
+   */
+  clickableLabel?: boolean;
   testId?: string;
 };
 
-export const Field = ({ text, action, testId, children }: PropsWithChildren<Props>) => {
+export const Field = ({ text, action, clickableLabel = true, testId, children }: PropsWithChildren<Props>) => {
   // When an action is provided, it must live OUTSIDE the <label> — otherwise
   // clicking the action chip is forwarded to the wrapped form control (e.g.
   // opens a signatory dropdown when the user only meant to trigger the
   // action). Without an action, keep the original single-label structure so
   // clicking the field text still focuses the control.
-  if (action) {
+  if (action || !clickableLabel) {
     return (
       <div className="flex w-full flex-col gap-y-2" data-testid={testId}>
         <div className="flex items-center justify-between gap-2 text-footnote font-medium text-text-tertiary">


### PR DESCRIPTION
## Summary

### 1. Pasted full address now surfaces the matching contact
Previously the suggestion list went empty whenever the input was a valid address — the user had to delete characters to see the contact. The query is now decoded to its `accountId` and matched against contacts and wallet accounts, so a full address pasted in **any** ss58 prefix shows the named entry for explicit confirmation before selecting.

### 2. Cleared destination address stays cleared
`handleBlur` skipped the commit for an empty field, so the previous value reappeared after clicking another cell. Blur now commits whatever is in the field, including empty.

### 3. Clickable area limited to the text box
`Field` wrapped the caption ("Pallet", parameter names) and the control in one full-width `<label>`, so clicking the caption focused the combobox, which opens its dropdown on focus. Added an opt-out `clickableLabel` prop to `Field` and applied it to `PalletSelect`, `CallSelect` and `ParameterField`. Field behavior elsewhere is unchanged.

### 4. Complete contact/account list in suggestions
The dropdown was hard-capped at 10 contacts / 20 accounts, which made the on-focus list look incomplete. Caps removed — the list is scrollable.

### 5. Apply template → jump to Build tab
After clicking **Apply** on a template the view now switches to the Build tab automatically (in both the draft-creation and call-data-execute modals), since the call data is already filled and the user's next step is tweaking the arguments.

### Supporting ui-kit change
`Combobox` gained an optional `onSelect` prop fired only on list-item selection, letting the account input distinguish picking a suggestion from typing/pasting. Backwards-compatible — existing consumers are unaffected.

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

https://github.com/user-attachments/assets/276529c2-54a7-4139-a285-18f7c7db6842

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines




Fixes novasamatech/nova-spektr-tracker#79
Fixes novasamatech/nova-spektr-tracker#80