### PR TITLE
fix: hide submitted drafts after reload and verify flex-delegated proxies

### DIFF
--- a/src/renderer/domains/backend/operations/service.test.ts
+++ b/src/renderer/domains/backend/operations/service.test.ts
@@ -1,0 +1,72 @@
+import { type Mock, beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { authFetch } from '@/shared/api/backend-fetch';
+
+import { operationsService } from './service';
+
+// vi.mock is hoisted above the imports by vitest, so authFetch resolves to the mock below.
+// parseResponse stays real — the paginated-envelope parsing is part of what's under test.
+vi.mock('@/shared/api/backend-fetch', async () => ({
+  ...(await vi.importActual('@/shared/api/backend-fetch')),
+  authFetch: vi.fn(),
+}));
+
+const authFetchMock = authFetch as unknown as Mock;
+
+const URL = 'https://address-book.test';
+
+function ok(body: unknown, status = 200) {
+  return { ok: true, status, headers: {}, body: JSON.stringify(body) };
+}
+
+function makeOperation(index: number, draftId: string | null = null) {
+  return { id: `op-${index}`, description: `description ${index}`, draftId };
+}
+
+describe('domains/backend/operations/service — fetchAllDescriptions', () => {
+  beforeEach(() => {
+    authFetchMock.mockReset();
+  });
+
+  it('parses the paginated { data, total } response from GET /operations', async () => {
+    const operations = [makeOperation(1, 'draft-1'), makeOperation(2)];
+    authFetchMock.mockResolvedValueOnce(ok({ data: operations, total: operations.length }));
+
+    const result = await operationsService.fetchAllDescriptions(URL);
+
+    expect(result).toEqual(operations);
+  });
+
+  it('walks every page until total is reached', async () => {
+    const pageOne = Array.from({ length: 100 }, (_, i) => makeOperation(i));
+    const pageTwo = Array.from({ length: 50 }, (_, i) => makeOperation(100 + i, `draft-${i}`));
+
+    authFetchMock
+      .mockResolvedValueOnce(ok({ data: pageOne, total: 150 }))
+      .mockResolvedValueOnce(ok({ data: pageTwo, total: 150 }));
+
+    const result = await operationsService.fetchAllDescriptions(URL);
+
+    expect(result).toHaveLength(150);
+    expect(result.at(-1)).toEqual(makeOperation(149, 'draft-49'));
+
+    const requestedUrls = authFetchMock.mock.calls.map(([url]) => url);
+    expect(requestedUrls).toHaveLength(2);
+    expect(requestedUrls[0]).toContain('page=1');
+    expect(requestedUrls[1]).toContain('page=2');
+  });
+
+  it('skips items that do not match the operation schema', async () => {
+    authFetchMock.mockResolvedValueOnce(ok({ data: [makeOperation(1), { unexpected: true }], total: 2 }));
+
+    const result = await operationsService.fetchAllDescriptions(URL);
+
+    expect(result).toEqual([makeOperation(1)]);
+  });
+
+  it('throws on a non-ok response', async () => {
+    authFetchMock.mockResolvedValueOnce({ ok: false, status: 500, headers: {}, body: '{}' });
+
+    await expect(operationsService.fetchAllDescriptions(URL)).rejects.toThrow('500');
+  });
+});

--- a/src/renderer/domains/backend/operations/service.ts
+++ b/src/renderer/domains/backend/operations/service.ts
@@ -1,6 +1,6 @@
 import { z } from 'zod';
 
-import { authFetch } from '@/shared/api/backend-fetch';
+import { authFetch, parseResponse } from '@/shared/api/backend-fetch';
 import { HttpError } from '../contacts/service';
 
 const backendOperationSchema = z.object({
@@ -72,17 +72,32 @@ async function fetchDescriptionsByIds(baseUrl: string, ids: string[]): Promise<B
   return operations;
 }
 
+const paginatedOperationsSchema = z.object({
+  data: z.array(z.unknown()),
+  total: z.number(),
+});
+
+// Backend caps pageSize at 100
+const OPERATIONS_PAGE_SIZE = 100;
+
+async function fetchDescriptionsPage(baseUrl: string, page: number) {
+  const result = await authFetch(`${baseUrl}/operations?page=${page}&pageSize=${OPERATIONS_PAGE_SIZE}`, {
+    method: 'GET',
+  });
+
+  return parseResponse(result, paginatedOperationsSchema);
+}
+
 async function fetchAllDescriptions(baseUrl: string): Promise<BackendOperation[]> {
-  const result = await authFetch(`${baseUrl}/operations`, { method: 'GET' });
+  const firstPage = await fetchDescriptionsPage(baseUrl, 1);
 
-  if (!result.ok) {
-    throw new Error(`Failed to fetch all operations: ${result.status}`);
-  }
+  const totalPages = Math.ceil(firstPage.total / OPERATIONS_PAGE_SIZE);
+  const restPages = await Promise.all(
+    Array.from({ length: totalPages - 1 }, (_, index) => fetchDescriptionsPage(baseUrl, index + 2)),
+  );
 
-  const body: unknown = JSON.parse(result.body);
-  const items = Array.isArray(body) ? body : [];
   const operations: BackendOperation[] = [];
-  for (const item of items) {
+  for (const item of [firstPage, ...restPages].flatMap(page => page.data)) {
     const parsed = backendOperationSchema.safeParse(item);
     if (parsed.success) {
       operations.push(parsed.data);

--- a/src/renderer/features/wallet-details/model/__tests__/proxies-model.test.ts
+++ b/src/renderer/features/wallet-details/model/__tests__/proxies-model.test.ts
@@ -285,6 +285,38 @@ describe('features/wallet-details/model/proxies-model', () => {
       const ops: MultisigOperation[] = [makeOp({ id: 'transfer', transaction: transfer })];
       expect(findLatestExecutedOperation(ops, chainId, pureProxy, proxyMultisig)?.id).toBe('transfer');
     });
+
+    // Flex delegate routes through its own pure before reaching the target:
+    // proxy.proxy(real=flexPure, proxy.proxy(real=target, remark)).
+    // `proxiedAccountId` mirrors extractProxiedAccountId and holds the OUTERMOST real.
+    const flexPure = ('0x' + 'cc'.repeat(32)) as AccountId;
+    const flexDelegatedTx = (targetReal: AccountId) =>
+      decodedTx('proxy', 'proxy', {
+        real: flexPure,
+        forceProxyType: ProxyTypes.ANY,
+        transaction: decodedTx('proxy', 'proxy', {
+          real: targetReal,
+          forceProxyType: ProxyTypes.ANY,
+          transaction: decodedTx('system', 'remarkWithEvent', { remark: 'ping' }),
+        }),
+      });
+
+    test('matches flex-delegated executed ops where the row pure is the innermost proxy.proxy real', () => {
+      const ops: MultisigOperation[] = [
+        makeOp({ id: 'nested', proxiedAccountId: flexPure, transaction: flexDelegatedTx(pureProxy) }),
+      ];
+
+      expect(findLatestExecutedOperation(ops, chainId, pureProxy, proxyMultisig)?.id).toBe('nested');
+    });
+
+    test('does not match nested executed ops whose innermost real targets a different pure', () => {
+      const otherPure = ('0x' + 'dd'.repeat(32)) as AccountId;
+      const ops: MultisigOperation[] = [
+        makeOp({ id: 'nested', proxiedAccountId: flexPure, transaction: flexDelegatedTx(otherPure) }),
+      ];
+
+      expect(findLatestExecutedOperation(ops, chainId, pureProxy, proxyMultisig)).toBeNull();
+    });
   });
 
   describe('isProxyVerifiable', () => {

--- a/src/renderer/features/wallet-details/model/proxies-model.ts
+++ b/src/renderer/features/wallet-details/model/proxies-model.ts
@@ -216,7 +216,11 @@ function findLatestExecutedOperation(
     if (op.chainId !== chainId) continue;
     if (op.status !== 'executed') continue;
     if (op.multisigAccountId !== proxyMultisigAccountId) continue;
-    if (op.proxiedAccountId !== pureProxyAccountId) continue;
+
+    // `op.proxiedAccountId` is the OUTERMOST proxy.proxy real — for flex-delegated ops that's
+    // the flex's own pure. Prefer the innermost real; fall back when call data isn't decodable.
+    const targetPureProxy = extractProxyExecutionArgs(op.transaction)?.real ?? op.proxiedAccountId;
+    if (targetPureProxy !== pureProxyAccountId) continue;
 
     // Lenient: any executed multisig op routed via this (multisig signer, pure proxy)
     // pair proves the proxy authority works, so it counts as "verified". The strict


### PR DESCRIPTION
## Problem

1. After signing a draft, it still appears in the drafts list. Visiting the History tab and returning to Pending hides it, but reloading the app brings it back.
2. After signing a verify remark through a draft, the proxied wallet is not marked as verified.

## Root causes

**Drafts re-appearing.** Submitted drafts are hidden client-side via `$linkedDraftIds`, hydrated from `GET /operations`. The backend returns a paginated `{ data, total }` envelope, but `fetchAllDescriptions` parsed the body with `Array.isArray(body) ? body : []` — so it has silently returned `[]` since the endpoint was introduced, and `$linkedDraftIds` was never populated on startup. The `by-ids` endpoint returns a bare array and parses fine, which is why visiting History (which fetches descriptions by visible operation ids) "fixed" the list until the next reload.

**Verified status.** `findLatestExecutedOperation` matched executed operations only by `op.proxiedAccountId`, which holds the *outermost* `proxy.proxy.real`. For flex-delegated routes the outermost real is the flex's own pure, never the target pure, so an executed verify ping could not flip the row to verified. The pending side of the same model already prefers the innermost real for exactly this reason.

## Changes

- `operationsService.fetchAllDescriptions` now parses the paginated envelope via the shared `parseResponse` helper and walks all pages (`pageSize=100`, pages 2+ fetched in parallel), so draft links beyond the first page can't be lost either.
- `findLatestExecutedOperation` prefers the innermost `proxy.proxy.real` via `extractProxyExecutionArgs` (mirroring the pending side) and falls back to `op.proxiedAccountId` when call data isn't decodable.

## Testing

- New unit tests: paginated envelope parsing, multi-page walk, schema-skip of malformed items, non-ok error path; flex-delegated nested-proxy match and a different-target guard for `findLatestExecutedOperation`.
- `domains/backend` + `wallet-details` + `drafts` suites pass (89 tests), typecheck and lint clean.

## Follow-ups (not in this PR)

- `submit-draft-model`: `$draft` is reset by `flowFinished`, so closing the submit modal before `submitModel.done` can suppress the post-submit description POST for that session.
- `requestOffchainOperations` in the multisig-operation store is exported but never wired — executed operations don't refresh from the indexer after `MultisigExecuted`, so derived statuses can stay stale until restart.
- `getCoreCallData` stores the outermost `proxy.proxy.real` in `proxiedAccountId`; other consumers (e.g. signing-path graph model) may share the outermost-real assumption for flex-delegated ops and deserve the same audit.

Fixes novasamatech/nova-spektr-tracker#78