### PR TITLE
feat: remember last used chain for address book pairing

### DIFF
--- a/src/renderer/aggregates/backend/README.md
+++ b/src/renderer/aggregates/backend/README.md
@@ -1,0 +1,56 @@
+# Address book backend connection & authentication
+
+## Overview
+
+Lets the user connect Nova Spektr to a self-hosted address-book backend and prove account ownership by signing a
+challenge. Once authenticated, contacts sync with the backend; the aggregate keeps the session alive and surfaces expiry
+or network issues.
+
+## Who can use it / when it applies
+
+- Reached from the address book via the backend configuration modal (add or edit a backend URL).
+- Signing requires at least one signable account: a Polkadot browser-extension account or a Polkadot Vault account.
+
+## States / scenarios
+
+| State             | When it appears                                | What the user sees                                                                          |
+| ----------------- | ---------------------------------------------- | ------------------------------------------------------------------------------------------- |
+| URL entry         | Modal opened with no backend or while editing  | URL input with live reachability probe (checking / reachable / unreachable / wrong backend) |
+| Account selection | URL is valid and the user is not yet connected | Account select, preselected with the previously used account when known                     |
+| Signing           | Connect pressed                                | Signing flow; for Vault accounts also a network selector (see below)                        |
+| Connected         | Session is live and the URL is unchanged       | Connected account with a disconnect action                                                  |
+| Error             | Challenge or signature verification failed     | Error alert with a "try again" action                                                       |
+| Session expired   | Background health check loses the session      | Toast with a reconnect shortcut                                                             |
+
+### Signing network selection
+
+Vault accounts sign on a specific network, so the signing step shows a network selector (networks listed in the same
+order as everywhere in the app: Polkadot group, Kusama group, others, testnets).
+
+- **First-ever pairing**: the selector defaults to the Polkadot relay chain.
+- **After a successful sign-in**: the network used is remembered on this device and preselected on every later pairing
+  or re-connection — users whose keys live on another network (e.g. Asset Hub) pick it once instead of on every login.
+- The remembered preference survives disconnects and sign-outs; it only changes when a later sign-in succeeds on a
+  different network.
+- If the remembered network is no longer available in the app (removed from the chains config), the selector falls back
+  to the Polkadot relay chain.
+
+## Lifecycle
+
+```mermaid
+flowchart TD
+    URL["Enter backend URL"] --> ACC["Select account"]
+    ACC --> SIGN["Sign challenge<br/>(Vault: pick network, last used preselected)"]
+    SIGN -- "verified" --> DONE["Connected — contacts sync"]
+    SIGN -- "failed" --> ERR["Error — try again"]
+    DONE --> HC{"Periodic session check"}
+    HC -- "expired" --> TOAST["Expired toast → reconnect"]
+```
+
+A successful sign-in stores the session, remembers the account and network for next time, and closes the modal. Clearing
+the URL disconnects, logs out, and forgets the remembered account (the network preference is kept).
+
+## Related
+
+- Challenge/verify contract with the address-book backend (`domains/backend`).
+- Message signing flow (`features/operations/OperationMessageSign`).

--- a/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
+++ b/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
@@ -2,6 +2,8 @@ import { allSettled, createWatch, fork } from 'effector';
 import { describe, expect, it, vi } from 'vitest';
 
 import { type ChainId } from '@/shared/core';
+import { polkadotChain } from '@/shared/mocks';
+import { networkModel } from '@/entities/network';
 import { messageSignModel } from '@/features/operations/OperationMessageSign';
 import { DEFAULT_AUTH_CHAIN_ID } from '../../lib/auth-chain';
 import { authModel } from '../auth-model';
@@ -10,7 +12,7 @@ import { backendConfigurationModel } from '../backend-configuration-model';
 const KUSAMA: ChainId = '0xb0a8d493285c2df73290dfb7e61f870f17b41801197a149ca93654499ea3dafe';
 
 describe('authModel — chain selector', () => {
-  it('defaults $selectedChainId to Polkadot Asset Hub', () => {
+  it('defaults $selectedChainId to Polkadot relay chain', () => {
     const scope = fork();
     expect(scope.getState(authModel.$selectedChainId)).toBe(DEFAULT_AUTH_CHAIN_ID);
   });
@@ -56,5 +58,59 @@ describe('authModel — chain selector', () => {
     await allSettled(authModel.events.chainSelected, { scope, params: KUSAMA });
 
     expect(spy).not.toHaveBeenCalled();
+  });
+});
+
+describe('authModel — persisted default chain', () => {
+  it('resets $selectedChainId to the persisted default instead of Polkadot relay', async () => {
+    const scope = fork({ values: [[authModel.__test.$defaultAuthChainId, KUSAMA]] });
+
+    await allSettled(authModel.events.modalClosed, { scope });
+
+    expect(scope.getState(authModel.$selectedChainId)).toBe(KUSAMA);
+  });
+
+  it('saves the chain used for a successful sign-in as the new default', async () => {
+    const scope = fork({
+      values: [[authModel.$selectedChainId, KUSAMA]],
+      handlers: [[authModel.__test.verifySignatureFx, () => ({ permissions: [] })]],
+    });
+
+    // sessionHealthCheck (5 min interval) starts on verifySignatureFx.done and keeps the
+    // scope busy, so allSettled never resolves — poll the store instead of awaiting it.
+    void allSettled(authModel.__test.verifySignatureFx, {
+      scope,
+      params: { baseUrl: 'https://backend.test', accountId: '0x00', challengeId: 'challenge', signature: '0x01' },
+    });
+
+    await vi.waitFor(() => {
+      expect(scope.getState(authModel.__test.$defaultAuthChainId)).toBe(KUSAMA);
+    });
+    // The post-connect reset preselects the freshly saved default for the next session.
+    expect(scope.getState(authModel.$selectedChainId)).toBe(KUSAMA);
+  });
+
+  it('falls back to Polkadot relay when the saved chain is missing from the chains config', async () => {
+    const scope = fork({
+      values: [
+        [authModel.__test.$defaultAuthChainId, KUSAMA],
+        [networkModel.$chains, { [polkadotChain.chainId]: polkadotChain }],
+      ],
+    });
+
+    await allSettled(authModel.events.modalClosed, { scope });
+
+    expect(scope.getState(authModel.$selectedChainId)).toBe(DEFAULT_AUTH_CHAIN_ID);
+  });
+
+  it('keeps the default chain after sign-out', async () => {
+    const scope = fork({
+      values: [[authModel.__test.$defaultAuthChainId, KUSAMA]],
+      handlers: [[authModel.__test.logoutFx, () => undefined]],
+    });
+
+    await allSettled(authModel.events.signOutClicked, { scope });
+
+    expect(scope.getState(authModel.__test.$defaultAuthChainId)).toBe(KUSAMA);
   });
 });

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -1,14 +1,16 @@
 import { combine, createEffect, createEvent, createStore, merge, sample } from 'effector';
+import { persist as persistLocal } from 'effector-storage/local';
 import { t } from 'i18next';
 import { interval, once } from 'patronum';
 import { toast } from 'sonner';
 
 import { persist } from '@/shared/api/storage';
 import { type ChainId } from '@/shared/core';
-import { assert, toAccountId } from '@/shared/lib/utils';
+import { assert, nonNullable, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { backendAuthService } from '@/domains/backend';
 import { type AnyAccount } from '@/domains/network';
+import { networkModel } from '@/entities/network';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
 import { polkadotExtensionService } from '@/features/extension-wallet';
 import { messageSignModel } from '@/features/operations/OperationMessageSign';
@@ -55,6 +57,10 @@ const $connectionResult = createStore<ConnectionResult>({ status: 'idle' });
 const $challengeId = createStore<string | null>(null);
 
 $selectedChainId.on(chainSelected, (_, chainId) => chainId);
+
+// Polkadot relay until the first successful sign-in, then the last successfully used chain.
+const $defaultAuthChainId = createStore<ChainId>(DEFAULT_AUTH_CHAIN_ID);
+persistLocal({ store: $defaultAuthChainId, key: 'address-book-default-auth-chain-id', sync: true });
 
 const $lastAuthedAccountId = createStore<AccountId | null>(null);
 persist({ store: $lastAuthedAccountId, key: 'address-book-last-authed-account-id' });
@@ -196,9 +202,21 @@ const resetAuthUiTriggers = [
 
 $authStep.on(resetAuthUiTriggers, () => 'selectAccount');
 $selectedAccountId.on(resetAuthUiTriggers, () => null);
-$selectedChainId.on(resetAuthUiTriggers, () => DEFAULT_AUTH_CHAIN_ID);
 $error.on(resetAuthUiTriggers, () => null);
 $challengeId.on(resetAuthUiTriggers, () => null);
+
+sample({
+  clock: resetAuthUiTriggers,
+  source: { defaultChainId: $defaultAuthChainId, chains: networkModel.$chains },
+  fn: ({ defaultChainId, chains }) => {
+    // The saved chain may have been removed from the chains config since it was saved;
+    // trust it while chains are still loading.
+    const isKnownChain = nonNullable(chains[defaultChainId]) || Object.keys(chains).length === 0;
+
+    return isKnownChain ? defaultChainId : DEFAULT_AUTH_CHAIN_ID;
+  },
+  target: $selectedChainId,
+});
 
 // Wiring: signConfirmed → requestChallengeFx
 $authStep.on(signConfirmed, () => 'signing');
@@ -273,6 +291,14 @@ sample({
     permissions: verifyData.permissions,
   }),
   target: $authState,
+});
+
+// Must stay declared before the connectCompleted sample below — it has to read
+// $selectedChainId before the connectCompleted-triggered reset overwrites it.
+sample({
+  clock: verifySignatureFx.done,
+  source: $selectedChainId,
+  target: $defaultAuthChainId,
 });
 
 const signInSucceeded = createEvent();
@@ -470,5 +496,7 @@ export const authModel = {
   __test: {
     logoutFx,
     checkSessionFx,
+    verifySignatureFx,
+    $defaultAuthChainId,
   },
 };


### PR DESCRIPTION
## Problem

When connecting the address book backend, the signing chain selector always defaulted to the Polkadot relay chain. Users whose keys live on another chain (e.g. Asset Hub) had to re-select their network on every single login.

Closes the second option from the reported feedback: let the default network follow user preference.

## Solution

- New persisted store `$defaultAuthChainId` (localStorage key `address-book-default-auth-chain-id`, `persist` from `effector-storage/local` with `sync: true` per project convention — synchronous hydration, no race with the first modal open).
- First-ever pairing still defaults to the Polkadot relay chain.
- After a successful sign-in, the chain that was used is saved and preselected on every later pairing/re-connection. Failed or cancelled attempts don't change the preference, and it deliberately survives sign-out / URL clear (unlike the last-authed account, which is cleared).
- If the saved chain was removed from the chains config in a later release, the selector falls back to the Polkadot relay chain instead of feeding a stale `chainId` into the Vault QR signing payload.
- Chain list ordering needed no change: `ChainSelect` already sorts options via `chainsService.sortChains`, the same ordering used across the app.

## Spec

Added `src/renderer/aggregates/backend/README.md` — product spec for the backend connection/auth flow, including the new default-chain rules.

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

https://github.com/user-attachments/assets/73e68bf6-8492-4d9e-acf8-50ad9c8bfda9

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

Fixes novasamatech/nova-spektr-tracker#76
Fixes novasamatech/nova-spektr-tracker#81