### PR TITLE
fix: proxy popover label overlapping form fields

### DIFF
--- a/src/renderer/entities/proxy/ui/ProxyPopover.tsx
+++ b/src/renderer/entities/proxy/ui/ProxyPopover.tsx
@@ -16,9 +16,9 @@ export const ProxyPopover = ({ children }: PropsWithChildren) => {
   return (
     <Popover dialog>
       <Popover.Trigger>
-        <div className="h-4">
+        <div className={children ? 'w-fit' : 'h-4'}>
           {children ? (
-            <LabelHelpBox className="mt-4 mb-6">{children}</LabelHelpBox>
+            <LabelHelpBox>{children}</LabelHelpBox>
           ) : (
             <IconButton name="questionOutline" className="hover:text-icon-hover active:text-icon-active" size={16} />
           )}

--- a/src/renderer/entities/proxy/ui/PureProxyPopover.tsx
+++ b/src/renderer/entities/proxy/ui/PureProxyPopover.tsx
@@ -16,9 +16,9 @@ export const PureProxyPopover = ({ children }: PropsWithChildren) => {
   return (
     <Popover>
       <Popover.Trigger>
-        <div>
+        <div className={children ? 'w-fit' : undefined}>
           {children ? (
-            <LabelHelpBox className="mt-4 mb-6">{children}</LabelHelpBox>
+            <LabelHelpBox>{children}</LabelHelpBox>
           ) : (
             <Icon name="questionOutline" className="hover:text-icon-hover active:text-icon-active" size={16} />
           )}


### PR DESCRIPTION
## Description
The \`Delegated authorities (proxies)\` help label in the **Add delegated authority (proxy)** modal was rendered inside a popover trigger wrapper with a fixed height of \`h-4\` (16px), while the \`LabelHelpBox\` content inside is 24px tall and carried legacy \`mt-4 mb-6\` margins. The content overflowed the 16px container and was painted on top of the \`Network\` field label (~8px overlap, measured via \`getBoundingClientRect\`).

The \`h-4\` constraint was added for the icon-only variant of the popover (the \`?\` icon in the wallet details empty-proxies title row) but was applied unconditionally, breaking the labeled variant. The \`mt-4 mb-6\` margins predate the current layout where the parent containers already space children with \`gap-4\`.

**Fix:**
- \`ProxyPopover\`: keep \`h-4\` only for the icon-only variant; drop the \`mt-4 mb-6\` hack margins — spacing now comes uniformly from the parent \`gap-4\` column.
- \`PureProxyPopover\`: drop the same \`mt-4 mb-6\` margins (they produced uneven extra spacing around the \`Pure proxies\` label in the **Create pure proxy** modal); add \`w-fit\` so the trigger's clickable area doesn't span the full row.

## Related Issues
—

## Changes Made
- \`ProxyPopover.tsx\`: trigger wrapper class is now conditional (\`children ? 'w-fit' : 'h-4'\`), removed \`mt-4 mb-6\` from \`LabelHelpBox\`
- \`PureProxyPopover.tsx\`: removed \`mt-4 mb-6\` from \`LabelHelpBox\`, added \`w-fit\` to the trigger wrapper

## Screenshots/Recordings

### Add delegated authority (proxy)

| Before (label overlaps `Network`) | After (uniform 16px gap) |
| --- | --- |
| <img width="1184" height="1032" alt="add-proxy-before" src="https://github.com/user-attachments/assets/144642bd-fb6c-46c9-9736-749c2300a23f" /> | <img width="1184" height="1048" alt="add-proxy-after" src="https://github.com/user-attachments/assets/16af3c62-f52b-4cd1-a0d6-664989150602" /> |

### Create pure proxy

| Before (extra margins around label) | After |
| --- | --- |
| <img width="1184" height="1048" alt="pure-proxy-before" src="https://github.com/user-attachments/assets/748e99fd-59cc-481d-a852-d47b639f0052" /> | <img width="1184" height="968" alt="pure-proxy-after" src="https://github.com/user-attachments/assets/abc50d4d-cd2a-488f-8814-62bb1a1ea075" /> |

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

### Verification notes
Verified in the running app (renderer in Chrome, seeded test vault wallet):
- **Add delegated authority (proxy)**: before — label bottom edge overlapped the \`Network\` label by 8px; after — clean 16px gap (matches the form's \`gap-4\` rhythm).
- **Create pure proxy**: extra top/bottom margins around the \`Pure proxies\` label are gone, same uniform 16px spacing.
- **Wallet details → empty proxies state** (icon-only \`?\` variant): untouched — the \`h-4\` branch is preserved for this case.
