### PR TITLE
docs: feature map index, validation and feature-specs skill

### DIFF
--- a/.claude/skills/feature-specs/SKILL.md
+++ b/.claude/skills/feature-specs/SKILL.md
@@ -1,0 +1,92 @@
+---
+name: feature-specs
+description: Maintain feature spec READMEs and the Feature Map index. Use when creating a new feature or aggregate, materially changing the behaviour of an existing one, writing or updating a spec README, or when asked about feature documentation coverage.
+---
+
+# Feature Specs & Feature Map Maintenance
+
+Non-trivial features (`src/renderer/features/`) and aggregates
+(`src/renderer/aggregates/`) carry a colocated `README.md` — a **product spec**
+of what the code does and why (states, scenarios, lifecycle), not how it is
+wired. All specs are indexed in the **Feature Map**:
+`src/renderer/features/README.md`.
+
+The canonical human-facing convention (what goes in a spec, the author-approval
+workflow) is `docs/content/docs/code/style/feature-specs.md` — read it before
+writing a spec. Worked example:
+`src/renderer/aggregates/multisig-operation-description/README.md`.
+
+## When a spec is required
+
+- New feature/aggregate with user-visible behaviour or non-obvious rules → write one.
+- Material behaviour change (new states, new gating, changed flow) → update the
+  existing spec **in the same change**.
+- Skip for trivial, presentation-only, or purely mechanical modules.
+- Before changing any feature: read its README first if it exists — it is the
+  source of product truth. If the code contradicts it, surface that.
+- A draft spec must be approved by the feature's author before the change is
+  finalized — treat the spec as a deliverable alongside the code.
+
+## Spec README template
+
+```markdown
+# <Feature name>
+
+> Part of the [Feature Map](<backlink>)
+
+## Overview
+What this feature is, the problem it solves, one-line behaviour summary.
+
+## Who can use it / when it applies
+Preconditions, permissions, audience.
+
+## States / scenarios
+Each visible state and the rule that triggers it (table and/or mermaid diagram).
+
+## Lifecycle
+Happy path from entry to outcome; notable failure handling.
+
+## Related
+Adjacent flows, backend contracts, constraints.
+```
+
+Backlink path: `../README.md` from `features/<name>/`,
+`../../features/README.md` from `aggregates/<name>/`. The backlink line is
+mandatory and sits right after the `# Title` heading. Match the depth to the
+feature — a small one needs only Overview + States.
+
+## Feature Map maintenance rules
+
+The map lists **every** module of both layers, grouped by product area, names
+only. Strict entry format (one line per module, validated by script):
+
+```markdown
+- `module-name`                                                    ← undocumented feature
+- [`module-name`](./module-name/README.md)                         ← documented feature
+- `module-name` (aggregate)                                        ← undocumented aggregate
+- [`module-name`](../aggregates/module-name/README.md) (aggregate) ← documented aggregate
+```
+
+- **New module** → add its entry to the section matching its product area
+  (multisig features under `## Multisig`, etc.). Only create a new section for a
+  genuinely new product area. Each module appears in exactly one home section.
+- **Cross-cutting module** → keep one home entry; reference it from related
+  sections with a blockquote note, never a duplicate entry:
+
+  ```markdown
+  > See also: [`module-name`](#section-anchor) — why it is related.
+  ```
+- **Spec README added** → convert the plain-name entry to a link.
+- **Module deleted/renamed** → update its entry in the same change.
+- **Counter** — the `**Documented: N / M**` line near the top must always match
+  reality (N = modules with README, M = total modules across both layers).
+
+## Always finish with validation
+
+```bash
+node scripts/check-feature-index.mjs
+```
+
+Fix every reported problem before finishing. The script verifies: every module
+listed exactly once, no stale entries, documented modules linked, backlinks
+present, counter accurate.

--- a/.claude/skills/feature-specs/SKILL.md
+++ b/.claude/skills/feature-specs/SKILL.md
@@ -1,92 +1,76 @@
 ---
 name: feature-specs
-description: Maintain feature spec READMEs and the Feature Map index. Use when creating a new feature or aggregate, materially changing the behaviour of an existing one, writing or updating a spec README, or when asked about feature documentation coverage.
+description:
+  Maintain feature spec READMEs and the Feature Map index. Use when creating a new feature or aggregate, materially
+  changing the behaviour of an existing one, writing or updating a spec README, or when asked about feature
+  documentation coverage.
 ---
 
 # Feature Specs & Feature Map Maintenance
 
-Non-trivial features (`src/renderer/features/`) and aggregates
-(`src/renderer/aggregates/`) carry a colocated `README.md` — a **product spec**
-of what the code does and why (states, scenarios, lifecycle), not how it is
-wired. All specs are indexed in the **Feature Map**:
-`src/renderer/features/README.md`.
+Non-trivial features (`src/renderer/features/`) and aggregates (`src/renderer/aggregates/`) carry a colocated
+`README.md` — a **product spec** of what the code does and why (states, scenarios, lifecycle), not how it is wired. All
+specs are indexed in the **Feature Map**: `src/renderer/features/README.md`.
 
-The canonical human-facing convention (what goes in a spec, the author-approval
-workflow) is `docs/content/docs/code/style/feature-specs.md` — read it before
-writing a spec. Worked example:
+The canonical human-facing convention (what goes in a spec, the author-approval workflow) is
+`docs/content/docs/code/style/feature-specs.md` — read it before writing a spec. Worked example:
 `src/renderer/aggregates/multisig-operation-description/README.md`.
 
 ## When a spec is required
 
 - New feature/aggregate with user-visible behaviour or non-obvious rules → write one.
-- Material behaviour change (new states, new gating, changed flow) → update the
-  existing spec **in the same change**.
+- Material behaviour change (new states, new gating, changed flow) → update the existing spec **in the same change**.
 - Skip for trivial, presentation-only, or purely mechanical modules.
-- Before changing any feature: read its README first if it exists — it is the
-  source of product truth. If the code contradicts it, surface that.
-- A draft spec must be approved by the feature's author before the change is
-  finalized — treat the spec as a deliverable alongside the code.
+- Before changing any feature: read its README first if it exists — it is the source of product truth. If the code
+  contradicts it, surface that.
+- A draft spec must be approved by the feature's author before the change is finalized — treat the spec as a deliverable
+  alongside the code.
 
-## Spec README template
+## Spec README structure
 
-```markdown
-# <Feature name>
+Use the template from the canonical convention doc (`docs/content/docs/code/style/feature-specs.md`, section "Template")
+— do not restate it here; the doc is the single source for the spec's structure.
 
-> Part of the [Feature Map](<backlink>)
-
-## Overview
-What this feature is, the problem it solves, one-line behaviour summary.
-
-## Who can use it / when it applies
-Preconditions, permissions, audience.
-
-## States / scenarios
-Each visible state and the rule that triggers it (table and/or mermaid diagram).
-
-## Lifecycle
-Happy path from entry to outcome; notable failure handling.
-
-## Related
-Adjacent flows, backend contracts, constraints.
-```
-
-Backlink path: `../README.md` from `features/<name>/`,
-`../../features/README.md` from `aggregates/<name>/`. The backlink line is
-mandatory and sits right after the `# Title` heading. Match the depth to the
-feature — a small one needs only Overview + States.
+One addition the template already includes but is easy to miss: the **backlink line is mandatory** and sits right after
+the `# Title` heading: `> Part of the [Feature Map](../README.md)` from `features/<name>/`,
+`> Part of the [Feature Map](../../features/README.md)` from `aggregates/<name>/`. Match the depth to the feature — a
+small one needs only Overview + States.
 
 ## Feature Map maintenance rules
 
-The map lists **every** module of both layers, grouped by product area, names
-only. Strict entry format (one line per module, validated by script):
+The map lists **every** module of both layers, grouped by product area, names only. Strict entry format (one line per
+module, validated by script):
 
 ```markdown
-- `module-name`                                                    ← undocumented feature
-- [`module-name`](./module-name/README.md)                         ← documented feature
-- `module-name` (aggregate)                                        ← undocumented aggregate
+- `module-name` ← feature awaiting a spec
+- [`module-name`](./module-name/README.md) ← documented feature
+- `module-name` (no spec planned) ← trivial feature, exempt
+- `module-name` (aggregate) ← aggregate awaiting a spec
 - [`module-name`](../aggregates/module-name/README.md) (aggregate) ← documented aggregate
+- `module-name` (aggregate, no spec planned) ← trivial aggregate, exempt
 ```
 
-- **New module** → add its entry to the section matching its product area
-  (multisig features under `## Multisig`, etc.). Only create a new section for a
-  genuinely new product area. Each module appears in exactly one home section.
-- **Cross-cutting module** → keep one home entry; reference it from related
-  sections with a blockquote note, never a duplicate entry:
+- **New module** → add its entry to the section matching its product area (multisig features under `## Multisig`, etc.).
+  Only create a new section for a genuinely new product area. Each module appears in exactly one home section.
+- **Cross-cutting module** → keep one home entry; reference it from related sections with a blockquote note, never a
+  duplicate entry:
 
   ```markdown
   > See also: [`module-name`](#section-anchor) — why it is related.
   ```
+
 - **Spec README added** → convert the plain-name entry to a link.
+- **Trivial module** (presentation-only, purely mechanical — same skip rule as above) → mark it `(no spec planned)` so
+  it doesn't read as documentation debt.
 - **Module deleted/renamed** → update its entry in the same change.
-- **Counter** — the `**Documented: N / M**` line near the top must always match
-  reality (N = modules with README, M = total modules across both layers).
+- There is no hand-maintained coverage counter — the validation script computes and prints coverage.
 
 ## Always finish with validation
 
 ```bash
-node scripts/check-feature-index.mjs
+pnpm check:feature-map
 ```
 
-Fix every reported problem before finishing. The script verifies: every module
-listed exactly once, no stale entries, documented modules linked, backlinks
-present, counter accurate.
+Fix every reported problem before finishing. The script verifies: every module listed exactly once, no stale entries,
+documented modules linked, backlinks present, `(no spec planned)` markers consistent with reality. It also runs in CI
+(lint workflow), so an out-of-sync map fails the PR.

--- a/.claude/skills/feature-specs/SKILL.md
+++ b/.claude/skills/feature-specs/SKILL.md
@@ -72,5 +72,10 @@ pnpm check:feature-map
 ```
 
 Fix every reported problem before finishing. The script verifies: every module listed exactly once, no stale entries,
-documented modules linked, backlinks present, `(no spec planned)` markers consistent with reality. It also runs in CI
-(lint workflow), so an out-of-sync map fails the PR.
+documented modules linked, backlinks present, `(no spec planned)` markers consistent with reality.
+
+CI (lint workflow) runs it with `--changed <PR base>`, which additionally fails the PR when a changed feature/aggregate
+has no spec, or its code changed without a spec update. So whenever you touch a module's code, either update its
+README.md in the same change (even a verified "still accurate" touch counts as review), write the missing spec, or mark
+a trivial module `(no spec planned)` in the map. To reproduce the CI check locally:
+`pnpm check:feature-map --changed origin/dev` (committed changes only).

--- a/.claude/skills/feature-specs/SKILL.md
+++ b/.claude/skills/feature-specs/SKILL.md
@@ -31,10 +31,23 @@ The canonical human-facing convention (what goes in a spec, the author-approval 
 Use the template from the canonical convention doc (`docs/content/docs/code/style/feature-specs.md`, section "Template")
 — do not restate it here; the doc is the single source for the spec's structure.
 
-One addition the template already includes but is easy to miss: the **backlink line is mandatory** and sits right after
-the `# Title` heading: `> Part of the [Feature Map](../README.md)` from `features/<name>/`,
-`> Part of the [Feature Map](../../features/README.md)` from `aggregates/<name>/`. Match the depth to the feature — a
-small one needs only Overview + States.
+One addition the template already includes but is easy to miss: the **backlink line is mandatory**, sits right after the
+`# Title` heading, and carries the **`Last reviewed` date**:
+
+```markdown
+> Part of the [Feature Map](../README.md) — Last reviewed: YYYY-MM-DD
+```
+
+(from `aggregates/<name>/` the path is `../../features/README.md`). Match the depth to the feature — a small one needs
+only Overview + States.
+
+**Date rules** (stamp with today's date, `date +%F`):
+
+- Creating a spec → set the date.
+- Updating a spec → bump the date.
+- Changing a module's code while the spec stays accurate → re-read the spec, confirm it still matches, bump the date —
+  the bump is the record that the spec was re-reviewed. CI fails the PR if module code changed and the date did not
+  move.
 
 ## Feature Map maintenance rules
 
@@ -72,10 +85,11 @@ pnpm check:feature-map
 ```
 
 Fix every reported problem before finishing. The script verifies: every module listed exactly once, no stale entries,
-documented modules linked, backlinks present, `(no spec planned)` markers consistent with reality.
+documented modules linked, backlinks present with a `Last reviewed` date, `(no spec planned)` markers consistent with
+reality.
 
 CI (lint workflow) runs it with `--changed <PR base>`, which additionally fails the PR when a changed feature/aggregate
-has no spec, or its code changed without a spec update. So whenever you touch a module's code, either update its
-README.md in the same change (even a verified "still accurate" touch counts as review), write the missing spec, or mark
-a trivial module `(no spec planned)` in the map. To reproduce the CI check locally:
-`pnpm check:feature-map --changed origin/dev` (committed changes only).
+has no spec, or its code changed without the spec's `Last reviewed` date moving. So whenever you touch a module's code,
+either review the spec and bump its date in the same change, write the missing spec, or mark a trivial module
+`(no spec planned)` in the map. To reproduce the CI check locally: `pnpm check:feature-map --changed origin/dev`
+(committed changes only).

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,5 +21,4 @@
 - [ ] I have provided screenshot of the working feature (if applicable)
 - [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
 - [ ] I have added tests that cover the base logic (if applicable)
-- [ ] I have checked the feature spec (`README.md`) of the modules I'm changing and updated it together with the Feature Map (`src/renderer/features/README.md`) (if applicable) — the `feature-specs` skill in Claude Code automates the update
 - [ ] My code follows the project's coding standards and style guidelines

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,4 +21,5 @@
 - [ ] I have provided screenshot of the working feature (if applicable)
 - [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
 - [ ] I have added tests that cover the base logic (if applicable)
+- [ ] I have checked the feature spec (`README.md`) of the modules I'm changing and updated it together with the Feature Map (`src/renderer/features/README.md`) (if applicable) — the `feature-specs` skill in Claude Code automates the update
 - [ ] My code follows the project's coding standards and style guidelines

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -26,3 +26,6 @@ jobs:
 
       - name: 📝 Check by linter
         run: TIMING=1 pnpm lint
+
+      - name: 🗺️ Check feature map
+        run: pnpm check:feature-map

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - name: ⚙️Checkout
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: ⚙️Install dependencies
         uses: ./.github/workflows/install-pnpm
@@ -28,4 +30,4 @@ jobs:
         run: TIMING=1 pnpm lint
 
       - name: 🗺️ Check feature map
-        run: pnpm check:feature-map
+        run: pnpm check:feature-map --changed origin/${{ github.base_ref }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -62,9 +62,10 @@ Project documentation:
 Non-trivial features and aggregates carry a colocated `README.md` product spec,
 indexed in the Feature Map (`src/renderer/features/README.md`). **When creating
 or materially changing a feature/aggregate, or writing/updating a spec README,
-invoke the `feature-specs` skill** — it owns the convention, template, and
-Feature Map maintenance rules. Before changing a feature, read its README first
-if one exists; surface any contradiction between spec and code.
+invoke the `feature-specs` skill** — it carries the operational rules and
+Feature Map maintenance steps; the canonical convention lives in
+`docs/content/docs/code/style/feature-specs.md`. Before changing a feature, read
+its README first if one exists; surface any contradiction between spec and code.
 
 ## Core Principles
 - Simplicity First: Make every change as simple as possible. Impact minimal code.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -11,7 +11,6 @@ Project documentation:
 - @docs/content/docs/onboarding/links.mdx
 - @docs/content/docs/code/style/naming.md
 - @docs/content/docs/code/style/effector.md
-- @docs/content/docs/code/style/feature-specs.md
 
 ## Workflow Orchestration
 
@@ -60,21 +59,12 @@ Project documentation:
 
 ## Feature Spec READMEs
 
-Non-trivial features and aggregates carry a colocated `README.md` — a **product
-spec** of what the code does and why (states, scenarios, lifecycle), not how it is
-wired. Full convention and template: @docs/content/docs/code/style/feature-specs.md.
-Worked example: `src/renderer/aggregates/multisig-operation-description/README.md`.
-
-- **Before changing a feature**: look for its `README.md` and read it first — it is
-  the source of product truth. If the code you touch contradicts it, surface that.
-- **When adding a feature or materially changing behavior**: draft or update the
-  `README.md` as part of the change, then get the author's approval on it before
-  finalizing — treat the spec as a deliverable alongside the code, never an
-  afterthought.
-- **Keep it in sync**: update the README in the same change that alters behavior;
-  never let it drift. Product-level English, mermaid diagrams where they help.
-- **Scope**: one README per feature/aggregate folder. Skip it for trivial,
-  presentation-only, or purely mechanical modules.
+Non-trivial features and aggregates carry a colocated `README.md` product spec,
+indexed in the Feature Map (`src/renderer/features/README.md`). **When creating
+or materially changing a feature/aggregate, or writing/updating a spec README,
+invoke the `feature-specs` skill** — it owns the convention, template, and
+Feature Map maintenance rules. Before changing a feature, read its README first
+if one exists; surface any contradiction between spec and code.
 
 ## Core Principles
 - Simplicity First: Make every change as simple as possible. Impact minimal code.

--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@
 
 # Development
 
+Product behaviour of individual features is documented in colocated spec READMEs,
+indexed in the [Feature Map](src/renderer/features/README.md).
+
 ## Requirements
 
 Minimum version of `Node.js` is `v24.x`.

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -33,7 +33,8 @@ All specs are indexed in the **Feature Map** — `src/renderer/features/README.m
 aggregate grouped by product area. Documented modules link to their spec; trivial modules are marked
 `(no spec planned)`; every spec links back with a `> Part of the [Feature Map](...)` line right after its title. When
 adding or renaming a module, or adding a spec, update the map in the same change; `pnpm check:feature-map` verifies the
-map is in sync (it also runs in CI) and prints the current coverage.
+map is in sync and prints the current coverage. In CI the check also fails the PR when a changed module has no spec or
+its code changed without a spec update — touching a module means reviewing its spec in the same PR.
 
 ## When to write or update one
 

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -116,3 +116,5 @@ Adjacent flows, backend contracts, or constraints that shape the behaviour.
 ````
 
 Match the depth to the feature — a small feature needs only Overview + States.
+The backlink path shown is for `features/<name>/`; from `aggregates/<name>/` it is
+`../../features/README.md`.

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -34,6 +34,14 @@ src/renderer/features/<name>/README.md
 
 Worked example: `src/renderer/aggregates/multisig-operation-description/README.md`.
 
+All specs are indexed in the **Feature Map** — `src/renderer/features/README.md` —
+a curated list of every feature and aggregate grouped by product area, with a
+`Documented: N / M` coverage counter. Documented modules link to their spec;
+every spec links back with a `> Part of the [Feature Map](...)` line right after
+its title. When adding or renaming a module, or adding a spec, update the map in
+the same change; `node scripts/check-feature-index.mjs` verifies the map and the
+counter are in sync.
+
 ## When to write or update one
 
 - **New feature / aggregate** with user-visible behaviour or non-obvious rules →
@@ -77,6 +85,8 @@ signatures. Those belong in code comments, not the spec.
 
 ````markdown
 # <Feature name>
+
+> Part of the [Feature Map](../README.md)
 
 ## Overview
 What this feature is, the problem it solves, and the one-line behaviour summary.

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -4,24 +4,19 @@ sidebar:
   order: 2
 ---
 
-Non-trivial features and aggregates carry a **product spec** as a colocated
-`README.md`. It describes _what_ the code does and _why_ — the behaviour a product
-owner or a new contributor needs to understand — and deliberately leaves out _how_
-it is wired (store names, samples, file maps). The spec is the single source of
-product truth, kept in the repo so both people and AI agents find it the moment
-they open the folder.
+Non-trivial features and aggregates carry a **product spec** as a colocated `README.md`. It describes _what_ the code
+does and _why_ — the behaviour a product owner or a new contributor needs to understand — and deliberately leaves out
+_how_ it is wired (store names, samples, file maps). The spec is the single source of product truth, kept in the repo so
+both people and AI agents find it the moment they open the folder.
 
 ## Why specs live next to the code
 
-- **Discoverable.** A `README.md` in the feature folder is the first thing read on
-  navigation — by a reviewer, a new teammate, or an AI agent about to change the
-  code. No wiki to hunt through.
-- **Reviewed with the change.** When the spec ships in the same PR as the code,
-  reviewers approve behaviour and implementation together, and the spec cannot
-  silently drift from reality.
-- **A shared contract.** The spec is what the author and the implementer (human or
-  AI) agree on before the code is final. It captures intent that the code alone
-  cannot.
+- **Discoverable.** A `README.md` in the feature folder is the first thing read on navigation — by a reviewer, a new
+  teammate, or an AI agent about to change the code. No wiki to hunt through.
+- **Reviewed with the change.** When the spec ships in the same PR as the code, reviewers approve behaviour and
+  implementation together, and the spec cannot silently drift from reality.
+- **A shared contract.** The spec is what the author and the implementer (human or AI) agree on before the code is
+  final. It captures intent that the code alone cannot.
 
 ## Where it lives
 
@@ -34,36 +29,32 @@ src/renderer/features/<name>/README.md
 
 Worked example: `src/renderer/aggregates/multisig-operation-description/README.md`.
 
-All specs are indexed in the **Feature Map** — `src/renderer/features/README.md` —
-a curated list of every feature and aggregate grouped by product area, with a
-`Documented: N / M` coverage counter. Documented modules link to their spec;
-every spec links back with a `> Part of the [Feature Map](...)` line right after
-its title. When adding or renaming a module, or adding a spec, update the map in
-the same change; `node scripts/check-feature-index.mjs` verifies the map and the
-counter are in sync.
+All specs are indexed in the **Feature Map** — `src/renderer/features/README.md` — a curated list of every feature and
+aggregate grouped by product area. Documented modules link to their spec; trivial modules are marked
+`(no spec planned)`; every spec links back with a `> Part of the [Feature Map](...)` line right after its title. When
+adding or renaming a module, or adding a spec, update the map in the same change; `pnpm check:feature-map` verifies the
+map is in sync (it also runs in CI) and prints the current coverage.
 
 ## When to write or update one
 
-- **New feature / aggregate** with user-visible behaviour or non-obvious rules →
-  write a spec.
-- **Materially changing behaviour** of an existing one (new states, new gating, a
-  changed flow) → update its spec in the same change.
-- **Skip** for trivial, presentation-only, or purely mechanical modules (a styled
-  wrapper, a pure formatter, a rename). When in doubt, a short spec beats none.
+- **New feature / aggregate** with user-visible behaviour or non-obvious rules → write a spec.
+- **Materially changing behaviour** of an existing one (new states, new gating, a changed flow) → update its spec in the
+  same change.
+- **Skip** for trivial, presentation-only, or purely mechanical modules (a styled wrapper, a pure formatter, a rename).
+  When in doubt, a short spec beats none.
 
 ## The workflow (author ↔ implementer)
 
 The spec is a deliverable, not an afterthought. For AI-assisted work the loop is:
 
-1. **Draft first.** Before or alongside the implementation, draft the spec from the
-   agreed requirements — states, scenarios, lifecycle.
-2. **Get approval.** Present the draft to the person who owns the feature and
-   confirm it matches intent _before_ finalizing the code. Disagreements are
-   cheaper to resolve in prose than in code.
-3. **Ship together.** Commit the spec with the code change it describes. A behaviour
-   change without a spec update is an incomplete change.
-4. **Re-read on touch.** When later modifying the feature, read its spec first and
-   reconcile any contradiction between spec and code before proceeding.
+1. **Draft first.** Before or alongside the implementation, draft the spec from the agreed requirements — states,
+   scenarios, lifecycle.
+2. **Get approval.** Present the draft to the person who owns the feature and confirm it matches intent _before_
+   finalizing the code. Disagreements are cheaper to resolve in prose than in code.
+3. **Ship together.** Commit the spec with the code change it describes. A behaviour change without a spec update is an
+   incomplete change.
+4. **Re-read on touch.** When later modifying the feature, read its spec first and reconcile any contradiction between
+   spec and code before proceeding.
 
 ## What goes in (and what stays out)
 
@@ -74,12 +65,11 @@ The spec is a deliverable, not an afterthought. For AI-assisted work the loop is
 - **States & scenarios** — every visible state and the rule that produces it.
 - **Lifecycle** — the happy path from entry to outcome, and notable failures.
 - **Related** — adjacent flows or backend contracts that shape behaviour.
-- **Diagrams** — `mermaid` flowcharts / sequence diagrams render on GitHub and the
-  docs site; use them when a picture beats a paragraph.
+- **Diagrams** — `mermaid` flowcharts / sequence diagrams render on GitHub and the docs site; use them when a picture
+  beats a paragraph.
 
-**Out** — implementation detail that the code already documents: Effector store
-names, `sample` graphs, file-by-file maps, import-cycle notes, internal helper
-signatures. Those belong in code comments, not the spec.
+**Out** — implementation detail that the code already documents: Effector store names, `sample` graphs, file-by-file
+maps, import-cycle notes, internal helper signatures. Those belong in code comments, not the spec.
 
 ## Template
 
@@ -89,12 +79,15 @@ signatures. Those belong in code comments, not the spec.
 > Part of the [Feature Map](../README.md)
 
 ## Overview
+
 What this feature is, the problem it solves, and the one-line behaviour summary.
 
 ## Who can use it / when it applies
+
 Preconditions, permissions, audience.
 
 ## States / scenarios
+
 Each visible state and the rule that triggers it. A decision diagram helps:
 
 ```mermaid
@@ -105,16 +98,17 @@ flowchart TD
 ```
 
 | State | When it appears | What the user sees |
-| --- | --- | --- |
-| ... | ... | ... |
+| ----- | --------------- | ------------------ |
+| ...   | ...             | ...                |
 
 ## Lifecycle
+
 The happy path from entry to outcome; notable failure handling.
 
 ## Related
+
 Adjacent flows, backend contracts, or constraints that shape the behaviour.
 ````
 
-Match the depth to the feature — a small feature needs only Overview + States.
-The backlink path shown is for `features/<name>/`; from `aggregates/<name>/` it is
-`../../features/README.md`.
+Match the depth to the feature — a small feature needs only Overview + States. The backlink path shown is for
+`features/<name>/`; from `aggregates/<name>/` it is `../../features/README.md`.

--- a/docs/content/docs/code/style/feature-specs.md
+++ b/docs/content/docs/code/style/feature-specs.md
@@ -77,7 +77,7 @@ maps, import-cycle notes, internal helper signatures. Those belong in code comme
 ````markdown
 # <Feature name>
 
-> Part of the [Feature Map](../README.md)
+> Part of the [Feature Map](../README.md) — Last reviewed: YYYY-MM-DD
 
 ## Overview
 
@@ -113,3 +113,7 @@ Adjacent flows, backend contracts, or constraints that shape the behaviour.
 
 Match the depth to the feature — a small feature needs only Overview + States. The backlink path shown is for
 `features/<name>/`; from `aggregates/<name>/` it is `../../features/README.md`.
+
+The `Last reviewed` date records when the spec was last checked against the code. Whenever a module's code changes, the
+spec must be re-reviewed and the date bumped in the same PR — CI compares the date against the PR base and fails if it
+did not move.

--- a/package.json
+++ b/package.json
@@ -72,6 +72,7 @@
     "lint": "pnpm lint:generic ./src",
     "lint:tests": "pnpm lint:generic ./tests",
     "lint:fix": "pnpm fmt:fix && pnpm lint --fix --quiet",
+    "check:feature-map": "node scripts/check-feature-index.mjs",
     "storybook": "storybook dev -p 6006",
     "storybook:build": "storybook build -o $(pnpm --silent run config folders.storybookBuild)",
     "githook:pre-commit": "lint-staged --relative",

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -1,0 +1,112 @@
+#!/usr/bin/env node
+/**
+ * Validates the Feature Map (src/renderer/features/README.md) against the
+ * filesystem: every feature/aggregate is listed exactly once, documented
+ * modules are linked, spec READMEs carry the Feature Map backlink, and the
+ * "Documented: N / M" counter is accurate. Exits non-zero on any drift.
+ */
+import { existsSync, readFileSync, readdirSync } from 'node:fs';
+import { join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const ROOT = fileURLToPath(new URL('..', import.meta.url));
+const FEATURES_DIR = join(ROOT, 'src/renderer/features');
+const AGGREGATES_DIR = join(ROOT, 'src/renderer/aggregates');
+const MAP_PATH = join(FEATURES_DIR, 'README.md');
+
+if (!existsSync(MAP_PATH)) {
+  console.error(`Feature Map not found at ${MAP_PATH}`);
+  process.exit(1);
+}
+
+const listModules = (dir) =>
+  readdirSync(dir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
+
+const features = listModules(FEATURES_DIR);
+const aggregates = listModules(AGGREGATES_DIR);
+const map = readFileSync(MAP_PATH, 'utf8');
+const errors = [];
+
+// Entry lines: "- `name`" or "- [`name`](link)", optionally suffixed " (aggregate)"
+const entryPattern = /^- (?:\[`([\w.-]+)`\]\(([^)]+)\)|`([\w.-]+)`)( \(aggregate\))?$/;
+const entries = [];
+for (const line of map.split('\n')) {
+  if (!line.startsWith('- ')) continue;
+  const match = line.match(entryPattern);
+  if (!match) {
+    errors.push(`Unparseable entry line: "${line}"`);
+    continue;
+  }
+  entries.push({
+    name: match[1] ?? match[3],
+    link: match[2] ?? null,
+    layer: match[4] ? 'aggregates' : 'features',
+  });
+}
+
+// Every module on disk is listed exactly once
+const layers = [
+  ['features', features],
+  ['aggregates', aggregates],
+];
+for (const [layer, names] of layers) {
+  for (const name of names) {
+    const found = entries.filter((entry) => entry.layer === layer && entry.name === name);
+    if (found.length === 0) errors.push(`Missing entry: ${layer}/${name}`);
+    if (found.length > 1) errors.push(`Duplicate entry (${found.length}x): ${layer}/${name}`);
+  }
+}
+
+// No stale entries; documented modules are linked correctly and carry a backlink
+let documented = 0;
+for (const entry of entries) {
+  const dir = entry.layer === 'features' ? FEATURES_DIR : AGGREGATES_DIR;
+  if (!existsSync(join(dir, entry.name))) {
+    errors.push(`Stale entry: ${entry.layer}/${entry.name} does not exist on disk`);
+    continue;
+  }
+
+  const readmePath = join(dir, entry.name, 'README.md');
+  const expectedLink =
+    entry.layer === 'features' ? `./${entry.name}/README.md` : `../aggregates/${entry.name}/README.md`;
+  const expectedBacklink =
+    entry.layer === 'features' ? '[Feature Map](../README.md)' : '[Feature Map](../../features/README.md)';
+
+  if (existsSync(readmePath)) {
+    documented += 1;
+    if (entry.link === null) {
+      errors.push(`${entry.layer}/${entry.name} has a README but is a plain-name entry — link it`);
+    } else if (entry.link !== expectedLink) {
+      errors.push(`${entry.layer}/${entry.name} link should be "${expectedLink}", got "${entry.link}"`);
+    }
+    if (!readFileSync(readmePath, 'utf8').includes(expectedBacklink)) {
+      errors.push(`${entry.layer}/${entry.name}/README.md is missing the backlink "> Part of the ${expectedBacklink}"`);
+    }
+  } else if (entry.link !== null) {
+    errors.push(`${entry.layer}/${entry.name} is linked in the map but has no README.md`);
+  }
+}
+
+// Counter
+const total = features.length + aggregates.length;
+const counter = map.match(/\*\*Documented: (\d+) \/ (\d+)\*\*/);
+if (!counter) {
+  errors.push('Counter line "**Documented: N / M**" not found in the map');
+} else {
+  if (Number(counter[1]) !== documented) {
+    errors.push(`Counter says ${counter[1]} documented, actual count is ${documented}`);
+  }
+  if (Number(counter[2]) !== total) {
+    errors.push(`Counter says ${counter[2]} total, actual count is ${total}`);
+  }
+}
+
+if (errors.length > 0) {
+  console.error(`Feature Map check failed — ${errors.length} problem(s):\n`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(`Feature Map OK — ${documented} / ${total} modules documented.`);

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -2,8 +2,9 @@
 /**
  * Validates the Feature Map (src/renderer/features/README.md) against the
  * filesystem: every feature/aggregate is listed exactly once, documented
- * modules are linked, spec READMEs carry the Feature Map backlink, and the
- * "Documented: N / M" counter is accurate. Exits non-zero on any drift.
+ * modules are linked, spec READMEs carry the Feature Map backlink, and
+ * "no spec planned" markers don't contradict reality. Exits non-zero on any
+ * drift and prints a coverage summary on success.
  */
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
@@ -29,20 +30,35 @@ const aggregates = listModules(AGGREGATES_DIR);
 const map = readFileSync(MAP_PATH, 'utf8');
 const errors = [];
 
-// Entry lines: "- `name`" or "- [`name`](link)", optionally suffixed " (aggregate)"
-const entryPattern = /^- (?:\[`([\w.-]+)`\]\(([^)]+)\)|`([\w.-]+)`)( \(aggregate\))?$/;
-const entries = [];
+// Re-join list items wrapped by prettier (proseWrap: always indents
+// continuation lines of a "- " item with two spaces).
+const lines = [];
 for (const line of map.split('\n')) {
+  if (/^ {2,}\S/.test(line) && lines.length > 0 && lines[lines.length - 1].startsWith('- ')) {
+    lines[lines.length - 1] += ` ${line.trim()}`;
+  } else {
+    lines.push(line);
+  }
+}
+
+// Entry lines: "- `name`" or "- [`name`](link)", optionally suffixed with
+// " (aggregate)", " (no spec planned)" or " (aggregate, no spec planned)"
+const entryPattern =
+  /^- (?:\[`([\w.-]+)`\]\(([^)]+)\)|`([\w.-]+)`)(?: \((aggregate|no spec planned|aggregate, no spec planned)\))?$/;
+const entries = [];
+for (const line of lines) {
   if (!line.startsWith('- ')) continue;
   const match = line.match(entryPattern);
   if (!match) {
     errors.push(`Unparseable entry line: "${line}"`);
     continue;
   }
+  const suffix = match[4] ?? '';
   entries.push({
     name: match[1] ?? match[3],
     link: match[2] ?? null,
-    layer: match[4] ? 'aggregates' : 'features',
+    layer: suffix.includes('aggregate') ? 'aggregates' : 'features',
+    noSpecPlanned: suffix.includes('no spec planned'),
   });
 }
 
@@ -59,8 +75,10 @@ for (const [layer, names] of layers) {
   }
 }
 
-// No stale entries; documented modules are linked correctly and carry a backlink
+// No stale entries; documented modules are linked correctly and carry a
+// backlink; "no spec planned" markers don't contradict an existing README
 let documented = 0;
+let noSpecPlanned = 0;
 for (const entry of entries) {
   const dir = entry.layer === 'features' ? FEATURES_DIR : AGGREGATES_DIR;
   if (!existsSync(join(dir, entry.name))) {
@@ -75,6 +93,16 @@ for (const entry of entries) {
     entry.layer === 'features'
       ? '> Part of the [Feature Map](../README.md)'
       : '> Part of the [Feature Map](../../features/README.md)';
+
+  if (entry.noSpecPlanned) {
+    noSpecPlanned += 1;
+    if (entry.link !== null) {
+      errors.push(`${entry.layer}/${entry.name} is linked but marked "no spec planned" — drop one of the two`);
+    } else if (existsSync(readmePath)) {
+      errors.push(`${entry.layer}/${entry.name} has a README but is marked "no spec planned" — link it instead`);
+    }
+    continue;
+  }
 
   if (existsSync(readmePath)) {
     documented += 1;
@@ -91,24 +119,14 @@ for (const entry of entries) {
   }
 }
 
-// Counter
-const total = features.length + aggregates.length;
-const counter = map.match(/\*\*Documented: (\d+) \/ (\d+)\*\*/);
-if (!counter) {
-  errors.push('Counter line "**Documented: N / M**" not found in the map');
-} else {
-  if (Number(counter[1]) !== documented) {
-    errors.push(`Counter says ${counter[1]} documented, actual count is ${documented}`);
-  }
-  if (Number(counter[2]) !== total) {
-    errors.push(`Counter says ${counter[2]} total, actual count is ${total}`);
-  }
-}
-
 if (errors.length > 0) {
   console.error(`Feature Map check failed — ${errors.length} problem(s):\n`);
   for (const error of errors) console.error(`  - ${error}`);
   process.exit(1);
 }
 
-console.log(`Feature Map OK — ${documented} / ${total} modules documented.`);
+const total = features.length + aggregates.length;
+const pending = total - documented - noSpecPlanned;
+console.log(
+  `Feature Map OK — ${total} modules: ${documented} documented, ${pending} awaiting a spec, ${noSpecPlanned} no spec planned.`,
+);

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -2,10 +2,15 @@
 /**
  * Validates the Feature Map (src/renderer/features/README.md) against the
  * filesystem: every feature/aggregate is listed exactly once, documented
- * modules are linked, spec READMEs carry the Feature Map backlink, and
- * "no spec planned" markers don't contradict reality. Exits non-zero on any
- * drift and prints a coverage summary on success.
+ * modules are linked, spec READMEs carry the Feature Map backlink, and "no spec
+ * planned" markers don't contradict reality. Exits non-zero on any drift and
+ * prints a coverage summary on success.
+ *
+ * With `--changed <base-ref>` it additionally diffs HEAD against the merge base
+ * with <base-ref> and fails when a changed feature/aggregate has no spec or its
+ * code changed without a spec update (used in CI with the PR base).
  */
+import { execSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -119,9 +124,67 @@ for (const entry of entries) {
   }
 }
 
+// --changed <base-ref>: fail when a changed module lacks a spec or its code
+// changed without a spec update
+const changedFlagIndex = process.argv.indexOf('--changed');
+if (changedFlagIndex !== -1) {
+  const baseRef = process.argv[changedFlagIndex + 1];
+  if (!baseRef) {
+    console.error('Usage: check-feature-index.mjs --changed <base-ref>');
+    process.exit(1);
+  }
+
+  let diffOutput;
+  try {
+    diffOutput = execSync(`git diff --name-only ${baseRef}...HEAD`, { cwd: ROOT, encoding: 'utf8' });
+  } catch {
+    console.error(`Could not diff against "${baseRef}" — is the ref fetched?`);
+    process.exit(1);
+  }
+
+  const changedModules = new Map();
+  for (const file of diffOutput.split('\n')) {
+    const match = file.match(/^src\/renderer\/(features|aggregates)\/([\w.-]+)\/(.+)$/);
+    if (!match) continue;
+    const key = `${match[1]}/${match[2]}`;
+    const module = changedModules.get(key) ?? {
+      layer: match[1],
+      name: match[2],
+      codeChanged: false,
+      readmeChanged: false,
+    };
+    if (match[3] === 'README.md') module.readmeChanged = true;
+    else module.codeChanged = true;
+    changedModules.set(key, module);
+  }
+
+  for (const module of changedModules.values()) {
+    const dir = module.layer === 'features' ? FEATURES_DIR : AGGREGATES_DIR;
+    // a deleted module surfaces as a stale map entry in the structural checks
+    if (!existsSync(join(dir, module.name))) continue;
+
+    const entry = entries.find((e) => e.layer === module.layer && e.name === module.name);
+    if (entry?.noSpecPlanned) continue;
+
+    const hasReadme = existsSync(join(dir, module.name, 'README.md'));
+    if (!hasReadme) {
+      errors.push(
+        `${module.layer}/${module.name} changed but has no spec — run the feature-specs skill to create one ` +
+          `(or mark it "(no spec planned)" in the Feature Map if it is trivial)`,
+      );
+    } else if (module.codeChanged && !module.readmeChanged) {
+      errors.push(
+        `${module.layer}/${module.name} code changed but its spec README.md was not updated — ` +
+          `run the feature-specs skill to review the spec and reconcile it with the change`,
+      );
+    }
+  }
+}
+
 if (errors.length > 0) {
   console.error(`Feature Map check failed — ${errors.length} problem(s):\n`);
   for (const error of errors) console.error(`  - ${error}`);
+  console.error('\nRun the `feature-specs` skill in Claude Code to create/update specs and fix the Feature Map.');
   process.exit(1);
 }
 

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -72,7 +72,9 @@ for (const entry of entries) {
   const expectedLink =
     entry.layer === 'features' ? `./${entry.name}/README.md` : `../aggregates/${entry.name}/README.md`;
   const expectedBacklink =
-    entry.layer === 'features' ? '[Feature Map](../README.md)' : '[Feature Map](../../features/README.md)';
+    entry.layer === 'features'
+      ? '> Part of the [Feature Map](../README.md)'
+      : '> Part of the [Feature Map](../../features/README.md)';
 
   if (existsSync(readmePath)) {
     documented += 1;
@@ -82,7 +84,7 @@ for (const entry of entries) {
       errors.push(`${entry.layer}/${entry.name} link should be "${expectedLink}", got "${entry.link}"`);
     }
     if (!readFileSync(readmePath, 'utf8').includes(expectedBacklink)) {
-      errors.push(`${entry.layer}/${entry.name}/README.md is missing the backlink "> Part of the ${expectedBacklink}"`);
+      errors.push(`${entry.layer}/${entry.name}/README.md is missing the backlink line "${expectedBacklink}"`);
     }
   } else if (entry.link !== null) {
     errors.push(`${entry.layer}/${entry.name} is linked in the map but has no README.md`);

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -10,7 +10,7 @@
  * with <base-ref> and fails when a changed feature/aggregate has no spec or its
  * code changed without a spec update (used in CI with the PR base).
  */
-import { execSync } from 'node:child_process';
+import { execFileSync } from 'node:child_process';
 import { existsSync, readFileSync, readdirSync } from 'node:fs';
 import { join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -146,8 +146,8 @@ if (changedFlagIndex !== -1) {
   let mergeBase;
   let diffOutput;
   try {
-    mergeBase = execSync(`git merge-base ${baseRef} HEAD`, { cwd: ROOT, encoding: 'utf8' }).trim();
-    diffOutput = execSync(`git diff --name-only ${mergeBase} HEAD`, { cwd: ROOT, encoding: 'utf8' });
+    mergeBase = execFileSync('git', ['merge-base', baseRef, 'HEAD'], { cwd: ROOT, encoding: 'utf8' }).trim();
+    diffOutput = execFileSync('git', ['diff', '--name-only', mergeBase, 'HEAD'], { cwd: ROOT, encoding: 'utf8' });
   } catch {
     console.error(`Could not diff against "${baseRef}" — is the ref fetched?`);
     process.exit(1);
@@ -190,7 +190,7 @@ if (changedFlagIndex !== -1) {
     // must move past the date in the merge base (a new spec always passes)
     let baseReadme = null;
     try {
-      baseReadme = execSync(`git show ${mergeBase}:src/renderer/${module.layer}/${module.name}/README.md`, {
+      baseReadme = execFileSync('git', ['show', `${mergeBase}:src/renderer/${module.layer}/${module.name}/README.md`], {
         cwd: ROOT,
         encoding: 'utf8',
         stdio: ['ignore', 'pipe', 'ignore'],
@@ -200,9 +200,9 @@ if (changedFlagIndex !== -1) {
     }
     const baseDate = baseReadme?.match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
     const currentDate = readFileSync(readmePath, 'utf8').match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
-    if (baseDate !== null && currentDate === baseDate) {
+    if (baseDate !== null && (currentDate === null || currentDate <= baseDate)) {
       errors.push(
-        `${module.layer}/${module.name} code changed but the spec's "Last reviewed" date was not updated — ` +
+        `${module.layer}/${module.name} code changed but the spec's "Last reviewed" date was not bumped — ` +
           `run the feature-specs skill to review the spec and bump the date`,
       );
     }

--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -35,6 +35,8 @@ const aggregates = listModules(AGGREGATES_DIR);
 const map = readFileSync(MAP_PATH, 'utf8');
 const errors = [];
 
+const REVIEWED_DATE_PATTERN = /Last reviewed: (\d{4}-\d{2}-\d{2})/;
+
 // Re-join list items wrapped by prettier (proseWrap: always indents
 // continuation lines of a "- " item with two spaces).
 const lines = [];
@@ -116,8 +118,15 @@ for (const entry of entries) {
     } else if (entry.link !== expectedLink) {
       errors.push(`${entry.layer}/${entry.name} link should be "${expectedLink}", got "${entry.link}"`);
     }
-    if (!readFileSync(readmePath, 'utf8').includes(expectedBacklink)) {
+    const readme = readFileSync(readmePath, 'utf8');
+    if (!readme.includes(expectedBacklink)) {
       errors.push(`${entry.layer}/${entry.name}/README.md is missing the backlink line "${expectedBacklink}"`);
+    }
+    if (!REVIEWED_DATE_PATTERN.test(readme)) {
+      errors.push(
+        `${entry.layer}/${entry.name}/README.md is missing a "Last reviewed: YYYY-MM-DD" date on the backlink line — ` +
+          `run the feature-specs skill to review the spec and stamp it`,
+      );
     }
   } else if (entry.link !== null) {
     errors.push(`${entry.layer}/${entry.name} is linked in the map but has no README.md`);
@@ -134,9 +143,11 @@ if (changedFlagIndex !== -1) {
     process.exit(1);
   }
 
+  let mergeBase;
   let diffOutput;
   try {
-    diffOutput = execSync(`git diff --name-only ${baseRef}...HEAD`, { cwd: ROOT, encoding: 'utf8' });
+    mergeBase = execSync(`git merge-base ${baseRef} HEAD`, { cwd: ROOT, encoding: 'utf8' }).trim();
+    diffOutput = execSync(`git diff --name-only ${mergeBase} HEAD`, { cwd: ROOT, encoding: 'utf8' });
   } catch {
     console.error(`Could not diff against "${baseRef}" — is the ref fetched?`);
     process.exit(1);
@@ -151,10 +162,8 @@ if (changedFlagIndex !== -1) {
       layer: match[1],
       name: match[2],
       codeChanged: false,
-      readmeChanged: false,
     };
-    if (match[3] === 'README.md') module.readmeChanged = true;
-    else module.codeChanged = true;
+    if (match[3] !== 'README.md') module.codeChanged = true;
     changedModules.set(key, module);
   }
 
@@ -166,16 +175,35 @@ if (changedFlagIndex !== -1) {
     const entry = entries.find((e) => e.layer === module.layer && e.name === module.name);
     if (entry?.noSpecPlanned) continue;
 
-    const hasReadme = existsSync(join(dir, module.name, 'README.md'));
-    if (!hasReadme) {
+    const readmePath = join(dir, module.name, 'README.md');
+    if (!existsSync(readmePath)) {
       errors.push(
         `${module.layer}/${module.name} changed but has no spec — run the feature-specs skill to create one ` +
           `(or mark it "(no spec planned)" in the Feature Map if it is trivial)`,
       );
-    } else if (module.codeChanged && !module.readmeChanged) {
+      continue;
+    }
+
+    if (!module.codeChanged) continue;
+
+    // code changed → the spec must be re-reviewed: its "Last reviewed" date
+    // must move past the date in the merge base (a new spec always passes)
+    let baseReadme = null;
+    try {
+      baseReadme = execSync(`git show ${mergeBase}:src/renderer/${module.layer}/${module.name}/README.md`, {
+        cwd: ROOT,
+        encoding: 'utf8',
+        stdio: ['ignore', 'pipe', 'ignore'],
+      });
+    } catch {
+      // README does not exist in the merge base — spec is new in this change
+    }
+    const baseDate = baseReadme?.match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
+    const currentDate = readFileSync(readmePath, 'utf8').match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
+    if (baseDate !== null && currentDate === baseDate) {
       errors.push(
-        `${module.layer}/${module.name} code changed but its spec README.md was not updated — ` +
-          `run the feature-specs skill to review the spec and reconcile it with the change`,
+        `${module.layer}/${module.name} code changed but the spec's "Last reviewed" date was not updated — ` +
+          `run the feature-specs skill to review the spec and bump the date`,
       );
     }
   }

--- a/src/renderer/aggregates/README.md
+++ b/src/renderer/aggregates/README.md
@@ -1,0 +1,5 @@
+# Aggregates
+
+Aggregates are indexed together with features in the [Feature Map](../features/README.md) — see it for the full
+product-area map and spec coverage. The spec convention lives in
+[`docs/content/docs/code/style/feature-specs.md`](../../../docs/content/docs/code/style/feature-specs.md).

--- a/src/renderer/aggregates/multisig-operation-description/README.md
+++ b/src/renderer/aggregates/multisig-operation-description/README.md
@@ -1,37 +1,33 @@
 # Multisig Operation Description
 
-> Part of the [Feature Map](../../features/README.md)
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-06-11
 
 ## Overview
 
-An **operation description** is a short note the initiator of a multisig operation
-attaches on the confirmation screen. Once the operation is included in a block, the
-note is published to the shared address book and stored against the multisig account,
-so the other signatories see the operation's context when they review and approve it.
+An **operation description** is a short note the initiator of a multisig operation attaches on the confirmation screen.
+Once the operation is included in a block, the note is published to the shared address book and stored against the
+multisig account, so the other signatories see the operation's context when they review and approve it.
 
-The description input appears on every operation confirmation screen, but it only
-shows up when it can actually be saved and read back by others. The feature decides
-this automatically — the user never sees a dead input or hits an avoidable error.
+The description input appears on every operation confirmation screen, but it only shows up when it can actually be saved
+and read back by others. The feature decides this automatically — the user never sees a dead input or hits an avoidable
+error.
 
 ## Who can post a description
 
-Descriptions live in the shared address book, which authorizes a write when **all**
-of the following hold:
+Descriptions live in the shared address book, which authorizes a write when **all** of the following hold:
 
 - the user has the **"write operations"** permission;
 - the multisig is a **known contact** in the address book;
-- the multisig is **reachable** by the user — i.e. they are connected to it as an
-  owner, proxy, or co-signer (which is exactly what makes a contact visible to them).
+- the multisig is **reachable** by the user — i.e. they are connected to it as an owner, proxy, or co-signer (which is
+  exactly what makes a contact visible to them).
 
-Because contact visibility and write access are governed by the same relationship,
-the rule simplifies to: **if the multisig is in your address book, you can describe
-its operations.** If it isn't, the address book rejects the note, so the feature
-surfaces that as an error instead of letting the user type into a field that will fail.
+Because contact visibility and write access are governed by the same relationship, the rule simplifies to: **if the
+multisig is in your address book, you can describe its operations.** If it isn't, the address book rejects the note, so
+the feature surfaces that as an error instead of letting the user type into a field that will fail.
 
 ## States of the description area
 
-The confirmation screen shows one of four states, chosen from the operation and the
-user's address-book connection.
+The confirmation screen shows one of four states, chosen from the operation and the user's address-book connection.
 
 ```mermaid
 flowchart TD
@@ -60,22 +56,20 @@ flowchart TD
     style HIDDEN4 fill:#37474f,color:#fff
 ```
 
-| State | When it appears | What the user sees |
-| --- | --- | --- |
-| **Field** | Multisig operation, online, user can write operations, multisig is in the address book | An editable note (up to 500 characters) |
-| **Error** | Same as above, but the multisig is **not** in the address book | An inline error showing the multisig and asking to add it to the address book / contact an administrator |
-| **Reconnect** | Multisig operation, address book offline, but the user has connected before | The note is disabled and covered by a **Reconnect** prompt |
-| **Hidden** | Not a multisig, a draft submission, no write permission while online, or the book was never used | Nothing is shown |
+| State         | When it appears                                                                                  | What the user sees                                                                                       |
+| ------------- | ------------------------------------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| **Field**     | Multisig operation, online, user can write operations, multisig is in the address book           | An editable note (up to 500 characters)                                                                  |
+| **Error**     | Same as above, but the multisig is **not** in the address book                                   | An inline error showing the multisig and asking to add it to the address book / contact an administrator |
+| **Reconnect** | Multisig operation, address book offline, but the user has connected before                      | The note is disabled and covered by a **Reconnect** prompt                                               |
+| **Hidden**    | Not a multisig, a draft submission, no write permission while online, or the book was never used | Nothing is shown                                                                                         |
 
-**Why an error instead of silently hiding.** When the user is online and allowed to
-write notes, a missing multisig is a fixable situation — someone needs to add the
-multisig to the address book. The feature names the exact multisig and points to the
-fix, rather than quietly dropping the field.
+**Why an error instead of silently hiding.** When the user is online and allowed to write notes, a missing multisig is a
+fixable situation — someone needs to add the multisig to the address book. The feature names the exact multisig and
+points to the fix, rather than quietly dropping the field.
 
-**Why the permission check only applies online.** The "write operations" permission is
-only known while the user is connected. Offline, the feature can't tell, so it keeps
-the Reconnect prompt; after reconnecting it re-evaluates and hides the note if the user
-turns out to lack the permission.
+**Why the permission check only applies online.** The "write operations" permission is only known while the user is
+connected. Offline, the feature can't tell, so it keeps the Reconnect prompt; after reconnecting it re-evaluates and
+hides the note if the user turns out to lack the permission.
 
 ## Lifecycle
 
@@ -94,16 +88,15 @@ sequenceDiagram
     Note over Confirm: on failure → a toast explains why<br/>(e.g. access denied)
 ```
 
-The note is captured at the moment of signing and published only after the operation
-successfully lands on-chain. It is **not** posted if the note is empty, the operation
-isn't a multisig, or a draft submission is in progress (drafts publish their own note).
+The note is captured at the moment of signing and published only after the operation successfully lands on-chain. It is
+**not** posted if the note is empty, the operation isn't a multisig, or a draft submission is in progress (drafts
+publish their own note).
 
 ## Related description paths
 
-Operation descriptions are also written from two other flows, governed by the same
-address-book authorization:
+Operation descriptions are also written from two other flows, governed by the same address-book authorization:
 
-- **Approving someone else's operation** — the approver is a signatory, so the
-  multisig is always reachable; no extra address-book check is needed.
-- **Submitting a saved draft** — the note comes from the draft itself, which is why
-  this feature hides its own field during a draft submission.
+- **Approving someone else's operation** — the approver is a signatory, so the multisig is always reachable; no extra
+  address-book check is needed.
+- **Submitting a saved draft** — the note comes from the draft itself, which is why this feature hides its own field
+  during a draft submission.

--- a/src/renderer/aggregates/multisig-operation-description/README.md
+++ b/src/renderer/aggregates/multisig-operation-description/README.md
@@ -1,5 +1,7 @@
 # Multisig Operation Description
 
+> Part of the [Feature Map](../../features/README.md)
+
 ## Overview
 
 An **operation description** is a short note the initiator of a multisig operation

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -182,6 +182,9 @@ section; related modules in other sections are referenced via "See also" notes.
 - `notifications`
 - `notifications-navigation`
 
+> See also: [`send-to-contact`](#transfers) — the transfer flow launched from the
+> contacts page.
+
 ## App Shell & Platform
 
 - `app-shell`

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -1,0 +1,202 @@
+# Feature Map
+
+> 🚧 **Documentation in progress.** Spec coverage is being added incrementally —
+> most modules are not documented yet. Documented modules link to their spec
+> README; plain names are modules still awaiting a spec.
+
+**Documented: 2 / 119**
+
+A curated index of every product module in [`src/renderer/features/`](./) and
+[`src/renderer/aggregates/`](../aggregates/), grouped by product area. Aggregates
+are marked with an `(aggregate)` suffix. Each module appears in exactly one home
+section; related modules in other sections are referenced via "See also" notes.
+
+## Wallets & Onboarding
+
+- `account-selector`
+- [`account-sync`](./account-sync/README.md)
+- `accounts-structure`
+- `wallets`
+- `wallet-details`
+- `wallet-fiat-balance`
+- `wallet-pairing`
+- `wallet-rename`
+- `wallet-select`
+- `hidden-wallets`
+- `hide-unnamed-wallets`
+- `extension-wallet`
+- `ledger-wallet-pairing`
+- `polkadot-vault-wallet`
+- `polkadot-vault-wallet-pairing`
+- `wallet-connect-wallet`
+- `wallet-connect-wallet-pairing`
+- `watch-only-wallet`
+- `watch-only-wallet-pairing`
+- `account-presets` (aggregate)
+- `wallet-select` (aggregate)
+
+> See also: [`multisig-wallet`](#multisig), [`proxied-wallet`](#proxy) — wallet
+> types managed in their own product areas.
+
+## Multisig
+
+- `multisig-operations`
+- `multisig-wallet`
+- `multisig-wallet-create`
+- `flexible-change-signatories`
+- `flexible-operation-details`
+- `multisig-candidates` (aggregate)
+- [`multisig-operation-description`](../aggregates/multisig-operation-description/README.md) (aggregate)
+- `selected-wallet-multisig-operations` (aggregate)
+
+> See also: [`account-sync`](#wallets--onboarding) — discovers multisig wallets
+> on-chain; [`call-data-execute`](#operations--signing) — executes pending
+> multisig call data.
+
+## Proxy
+
+- `proxies`
+- `proxy-add`
+- `proxy-basket`
+- `proxy-operation-details`
+- `proxy-remove`
+- `proxy-verify`
+- `proxied-add-pure`
+- `proxied-wallet`
+
+> See also: [`account-sync`](#wallets--onboarding) — discovers proxied wallets
+> on-chain.
+
+## Staking
+
+- `staking`
+- `staking-navigation`
+- `staking-basket`
+- `staking-bond-extra`
+- `staking-bond-nominate`
+- `staking-nominate`
+- `staking-operation-details`
+- `staking-payee`
+- `staking-restake`
+- `staking-unstake`
+- `staking-withdraw`
+- `staking-accounts` (aggregate)
+- `staking-network` (aggregate)
+
+> See also: [`dashboard-staking`](#dashboard) — staking summary on the dashboard.
+
+## Governance
+
+- `governance`
+- `governance-navigation`
+- `governance-basket`
+- `governance-operation-details`
+- `governance-meta-provider` (aggregate)
+
+> See also: [`dashboard-governance`](#dashboard) — governance summary on the
+> dashboard.
+
+## Fellowship
+
+- `fellowship-activity-feed`
+- `fellowship-basket`
+- `fellowship-evidence`
+- `fellowship-evidence-salary`
+- `fellowship-members`
+- `fellowship-navigation`
+- `fellowship-overview`
+- `fellowship-profile`
+- `fellowship-promotion`
+- `fellowship-referendum-details`
+- `fellowship-retention`
+- `fellowship-salary`
+- `fellowship-tasks`
+- `fellowship-voting`
+- `fellowship-voting-history`
+- `fellowship-member` (aggregate)
+- `fellowship-network` (aggregate)
+- `fellowship-promotion` (aggregate)
+- `fellowship-retention` (aggregate)
+
+## Transfers
+
+- `transfer`
+- `transfer-basket`
+- `transfer-operation-details`
+- `multi-transfer`
+- `multi-transfer-operation-details`
+- `vested-transfer`
+- `vested-transfer-operation-details`
+- `send-to-contact`
+
+## Assets & Balances
+
+- `assets`
+- `assets-balances`
+- `assets-navigation`
+- `assets-transaction`
+- `assethub-migration-modal`
+- `currency`
+- `currency-select` (aggregate)
+
+> See also: [`dashboard-portfolio-overview`](#dashboard),
+> [`dashboard-price-charts`](#dashboard) — portfolio and price views on the
+> dashboard.
+
+## Operations & Signing
+
+- `operations`
+- `operations-navigation`
+- `operation-templates`
+- `app-custom-operations`
+- `call-data-execute`
+- `extrinsic-builder`
+- `drafts`
+- `signing-path`
+- `sign-wallet-connect`
+
+## Basket
+
+- `basket-navigation`
+- `basket-operations`
+- `basket-operations` (aggregate)
+
+> See also: domain basket flows live with their domains —
+> [`staking-basket`](#staking), [`transfer-basket`](#transfers),
+> [`proxy-basket`](#proxy), [`governance-basket`](#governance),
+> [`fellowship-basket`](#fellowship).
+
+## Dashboard
+
+- `dashboard-governance`
+- `dashboard-navigation`
+- `dashboard-operations-queue`
+- `dashboard-portfolio-overview`
+- `dashboard-price-charts`
+- `dashboard-staking`
+
+## Contacts & Notifications
+
+- `contacts`
+- `contacts-navigation`
+- `notifications`
+- `notifications-navigation`
+
+## App Shell & Platform
+
+- `app-shell`
+- `navigation`
+- `network`
+- `settings-navigation`
+- `dapp-browser`
+- `import-db`
+- `emptyList`
+- `backend` (aggregate)
+
+---
+
+🚧 This index is under active development — not every feature has a spec yet.
+To add a spec, follow the convention in
+[`docs/content/docs/code/style/feature-specs.md`](../../../docs/content/docs/code/style/feature-specs.md);
+Claude Code users: the `feature-specs` skill automates the workflow. Run
+`node scripts/check-feature-index.mjs` to verify the map is in sync.

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -1,15 +1,13 @@
 # Feature Map
 
-> 🚧 **Documentation in progress.** Spec coverage is being added incrementally —
-> most modules are not documented yet. Documented modules link to their spec
-> README; plain names are modules still awaiting a spec.
-
-**Documented: 2 / 119**
+> 🚧 **Documentation in progress.** Spec coverage is being added incrementally — most modules are not documented yet.
+> Documented modules link to their spec README; plain names are modules still awaiting a spec; trivial modules are
+> marked `(no spec planned)`. Run `node scripts/check-feature-index.mjs` for current coverage numbers.
 
 A curated index of every product module in [`src/renderer/features/`](./) and
-[`src/renderer/aggregates/`](../aggregates/), grouped by product area. Aggregates
-are marked with an `(aggregate)` suffix. Each module appears in exactly one home
-section; related modules in other sections are referenced via "See also" notes.
+[`src/renderer/aggregates/`](../aggregates/), grouped by product area. Aggregates are marked with an `(aggregate)`
+suffix. Each module appears in exactly one home section; related modules in other sections are referenced via "See also"
+notes.
 
 ## Wallets & Onboarding
 
@@ -35,8 +33,8 @@ section; related modules in other sections are referenced via "See also" notes.
 - `account-presets` (aggregate)
 - `wallet-select` (aggregate)
 
-> See also: [`multisig-wallet`](#multisig), [`proxied-wallet`](#proxy) — wallet
-> types managed in their own product areas.
+> See also: [`multisig-wallet`](#multisig), [`proxied-wallet`](#proxy) — wallet types managed in their own product
+> areas.
 
 ## Multisig
 
@@ -49,9 +47,8 @@ section; related modules in other sections are referenced via "See also" notes.
 - [`multisig-operation-description`](../aggregates/multisig-operation-description/README.md) (aggregate)
 - `selected-wallet-multisig-operations` (aggregate)
 
-> See also: [`account-sync`](#wallets--onboarding) — discovers multisig wallets
-> on-chain; [`call-data-execute`](#operations--signing) — executes pending
-> multisig call data.
+> See also: [`account-sync`](#wallets--onboarding) — discovers multisig wallets on-chain;
+> [`call-data-execute`](#operations--signing) — executes pending multisig call data.
 
 ## Proxy
 
@@ -64,13 +61,12 @@ section; related modules in other sections are referenced via "See also" notes.
 - `proxied-add-pure`
 - `proxied-wallet`
 
-> See also: [`account-sync`](#wallets--onboarding) — discovers proxied wallets
-> on-chain.
+> See also: [`account-sync`](#wallets--onboarding) — discovers proxied wallets on-chain.
 
 ## Staking
 
 - `staking`
-- `staking-navigation`
+- `staking-navigation` (no spec planned)
 - `staking-basket`
 - `staking-bond-extra`
 - `staking-bond-nominate`
@@ -88,13 +84,12 @@ section; related modules in other sections are referenced via "See also" notes.
 ## Governance
 
 - `governance`
-- `governance-navigation`
+- `governance-navigation` (no spec planned)
 - `governance-basket`
 - `governance-operation-details`
 - `governance-meta-provider` (aggregate)
 
-> See also: [`dashboard-governance`](#dashboard) — governance summary on the
-> dashboard.
+> See also: [`dashboard-governance`](#dashboard) — governance summary on the dashboard.
 
 ## Fellowship
 
@@ -103,7 +98,7 @@ section; related modules in other sections are referenced via "See also" notes.
 - `fellowship-evidence`
 - `fellowship-evidence-salary`
 - `fellowship-members`
-- `fellowship-navigation`
+- `fellowship-navigation` (no spec planned)
 - `fellowship-overview`
 - `fellowship-profile`
 - `fellowship-promotion`
@@ -133,43 +128,40 @@ section; related modules in other sections are referenced via "See also" notes.
 
 - `assets`
 - `assets-balances`
-- `assets-navigation`
+- `assets-navigation` (no spec planned)
 - `assets-transaction`
 - `assethub-migration-modal`
 - `currency`
 - `currency-select` (aggregate)
 
-> See also: [`dashboard-portfolio-overview`](#dashboard),
-> [`dashboard-price-charts`](#dashboard) — portfolio and price views on the
-> dashboard.
+> See also: [`dashboard-portfolio-overview`](#dashboard), [`dashboard-price-charts`](#dashboard) — portfolio and price
+> views on the dashboard.
 
 ## Operations & Signing
 
 - `operations`
-- `operations-navigation`
+- `operations-navigation` (no spec planned)
 - `operation-templates`
 - `app-custom-operations`
 - `call-data-execute`
 - `extrinsic-builder`
 - `drafts`
 - `signing-path`
-- `sign-wallet-connect`
+- `sign-wallet-connect` (no spec planned)
 
 ## Basket
 
-- `basket-navigation`
+- `basket-navigation` (no spec planned)
 - `basket-operations`
 - `basket-operations` (aggregate)
 
-> See also: domain basket flows live with their domains —
-> [`staking-basket`](#staking), [`transfer-basket`](#transfers),
-> [`proxy-basket`](#proxy), [`governance-basket`](#governance),
-> [`fellowship-basket`](#fellowship).
+> See also: domain basket flows live with their domains — [`staking-basket`](#staking), [`transfer-basket`](#transfers),
+> [`proxy-basket`](#proxy), [`governance-basket`](#governance), [`fellowship-basket`](#fellowship).
 
 ## Dashboard
 
 - `dashboard-governance`
-- `dashboard-navigation`
+- `dashboard-navigation` (no spec planned)
 - `dashboard-operations-queue`
 - `dashboard-portfolio-overview`
 - `dashboard-price-charts`
@@ -178,28 +170,26 @@ section; related modules in other sections are referenced via "See also" notes.
 ## Contacts & Notifications
 
 - `contacts`
-- `contacts-navigation`
+- `contacts-navigation` (no spec planned)
 - `notifications`
-- `notifications-navigation`
+- `notifications-navigation` (no spec planned)
 
-> See also: [`send-to-contact`](#transfers) — the transfer flow launched from the
-> contacts page.
+> See also: [`send-to-contact`](#transfers) — the transfer flow launched from the contacts page.
 
 ## App Shell & Platform
 
 - `app-shell`
 - `navigation`
 - `network`
-- `settings-navigation`
+- `settings-navigation` (no spec planned)
 - `dapp-browser`
 - `import-db`
-- `emptyList`
+- `emptyList` (no spec planned)
 - `backend` (aggregate)
 
 ---
 
-🚧 This index is under active development — not every feature has a spec yet.
 To add a spec, follow the convention in
-[`docs/content/docs/code/style/feature-specs.md`](../../../docs/content/docs/code/style/feature-specs.md);
-Claude Code users: the `feature-specs` skill automates the workflow. Run
-`node scripts/check-feature-index.mjs` to verify the map is in sync.
+[`docs/content/docs/code/style/feature-specs.md`](../../../docs/content/docs/code/style/feature-specs.md); Claude Code
+users: the `feature-specs` skill automates the workflow. Run `node scripts/check-feature-index.mjs` (or
+`pnpm check:feature-map`) to verify the map is in sync — it also prints the current coverage numbers.

--- a/src/renderer/features/account-sync/README.md
+++ b/src/renderer/features/account-sync/README.md
@@ -1,5 +1,7 @@
 # Account Sync
 
+> Part of the [Feature Map](../README.md)
+
 ## Overview
 
 **Account sync** keeps the user's _derived_ wallets in step with on-chain reality.

--- a/src/renderer/features/account-sync/README.md
+++ b/src/renderer/features/account-sync/README.md
@@ -1,38 +1,32 @@
 # Account Sync
 
-> Part of the [Feature Map](../README.md)
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-06-11
 
 ## Overview
 
-**Account sync** keeps the user's _derived_ wallets in step with on-chain reality.
-The user only ever adds a **signing wallet** (a Vault, a key, a watch-only address);
-the multisig, flexible-multisig, and delegated-authority (proxy) wallets that depend
-on it are never added by hand — the sync service discovers them, creates them as
-watch-only wallets, keeps their details current, and removes them once they no longer
-exist on-chain.
+**Account sync** keeps the user's _derived_ wallets in step with on-chain reality. The user only ever adds a **signing
+wallet** (a Vault, a key, a watch-only address); the multisig, flexible-multisig, and delegated-authority (proxy)
+wallets that depend on it are never added by hand — the sync service discovers them, creates them as watch-only wallets,
+keeps their details current, and removes them once they no longer exist on-chain.
 
-It runs in the background and is mostly invisible: the only direct UI is a refresh
-control in the wallet panel. Everything else surfaces as wallets appearing or
-disappearing and as "wallet added" notifications.
+It runs in the background and is mostly invisible: the only direct UI is a refresh control in the wallet panel.
+Everything else surfaces as wallets appearing or disappearing and as "wallet added" notifications.
 
 ## What it discovers
 
-Starting from the user's own accounts as seeds, sync asks the indexer (and verifies
-against the live chains) for three kinds of derived account, then keeps expanding:
+Starting from the user's own accounts as seeds, sync asks the indexer (and verifies against the live chains) for three
+kinds of derived account, then keeps expanding:
 
-- **Multisig** — a multisig account the user is a signatory of. The account id is
-  re-derived from the returned signatories + threshold and only accepted if it
-  matches, so an indexer can't fabricate a membership.
-- **Delegated authority (proxy)** — an account that has delegated a proxy to one of
-  the user's accounts. Only **immediate** proxies are tracked (delay `0`); delayed
-  proxies are ignored.
-- **Flexible multisig** — a pure proxy whose delegate is a discovered multisig
-  account (a multisig that controls a pure-proxy account).
+- **Multisig** — a multisig account the user is a signatory of. The account id is re-derived from the returned
+  signatories + threshold and only accepted if it matches, so an indexer can't fabricate a membership.
+- **Delegated authority (proxy)** — an account that has delegated a proxy to one of the user's accounts. Only
+  **immediate** proxies are tracked (delay `0`); delayed proxies are ignored.
+- **Flexible multisig** — a pure proxy whose delegate is a discovered multisig account (a multisig that controls a
+  pure-proxy account).
 
-Discovery is **recursive**: every newly found account becomes a seed for the next
-round, so chains of relationships (a proxy of a multisig of a proxy …) are walked to
-their end. Only accounts the user has **permission to act with** are used as the
-initial seeds.
+Discovery is **recursive**: every newly found account becomes a seed for the next round, so chains of relationships (a
+proxy of a multisig of a proxy …) are walked to their end. Only accounts the user has **permission to act with** are
+used as the initial seeds.
 
 ## When it runs
 
@@ -49,27 +43,25 @@ flowchart TD
     RUN --> ONLYLAST["Only the latest trigger wins<br/>(overlapping runs collapse to one)"]
 ```
 
-- **First run** waits until *all* chains that support proxies/multisigs are
-  connected — syncing against a half-connected node set would produce false deletes.
-- **Cascade re-run.** When a pass actually deletes wallets, it kicks another pass so
-  that wallets which only existed *because of* the now-deleted ones (a proxied of a
-  removed multisig, and so on) collapse too. It terminates as soon as a pass deletes
-  nothing.
+- **First run** waits until _all_ chains that support proxies/multisigs are connected — syncing against a half-connected
+  node set would produce false deletes.
+- **Cascade re-run.** When a pass actually deletes wallets, it kicks another pass so that wallets which only existed
+  _because of_ the now-deleted ones (a proxied of a removed multisig, and so on) collapse too. It terminates as soon as
+  a pass deletes nothing.
 - Concurrent triggers don't stack — only the most recent run is kept.
 
 ## States the user sees
 
 The sync service has a single visible control — a button in the wallet-select panel:
 
-| State | When it appears | What the user sees |
-| --- | --- | --- |
-| **Idle** | No sync in progress | A refresh icon; clicking it starts a manual sync |
-| **Syncing** | A sync pass is running | A spinner with a "Syncing accounts…" tooltip |
+| State       | When it appears        | What the user sees                               |
+| ----------- | ---------------------- | ------------------------------------------------ |
+| **Idle**    | No sync in progress    | A refresh icon; clicking it starts a manual sync |
+| **Syncing** | A sync pass is running | A spinner with a "Syncing accounts…" tooltip     |
 
-Indirectly, a sync pass may: add watch-only wallets (multisig / flexible multisig /
-delegated authority), update an existing proxied wallet's connections and deposit,
-remove wallets that no longer exist on-chain, and raise a "wallet added"
-notification for each newly created wallet.
+Indirectly, a sync pass may: add watch-only wallets (multisig / flexible multisig / delegated authority), update an
+existing proxied wallet's connections and deposit, remove wallets that no longer exist on-chain, and raise a "wallet
+added" notification for each newly created wallet.
 
 ## Lifecycle
 
@@ -90,23 +82,20 @@ sequenceDiagram
     Wallets-->>Seeds: if anything was deleted, cascade another pass
 ```
 
-A pass discovers accounts, fetches each chain's last-indexed block and the identities
-used to name new wallets, then reconciles the wallet store: create what's new, update
-what changed, and delete what's gone.
+A pass discovers accounts, fetches each chain's last-indexed block and the identities used to name new wallets, then
+reconciles the wallet store: create what's new, update what changed, and delete what's gone.
 
 ### When a derived wallet is deleted
 
-A derived wallet is removed for one of two distinct reasons, decided differently. The
-distinction matters: confusing them is what used to leave orphaned wallets behind.
+A derived wallet is removed for one of two distinct reasons, decided differently. The distinction matters: confusing
+them is what used to leave orphaned wallets behind.
 
-**1. Its local source is gone — immediate, local, no source needed.** A derived wallet
-is only _yours_ because one of your **signable** accounts sits behind it as a signatory
-or delegate — possibly through a chain of other derived wallets. The moment that last
-signable account disappears (you removed the wallet, or an upstream derived wallet was
-itself removed), the dependent wallet is provably orphaned and is deleted **right away,
-from local data alone** — no indexer, no chain call. Because the dependency is followed
-recursively, a single pass collapses a whole chain at once (a proxied of a multisig of a
-removed key). This check runs both when you remove a wallet **and** as the first step of
+**1. Its local source is gone — immediate, local, no source needed.** A derived wallet is only _yours_ because one of
+your **signable** accounts sits behind it as a signatory or delegate — possibly through a chain of other derived
+wallets. The moment that last signable account disappears (you removed the wallet, or an upstream derived wallet was
+itself removed), the dependent wallet is provably orphaned and is deleted **right away, from local data alone** — no
+indexer, no chain call. Because the dependency is followed recursively, a single pass collapses a whole chain at once (a
+proxied of a multisig of a removed key). This check runs both when you remove a wallet **and** as the first step of
 every sync pass, so a derived wallet never lingers waiting for a source to respond.
 
 ```mermaid
@@ -118,23 +107,18 @@ flowchart TD
     style KEEP fill:#1b5e20,color:#fff
 ```
 
-**2. The on-chain relationship was revoked — confirmed against sources.** The wallet
-still has a local signer, but the proxy was revoked or the multisig dissolved on-chain.
-This needs external confirmation and the indexer can lag, so deletion stays guarded: the
-chain must have been part of the pass, the indexer must report a last-processed block for
-it, and that block must be **at or past** the account's creation block (accounts newer
-than the indexer's checkpoint are kept until it catches up). Proxied wallets get an extra
-on-chain check — kept if any delegate is still valid on live chain state; unreachable
-chains are left untouched. A wrongful removal here heals on the next pass.
+**2. The on-chain relationship was revoked — confirmed against sources.** The wallet still has a local signer, but the
+proxy was revoked or the multisig dissolved on-chain. This needs external confirmation and the indexer can lag, so
+deletion stays guarded: the chain must have been part of the pass, the indexer must report a last-processed block for
+it, and that block must be **at or past** the account's creation block (accounts newer than the indexer's checkpoint are
+kept until it catches up). Proxied wallets get an extra on-chain check — kept if any delegate is still valid on live
+chain state; unreachable chains are left untouched. A wrongful removal here heals on the next pass.
 
 ## Related
 
-- **`domains/network/account-sync`** — the discovery engine and the indexer/on-chain
-  providers (proxy, multisig, indexed-blocks). This feature orchestrates those
-  results into wallet create/update/delete, identity naming, proxy-store
-  reconciliation, and notifications.
-- **Identity, proxy, notification, and wallet** domains/entities consume the output
-  of each pass.
-- The discovery providers read from the accounts SubQuery indexer and cross-check
-  against connected chain APIs; indexer lag is the reason for the block-number and
-  on-chain deletion guards above.
+- **`domains/network/account-sync`** — the discovery engine and the indexer/on-chain providers (proxy, multisig,
+  indexed-blocks). This feature orchestrates those results into wallet create/update/delete, identity naming,
+  proxy-store reconciliation, and notifications.
+- **Identity, proxy, notification, and wallet** domains/entities consume the output of each pass.
+- The discovery providers read from the accounts SubQuery indexer and cross-check against connected chain APIs; indexer
+  lag is the reason for the block-number and on-chain deletion guards above.


### PR DESCRIPTION
## Description

Builds out the Feature Spec README convention (#5916) into a maintained system:

- **Feature Map** (`src/renderer/features/README.md`) — a curated index of all 119 modules (104 features + 15 aggregates) grouped by product area. Documented modules link to their spec, trivial ones are marked `(no spec planned)`, cross-cutting modules get "See also" references.
- **Backlinks** — every spec README opens with `> Part of the [Feature Map](...)`; the root README and `src/renderer/aggregates/README.md` point at the map.
- **Validation** — `pnpm check:feature-map` (`scripts/check-feature-index.mjs`, dependency-free) verifies the map against the filesystem: every module listed exactly once, no stale entries, documented modules linked, backlinks present, `(no spec planned)` markers consistent. The parser tolerates prettier `proseWrap` line wrapping.
- **Spec enforcement in CI** — the lint workflow runs the check with `--changed <PR base>`: a PR fails when a changed feature/aggregate has no spec (write one or mark it `(no spec planned)`), or when module code changed without the spec being re-reviewed. Re-review is recorded by the `Last reviewed: YYYY-MM-DD` date on the spec backlink line — CI compares it with the PR base and requires it to move. Error messages point to the `feature-specs` skill. Reproduce locally: `pnpm check:feature-map --changed origin/dev`.
- **`feature-specs` skill** (`.claude/skills/feature-specs/SKILL.md`) — operational rules for Claude Code: when a spec is required, map maintenance steps, final validation. The CLAUDE.md section shrinks to a trigger; the canonical convention stays in `docs/content/docs/code/style/feature-specs.md` (updated with the map/backlink rules).

Coverage is computed by the script (no hand-maintained counter): currently 2 documented, 105 awaiting a spec, 12 no spec planned.

## Changes Made

- Added `src/renderer/features/README.md` (Feature Map) and `src/renderer/aggregates/README.md` (pointer)
- Added `scripts/check-feature-index.mjs` + `pnpm check:feature-map` + CI step in `lint.yaml` (with `--changed` spec enforcement, `fetch-depth: 0` for the merge base)
- Added `.claude/skills/feature-specs/SKILL.md`; slimmed the CLAUDE.md section; updated `docs/content/docs/code/style/feature-specs.md`
- Added Feature Map backlinks to the two existing spec READMEs

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected (validator: positive run + negative tests for missing entry, stale entry, broken backlink, marker contradictions, wrapped lines, and `--changed` cases: new module without spec, code change without spec update, exempt modules)
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable) — the validation script is the test, wired into CI
- [x] My code follows the project's coding standards and style guidelines
