### PR TITLE
docs: link proxy-verify and backend specs in feature map

### DIFF
--- a/src/renderer/aggregates/backend/README.md
+++ b/src/renderer/aggregates/backend/README.md
@@ -1,5 +1,7 @@
 # Address book backend connection & authentication
 
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-06-22
+
 ## Overview
 
 Lets the user connect Nova Spektr to a self-hosted address-book backend and prove account ownership by signing a

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -57,7 +57,7 @@ notes.
 - `proxy-basket`
 - `proxy-operation-details`
 - `proxy-remove`
-- `proxy-verify`
+- [`proxy-verify`](./proxy-verify/README.md)
 - `proxied-add-pure`
 - `proxied-wallet`
 
@@ -185,7 +185,7 @@ notes.
 - `dapp-browser`
 - `import-db`
 - `emptyList` (no spec planned)
-- `backend` (aggregate)
+- [`backend`](../aggregates/backend/README.md) (aggregate)
 
 ---
 

--- a/src/renderer/features/proxy-verify/README.md
+++ b/src/renderer/features/proxy-verify/README.md
@@ -1,5 +1,7 @@
 # Proxy verification
 
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-06-22
+
 ## Overview
 
 Lets a user prove that a newly added proxy (delegate) actually has working authority over a pure-proxied wallet. The


### PR DESCRIPTION
## What

Fixes the Feature Map lint failures reported by `node scripts/check-feature-index.mjs --changed origin/dev`.

- Add the mandatory backlink line with `Last reviewed: 2026-06-22` to:
  - `features/proxy-verify/README.md`
  - `aggregates/backend/README.md`
- Convert both plain-name Feature Map entries to links (`proxy-verify`, `backend` aggregate).

Both specs were re-read and still match the code, so the review date stamp is valid.

## Check

```
Feature Map OK — 119 modules: 4 documented, 103 awaiting a spec, 12 no spec planned.
```
