### PR TITLE
fix: self-heal stale chain metadata to prevent spec version mismatch

### DIFF
--- a/src/renderer/entities/transaction/ui/QrCode/QrGeneratorContainer/QrGeneratorContainer.test.tsx
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGeneratorContainer/QrGeneratorContainer.test.tsx
@@ -1,0 +1,41 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { type ChainId } from '@/shared/core';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: vi.fn().mockReturnValue({
+    t: (key: string) => key,
+  }),
+}));
+
+import { QrGeneratorContainer } from './QrGeneratorContainer';
+
+const CHAIN_ID = '0x00' as ChainId;
+
+describe('ui/QrGeneratorContainer', () => {
+  test('renders the qr children while there is no error', () => {
+    render(
+      <QrGeneratorContainer countdown={60} chainId={CHAIN_ID} onQrReset={vi.fn()}>
+        <div data-testid="qr-child" />
+      </QrGeneratorContainer>,
+    );
+
+    expect(screen.getByTestId('qr-child')).toBeInTheDocument();
+  });
+
+  test('shows a metadata error with a retry action instead of the loading qr when error is set', () => {
+    const onQrReset = vi.fn();
+
+    render(
+      <QrGeneratorContainer countdown={60} chainId={CHAIN_ID} error onQrReset={onQrReset}>
+        <div data-testid="qr-child" />
+      </QrGeneratorContainer>,
+    );
+
+    expect(screen.queryByTestId('qr-child')).not.toBeInTheDocument();
+    expect(screen.getByText('signing.metadataLoadError')).toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('signing.generateNewQrButton'));
+    expect(onQrReset).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/renderer/entities/transaction/ui/QrCode/QrGeneratorContainer/QrGeneratorContainer.tsx
+++ b/src/renderer/entities/transaction/ui/QrCode/QrGeneratorContainer/QrGeneratorContainer.tsx
@@ -10,6 +10,7 @@ type Props = {
   countdown: number | null;
   chainId: ChainId;
   isLegacyQR?: boolean;
+  error?: boolean;
   testId?: string;
   tabSlot?: ReactNode;
   onQrReset: () => void;
@@ -23,6 +24,7 @@ export const QrGeneratorContainer = ({
   tabSlot,
   onQrReset,
   isLegacyQR = true,
+  error = false,
 }: PropsWithChildren<Props>) => {
   const { t } = useI18n();
 
@@ -45,7 +47,17 @@ export const QrGeneratorContainer = ({
         className="relative flex min-h-[250px] w-[250px] flex-col items-center justify-center gap-y-4"
         data-testid={testId}
       >
-        {children &&
+        {error ? (
+          <>
+            {/* metadata (or payload) failed to load */}
+            <Icon name="qrFrame" className="absolute h-full w-full" />
+            <FootnoteText className="px-2 text-center">{t('signing.metadataLoadError')}</FootnoteText>
+            <Button className="z-10" size="sm" prefixElement={<Icon size={16} name="refresh" />} onClick={onQrReset}>
+              {t('signing.generateNewQrButton')}
+            </Button>
+          </>
+        ) : (
+          children &&
           (countdown === null || countdown > 0 ? (
             children
           ) : (
@@ -57,7 +69,8 @@ export const QrGeneratorContainer = ({
                 {t('signing.generateNewQrButton')}
               </Button>
             </>
-          ))}
+          ))
+        )}
       </div>
 
       <div className="mt-6 mb-4 flex flex-row items-center gap-x-2 py-1">

--- a/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanMultiframeQr.tsx
@@ -56,6 +56,7 @@ export const ScanMultiframeQr = ({
 
   const [txPayloads, setTxPayloads] = useState<Uint8Array[]>([]);
   const [qrPayload, setQrPayload] = useState<Uint8Array>();
+  const [error, setError] = useState(false);
 
   const signingType = signingPayloads[0]!.signatory.signingType;
   const isMetadataProofsSupported = signingPayloads[0]!.chain.additional?.supportsGenericLedgerApp ?? false;
@@ -64,8 +65,14 @@ export const ScanMultiframeQr = ({
     const currentId = ++setupIdRef.current;
     setTxPayloads([]);
     setQrPayload(undefined);
+    setError(false);
 
-    setupTransactions(currentId).catch(() => console.warn('ScanMultiQr | setupTransactions() failed'));
+    setupTransactions(currentId).catch((e) => {
+      console.warn('ScanMultiQr | setupTransactions() failed', e);
+      if (currentId === setupIdRef.current) {
+        setError(true);
+      }
+    });
   }, [tab]);
 
   const setupTransactions = async (setupId?: number): Promise<void> => {
@@ -200,7 +207,13 @@ export const ScanMultiframeQr = ({
     const currentId = ++setupIdRef.current;
     setTxPayloads([]);
     setQrPayload(undefined);
-    setupTransactions(currentId).catch(() => console.warn('ScanMultiQr | setupTransactions() failed'));
+    setError(false);
+    setupTransactions(currentId).catch((e) => {
+      console.warn('ScanMultiQr | setupTransactions() failed', e);
+      if (currentId === setupIdRef.current) {
+        setError(true);
+      }
+    });
   };
 
   return (
@@ -209,6 +222,7 @@ export const ScanMultiframeQr = ({
         countdown={countdown}
         chainId={signingPayloads[0]!.chain.chainId}
         isLegacyQR={tab === 'legacy'}
+        error={error}
         testId={TEST_IDS.OPERATIONS.QR_CODE_CONTAINER}
         tabSlot={
           isMetadataProofsSupported ? (

--- a/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
+++ b/src/renderer/entities/transaction/ui/Scanning/ScanSingleframeQr.tsx
@@ -55,6 +55,7 @@ export const ScanSingleframeQr = ({
 
   const [txPayload, setTxPayload] = useState<Uint8Array>();
   const [qrPayload, setQrPayload] = useState<Uint8Array>();
+  const [error, setError] = useState(false);
 
   const isMetadataProofsSupported = chain.additional?.supportsGenericLedgerApp ?? false;
   const isEthereumAccount = accountUtils.isEthereumBased(account);
@@ -63,6 +64,7 @@ export const ScanSingleframeQr = ({
     const currentId = ++setupIdRef.current;
     setTxPayload(undefined);
     setQrPayload(undefined);
+    setError(false);
 
     setupTransaction(currentId).catch(() => console.warn('ScanSingleframeQr | setupTransaction() failed'));
   }, [tab]);
@@ -149,8 +151,11 @@ export const ScanSingleframeQr = ({
         setQrPayload(qrPayload);
         onResetCountdown(mortalitySeconds);
       }
-    } catch (error) {
-      console.warn(error);
+    } catch (e) {
+      console.warn(e);
+      if (setupId === undefined || setupId === setupIdRef.current) {
+        setError(true);
+      }
     }
   };
 
@@ -158,6 +163,7 @@ export const ScanSingleframeQr = ({
     const currentId = ++setupIdRef.current;
     setTxPayload(undefined);
     setQrPayload(undefined);
+    setError(false);
     setupTransaction(currentId).catch(() => console.warn('ScanSingleframeQr | setupTransaction() failed'));
   };
 
@@ -167,6 +173,7 @@ export const ScanSingleframeQr = ({
         countdown={countdown}
         chainId={chain.chainId}
         isLegacyQR={tab === 'legacy'}
+        error={error}
         testId={TEST_IDS.OPERATIONS.QR_CODE_CONTAINER}
         tabSlot={
           isMetadataProofsSupported ? (

--- a/src/renderer/shared/api/network/provider/CachedProvider.ts
+++ b/src/renderer/shared/api/network/provider/CachedProvider.ts
@@ -1,29 +1,86 @@
 import { type ProviderInterface } from '@polkadot/rpc-provider/types';
+import { compactStripLength, hexToU8a, u8aToHex } from '@polkadot/util';
 import { isString } from 'lodash';
 import mitt from 'mitt';
 
-import { type ChainMetadata } from '@/shared/core';
-import { scaleEncodedToNumber } from '@/shared/lib/utils';
+import { type ChainMetadata, type HexString } from '@/shared/core';
+import { readSpecVersion, scaleEncodedToNumber } from '@/shared/lib/utils';
 import { type ProviderMetadata, type ProviderWithMetadata } from '../lib/types';
 
 const LEGACY_METADATA_VERSION = 14;
 const STATE_CALL_METHOD = 'state_call';
 const STATE_METADATA_METHOD = 'state_getMetadata';
+const OPTION_SOME_BYTE = 0x01;
+
+/**
+ * Returns the SCALE-encoded `RuntimeMetadataPrefixed` bytes, unwrapping the
+ * `Option<OpaqueMetadata>` envelope that `Metadata_metadata_at_version` adds
+ * (Some => 0x01 + compact-length-prefixed metadata).
+ */
+function toRuntimeMetadataHex(metadataHex: HexString): HexString {
+  const u8a = hexToU8a(metadataHex);
+
+  if (u8a[0] !== OPTION_SOME_BYTE) {
+    return metadataHex;
+  }
+
+  const [, metadataBytes] = compactStripLength(u8a.slice(1));
+
+  return u8aToHex(metadataBytes);
+}
 
 export function createCachedProvider(Provider: new (...args: any[]) => ProviderInterface, metadata?: ChainMetadata) {
   class CachedProvider extends Provider implements ProviderWithMetadata {
     private metadata: ProviderMetadata | null = metadata || null;
     private events = mitt<{ metadataReceived: ProviderMetadata }>();
+    // Decoding a metadata blob is expensive (full registry build), so memoize the
+    // last result keyed by the bytes to avoid re-decoding on every cache check.
+    private specVersionCache: { metadata: HexString; specVersion: number | null } | null = null;
+
+    /**
+     * Spec version decoded from the metadata BYTES (not a separately fetched
+     * label). The label is set from a `state_getRuntimeVersion` call made apart
+     * from the metadata fetch, so it can drift from the actual bytes during a
+     * runtime upgrade — leaving a stale blob stamped with the new runtime
+     * version that the cache would otherwise keep serving. Reading from the
+     * bytes makes both the stored label and the cache check authoritative.
+     * Returns null when undecodable.
+     */
+    private decodeSpecVersion(metadataHex: HexString): number | null {
+      if (this.specVersionCache?.metadata === metadataHex) {
+        return this.specVersionCache.specVersion;
+      }
+
+      let specVersion: number | null = null;
+      try {
+        specVersion = readSpecVersion(toRuntimeMetadataHex(metadataHex));
+      } catch {
+        specVersion = null;
+      }
+
+      this.specVersionCache = { metadata: metadataHex, specVersion };
+
+      return specVersion;
+    }
 
     private updateMetadata(metadata: ProviderMetadata) {
-      this.metadata = metadata;
-      this.events.emit('metadataReceived', metadata);
+      const specVersion = this.decodeSpecVersion(metadata.metadata);
+      const normalized: ProviderMetadata = { ...metadata, runtimeVersion: specVersion ?? metadata.runtimeVersion };
+
+      this.metadata = normalized;
+      this.events.emit('metadataReceived', normalized);
     }
 
     onMetadataReceived(callback: (value: ProviderMetadata) => unknown): VoidFunction {
       this.events.on('metadataReceived', callback);
 
       return () => this.events.off('metadataReceived', callback);
+    }
+
+    private isCacheFresh(liveSpecVersion: number, metadataVersion: number): boolean {
+      if (!this.metadata || this.metadata.metadataVersion !== metadataVersion) return false;
+
+      return this.decodeSpecVersion(this.metadata.metadata) === liveSpecVersion;
     }
 
     stateCall(method: string, ...args: unknown[]) {
@@ -38,15 +95,12 @@ export function createCachedProvider(Provider: new (...args: any[]) => ProviderI
       const hasParams = params.length > 0;
 
       if (method === STATE_METADATA_METHOD && !hasParams) {
-        if (this.metadata) {
-          const runtimeVersion = await this.getRuntimeVersion();
-          if (runtimeVersion.specVersion === this.metadata.runtimeVersion) {
-            return Promise.resolve(this.metadata.metadata);
-          }
+        const runtimeVersion = await this.getRuntimeVersion();
+        if (this.isCacheFresh(runtimeVersion.specVersion, LEGACY_METADATA_VERSION)) {
+          return Promise.resolve(this.metadata!.metadata);
         }
 
         const metadata = await super.send(method, params, ...args);
-        const runtimeVersion = await this.getRuntimeVersion();
 
         this.updateMetadata({
           runtimeVersion: runtimeVersion.specVersion,
@@ -62,15 +116,12 @@ export function createCachedProvider(Provider: new (...args: any[]) => ProviderI
 
         if (call === 'Metadata_metadata_at_version') {
           const metadataVersion = isString(rawVersion) ? scaleEncodedToNumber(rawVersion) : 0;
-          if (metadataVersion === this.metadata?.metadataVersion) {
-            const runtimeVersion = await this.getRuntimeVersion();
-            if (runtimeVersion.specVersion === this.metadata.runtimeVersion) {
-              return Promise.resolve(this.metadata.metadata);
-            }
+          const runtimeVersion = await this.getRuntimeVersion();
+          if (this.isCacheFresh(runtimeVersion.specVersion, metadataVersion)) {
+            return Promise.resolve(this.metadata!.metadata);
           }
 
           const metadata = await super.send(method, params, ...args);
-          const runtimeVersion = await this.getRuntimeVersion();
 
           this.updateMetadata({
             runtimeVersion: runtimeVersion.specVersion,

--- a/src/renderer/shared/api/network/provider/__tests__/CachedProvider.test.ts
+++ b/src/renderer/shared/api/network/provider/__tests__/CachedProvider.test.ts
@@ -1,0 +1,107 @@
+import { type ProviderInterface } from '@polkadot/rpc-provider/types';
+import { compactAddLength, u8aToHex } from '@polkadot/util';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type ChainMetadata, type HexString } from '@/shared/core';
+import { createCachedProvider } from '../CachedProvider';
+
+// Inner metadata bytes ("meta" + 0x0f version marker + a distinguishing byte).
+const OLD_INNER = new Uint8Array([0x6d, 0x65, 0x74, 0x61, 0x0f, 0x01]);
+const NEW_INNER = new Uint8Array([0x6d, 0x65, 0x74, 0x61, 0x0f, 0x02]);
+
+const OLD_INNER_HEX = u8aToHex(OLD_INNER);
+const NEW_INNER_HEX = u8aToHex(NEW_INNER);
+
+const OLD_SPEC = 1003004;
+const NEW_SPEC = 2003001;
+
+// Wrap inner bytes the way `Metadata_metadata_at_version` returns them:
+// Option<OpaqueMetadata> => 0x01 (Some) + compact-length-prefixed inner bytes.
+function buildV15Response(inner: Uint8Array): HexString {
+  return u8aToHex(new Uint8Array([0x01, ...compactAddLength(inner)]));
+}
+
+const OLD_V15_RESPONSE = buildV15Response(OLD_INNER);
+const NEW_V15_RESPONSE = buildV15Response(NEW_INNER);
+
+// readSpecVersion is exercised against a real metadata fixture in its own test; here
+// we only verify cache-invalidation, so map inner bytes -> spec version deterministically.
+vi.mock('@/shared/lib/utils', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    readSpecVersion: vi.fn((hex: HexString) => {
+      if (hex === OLD_INNER_HEX) return OLD_SPEC;
+      if (hex === NEW_INNER_HEX) return NEW_SPEC;
+      throw new Error(`unexpected metadata hex in test: ${hex}`);
+    }),
+  };
+});
+
+const STATE_CALL_PARAMS = ['Metadata_metadata_at_version', '0x0f000000'];
+
+class MockProvider {
+  liveSpecVersion = NEW_SPEC;
+  freshV15Response: HexString = NEW_V15_RESPONSE;
+
+  async send(method: string, params: unknown[]): Promise<unknown> {
+    if (method === 'state_getRuntimeVersion') {
+      return { specVersion: this.liveSpecVersion };
+    }
+    if (method === 'state_call' && (params as string[])[0] === 'Metadata_metadata_at_version') {
+      return this.freshV15Response;
+    }
+
+    return null;
+  }
+}
+
+function createProvider(seed: Partial<ChainMetadata>) {
+  const metadata = {
+    id: 1,
+    chainId: '0x68d56f15' as `0x${string}`,
+    metadataVersion: 15,
+    runtimeVersion: NEW_SPEC,
+    metadata: OLD_V15_RESPONSE,
+    ...seed,
+  } as ChainMetadata;
+
+  const CachedProvider = createCachedProvider(MockProvider as unknown as new () => ProviderInterface, metadata);
+
+  return new CachedProvider();
+}
+
+function countMetadataFetches(spy: ReturnType<typeof vi.spyOn>): number {
+  return spy.mock.calls.filter(
+    ([method, params]: [string, unknown]) =>
+      method === 'state_call' && (params as string[])?.[0] === 'Metadata_metadata_at_version',
+  ).length;
+}
+
+describe('CachedProvider', () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it('refetches v15 metadata when cached bytes are stale despite a matching runtimeVersion label', async () => {
+    // The bug: label says 2003001, but the cached bytes decode to 1003004.
+    const provider = createProvider({ runtimeVersion: NEW_SPEC, metadata: OLD_V15_RESPONSE, metadataVersion: 15 });
+    const baseSend = vi.spyOn(MockProvider.prototype, 'send');
+
+    const result = await provider.send('state_call', STATE_CALL_PARAMS);
+
+    expect(result).toBe(NEW_V15_RESPONSE);
+    expect(countMetadataFetches(baseSend)).toBe(1);
+  });
+
+  it('serves cached v15 metadata without refetching when the bytes match the live runtime', async () => {
+    const provider = createProvider({ runtimeVersion: NEW_SPEC, metadata: NEW_V15_RESPONSE, metadataVersion: 15 });
+    const baseSend = vi.spyOn(MockProvider.prototype, 'send');
+
+    const result = await provider.send('state_call', STATE_CALL_PARAMS);
+
+    expect(result).toBe(NEW_V15_RESPONSE);
+    expect(countMetadataFetches(baseSend)).toBe(0);
+  });
+});

--- a/src/renderer/shared/api/network/service/__tests__/metadataV15Service.test.ts
+++ b/src/renderer/shared/api/network/service/__tests__/metadataV15Service.test.ts
@@ -18,21 +18,40 @@ function buildRawV15ResponseHex(metadataBytes: Uint8Array): `0x${string}` {
   return u8aToHex(buildRawV15Response(metadataBytes));
 }
 
+// A distinct "meta" payload used to represent metadata bytes that decode to a
+// different spec version than the row/runtime they are labeled with.
+const POISONED_MAGIC = new Uint8Array([0x6d, 0x65, 0x74, 0x61, 0x09, 0x08, 0x07]);
+
 const DECODED_HEX = u8aToHex(METADATA_MAGIC);
 const RAW_HEX = buildRawV15ResponseHex(METADATA_MAGIC);
+const POISONED_HEX = u8aToHex(POISONED_MAGIC);
 
 const CHAIN_ID = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3';
 const RUNTIME_VERSION = 1001002;
+const WRONG_SPEC_VERSION = 999999;
 
 vi.mock('@/shared/api/storage', () => ({
   storageService: {
     metadata: {
       readAll: vi.fn().mockResolvedValue([]),
+      deleteAll: vi.fn().mockResolvedValue([]),
     },
   },
 }));
 
+// readSpecVersion is verified against a real metadata fixture in its own test; here
+// map the synthetic byte payloads to spec versions so the validation path is testable.
+vi.mock('@/shared/lib/utils', async (importOriginal) => {
+  const actual = (await importOriginal()) as Record<string, unknown>;
+
+  return {
+    ...actual,
+    readSpecVersion: vi.fn((hex: string) => (hex === POISONED_HEX ? WRONG_SPEC_VERSION : RUNTIME_VERSION)),
+  };
+});
+
 const { storageService } = await import('@/shared/api/storage');
+const { readSpecVersion } = await import('@/shared/lib/utils');
 
 function createMockApi(overrides?: {
   chainId?: string;
@@ -66,6 +85,10 @@ describe('metadataV15Service', () => {
   afterEach(() => {
     metadataV15Service._clearCache();
     vi.mocked(storageService.metadata.readAll).mockResolvedValue([]);
+    vi.mocked(storageService.metadata.deleteAll).mockClear();
+    vi.mocked(readSpecVersion).mockImplementation((hex: string) =>
+      hex === POISONED_HEX ? WRONG_SPEC_VERSION : RUNTIME_VERSION,
+    );
   });
 
   it('should fetch and decode v15 metadata from RPC on first call', async () => {
@@ -144,6 +167,10 @@ describe('metadataV15Service', () => {
     const v1Api = createMockApi({ runtimeVersion: 1001000 });
     const v2Api = createMockApi({ runtimeVersion: 1001001 });
 
+    // The synthetic fixture returns identical bytes for both apis; make the decoded
+    // spec version match each api's runtime version so validation passes.
+    vi.mocked(readSpecVersion).mockReturnValueOnce(1001000).mockReturnValueOnce(1001001);
+
     await metadataV15Service.getDecodedMetadataV15(v1Api);
     await metadataV15Service.getDecodedMetadataV15(v2Api);
 
@@ -196,5 +223,58 @@ describe('metadataV15Service', () => {
     await metadataV15Service.getDecodedMetadataV15(api);
 
     expect(api.rpc.state.call).toHaveBeenCalledTimes(1);
+  });
+
+  it('should evict a DB entry whose bytes decode to a different spec and refetch from RPC', async () => {
+    // Row is labeled with the current runtime version, but its bytes are stale.
+    vi.mocked(storageService.metadata.readAll).mockResolvedValue([
+      {
+        id: 7,
+        chainId: CHAIN_ID as `0x${string}`,
+        runtimeVersion: RUNTIME_VERSION,
+        metadataVersion: 15,
+        metadata: POISONED_HEX as `0x${string}`,
+      },
+    ]);
+
+    const api = createMockApi();
+    const result = await metadataV15Service.getDecodedMetadataV15(api);
+
+    expect(storageService.metadata.deleteAll).toHaveBeenCalledWith([7]);
+    expect(api.rpc.state.call).toHaveBeenCalledTimes(1);
+    expect(result).toBe(DECODED_HEX);
+  });
+
+  it('should evict every mislabeled DB entry for the runtime version, not just the first', async () => {
+    vi.mocked(storageService.metadata.readAll).mockResolvedValue([
+      {
+        id: 7,
+        chainId: CHAIN_ID as `0x${string}`,
+        runtimeVersion: RUNTIME_VERSION,
+        metadataVersion: 15,
+        metadata: POISONED_HEX as `0x${string}`,
+      },
+      {
+        id: 8,
+        chainId: CHAIN_ID as `0x${string}`,
+        runtimeVersion: RUNTIME_VERSION,
+        metadataVersion: 15,
+        metadata: POISONED_HEX as `0x${string}`,
+      },
+    ]);
+
+    const api = createMockApi();
+    const result = await metadataV15Service.getDecodedMetadataV15(api);
+
+    expect(storageService.metadata.deleteAll).toHaveBeenCalledWith([7, 8]);
+    expect(result).toBe(DECODED_HEX);
+  });
+
+  it('should throw when freshly fetched metadata does not match the runtime version', async () => {
+    vi.mocked(readSpecVersion).mockReturnValue(WRONG_SPEC_VERSION);
+
+    const api = createMockApi();
+
+    await expect(metadataV15Service.getDecodedMetadataV15(api)).rejects.toThrow(/spec/i);
   });
 });

--- a/src/renderer/shared/api/network/service/metadataV15Service.ts
+++ b/src/renderer/shared/api/network/service/metadataV15Service.ts
@@ -3,6 +3,7 @@ import { compactStripLength, hexToU8a, u8aToHex } from '@polkadot/util';
 
 import { storageService } from '@/shared/api/storage';
 import { type ChainId, type HexString } from '@/shared/core';
+import { readSpecVersion } from '@/shared/lib/utils';
 
 const METADATA_V15 = 15;
 const METADATA_V15_SCALE_ENCODED = '0x0f000000';
@@ -97,19 +98,50 @@ async function resolveMetadataV15(
   key: string,
 ): Promise<HexString> {
   const allMetadata = await storageService.metadata.readAll();
-  const dbEntry = allMetadata.find(
+  const dbEntries = allMetadata.filter(
     (m) => m.chainId === chainId && m.runtimeVersion === runtimeVersion && m.metadataVersion === METADATA_V15,
   );
 
-  if (dbEntry) {
+  for (const dbEntry of dbEntries) {
     const decoded = ensureDecodedV15(dbEntry.metadata);
-    decodedV15Cache.set(key, decoded);
 
-    return decoded;
+    // The row is labeled with `runtimeVersion`, but the labeling and the bytes are
+    // written separately, so a stale blob can end up stamped with the new runtime
+    // version. Trust the bytes: if their spec version disagrees, drop the row and
+    // refetch instead of feeding stale metadata downstream (e.g. to merkleize).
+    if (specVersionMatches(decoded, runtimeVersion)) {
+      decodedV15Cache.set(key, decoded);
+
+      return decoded;
+    }
+  }
+
+  // None of the labeled rows carried matching bytes — drop the stale ones.
+  if (dbEntries.length > 0) {
+    await storageService.metadata.deleteAll(dbEntries.map((entry) => entry.id));
   }
 
   const decoded = await fetchFromRpc(api);
+
+  if (!specVersionMatches(decoded, runtimeVersion)) {
+    throw new Error(
+      `[metadataV15Service] Fetched metadata spec version does not match runtime version ${runtimeVersion}`,
+    );
+  }
+
   decodedV15Cache.set(key, decoded);
 
   return decoded;
+}
+
+/**
+ * True when the spec version encoded in the metadata bytes equals
+ * `runtimeVersion`.
+ */
+function specVersionMatches(decodedMetadata: HexString, runtimeVersion: number): boolean {
+  try {
+    return readSpecVersion(decodedMetadata) === runtimeVersion;
+  } catch {
+    return false;
+  }
 }

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -3096,6 +3096,7 @@
     "continueButton": "Continue",
     "generateNewQrButton": "Generate new QR code",
     "loadingMetadata": "Loading metadata...",
+    "metadataLoadError": "Couldn’t load up-to-date metadata. Please try again.",
     "loadingQr": "Generating QR code...",
     "loadingSignData": "Preparing signing data...",
     "metadataPortalLink": "Update metadata in Polkadot Vault",

--- a/src/renderer/shared/lib/utils/__tests__/substrate.test.ts
+++ b/src/renderer/shared/lib/utils/__tests__/substrate.test.ts
@@ -1,9 +1,11 @@
 import { type ApiPromise } from '@polkadot/api';
 import { BN, BN_TWO } from '@polkadot/util';
 
-import { type Chain } from '@/shared/core';
+import { type Chain, type HexString } from '@/shared/core';
+// eslint-disable-next-line boundaries/entry-point -- reusing a real metadata blob fixture in tests only
+import { metadata as KUSAMA_V14_METADATA } from '@/entities/transaction/lib/__tests__/metadata';
 import { DEFAULT_TIME, THRESHOLD } from '../constants';
-import { getExpectedBlockTime } from '../substrate';
+import { getExpectedBlockTime, readSpecVersion } from '../substrate';
 
 describe('shared/lib/onChainUtils/substrate', () => {
   const blockTime = new BN(10_000);
@@ -43,5 +45,15 @@ describe('shared/lib/onChainUtils/substrate', () => {
     };
     const time = getTime(params);
     expect(time).toEqual(DEFAULT_TIME);
+  });
+});
+
+describe('readSpecVersion', () => {
+  test('reads spec version from the System.Version constant of v14 metadata', () => {
+    expect(readSpecVersion(KUSAMA_V14_METADATA as HexString)).toEqual(9430);
+  });
+
+  test('throws when the bytes are not decodable metadata', () => {
+    expect(() => readSpecVersion('0xdeadbeef' as HexString)).toThrow();
   });
 });

--- a/src/renderer/shared/lib/utils/substrate.ts
+++ b/src/renderer/shared/lib/utils/substrate.ts
@@ -1,5 +1,5 @@
 import { type ApiPromise } from '@polkadot/api';
-import { type u32 } from '@polkadot/types';
+import { type u32, Metadata, TypeRegistry } from '@polkadot/types';
 import { type SignerPayloadJSON } from '@polkadot/types/types/extrinsic';
 import { BN, BN_TWO, bnMin, hexToU8a, isHex, numberToU8a, u8aToHex, u8aToNumber } from '@polkadot/util';
 import { blake2AsHex } from '@polkadot/util-crypto';
@@ -244,3 +244,34 @@ export const getSecondsDurationToBlock = (timeToBlock: number): number => {
 export const numberToScaleEncoded = (value: number) => u8aToHex(numberToU8a(value));
 
 export const scaleEncodedToNumber = (value: string) => u8aToNumber(hexToU8a(value));
+
+/**
+ * Decodes the `spec_version` carried inside the `System.Version` constant of a
+ * SCALE-encoded runtime metadata blob (`RuntimeMetadataPrefixed`, v14 or v15).
+ *
+ * This reads the spec version from the metadata bytes themselves, independent
+ * of any externally provided/cached label — use it to detect metadata that has
+ * been mislabeled with a runtime version it does not actually belong to.
+ *
+ * @param metadataHex - Hex of the full metadata blob (with the `meta` magic
+ *   prefix)
+ *
+ * @returns The decoded spec version
+ */
+export const readSpecVersion = (metadataHex: HexString): number => {
+  const registry = new TypeRegistry();
+  const metadata = new Metadata(registry, metadataHex);
+  registry.setMetadata(metadata);
+
+  const system = metadata.asLatest.pallets.find((pallet) => pallet.name.toString() === 'System');
+  const versionConstant = system?.constants.find((constant) => constant.name.toString() === 'Version');
+
+  assert(versionConstant, 'System.Version constant not found in metadata');
+
+  const versionType = registry.createLookupType(versionConstant.type);
+  // `createType` returns an opaque `Codec`; the System.Version constant always
+  // decodes to a RuntimeVersion struct, so reading `specVersion` requires a cast.
+  const runtimeVersion = registry.createType(versionType, versionConstant.value.toU8a(true));
+
+  return (runtimeVersion as unknown as { specVersion: u32 }).specVersion.toNumber();
+};


### PR DESCRIPTION
## Problem

The QR signing flow (e.g. **Verify proxy on Polkadot Asset Hub**) hangs on *"Loading metadata..."* and the console shows:

```
Error: Spec version not expected. Received 2003001 expected 1003004
```

thrown by `@polkadot-api/merkleize-metadata`. The metadata bytes handed to merkleize embed an **older** spec version (`1003004`) than the live runtime (`2003001`, post Asset Hub Migration).

## Root cause

`CachedProvider` labels cached metadata with a runtime version fetched in a **separate** `state_getRuntimeVersion` call, independent of the metadata fetch. During a runtime upgrade, a blob fetched from the node (old bytes) gets stamped with the new runtime version. The cache-freshness check only compares *stored label vs live label*, so the mislabeled, stale blob is never invalidated and is replayed for the whole session (in memory; it can also be persisted to the DB under the new label). Verified against the live node `wss://asset-hub-polkadot-rpc.n.dwellir.com`, which is fully self-consistent at `2003001` — confirming the staleness is local, not a node issue.

The thrown error was also swallowed by a `catch { console.warn }`, leaving the QR step on an infinite "Loading metadata…" spinner.

## Fix

- **`readSpecVersion(metadataHex)`** (`shared/lib/utils/substrate.ts`) — decode the spec version straight from the metadata bytes (`System.Version`).
- **`CachedProvider`** — derive the runtime-version label *and* the cache-freshness check from the bytes via `readSpecVersion` instead of a separately fetched label. A stale/mislabeled entry now self-invalidates and refetches.
- **`metadataV15Service`** — validate resolved bytes against the runtime version; evict mislabeled DB rows and refetch; throw a clear error if a fresh fetch still mismatches (instead of feeding stale bytes to merkleize).
- **`QrGeneratorContainer` + `Scan{Single,Multi}frameQr`** — surface a retry action on a metadata load failure instead of hanging on the loading spinner.

<img width="1080" height="1060" alt="qr-error" src="https://github.com/user-attachments/assets/2aa18946-33de-491a-b9a2-9733aab2a13b" />
<img width="1080" height="1060" alt="qr-success" src="https://github.com/user-attachments/assets/4f3c636e-8bf8-4406-88d9-e86a8b17962e" />
