### PR TITLE
ci: parallelize unit tests with sharding

### DIFF
--- a/.github/workflows/tests_unit.yaml
+++ b/.github/workflows/tests_unit.yaml
@@ -11,9 +11,19 @@ permissions:
   pull-requests: write
   checks: write
 
+env:
+  # GitHub-hosted ubuntu-latest runners expose 4 vCPUs. Match the forks pool to it.
+  VITEST_MAX_FORKS: 4
+  NODE_OPTIONS: '--max-old-space-size=8192'
+
 jobs:
   unit-tests:
     runs-on: ubuntu-latest
+    strategy:
+      # Run every shard even if one fails, so the report covers the whole suite.
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4]
 
     steps:
       - name: ⚙️Checkout
@@ -22,14 +32,34 @@ jobs:
       - name: ⚙️Install dependencies
         uses: ./.github/workflows/install-pnpm
 
-      - name: 🧪 Run tests
-        run: pnpm test:unit
+      - name: 🧪 Run tests (shard ${{ matrix.shard }}/4)
+        run: pnpm test:unit --shard=${{ matrix.shard }}/4 --outputFile.junit=./junit-${{ matrix.shard }}.xml
+
+      - name: ⬆️ Upload shard report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: junit-${{ matrix.shard }}
+          path: ./junit-${{ matrix.shard }}.xml
+          retention-days: 1
+
+  publish-results:
+    needs: unit-tests
+    if: always()
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⬇️ Download shard reports
+        uses: actions/download-artifact@v4
+        with:
+          pattern: junit-*
+          path: ./reports
+          merge-multiple: true
 
       - name: 📄 Post results
-        if: always()
         uses: EnricoMi/publish-unit-test-result-action@v2
         with:
-          files: ./junit.xml
+          files: ./reports/junit-*.xml
           check_name: 'Unit Test Results'
           comment_mode: 'changes'
           github_token: ${{ secrets.GITHUB_TOKEN }}

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -51,21 +51,12 @@ const config: ViteUserConfigFnPromise = async (options) => {
       globals: true,
       environment: 'happy-dom',
       setupFiles: resolve(folders.root, './vitest.setup.js'),
-      reporters: [
-        'default',
-        'junit',
-        [
-          'allure-vitest/reporter',
-          {
-            resultsDir: resolve(folders.root, './allure-results'),
-            links: {
-              issue: {
-                urlTemplate: 'https://github.com/novasamatech/nova-spektr/issues/%s',
-              },
-            },
-          },
-        ],
-      ],
+      // Allure reporter is intentionally omitted here: the unit workflow only
+      // publishes junit.xml and never uploads allure-results, so the per-test
+      // allure serialization was pure overhead. Allure stays in the integration
+      // config (tests/integrations/vitest.config.ts), where it is uploaded to
+      // Allure TestOps.
+      reporters: ['default', 'junit'],
       outputFile: {
         junit: resolve(folders.root, './junit.xml'),
       },
@@ -86,6 +77,14 @@ const config: ViteUserConfigFnPromise = async (options) => {
         reporter: 'json-summary',
       },
       pool: 'forks',
+      // Worker count for the forks pool. Vitest defaults to the number of CPUs;
+      // on CI we tune it via VITEST_MAX_FORKS per shard runner. Left undefined
+      // locally so dev machines keep using all cores.
+      poolOptions: {
+        forks: {
+          ...(process.env.VITEST_MAX_FORKS ? { maxForks: Number(process.env.VITEST_MAX_FORKS) } : {}),
+        },
+      },
       maxConcurrency: 8,
       deps: { optimizer: { web: { enabled: true } } },
     },


### PR DESCRIPTION
## Problem

Unit tests were slow on CI: the whole suite (224 files / ~1480 cases) ran on a **single** `ubuntu-latest` runner without sharding. A local measurement shows the actual test execution takes ~5s, while the dominant cost is **module transform + import** during fork startup — which is exactly what parallelizes well across runners.

> Clarification: unit and integration tests are **already** separated (distinct configs and workflows, running in parallel on PRs). The bottleneck was specifically the single unit job with no internal parallelism.

## Changes

**`.github/workflows/tests_unit.yaml`**
- Matrix of **4 shards** (`vitest --shard=N/4`), `fail-fast: false` so every shard runs and the report covers the whole suite.
- Each shard writes its own `junit-N.xml` and uploads it as an artifact.
- A separate `publish-results` job downloads all junit files and posts a single merged comment (`EnricoMi/publish-unit-test-result-action`).
- `NODE_OPTIONS=--max-old-space-size=8192` (matching the integration workflow) to relieve GC pressure.

**`vitest.config.ts`**
- Removed `allure-vitest/reporter` from the unit run → `reporters: ['default', 'junit']`. The unit workflow only publishes `junit.xml` and never uploaded allure results, so the per-test allure serialization was pure overhead. Allure stays in the integration config, where results are actually uploaded to Allure TestOps.
- Added `poolOptions.forks.maxForks` via `VITEST_MAX_FORKS` (set to 4 on CI for ubuntu-latest; left unset locally → defaults to all cores).

## Expected impact

Unit job wall-clock ≈ ÷3-4 thanks to 4 parallel runners (minus the per-shard `pnpm install` overhead, partially cached via `cache: pnpm`).

## Verification

Ran shard `1/4` locally — it picked 57/224 files (≈ a quarter), `--outputFile.junit` correctly writes the per-shard report, and the config loads without errors.
