### PR TITLE
Set up Cursor Cloud dev environment + AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,37 @@
+# AGENTS.md
+
+For full development command reference see `docs/content/docs/onboarding/getting-started.mdx`
+and the `scripts` block in `package.json`. Repo conventions live in `CLAUDE.md`.
+
+## Cursor Cloud specific instructions
+
+Nova Spektr is an Electron + React (Vite) desktop wallet. The relevant dev surface
+in this VM is the **renderer** (the React UI), which can run standalone in a browser.
+
+### Runtime / toolchain (already provisioned in the snapshot)
+- Project requires **Node >=24** and **pnpm 11** (`engines` in `package.json`). The VM's
+  default `/exec-daemon/node` is Node 22 and is first on `PATH`, so Node 24 (via nvm) and
+  `pnpm` (via corepack) are symlinked into `/usr/local/cargo/bin` (which precedes
+  `/exec-daemon` on `PATH`) so the correct versions win in every shell. Verify with
+  `node --version` (expect v24.x) and `pnpm --version` (expect 11.4.0). If Node resolves
+  to v22, re-create those symlinks from `~/.nvm/versions/node/v24.*/bin`.
+- pnpm build-script approval is non-interactive via `allowBuilds:` in `pnpm-workspace.yaml`
+  (electron, sharp, @swc/core, esbuild, etc.) — do not run `pnpm approve-builds`.
+
+### Running the app
+- **Renderer in browser (use this in the VM):** `pnpm start:renderer` serves the full UI
+  at `https://localhost:3000/`. It uses a self-signed `vite-plugin-mkcert` certificate, so
+  Chrome shows a "Your connection is not private" warning — click Advanced → Proceed.
+  Dev mode uses test chains (`chains_dev`) and still connects to live networks for balances.
+- **`pnpm start` (full Electron app) needs a display** (X server) and will not run headless
+  as-is; prefer the renderer-in-browser flow above for verification.
+- **First-load gotcha:** on the very first load the app often shows a "Sorry, something went
+  wrong" error boundary (dev mode disables smooth error handling on purpose). Just click
+  **Refresh** — onboarding then loads normally. This is expected, not an environment break.
+
+### Lint / typecheck / test
+- Lint: `pnpm lint` (passes with many non-blocking warnings; 0 errors = success).
+- Types: prefer `pnpm types:go` (tsgo, ~6× faster than `pnpm types`).
+- Unit tests: `pnpm test:unit` (vitest; ~5 min, writes `junit.xml`). Integration:
+  `pnpm test:integration`. System e2e (`pnpm test:system`, Playwright) needs the renderer
+  server + browsers and is heavier.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
Sets up the development environment for Nova Spektr in Cursor Cloud and documents durable, non-obvious run instructions for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section covering the Node 24 / pnpm 11 toolchain, how to run the renderer in a browser, the first-load error-boundary gotcha, and lint/typecheck/test commands.

No application code is changed.

## Environment setup performed (one-off, captured by the VM snapshot)
- Installed Node 24 via nvm and symlinked `node`/`npm`/`npx`/`corepack` + `pnpm@11.4.0` into `/usr/local/cargo/bin` so the project-required versions win over the VM default `/exec-daemon/node` (Node 22).
- Update script set to `pnpm install` (runs `papi` codegen via `postinstall`).

## Verification
- `pnpm install` — clean (build scripts auto-approved via `allowBuilds` in `pnpm-workspace.yaml`).
- `pnpm lint` — 0 errors (warnings only).
- `pnpm types:go` — passes.
- `pnpm test:unit` — 1649 passed, 8 skipped (224 test files).
- `pnpm start:renderer` — served at `https://localhost:3000`; created a Watch-only wallet and reached the dashboard with live balances.

[nova_spektr_watch_only_wallet_onboarding.mp4](https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fnova_spektr_watch_only_wallet_onboarding.mp4)

[Onboarding screen](https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fonboarding_screen.webp)
[Watch-only form filled](https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fwatchonly_form.webp)
[Dashboard with created wallet](https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdashboard_created.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

