### PR TITLE
test(e2e): fix Sign/close selectors, governance mock endpoint, and live-network flakiness

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -11,8 +11,9 @@ export default defineConfig({
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */
   forbidOnly: !!process.env.CI,
-  /* Retry on CI only */
-  retries: process.env.CI ? 3 : 0,
+  /* Retry to absorb live-network flakiness (RPC/indexer latency to public testnets).
+   * One local retry keeps feedback fast while smoothing over transient connection hiccups. */
+  retries: process.env.CI ? 3 : 1,
   /* Opt out of parallel tests on CI. */
   workers: process.env.CI ? 1 : undefined,
   /* Reporter to use. See https://playwright.dev/docs/test-reporters */
@@ -49,6 +50,8 @@ export default defineConfig({
     },
   ],
 
-  timeout: 60000,
+  /* Per-test timeout. Transfer/governance flows wait on live RPC dry-runs and indexer
+   * queries to public testnets, which can be slow; 90s reduces false timeouts. */
+  timeout: 90000,
   globalSetup: './scripts/updateTestData.js',
 });

--- a/src/renderer/entities/operations/ui/SignButton.tsx
+++ b/src/renderer/entities/operations/ui/SignButton.tsx
@@ -1,5 +1,6 @@
 import { t } from 'i18next';
 
+import { TEST_IDS } from '@/shared/constants';
 import { type SignableWalletFamily, WalletType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { Button, Icon } from '@/shared/ui';
@@ -42,6 +43,7 @@ export const SignButton = ({ disabled, isDefault, isLoading, type, className, on
   return (
     <Button
       className={className}
+      testId={TEST_IDS.OPERATIONS.SIGN_BUTTON}
       disabled={disabled}
       isLoading={isLoading}
       prefixElement={

--- a/src/renderer/shared/constants/testIds.ts
+++ b/src/renderer/shared/constants/testIds.ts
@@ -51,6 +51,7 @@ export const TEST_IDS = {
     XCM_SELECTOR: 'operations-xcm-selector',
     MYSELF_BUTTON: 'myself-button',
     FEE_LOADER: 'fee-loader',
+    SIGN_BUTTON: 'operation-sign-button',
   },
   GOVERNANCE: {
     FILTER_BUTTON: 'governance-filter-button',

--- a/tests/system/pages/_elements/ConfirmationModalElements.ts
+++ b/tests/system/pages/_elements/ConfirmationModalElements.ts
@@ -1,5 +1,10 @@
+import { TEST_IDS } from '@/shared/constants';
+
 export class ConfirmationModalElements {
-  static confirmButton = 'Sign';
+  // Sign/confirm button is matched by a stable test id: its visible label varies by
+  // wallet type ("Sign", "Sign with Nova Wallet", …) and the substring "Sign" also
+  // collides with the multi-hop "Signing path" chip, breaking role-by-name lookups.
+  static confirmButton = TEST_IDS.OPERATIONS.SIGN_BUTTON;
   static cancelButton = 'Cancel';
   static addToBasketButton = 'Basket';
 }

--- a/tests/system/pages/modals/ConfirmationModalWindow.ts
+++ b/tests/system/pages/modals/ConfirmationModalWindow.ts
@@ -19,7 +19,7 @@ export class ConfirmationModalWindow extends BaseModal<ConfirmationModalElements
   public async confirm(): Promise<SigningModalWindow> {
     return await step('Confirm transaction', async () => {
       await this.checkForAlerts();
-      await this.page.getByRole('button', { name: ConfirmationModalElements.confirmButton }).click();
+      await this.page.getByTestId(ConfirmationModalElements.confirmButton).click();
       await this.checkForAlerts();
       return new SigningModalWindow(this.page, new SigningModalElements(), this.previousPage);
     });

--- a/tests/system/pages/modals/TransferModalWindow.ts
+++ b/tests/system/pages/modals/TransferModalWindow.ts
@@ -188,7 +188,12 @@ export class TransferModalWindow extends BaseModal<TransferModalElements> {
   public async close(): Promise<BasePage> {
     await step('Close transfer modal', async () => {
       const modal = this.page.getByTestId(TEST_IDS.TRANSFER.MODAL);
-      await modal.getByTestId(TEST_IDS.CLOSE_BUTTON).click();
+      // Once a recipient is committed, the recipient "clear" icon-button reuses the same
+      // close icon as the modal header close button. Scope to the modal's own close button
+      // by excluding the recipient-clear test id to avoid a strict-mode violation.
+      await modal
+        .locator(`button[aria-label="icon button: close"]:not([data-testid="${TEST_IDS.OPERATIONS.RECIPIENT_CLEAR}"])`)
+        .click();
       await modal.waitFor({ state: 'hidden', timeout: 15000 });
     });
 

--- a/tests/system/pages/modals/TransferModalWindow.ts
+++ b/tests/system/pages/modals/TransferModalWindow.ts
@@ -57,8 +57,8 @@ export class TransferModalWindow extends BaseModal<TransferModalElements> {
     await step('Wait until all fees are loaded', async () => {
       const loaders = await feeLoaders.all();
       for (const loader of loaders) {
-        // TODO: investigate why it took so long to load the fees
-        await expect(loader).toBeHidden({ timeout: 30_000 });
+        // Fee estimation runs a live dry-run against public RPCs, which can be slow.
+        await expect(loader).toBeHidden({ timeout: 60_000 });
       }
     });
 

--- a/tests/system/utils/baseRegularFixture.ts
+++ b/tests/system/utils/baseRegularFixture.ts
@@ -92,7 +92,7 @@ type WorkerFixtureConfig = {
 };
 
 function createWorkerScopedFixture(config: WorkerFixtureConfig) {
-  const { dbFixture, waitForConnections = true, connectionTimeout = 60_000 } = config;
+  const { dbFixture, waitForConnections = true, connectionTimeout = 90_000 } = config;
 
   return base.extend<WorkerScopedTestFixtures, WorkerScopedWorkerFixtures>({
     workerContext: [

--- a/tests/system/utils/httpInterception.ts
+++ b/tests/system/utils/httpInterception.ts
@@ -33,7 +33,10 @@ export async function interceptRoute({
 export async function interceptGovernanceSubquery(page: Page, mockData: any) {
   return interceptRoute({
     page,
-    routePattern: '**/subquery-governance-polkadot-prod.novasama-tech.org/**',
+    // The governance-delegations endpoint differs per environment: the dev chains config
+    // (chains_dev.json) points Polkadot to "-stg", while production uses "-prod". Match any
+    // env suffix so the mock intercepts regardless of which chains file the suite runs with.
+    routePattern: '**/subquery-governance-polkadot-*.novasama-tech.org/**',
     mockData,
   });
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Fixes several Playwright e2e (`pnpm test:system`) failures discovered by running the full suite (was 55 passed / 16 failed). Three independent issues are addressed.

### 1. Sign button collides with the "Signing path" chip (4 tests)
`ConfirmationModalWindow.confirm()` used `getByRole('button', { name: 'Sign' })`. Role-name matching is a case-insensitive substring, so the multi-hop `signing-path` `PathChip` ("**Sign**ing path") matched alongside "**Sign** with …".
Fix: add a stable `operation-sign-button` test id to the shared `SignButton` (`entities/operations/ui/SignButton.tsx`) and target it by test id (robust across all wallet labels).
Affected: `transfers` multisig (KAH/PAH/Hydration) + proxy transfer.

### 2. Modal close collides with recipient "clear" (1 test)
`TransferModalWindow.close()` used `getByTestId('Icon:close')`; once a recipient is set, the recipient clear button reuses the same close icon.
Fix: scope to the modal's own close button, excluding the recipient-clear test id.
Affected: `validations` → proxy permission rights.

### 3. Governance mock never intercepted (governance suite)
`interceptGovernanceSubquery` matched only `subquery-governance-polkadot-**prod**…`, but the dev chains config (`chains_dev.json`) points Polkadot `governance-delegations` to a different environment endpoint (observed `…-polkadot-ah-prod…`, dev relay uses `…-stg…`). The mock never matched, so tests received real on-chain data (e.g. "ChaosDAO OpenGov").
Fix: match any environment suffix (`subquery-governance-polkadot-*.novasama-tech.org`).
Result: interception now works — the single-wallet delegated-votes case passes (was failing with live data).

### 4. Live-network flakiness (transfers/validations/governance)
Worker setup `waitForNetworkConnections`, transfer fee dry-runs, and indexer queries depend on live public-testnet latency.
Fix: one local retry (CI already retries 3×), per-test timeout 60s→90s, worker connection-wait default 60s→90s, transfer fee-loader wait 30s→60s.

## Verification
- ✅ Deterministic, network-free selector check: old selectors match **2** elements (bug), new selectors match exactly **1** (fixed).
- ✅ `governance … single wallet … AYE X1` passes with the mock fix (interception confirmed via request logs); previously failed with real data.
- After the selector fix, live confirm/close steps no longer throw strict-mode violations.

## Known remaining (separate, not in scope here)
- A few governance assertions still encode **conviction-weighted** expected amounts (e.g. expects `4,000` while the app now renders the raw delegated `2,000` via `VotedByDelegates`), and the DD-wallet cases don't render vote-details. These are behavioral/test-data drift unrelated to interception and need product confirmation before changing expected values.
- `load.fee` for a few parachains (Zeitgeist/Phala) and some connection waits remain environment-dependent on public-RPC availability; the timeout/retry changes reduce, but cannot eliminate, this.

## Notes
- App change is limited to one `data-testid`; no behavior change. The signing/QR flow targets the QR container, not the button id, so it is unaffected.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5a8b06cc-45f1-48dc-91ad-2f12964b2736"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

