### PR TITLE
fix: multisig operation handling with execution results

### DIFF
--- a/.claude/commands/pr.md
+++ b/.claude/commands/pr.md
@@ -1,0 +1,16 @@
+Generate a pull request description for the current branch.
+
+Instructions:
+1. Run `git diff dev...HEAD --stat` to see which files changed
+2. Run `git diff dev...HEAD` to see the full diff
+3. Analyze the changes and produce a PR description in this format:
+
+.github/PULL_REQUEST_TEMPLATE.md
+
+Rules:
+- Keep it concise — a reviewer should understand the PR in 30 seconds
+- Focus on the "why" not the "what" — the diff shows the what
+- Group related changes together
+- Include specific test steps, not generic ones
+- Do NOT include a title — that will be set separately
+- Output ONLY the markdown body, ready to paste

--- a/src/renderer/domains/network/multisig-operation/resource.ts
+++ b/src/renderer/domains/network/multisig-operation/resource.ts
@@ -553,7 +553,13 @@ export const subscribeNewMultisigEventsResource = createSubscriptionResource<{
   })
   .build();
 
-export const $completionEvents = createStore<{ chainId: ChainId; operationId: string; event: MultisigEvent }[]>([]);
+// Outcome of a MultisigExecuted event's inner call: success or error. `null` for
+// non-execution events (approvals/cancellations), which carry no DispatchResult.
+export type ExecutionResult = 'success' | 'error' | null;
+
+export const $completionEvents = createStore<
+  { chainId: ChainId; operationId: string; event: MultisigEvent; executionResult: ExecutionResult }[]
+>([]);
 
 export const subscribeEventsResource = createSubscriptionResource<{
   api: ApiPromise;
@@ -561,42 +567,54 @@ export const subscribeEventsResource = createSubscriptionResource<{
 }>({
   key: ({ api, accountId }) => `${api.genesisHash.toHex()}-${accountId}`,
 })
-  .subscribe<{ event: MultisigEvent; operationId: string }>(async ({ api, accountId }, callback) => {
-    return await polkadotjsHelpers.subscribeSystemEvents(
-      { api, section: 'multisig', methods: ['MultisigApproval', 'MultisigExecuted', 'MultisigCancelled'] },
-      event => {
-        const data = multisigEvent.parse(event.data);
+  .subscribe<{ event: MultisigEvent; operationId: string; executionResult: ExecutionResult }>(
+    async ({ api, accountId }, callback) => {
+      return await polkadotjsHelpers.subscribeSystemEvents(
+        { api, section: 'multisig', methods: ['MultisigApproval', 'MultisigExecuted', 'MultisigCancelled'] },
+        event => {
+          const data = multisigEvent.parse(event.data);
 
-        if (data.multisigAccountId !== accountId) return;
+          if (data.multisigAccountId !== accountId) return;
 
-        const operationId = multisigOperationService.getOperationId(
-          api.genesisHash.toHex(),
-          data.callHash,
-          data.multisigAccountId,
-          data.timepoint.height,
-          data.timepoint.index,
-        );
+          const operationId = multisigOperationService.getOperationId(
+            api.genesisHash.toHex(),
+            data.callHash,
+            data.multisigAccountId,
+            data.timepoint.height,
+            data.timepoint.index,
+          );
 
-        const eventStatus = event.method === 'MultisigCancelled' ? 'reject' : 'approve';
+          const eventStatus = event.method === 'MultisigCancelled' ? 'reject' : 'approve';
+          // MultisigExecuted carries the inner call's DispatchResult; a non-Ok result means the
+          // multisig extrinsic itself succeeded but the dispatched call failed. Normalize it here
+          // (mirroring the indexer's getExecutionResult) so a live-caught failure surfaces as error.
+          const executionResult: ExecutionResult =
+            event.method === 'MultisigExecuted' && 'status' in data
+              ? data.status === 'Ok'
+                ? 'success'
+                : 'error'
+              : null;
 
-        callback({
-          operationId,
-          event: {
-            id: multisigOperationService.getEventId(operationId, data.accountId, eventStatus),
-            accountId: data.accountId,
-            status: eventStatus,
-            indexCreated: data.timepoint.index,
-            blockCreated: data.timepoint.height,
-            timestamp: Date.now(),
-          },
-        });
-      },
-    );
-  })
+          callback({
+            operationId,
+            executionResult,
+            event: {
+              id: multisigOperationService.getEventId(operationId, data.accountId, eventStatus),
+              accountId: data.accountId,
+              status: eventStatus,
+              indexCreated: data.timepoint.index,
+              blockCreated: data.timepoint.height,
+              timestamp: Date.now(),
+            },
+          });
+        },
+      );
+    },
+  )
   .cache({
     store: $completionEvents,
-    map: (state, { event, operationId }, { api }) => {
-      return [...state, { chainId: api.genesisHash.toHex(), operationId, event }];
+    map: (state, { event, operationId, executionResult }, { api }) => {
+      return [...state, { chainId: api.genesisHash.toHex(), operationId, event, executionResult }];
     },
   })
   .build();

--- a/src/renderer/domains/network/multisig-operation/store.test.ts
+++ b/src/renderer/domains/network/multisig-operation/store.test.ts
@@ -5,9 +5,9 @@ import { type ChainId, AccountType } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accounts } from '../account/store';
 
-import { fetchOffchainResource, initialOnChainFetch } from './resource';
+import { $completionEvents, fetchOffchainResource, initialOnChainFetch } from './resource';
 import { multisigOperation } from './store';
-import { type MultisigOperation } from './types';
+import { type MultisigEvent, type MultisigOperation } from './types';
 
 describe('multisigOperation store', () => {
   const mockChainId1 = '0x123' as ChainId;
@@ -222,6 +222,54 @@ describe('multisigOperation store', () => {
       await allSettled(nukeAccounts, { scope, params: [plainMultisig] });
 
       expect(scope.getState(multisigOperation.__test.$cachedOperations)).toBe(original);
+    });
+  });
+
+  describe('live-completion status derivation', () => {
+    const MULTI_ID = '0xmulti' as AccountId;
+
+    const baseOp = {
+      id: 'op-1',
+      status: 'pending',
+      multisigAccountId: MULTI_ID,
+      chainId: mockChainId1,
+      events: [],
+    } as unknown as MultisigOperation;
+
+    const approveEvent: MultisigEvent = { id: 'e-approve', status: 'approve' } as unknown as MultisigEvent;
+    const rejectEvent: MultisigEvent = { id: 'e-reject', status: 'reject' } as unknown as MultisigEvent;
+
+    const completion = (event: MultisigEvent, executionResult: 'success' | 'error' | null) => ({
+      chainId: mockChainId1,
+      operationId: baseOp.id,
+      event,
+      executionResult,
+    });
+
+    const deriveStatus = async (
+      completionEvents: ReturnType<typeof completion>[],
+    ): Promise<MultisigOperation['status'] | undefined> => {
+      const scope = fork({
+        values: new Map<any, any>([
+          [multisigOperation.__test.$removedFromChainStorageOperations, [baseOp]],
+          [$completionEvents, completionEvents],
+        ]),
+      });
+
+      const derived = scope.getState(multisigOperation.__test.$completedLiveOperations);
+      return derived[0]?.status;
+    };
+
+    it('marks a successful MultisigExecuted as executed', async () => {
+      expect(await deriveStatus([completion(approveEvent, 'success')])).toBe('executed');
+    });
+
+    it('marks a failed inner-call MultisigExecuted as error', async () => {
+      expect(await deriveStatus([completion(approveEvent, 'error')])).toBe('error');
+    });
+
+    it('marks a MultisigCancelled as cancelled, taking precedence over a failed execution', async () => {
+      expect(await deriveStatus([completion(rejectEvent, null), completion(approveEvent, 'error')])).toBe('cancelled');
     });
   });
 });

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -345,7 +345,13 @@ const $completedLiveOperations = combine(
       if (!events || events.length === 0) return op;
 
       const newEvents = uniqBy(op.events.concat(events.map(e => e.event)), e => e.id);
-      const newStatus = newEvents.find(e => e.status === 'reject') ? 'cancelled' : 'executed';
+      // A reject event ⇒ cancelled; a MultisigExecuted with a failed inner call ⇒ error;
+      // otherwise executed. Keeps parity with the indexer's error status on the live path.
+      const newStatus = newEvents.find(e => e.status === 'reject')
+        ? 'cancelled'
+        : events.some(e => e.executionResult === 'error')
+          ? 'error'
+          : 'executed';
       return { ...op, events: newEvents, status: newStatus };
     }) satisfies MultisigOperation[];
   },
@@ -552,5 +558,7 @@ export const multisigOperation = {
     $fetchedChainIds: $initializedChainIds,
     $offChainReady: $offChainFetched,
     $onChainReady: $initialOnChainFetched,
+    $completedLiveOperations,
+    $removedFromChainStorageOperations,
   },
 };


### PR DESCRIPTION
## Description
Multisig operations completed via live event subscription only distinguished between cancelled (a reject event was seen) and executed — every non-cancelled completion was marked executed. But a MultisigExecuted event carries the inner call's DispatchResult: the multisig extrinsic can succeed while the dispatched call fails. Those failures were silently shown as successful executions.

This surfaces failed inner calls as error on the live path, matching the status the off-chain indexer already assigns (getExecutionResult), so live-caught and indexed operations stay consistent.

## Related Issues
https://novasama-technologies.atlassian.net/browse/SPEK-695

## Changes Made
- resource.ts — the multisig event subscription now normalizes a MultisigExecuted event's DispatchResult into an ExecutionResult ('success' | 'error' | null) and threads it through $completionEvents. Approvals/cancellations carry null (no DispatchResult).
- store.ts — $completedLiveOperations derives cancelled → error (failed execution) → executed, preserving cancellation precedence. Exposed $completedLiveOperations and $removedFromChainStorageOperations on __test.
- store.test.ts — added coverage for the three status derivations: successful execution → executed, failed inner call → error, and cancellation taking precedence over a failed execution.

## Screenshots/Recordings
<!-- If applicable, add screenshots or recordings to help explain your changes -->

## Checklist
<!-- Please check all applicable items before submitting your PR -->
- [X] I have performed a self-review of my own code
- [X] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [X] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [X] I have added tests that cover the base logic (if applicable)
- [X] My code follows the project's coding standards and style guidelines
