### PR TITLE
fix: tolerate null lastProcessedHeight in account sync indexer metadata

### DIFF
--- a/src/renderer/domains/network/account-sync/resource.test.ts
+++ b/src/renderer/domains/network/account-sync/resource.test.ts
@@ -1,0 +1,55 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+import { type ChainId } from '@/shared/core';
+
+const { graphqlRequestMock } = vi.hoisted(() => ({
+  graphqlRequestMock: vi.fn(async () => ({ _metadatas: { nodes: [] as unknown[] } })),
+}));
+vi.mock('graphql-request', () => {
+  class MockGraphQLClient {
+    request = graphqlRequestMock;
+  }
+  return { gql: (s: TemplateStringsArray) => s.join(''), GraphQLClient: MockGraphQLClient };
+});
+
+const POLKADOT = '0x91b171bb158e2d3848fa23a9f1c25182fb8e20313b2c1eb49219da7a70ce90c3' as ChainId;
+const COLLECTIVES = '0x46ee89aa2eedd13e988962630ec9fb7565964cf5023bb351f2b6b25c1b68b0b2' as ChainId;
+
+describe('indexedBlocksProvider', () => {
+  beforeEach(() => {
+    graphqlRequestMock.mockClear();
+  });
+
+  it('skips chains with a null lastProcessedHeight instead of failing the whole sync', async () => {
+    const { indexedBlocksProvider } = await import('./resource');
+
+    graphqlRequestMock.mockResolvedValueOnce({
+      _metadatas: {
+        nodes: [
+          { chain: 'Polkadot', genesisHash: POLKADOT, lastProcessedHeight: 31992635 },
+          { chain: 'Collectives', genesisHash: COLLECTIVES, lastProcessedHeight: null },
+        ],
+      },
+    });
+
+    const result = await indexedBlocksProvider.fn();
+
+    expect(result.get(POLKADOT)).toBe(31992635);
+    expect(result.has(COLLECTIVES)).toBe(false);
+  }, 30_000);
+
+  it('maps every indexed chain to its height', async () => {
+    const { indexedBlocksProvider } = await import('./resource');
+
+    graphqlRequestMock.mockResolvedValueOnce({
+      _metadatas: {
+        nodes: [{ chain: 'Polkadot', genesisHash: POLKADOT, lastProcessedHeight: 100 }],
+      },
+    });
+
+    const result = await indexedBlocksProvider.fn();
+
+    expect(result.size).toBe(1);
+    expect(result.get(POLKADOT)).toBe(100);
+  }, 30_000);
+});

--- a/src/renderer/domains/network/account-sync/resource.ts
+++ b/src/renderer/domains/network/account-sync/resource.ts
@@ -242,7 +242,7 @@ const METADATAS_QUERY = gql`
 
 const metadataSchema = z.object({
   chain: z.string(),
-  lastProcessedHeight: z.number(),
+  lastProcessedHeight: z.number().nullable(),
   genesisHash: z.string<ChainId>(),
 });
 
@@ -250,13 +250,14 @@ export const indexedBlocksProvider = {
   async fn(): Promise<Map<ChainId, number>> {
     const client = new GraphQLClient(INDEXER_URL);
     const response = await client.request<{
-      _metadatas: { nodes: { chain: string; genesisHash: ChainId; lastProcessedHeight: number }[] };
+      _metadatas: { nodes: { chain: string; genesisHash: ChainId; lastProcessedHeight: number | null }[] };
     }>(METADATAS_QUERY);
 
     const parsedData = response._metadatas.nodes.map(x => metadataSchema.parse(x));
     const metadataMap = new Map<ChainId, number>();
 
     for (const meta of parsedData) {
+      if (nullable(meta.lastProcessedHeight)) continue;
       metadataMap.set(meta.genesisHash, meta.lastProcessedHeight);
     }
 


### PR DESCRIPTION
## Problem

Account sync silently finds **no multisigs and no proxies**, even for accounts that provably have them in the indexer.

## Root cause

`indexedBlocksProvider` parses the indexer's `_metadatas` with a schema that requires `lastProcessedHeight: z.number()`:

```ts
const metadataSchema = z.object({
  chain: z.string(),
  lastProcessedHeight: z.number(), // ← rejects null
  genesisHash: z.string<ChainId>(),
});
```

The indexer currently returns `lastProcessedHeight: null` for a chain it knows about but hasn't indexed yet — observed live for **Collectives** on both `subquery-accounts-prod` and `subquery-accounts-prod-2`:

```
0x46ee89aa2eedd13e988962630ec9fb7565964cf5023bb351f2b6b25c1b68b0b2  null  Collectives
```

`.map(x => metadataSchema.parse(x))` throws a `ZodError` on that one null. Since `indexedBlocksProvider.fn()` is awaited inside `Promise.all([...])` in `accountSyncService.syncAccounts` (`service.ts:76`), the rejection **fails the entire sync run** — before any multisig/proxy account is created. A single not-yet-indexed chain takes down account discovery for every user.

Observed in-app as:

```
ZodError: [{ code: "invalid_type", path: ["lastProcessedHeight"],
             message: "expected number, received null" }]
  at resource.ts (indexedBlocksProvider metadata parse)
  at Object.syncAccounts (service.ts:76)
```

## Fix

Make `lastProcessedHeight` nullable and skip not-yet-indexed chains when building the height map. A chain with no processed height is correctly treated as "not indexed" downstream (those chains are never used to delete accounts), so omitting it from the map is the right semantics.

## Tests

Adds `resource.test.ts` covering `indexedBlocksProvider`:
- a `null` height no longer throws — that chain is skipped, others still map;
- regular metadata maps every chain to its height.

Verified the test fails with the original `ZodError` before the fix and passes after.
