### PR TITLE
fix: resolve address book names for Polkadot Vault derived accounts

### DIFF
--- a/src/renderer/domains/network/account/hooks.ts
+++ b/src/renderer/domains/network/account/hooks.ts
@@ -31,6 +31,7 @@ export const useAccountsNames = (accounts: AnyAccount[], chain?: Chain | null) =
         const key = createAccountNameCacheKey({
           accountId: account.accountId,
           chain,
+          account,
         });
         result[key] = cache[key] ?? account.name;
       }
@@ -42,6 +43,7 @@ export const useAccountsNames = (accounts: AnyAccount[], chain?: Chain | null) =
     const key = createAccountNameCacheKey({
       accountId: account.accountId,
       chain,
+      account,
     });
     const resolvedName = accountNames[key];
     return resolvedName ? { ...account, name: resolvedName } : account;

--- a/src/renderer/domains/network/account/resource.test.ts
+++ b/src/renderer/domains/network/account/resource.test.ts
@@ -1,0 +1,84 @@
+import { describe, expect, it } from 'vitest';
+
+import { CryptoType, SigningType } from '@/shared/core';
+import { createAccountId, polkadotChain, polkadotChainId } from '@/shared/mocks';
+
+import { accountsNameResource, createAccountNameCacheKey } from './resource';
+import { type ChainAccount } from './types';
+
+describe('createAccountNameCacheKey', () => {
+  it('should key on the specific account id, not just accountId, so accounts sharing an accountId across wallets do not collide', () => {
+    const sharedAccountId = createAccountId('shared');
+
+    const vaultDerivedAccount: ChainAccount = {
+      id: 'vault-account',
+      type: 'chain',
+      accountId: sharedAccountId,
+      chainId: polkadotChainId,
+      name: '//polkadot//0',
+      walletId: 1,
+      signingType: SigningType.POLKADOT_VAULT,
+      cryptoType: CryptoType.SR25519,
+      createdAt: Date.now(),
+    };
+    const watchOnlyAccount: ChainAccount = {
+      ...vaultDerivedAccount,
+      id: 'watch-only-account',
+      walletId: 2,
+      name: 'My Watch-Only',
+    };
+
+    const vaultKey = createAccountNameCacheKey({
+      accountId: sharedAccountId,
+      chain: polkadotChain,
+      account: vaultDerivedAccount,
+    });
+    const watchOnlyKey = createAccountNameCacheKey({
+      accountId: sharedAccountId,
+      chain: polkadotChain,
+      account: watchOnlyAccount,
+    });
+
+    expect(vaultKey).not.toBe(watchOnlyKey);
+  });
+
+  it('should fall back to accountId when no specific account is known (e.g. an arbitrary address)', () => {
+    const accountId = createAccountId('arbitrary');
+
+    const key = createAccountNameCacheKey({ accountId, chain: polkadotChain });
+
+    expect(key).toBe(`${accountId}:${polkadotChainId}:${polkadotChain.addressPrefix}:`);
+  });
+});
+
+describe('accountsNameResource.createKey', () => {
+  it('should not collide for two different account lists that share an accountId across wallets', () => {
+    const sharedAccountId = createAccountId('shared');
+
+    const vaultDerivedAccount: ChainAccount = {
+      id: 'vault-account',
+      type: 'chain',
+      accountId: sharedAccountId,
+      chainId: polkadotChainId,
+      name: '//polkadot//0',
+      walletId: 1,
+      signingType: SigningType.POLKADOT_VAULT,
+      cryptoType: CryptoType.SR25519,
+      createdAt: Date.now(),
+    };
+    const watchOnlyAccount: ChainAccount = {
+      ...vaultDerivedAccount,
+      id: 'watch-only-account',
+      walletId: 2,
+      name: 'My Watch-Only',
+    };
+
+    // Same accountId set (just the one, shared, address) requested from two
+    // different account lists — a resource-key collision here would make the
+    // second request reuse the first's cached response wholesale.
+    const firstListKey = accountsNameResource.createKey({ accounts: [vaultDerivedAccount], chain: polkadotChain });
+    const secondListKey = accountsNameResource.createKey({ accounts: [watchOnlyAccount], chain: polkadotChain });
+
+    expect(firstListKey).not.toBe(secondListKey);
+  });
+});

--- a/src/renderer/domains/network/account/resource.ts
+++ b/src/renderer/domains/network/account/resource.ts
@@ -15,6 +15,14 @@ export type AccountNameParams = {
   accountId: AccountId;
   chain?: Chain | null;
   title?: string;
+  /**
+   * The specific account this name is being resolved for, when the caller
+   * already knows it (e.g. resolving names for a known list of accounts rather
+   * than an arbitrary accountId). Passed through to
+   * accountService.resolveAccountName to avoid re-deriving it, which can't
+   * disambiguate accounts that share an accountId across wallets.
+   */
+  account?: AnyAccount;
 };
 
 export type WalletNameParams = {
@@ -39,11 +47,15 @@ const getNameResolverSource = () => {
   });
 };
 
-export const createAccountNameCacheKey = ({ accountId, chain, title }: AccountNameParams): string => {
+export const createAccountNameCacheKey = ({ accountId, chain, title, account }: AccountNameParams): string => {
   const chainKey = chain?.chainId ?? 'anyChain';
   const prefixKey = chain ? `${chain.addressPrefix}` : 'defaultPrefix';
+  // accountId alone collides when different accounts (e.g. across wallets) share
+  // it — key on the specific account's own id when the caller knows it, so each
+  // gets its own cache slot instead of clobbering one another's resolved name.
+  const identityKey = account?.id ?? accountId;
 
-  return `${accountId}:${chainKey}:${prefixKey}:${title ?? ''}`;
+  return `${identityKey}:${chainKey}:${prefixKey}:${title ?? ''}`;
 };
 
 export const createWalletNameCacheKey = ({ wallet }: WalletNameParams): string => {
@@ -74,6 +86,7 @@ export const accountNameResource = createQueryResource<AccountNameParams>({
           accountId: params.accountId,
           chain: params.chain,
           title: params.title,
+          account: params.account,
           contacts,
           identities,
           chains,
@@ -142,11 +155,17 @@ export const walletsNameResource = createQueryResource<WalletsNameParams>({
 export const accountsNameResource = createQueryResource<AccountsNameParams>({
   key: ({ accounts, chain }) => {
     const chainKey = chain?.chainId ?? 'anyChain';
-    const accountIds = accounts
-      .map(a => a.accountId)
+    // Key on each account's own id, not accountId — two different account lists
+    // sharing an accountId (e.g. across wallets) must not collide here. A
+    // collision would make the second request reuse the first's cached
+    // response wholesale (see requestsCache.get in createQueryResource), and
+    // since that response is keyed per-account by createAccountNameCacheKey,
+    // the second list's accounts would never get their own entries written.
+    const accountKeys = accounts
+      .map(a => a.id)
       .sort()
       .join(',');
-    return `${chainKey}:${accountIds}`;
+    return `${chainKey}:${accountKeys}`;
   },
 })
   .request(
@@ -160,11 +179,13 @@ export const accountsNameResource = createQueryResource<AccountsNameParams>({
             accountId: account.accountId,
             chain,
             title: undefined,
+            account,
           });
           const name = accountService.resolveAccountName({
             accountId: account.accountId,
             chain,
             title: undefined,
+            account,
             contacts,
             identities,
             chains,
@@ -191,18 +212,39 @@ export const accountsNameResource = createQueryResource<AccountsNameParams>({
 // useResource only re-fetches a resource when its request params change, so
 // once an account/wallet name is resolved and cached it stays cached even
 // after the data it was resolved from changes (e.g. reconnecting the backend
-// address book, or editing a local contact) — a mounted consumer (e.g. an
-// open Transfer modal) would otherwise show a stale name until it remounts.
-// Track the params behind every resolved cache entry, then recompute them
-// all whenever contacts change so mounted views pick up the update live.
+// address book, editing a local contact, an identity resolving, or an
+// account/wallet rename) — a mounted consumer (e.g. an open Transfer modal)
+// would otherwise show a stale name until it remounts. Track the params
+// behind every resolved cache entry, then recompute them all whenever any of
+// that data changes so mounted views pick up the update live.
 const $contacts = getContactsStore();
+
+// Bounds how many resolved-name params stay tracked for live recompute.
+// Without a cap this grows forever (full Wallet snapshots for wallet names),
+// since nothing currently signals when a consumer unmounts.
+const MAX_TRACKED_NAME_PARAMS = 500;
+
+function withCapacityLimit<T>(next: Record<string, T>, limit: number): Record<string, T> {
+  const keys = Object.keys(next);
+  const excess = keys.length - limit;
+  if (excess <= 0) {
+    return next;
+  }
+
+  for (const key of keys.slice(0, excess)) {
+    delete next[key];
+  }
+
+  return next;
+}
 
 const $accountNameParams = createStore<Record<string, AccountNameParams>>({});
 
 sample({
   clock: accountNameResource.push,
   source: $accountNameParams,
-  fn: (state, { params }) => ({ ...state, [createAccountNameCacheKey(params)]: params }),
+  fn: (state, { params }) =>
+    withCapacityLimit({ ...state, [createAccountNameCacheKey(params)]: params }, MAX_TRACKED_NAME_PARAMS),
   target: $accountNameParams,
 });
 
@@ -213,11 +255,11 @@ sample({
     const next = { ...state };
 
     for (const account of params.accounts) {
-      const accountParams: AccountNameParams = { accountId: account.accountId, chain: params.chain };
+      const accountParams: AccountNameParams = { accountId: account.accountId, chain: params.chain, account };
       next[createAccountNameCacheKey(accountParams)] = accountParams;
     }
 
-    return next;
+    return withCapacityLimit(next, MAX_TRACKED_NAME_PARAMS);
   },
   target: $accountNameParams,
 });
@@ -235,29 +277,38 @@ sample({
       next[createWalletNameCacheKey(walletParams)] = walletParams;
     }
 
-    return next;
+    return withCapacityLimit(next, MAX_TRACKED_NAME_PARAMS);
   },
   target: $walletNameParams,
 });
 
 sample({
-  clock: $contacts,
+  clock: [
+    $contacts,
+    identity.$list,
+    accounts.$list,
+    networkModel.$chains,
+    accountNameResource.push,
+    accountsNameResource.push,
+  ],
   source: {
     accountParams: $accountNameParams,
+    cache: $accountNameCache,
     contacts: $contacts,
     identities: identity.$list,
     chains: networkModel.$chains,
     accounts: accounts.$list,
   },
   filter: ({ accountParams }) => Object.keys(accountParams).length > 0,
-  fn: ({ accountParams, contacts, identities, chains, accounts: allAccounts }) => {
-    const next: NameCache = {};
+  fn: ({ accountParams, cache, contacts, identities, chains, accounts: allAccounts }) => {
+    const next = { ...cache };
 
     for (const [key, params] of Object.entries(accountParams)) {
       next[key] = accountService.resolveAccountName({
         accountId: params.accountId,
         chain: params.chain,
         title: params.title,
+        account: params.account,
         contacts,
         identities,
         chains,
@@ -271,17 +322,18 @@ sample({
 });
 
 sample({
-  clock: $contacts,
+  clock: [$contacts, identity.$list, accounts.$list, networkModel.$chains, walletsNameResource.push],
   source: {
     walletParams: $walletNameParams,
+    cache: $walletNameCache,
     contacts: $contacts,
     identities: identity.$list,
     chains: networkModel.$chains,
     accounts: accounts.$list,
   },
   filter: ({ walletParams }) => Object.keys(walletParams).length > 0,
-  fn: ({ walletParams, contacts, identities, chains, accounts: allAccounts }) => {
-    const next: NameCache = {};
+  fn: ({ walletParams, cache, contacts, identities, chains, accounts: allAccounts }) => {
+    const next = { ...cache };
 
     for (const [key, params] of Object.entries(walletParams)) {
       next[key] = accountService.resolveWalletName({

--- a/src/renderer/domains/network/account/resource.ts
+++ b/src/renderer/domains/network/account/resource.ts
@@ -1,4 +1,4 @@
-import { attach, combine, createStore } from 'effector';
+import { attach, combine, createStore, sample } from 'effector';
 
 import { type Chain, type Wallet } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
@@ -187,3 +187,113 @@ export const accountsNameResource = createQueryResource<AccountsNameParams>({
     },
   })
   .build();
+
+// useResource only re-fetches a resource when its request params change, so
+// once an account/wallet name is resolved and cached it stays cached even
+// after the data it was resolved from changes (e.g. reconnecting the backend
+// address book, or editing a local contact) — a mounted consumer (e.g. an
+// open Transfer modal) would otherwise show a stale name until it remounts.
+// Track the params behind every resolved cache entry, then recompute them
+// all whenever contacts change so mounted views pick up the update live.
+const $contacts = getContactsStore();
+
+const $accountNameParams = createStore<Record<string, AccountNameParams>>({});
+
+sample({
+  clock: accountNameResource.push,
+  source: $accountNameParams,
+  fn: (state, { params }) => ({ ...state, [createAccountNameCacheKey(params)]: params }),
+  target: $accountNameParams,
+});
+
+sample({
+  clock: accountsNameResource.push,
+  source: $accountNameParams,
+  fn: (state, { params }) => {
+    const next = { ...state };
+
+    for (const account of params.accounts) {
+      const accountParams: AccountNameParams = { accountId: account.accountId, chain: params.chain };
+      next[createAccountNameCacheKey(accountParams)] = accountParams;
+    }
+
+    return next;
+  },
+  target: $accountNameParams,
+});
+
+const $walletNameParams = createStore<Record<string, WalletNameParams>>({});
+
+sample({
+  clock: walletsNameResource.push,
+  source: $walletNameParams,
+  fn: (state, { params }) => {
+    const next = { ...state };
+
+    for (const wallet of params.wallets) {
+      const walletParams: WalletNameParams = { wallet };
+      next[createWalletNameCacheKey(walletParams)] = walletParams;
+    }
+
+    return next;
+  },
+  target: $walletNameParams,
+});
+
+sample({
+  clock: $contacts,
+  source: {
+    accountParams: $accountNameParams,
+    contacts: $contacts,
+    identities: identity.$list,
+    chains: networkModel.$chains,
+    accounts: accounts.$list,
+  },
+  filter: ({ accountParams }) => Object.keys(accountParams).length > 0,
+  fn: ({ accountParams, contacts, identities, chains, accounts: allAccounts }) => {
+    const next: NameCache = {};
+
+    for (const [key, params] of Object.entries(accountParams)) {
+      next[key] = accountService.resolveAccountName({
+        accountId: params.accountId,
+        chain: params.chain,
+        title: params.title,
+        contacts,
+        identities,
+        chains,
+        accounts: allAccounts,
+      });
+    }
+
+    return next;
+  },
+  target: $accountNameCache,
+});
+
+sample({
+  clock: $contacts,
+  source: {
+    walletParams: $walletNameParams,
+    contacts: $contacts,
+    identities: identity.$list,
+    chains: networkModel.$chains,
+    accounts: accounts.$list,
+  },
+  filter: ({ walletParams }) => Object.keys(walletParams).length > 0,
+  fn: ({ walletParams, contacts, identities, chains, accounts: allAccounts }) => {
+    const next: NameCache = {};
+
+    for (const [key, params] of Object.entries(walletParams)) {
+      next[key] = accountService.resolveWalletName({
+        wallet: params.wallet,
+        contacts,
+        identities,
+        chains,
+        accounts: allAccounts,
+      });
+    }
+
+    return next;
+  },
+  target: $walletNameCache,
+});

--- a/src/renderer/domains/network/account/service.test.ts
+++ b/src/renderer/domains/network/account/service.test.ts
@@ -632,7 +632,7 @@ describe('account service', () => {
       expect(result).toBe('Identity Name');
     });
 
-    it('should return short address if no contact or identity', () => {
+    it('should return short address if no contact, identity or stored account name', () => {
       const result = accountService.resolveAccountName({
         accountId,
         chain: polkadotChain,
@@ -643,6 +643,27 @@ describe('account service', () => {
       });
 
       expect(result).toMatch(/^[A-Za-z0-9]{5}\.\.\.[A-Za-z0-9]{5}$/);
+    });
+
+    it('should return the stored generated name if no contact or identity match', () => {
+      const generatedAccountId = createAccountId('generated');
+      const generatedAccount: ChainAccount = {
+        ...chainAccount,
+        accountId: generatedAccountId,
+        nameType: AccountNameType.GENERATED,
+        name: 'Main',
+      };
+
+      const result = accountService.resolveAccountName({
+        accountId: generatedAccountId,
+        chain: polkadotChain,
+        accounts: [generatedAccount],
+        contacts: emptyContacts,
+        identities: emptyIdentities,
+        chains,
+      });
+
+      expect(result).toBe('Main');
     });
 
     it('should prioritize custom name over local contact', () => {

--- a/src/renderer/domains/network/account/service.test.ts
+++ b/src/renderer/domains/network/account/service.test.ts
@@ -759,6 +759,106 @@ describe('account service', () => {
 
       expect(result).toBe('Backend Contact Name');
     });
+
+    it('should use the passed-in account instead of re-deriving it from accountId, when a different account shares the same accountId', () => {
+      const sharedAccountId = createAccountId('shared');
+
+      // Found first by a plain accountId-only lookup, and CUSTOM — would win under
+      // the old accounts.find(accountId) logic even though it's the wrong account.
+      const arrayFirstAccount: ChainAccount = {
+        ...chainAccount,
+        id: 'array-first',
+        accountId: sharedAccountId,
+        nameType: AccountNameType.CUSTOM,
+        name: 'Array First',
+      };
+      // The account the caller actually knows it's resolving a name for.
+      const passedAccount: ChainAccount = {
+        ...chainAccount,
+        id: 'passed',
+        accountId: sharedAccountId,
+        nameType: AccountNameType.GENERATED,
+        name: 'Passed Account',
+      };
+
+      const result = accountService.resolveAccountName({
+        accountId: sharedAccountId,
+        chain: polkadotChain,
+        account: passedAccount,
+        accounts: [arrayFirstAccount, passedAccount],
+        contacts: emptyContacts,
+        identities: emptyIdentities,
+        chains,
+      });
+
+      expect(result).toBe('Passed Account');
+    });
+
+    it('should prefer a chain-matching account when accountId is ambiguous and no specific account is passed', () => {
+      const sharedAccountId = createAccountId('shared-chain');
+
+      const kusamaCandidate: ChainAccount = {
+        ...chainAccount,
+        id: 'kusama-candidate',
+        accountId: sharedAccountId,
+        chainId: kusamaChainId,
+        nameType: AccountNameType.GENERATED,
+        name: 'Kusama Candidate',
+      };
+      const polkadotCandidate: ChainAccount = {
+        ...chainAccount,
+        id: 'polkadot-candidate',
+        accountId: sharedAccountId,
+        chainId: polkadotChainId,
+        nameType: AccountNameType.GENERATED,
+        name: 'Polkadot Candidate',
+      };
+
+      const result = accountService.resolveAccountName({
+        accountId: sharedAccountId,
+        chain: polkadotChain,
+        // Kusama candidate listed first — a plain array-order find would pick it.
+        accounts: [kusamaCandidate, polkadotCandidate],
+        contacts: emptyContacts,
+        identities: emptyIdentities,
+        chains,
+      });
+
+      expect(result).toBe('Polkadot Candidate');
+    });
+
+    it('should prefer a CUSTOM-named account over a GENERATED one when accountId is ambiguous and chain does not disambiguate', () => {
+      const sharedAccountId = createAccountId('shared-custom');
+
+      // e.g. a Vault-derived key's raw derivation path...
+      const generatedCandidate: ChainAccount = {
+        ...chainAccount,
+        id: 'generated-candidate',
+        accountId: sharedAccountId,
+        nameType: AccountNameType.GENERATED,
+        name: '//kusama//hot//0',
+      };
+      // ...that shouldn't shadow a user's custom-named watch-only account for the same address.
+      const customCandidate: ChainAccount = {
+        ...chainAccount,
+        id: 'custom-candidate',
+        accountId: sharedAccountId,
+        nameType: AccountNameType.CUSTOM,
+        name: 'My Watch-Only',
+      };
+
+      const result = accountService.resolveAccountName({
+        accountId: sharedAccountId,
+        chain: null,
+        // Generated candidate listed first — a plain array-order find would pick it.
+        accounts: [generatedCandidate, customCandidate],
+        contacts: emptyContacts,
+        identities: emptyIdentities,
+        chains,
+      });
+
+      expect(result).toBe('My Watch-Only');
+    });
   });
 
   describe('resolveWalletName', () => {

--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -144,7 +144,42 @@ type ResolveAccountNameParams = {
   chains: Record<string, Chain>;
   chain?: Chain | null;
   title?: string;
+  /**
+   * The specific account this name is being resolved for, when the caller
+   * already knows it. Skips the accountId-only lookup below, which cannot
+   * disambiguate between different accounts (e.g. across wallets) that happen
+   * to share the same accountId.
+   */
+  account?: AnyAccount;
 };
+
+/**
+ * AccountId alone doesn't disambiguate between accounts that share it across
+ * different wallets (e.g. a Vault derived key and an unrelated watch-only
+ * account for the same address). Prefer a chain-matching account, then one with
+ * a user-chosen (CUSTOM) name, before falling back to array order.
+ */
+function findRelatedAccount(
+  accounts: AnyAccount[],
+  accountId: AccountId,
+  chain?: Chain | null,
+): AnyAccount | undefined {
+  const candidates = accounts.filter(account => account.accountId === accountId);
+  if (candidates.length <= 1) {
+    return candidates[0];
+  }
+
+  if (chain) {
+    const chainMatch = candidates.find(
+      account => accountService.isChainAccount(account) && account.chainId === chain.chainId,
+    );
+    if (chainMatch) {
+      return chainMatch;
+    }
+  }
+
+  return candidates.find(isCustomAccountName) ?? candidates[0];
+}
 
 function getAccountById(accounts: AnyAccount[], accountId: AccountId | null): AnyAccount | undefined {
   if (nullable(accountId)) {
@@ -307,12 +342,13 @@ function resolveAccountName({
   identities,
   chains,
   title,
+  account,
 }: ResolveAccountNameParams): string {
   if (title) {
     return title;
   }
 
-  const relatedAccount = accounts.find(account => account.accountId === accountId);
+  const relatedAccount = account ?? findRelatedAccount(accounts, accountId, chain);
   if (relatedAccount && isCustomAccountName(relatedAccount)) {
     return relatedAccount.name;
   }

--- a/src/renderer/domains/network/account/service.ts
+++ b/src/renderer/domains/network/account/service.ts
@@ -334,6 +334,10 @@ function resolveAccountName({
     }
   }
 
+  if (relatedAccount?.name) {
+    return relatedAccount.name;
+  }
+
   let prefix = chain?.addressPrefix;
 
   if (!prefix) {

--- a/src/renderer/entities/wallet/model/wallet-model.ts
+++ b/src/renderer/entities/wallet/model/wallet-model.ts
@@ -13,6 +13,7 @@ import {
   type WatchOnlyAccount,
   type WcAccount,
   AccountNameType,
+  AccountType,
 } from '@/shared/core';
 import { groupBy, nonNullable, toKeysRecord } from '@/shared/lib/utils';
 import { accounts } from '@/domains/network';
@@ -67,6 +68,23 @@ type CreateResult = {
   wallet: Wallet;
   accounts: AnyAccount[];
 };
+
+// CHAIN/SHARD accounts are exclusively Polkadot Vault derived keys (auto-labeled
+// with a derivation path, never user-typed) — every other account type here is
+// a root/base account whose name the user chose, so CUSTOM is the right default
+// for those. Keying off accountType means any future Vault-derived-key creation
+// path gets the right default automatically, instead of relying on every call
+// site to remember to stamp it explicitly. accountType isn't part of the
+// domains/network account shape (only shared/core's wallet-specific account
+// types carry it), so it's read defensively via an `in` check.
+function defaultAccountNameType(account: object): AccountNameType {
+  const isVaultDerivedKey =
+    'accountType' in account &&
+    (account.accountType === AccountType.CHAIN || account.accountType === AccountType.SHARD);
+
+  return isVaultDerivedKey ? AccountNameType.GENERATED : AccountNameType.CUSTOM;
+}
+
 const createWalletFx = createEffect(
   async ({ wallet, accounts: accountDrafts }: WalletCreateParams): Promise<CreateResult | undefined> => {
     const dbWallet = await storageService.wallets.create(wallet);
@@ -77,7 +95,7 @@ const createWalletFx = createEffect(
       acc.push({
         ...account,
         walletId: dbWallet.id,
-        nameType: account.nameType ?? AccountNameType.CUSTOM,
+        nameType: account.nameType ?? defaultAccountNameType(account),
       } as AnyAccountDraft);
 
       return acc;

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -24,8 +24,8 @@ notes.
 - `hide-unnamed-wallets`
 - `extension-wallet`
 - `ledger-wallet-pairing`
-- `polkadot-vault-wallet`
-- `polkadot-vault-wallet-pairing`
+- [`polkadot-vault-wallet`](./polkadot-vault-wallet/README.md)
+- [`polkadot-vault-wallet-pairing`](./polkadot-vault-wallet-pairing/README.md)
 - `wallet-connect-wallet`
 - `wallet-connect-wallet-pairing`
 - `watch-only-wallet`

--- a/src/renderer/features/polkadot-vault-wallet-pairing/README.md
+++ b/src/renderer/features/polkadot-vault-wallet-pairing/README.md
@@ -1,0 +1,76 @@
+# Polkadot Vault Wallet Pairing
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-07
+>
+> **Draft — pending author review.** Written from reading the code; needs sign-off from the feature owner before it is
+> treated as the source of product truth.
+
+## Overview
+
+Connects a Polkadot Vault (or legacy Parity Signer) device to Spektr by scanning a QR code, and turns the scanned keys
+into a wallet. The same modal handles two very different device generations — a single-account legacy signer and a
+modern Vault that can expose many keys, one per chain — and picks the right flow automatically from what the QR code
+contains.
+
+## Who can use it / when it applies
+
+Gated by the `polkadotVault` feature flag. Two entry points open the same pairing modal:
+
+- the onboarding welcome screen (first wallet in the app), and
+- the "add wallet" dropdown available once at least one wallet exists.
+
+## States / scenarios
+
+```mermaid
+flowchart TD
+    START["Scan QR code"] --> Q1{"Payload has a name<br/>or derived keys?"}
+    Q1 -- "no" --> SINGLE["Singleshard flow<br/>(legacy Parity Signer, one account)"]
+    Q1 -- "yes" --> VAULT["Vault flow<br/>(modern device, one key per chain)"]
+
+    SINGLE --> S1["Name defaults to on-chain identity<br/>if one is found, else blank"]
+    S1 --> S2["Confirm → wallet + single universal account created"]
+
+    VAULT --> V1["Auto-derives one 'Main' key<br/>per relay chain from the QR"]
+    V1 --> V2{"Add more keys?"}
+    V2 -- "Import" --> V3["Paste/scan a list of derivation paths"]
+    V2 -- "Constructor" --> V4["Build paths interactively"]
+    V2 -- "no" --> V5["Name the wallet"]
+    V3 --> V5
+    V4 --> V5
+    V5 --> V6["Review keys<br/>(hold Option/Ctrl to reveal full addresses & paths)"]
+    V6 --> V7["Confirm on the address-preview modal"]
+    V7 --> V8["Wallet + all reviewed accounts created"]
+```
+
+| State                  | When it appears                                                  | What the user sees                                                                                    |
+| ----------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------------- |
+| **Scan**               | Always, first step                                                 | Camera QR reader with a tutorial video alongside it                                                    |
+| **Singleshard review** | Scanned payload has no wallet name and no derived keys              | A single account preview; wallet name pre-fills from an on-chain identity lookup if one resolves        |
+| **Vault review**       | Scanned payload carries a wallet name and/or a list of derived keys | A wallet-name field plus the list of keys grouped by chain, with Import/Constructor actions to add more |
+
+**Why the fork instead of one flow.** The two device generations produce structurally different QR payloads — a legacy
+signer's payload has no name or derived-key list, a Vault's does — so the app tells them apart from the payload shape
+alone rather than asking the user which device they have.
+
+**Why keys can be added two ways.** Import accepts a list of derivation paths a user already has (e.g. from a QR or
+pasted text); Constructor is for building paths interactively when the user doesn't already have them written down.
+Both feed the same review list before confirmation.
+
+## Lifecycle
+
+1. User scans a QR code with a Vault/Parity Signer device.
+2. The payload shape decides Singleshard vs. Vault review (see above).
+3. **Singleshard:** the wallet is created immediately from the single scanned account, using an identity-derived name if
+   one is found.
+4. **Vault:** the user names the wallet, reviews the auto-derived "Main" keys (one per relay chain) plus anything added
+   via Import/Constructor, then confirms on an address-preview modal.
+5. On confirmation, the wallet and its accounts are created, on-chain data is synced for the new accounts, and — for
+   the Vault flow — the new wallet is auto-selected as the active wallet.
+
+## Related
+
+- Key review/editing UI (Import, Constructor, the address-preview modal) lives in `@/features/wallets`, shared with
+  other flows that manage derived keys.
+- [`polkadot-vault-wallet`](../polkadot-vault-wallet/README.md) owns how the resulting wallet behaves once created —
+  signing permissions, wallet-switcher display — and reuses this feature's draft-building logic when the user adds more
+  keys to an existing wallet later.

--- a/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/model/__tests__/manage-vault-model.test.ts
+++ b/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/model/__tests__/manage-vault-model.test.ts
@@ -1,7 +1,7 @@
 import { hexToU8a } from '@polkadot/util';
 import { allSettled, fork } from 'effector';
 
-import { type VaultChainAccount, CryptoType, SigningType } from '@/shared/core';
+import { type VaultChainAccount, AccountNameType, CryptoType, SigningType } from '@/shared/core';
 import { TEST_HASH } from '@/shared/lib/utils';
 import { networkModel } from '@/entities/network';
 import { type SeedInfo } from '@/entities/transaction';
@@ -62,6 +62,7 @@ describe('pages/Onboarding/Vault/ManageVault/model/manage-vault-model', () => {
       derivationPath: '//polkadot',
       keyType: 'main',
       name: 'Main',
+      nameType: AccountNameType.GENERATED,
       accountType: 'chain',
       type: 'chain',
       createdAt: expect.any(Number),

--- a/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/model/manage-vault-model.ts
+++ b/src/renderer/features/polkadot-vault-wallet-pairing/components/ManageVault/model/manage-vault-model.ts
@@ -12,7 +12,7 @@ import {
   type VaultShardAccount,
   SigningType,
 } from '@/shared/core';
-import { AccountType, CryptoType, KeyType } from '@/shared/core';
+import { AccountNameType, AccountType, CryptoType, KeyType } from '@/shared/core';
 import { nullable } from '@/shared/lib/utils';
 import { networkModel, networkUtils } from '@/entities/network';
 import { type SeedInfo } from '@/entities/transaction';
@@ -100,6 +100,7 @@ sample({
       keys.push({
         chainId: chain.chainId,
         name: KEY_NAMES[KeyType.MAIN],
+        nameType: AccountNameType.GENERATED,
         derivationPath: `//${chain.specName}`,
         cryptoType: networkUtils.isEthereumBased(chain.options) ? CryptoType.ETHEREUM : CryptoType.SR25519,
         signingType: SigningType.POLKADOT_VAULT,
@@ -117,6 +118,7 @@ sample({
       keys.push({
         chainId: chain.chainId,
         name: key.derivationPath,
+        nameType: AccountNameType.GENERATED,
         derivationPath: key.derivationPath,
         cryptoType: networkUtils.isEthereumBased(chain.options) ? CryptoType.ETHEREUM : CryptoType.SR25519,
         signingType: SigningType.POLKADOT_VAULT,

--- a/src/renderer/features/polkadot-vault-wallet/README.md
+++ b/src/renderer/features/polkadot-vault-wallet/README.md
@@ -1,0 +1,54 @@
+# Polkadot Vault Wallet
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-07
+>
+> **Draft — pending author review.** Written from reading the code; needs sign-off from the feature owner before it is
+> treated as the source of product truth.
+
+## Overview
+
+Defines how an already-paired Polkadot Vault (or legacy Parity Signer) wallet behaves and appears in the rest of the
+app: which accounts can sign, where they're available, how the wallet is drawn in the wallet switcher, and the shared
+draft-building logic reused whenever more keys are added to an existing wallet later.
+
+## Who can use it / when it applies
+
+Applies to any account whose signing type is Polkadot Vault (a QR-based, offline signer — the device never connects
+online, so every transaction is scanned and returned as a signed QR code). Gated by the same `polkadotVault` feature
+flag as the pairing flow.
+
+## States / scenarios
+
+| Situation                                          | Behaviour                                                                                                          |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------- |
+| Wallet has exactly one account (legacy Parity Signer) | Wallet-switcher icon is keyed to that single account's address                                                     |
+| Wallet has multiple derived accounts (modern Vault)   | Wallet-switcher icon is keyed to the wallet's root account instead of any one derived key                          |
+| Account is Ethereum-based                            | Icon theme is `ethereum`                                                                                           |
+| Single-account, non-Ethereum                          | Icon theme is `polkadot`                                                                                           |
+| Multi-account, non-Ethereum                           | Icon theme is `jdenticon`                                                                                          |
+| Any Vault account                                     | Can sign, can batch-sign multiple transactions in one scan, and is available on any chain matching its own or a parent chain |
+
+Wallets are listed in the wallet-switcher's "Polkadot Vault" group, searchable by wallet name or any of its addresses,
+each row showing its live fiat balance.
+
+**Why batch signing is always allowed.** Signing happens by scanning a QR code with the physical device, not through a
+per-transaction online approval — so there's no session-based reason to limit a Vault wallet to one transaction at a
+time the way an online signer might be.
+
+## Lifecycle
+
+A wallet enters this feature's scope the moment [`polkadot-vault-wallet-pairing`](../polkadot-vault-wallet-pairing/README.md)
+creates it. From then on:
+
+1. It appears in the wallet switcher, grouped with other Polkadot Vault wallets.
+2. Its accounts become eligible to sign and to appear in balance/chain views per the availability rules above.
+3. If the user later adds more derived keys from the wallet's own details screen, that flow reuses this feature's
+   draft-building service (`populateDraftAccounts`) to shape the new key drafts the same way the pairing flow does —
+   same defaults, same derivation-path-based naming — before handing them to account creation.
+
+## Related
+
+- [`polkadot-vault-wallet-pairing`](../polkadot-vault-wallet-pairing/README.md) — the onboarding flow that creates the
+  wallet in the first place.
+- `wallet-details` — the existing-wallet settings screen that calls back into this feature's draft-building service
+  when adding keys after initial creation.

--- a/src/renderer/features/polkadot-vault-wallet/service.ts
+++ b/src/renderer/features/polkadot-vault-wallet/service.ts
@@ -4,6 +4,7 @@ import {
   type DraftAccount,
   type VaultChainAccount,
   type VaultShardAccount,
+  AccountNameType,
   AccountType,
   CryptoType,
   KeyType,
@@ -25,6 +26,7 @@ function createDraftAccount(
   return {
     type: 'chain',
     name: draft.derivationPath,
+    nameType: AccountNameType.GENERATED,
     keyType: KeyType.CUSTOM,
     chainId: draft.chainId,
     accountType: isSharded ? AccountType.SHARD : AccountType.CHAIN,

--- a/src/renderer/shared/api/storage/migration/__tests__/migration-21.test.ts
+++ b/src/renderer/shared/api/storage/migration/__tests__/migration-21.test.ts
@@ -1,0 +1,159 @@
+import { type Transaction } from 'dexie';
+import { beforeEach } from 'vitest';
+
+import { resetVaultAccountNameType } from '@/shared/api/storage/migration';
+import { AccountNameType, AccountType, SigningType } from '@/shared/core';
+
+describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM to GENERATED', () => {
+  const db = {
+    accounts2: [] as Record<string, unknown>[],
+  };
+
+  const transactionMock = {
+    table: vi.fn().mockImplementation((tableName: 'accounts2') => {
+      return {
+        toCollection: vi.fn(() => ({
+          modify: vi.fn((fn: (record: Record<string, unknown>) => void) => {
+            for (const record of db[tableName]) {
+              fn(record);
+            }
+          }),
+        })),
+      };
+    }),
+  } as unknown as Transaction;
+
+  beforeEach(() => {
+    db.accounts2 = [];
+  });
+
+  it('should reset a CUSTOM-named Vault chain account to GENERATED', async () => {
+    db.accounts2 = [
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.CHAIN,
+        name: 'Main',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.CHAIN,
+        name: 'Main',
+        nameType: AccountNameType.GENERATED,
+      },
+    ]);
+  });
+
+  it('should reset a CUSTOM-named Vault shard account to GENERATED', async () => {
+    db.accounts2 = [
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.SHARD,
+        name: '//polkadot//0',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.SHARD,
+        name: '//polkadot//0',
+        nameType: AccountNameType.GENERATED,
+      },
+    ]);
+  });
+
+  it('should leave an already-GENERATED Vault chain account untouched', async () => {
+    db.accounts2 = [
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.CHAIN,
+        name: '//polkadot//0',
+        nameType: AccountNameType.GENERATED,
+      },
+    ];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.CHAIN,
+        name: '//polkadot//0',
+        nameType: AccountNameType.GENERATED,
+      },
+    ]);
+  });
+
+  it('should not touch a CUSTOM-named Vault BASE account (zero-derivation fallback, name is user-typed)', async () => {
+    db.accounts2 = [
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.BASE,
+        type: 'universal',
+        name: 'My wallet',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([
+      {
+        id: 1,
+        signingType: SigningType.POLKADOT_VAULT,
+        accountType: AccountType.BASE,
+        type: 'universal',
+        name: 'My wallet',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ]);
+  });
+
+  it('should not touch CUSTOM-named non-Vault accounts', async () => {
+    db.accounts2 = [
+      {
+        id: 1,
+        signingType: SigningType.MULTISIG,
+        accountType: AccountType.MULTISIG,
+        name: 'My multisig',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([
+      {
+        id: 1,
+        signingType: SigningType.MULTISIG,
+        accountType: AccountType.MULTISIG,
+        name: 'My multisig',
+        nameType: AccountNameType.CUSTOM,
+      },
+    ]);
+  });
+
+  it('should handle empty accounts2 table', async () => {
+    db.accounts2 = [];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2).toEqual([]);
+  });
+});

--- a/src/renderer/shared/api/storage/migration/__tests__/migration-21.test.ts
+++ b/src/renderer/shared/api/storage/migration/__tests__/migration-21.test.ts
@@ -2,21 +2,29 @@ import { type Transaction } from 'dexie';
 import { beforeEach } from 'vitest';
 
 import { resetVaultAccountNameType } from '@/shared/api/storage/migration';
-import { AccountNameType, AccountType, SigningType } from '@/shared/core';
+import { AccountNameType, AccountType, SigningType, WalletType } from '@/shared/core';
 
 describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM to GENERATED', () => {
   const db = {
+    wallets: [] as Record<string, unknown>[],
     accounts2: [] as Record<string, unknown>[],
   };
 
   const transactionMock = {
-    table: vi.fn().mockImplementation((tableName: 'accounts2') => {
+    table: vi.fn().mockImplementation((tableName: 'wallets' | 'accounts2') => {
       return {
+        toArray: vi.fn(() => Promise.resolve(db[tableName])),
         toCollection: vi.fn(() => ({
-          modify: vi.fn((fn: (record: Record<string, unknown>) => void) => {
-            for (const record of db[tableName]) {
-              fn(record);
-            }
+          // Mirrors real Dexie semantics (dexie.js Collection.modify): the callback
+          // receives a clone, and the record is only written back if the callback
+          // returns anything other than `false` — a bare `return;` (undefined) still
+          // writes back.
+          modify: vi.fn((fn: (record: Record<string, unknown>) => boolean | void) => {
+            db[tableName] = db[tableName].map((record) => {
+              const clone = { ...record };
+              const result = fn(clone);
+              return result === false ? record : clone;
+            });
           }),
         })),
       };
@@ -24,13 +32,16 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
   } as unknown as Transaction;
 
   beforeEach(() => {
+    db.wallets = [];
     db.accounts2 = [];
   });
 
   it('should reset a CUSTOM-named Vault chain account to GENERATED', async () => {
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
     db.accounts2 = [
       {
         id: 1,
+        walletId: 1,
         signingType: SigningType.POLKADOT_VAULT,
         accountType: AccountType.CHAIN,
         name: 'Main',
@@ -43,6 +54,7 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     expect(db.accounts2).toEqual([
       {
         id: 1,
+        walletId: 1,
         signingType: SigningType.POLKADOT_VAULT,
         accountType: AccountType.CHAIN,
         name: 'Main',
@@ -52,9 +64,11 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
   });
 
   it('should reset a CUSTOM-named Vault shard account to GENERATED', async () => {
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
     db.accounts2 = [
       {
         id: 1,
+        walletId: 1,
         signingType: SigningType.POLKADOT_VAULT,
         accountType: AccountType.SHARD,
         name: '//polkadot//0',
@@ -67,6 +81,7 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     expect(db.accounts2).toEqual([
       {
         id: 1,
+        walletId: 1,
         signingType: SigningType.POLKADOT_VAULT,
         accountType: AccountType.SHARD,
         name: '//polkadot//0',
@@ -75,14 +90,19 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     ]);
   });
 
-  it('should leave an already-GENERATED Vault chain account untouched', async () => {
+  it('should reset a legacy account carrying a stale signingType from a pre-accounts2 Multishard migration', async () => {
+    // migration-2 stamped `wallet.signingType = PARITY_SIGNER` for old Multishard
+    // wallets, migration-3 copied it onto every account, and migration-6 regrouped
+    // these accounts into today's Vault wallet without ever rewriting signingType.
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
     db.accounts2 = [
       {
         id: 1,
-        signingType: SigningType.POLKADOT_VAULT,
+        walletId: 1,
+        signingType: SigningType.PARITY_SIGNER,
         accountType: AccountType.CHAIN,
         name: '//polkadot//0',
-        nameType: AccountNameType.GENERATED,
+        nameType: AccountNameType.CUSTOM,
       },
     ];
 
@@ -91,7 +111,8 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     expect(db.accounts2).toEqual([
       {
         id: 1,
-        signingType: SigningType.POLKADOT_VAULT,
+        walletId: 1,
+        signingType: SigningType.PARITY_SIGNER,
         accountType: AccountType.CHAIN,
         name: '//polkadot//0',
         nameType: AccountNameType.GENERATED,
@@ -99,14 +120,15 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     ]);
   });
 
-  it('should not touch a CUSTOM-named Vault BASE account (zero-derivation fallback, name is user-typed)', async () => {
+  it('should reset a CUSTOM-named account under a SingleShard (single Parity Signer) wallet', async () => {
+    db.wallets = [{ id: 1, type: WalletType.SINGLE_PARITY_SIGNER }];
     db.accounts2 = [
       {
         id: 1,
-        signingType: SigningType.POLKADOT_VAULT,
-        accountType: AccountType.BASE,
-        type: 'universal',
-        name: 'My wallet',
+        walletId: 1,
+        signingType: SigningType.PARITY_SIGNER,
+        accountType: AccountType.CHAIN,
+        name: '//polkadot',
         nameType: AccountNameType.CUSTOM,
       },
     ];
@@ -116,40 +138,69 @@ describe('Migration 21 - Reset Polkadot Vault derived-key nameType from CUSTOM t
     expect(db.accounts2).toEqual([
       {
         id: 1,
-        signingType: SigningType.POLKADOT_VAULT,
-        accountType: AccountType.BASE,
-        type: 'universal',
-        name: 'My wallet',
-        nameType: AccountNameType.CUSTOM,
+        walletId: 1,
+        signingType: SigningType.PARITY_SIGNER,
+        accountType: AccountType.CHAIN,
+        name: '//polkadot',
+        nameType: AccountNameType.GENERATED,
       },
     ]);
   });
 
-  it('should not touch CUSTOM-named non-Vault accounts', async () => {
-    db.accounts2 = [
-      {
-        id: 1,
-        signingType: SigningType.MULTISIG,
-        accountType: AccountType.MULTISIG,
-        name: 'My multisig',
-        nameType: AccountNameType.CUSTOM,
-      },
-    ];
+  it('should leave an already-GENERATED Vault chain account untouched and not write it back', async () => {
+    const original = {
+      id: 1,
+      walletId: 1,
+      signingType: SigningType.POLKADOT_VAULT,
+      accountType: AccountType.CHAIN,
+      name: '//polkadot//0',
+      nameType: AccountNameType.GENERATED,
+    };
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
+    db.accounts2 = [original];
 
     await resetVaultAccountNameType(transactionMock);
 
-    expect(db.accounts2).toEqual([
-      {
-        id: 1,
-        signingType: SigningType.MULTISIG,
-        accountType: AccountType.MULTISIG,
-        name: 'My multisig',
-        nameType: AccountNameType.CUSTOM,
-      },
-    ]);
+    expect(db.accounts2[0]).toBe(original);
+  });
+
+  it('should not touch a CUSTOM-named Vault BASE account (zero-derivation fallback, name is user-typed) and not write it back', async () => {
+    const original = {
+      id: 1,
+      walletId: 1,
+      signingType: SigningType.POLKADOT_VAULT,
+      accountType: AccountType.BASE,
+      type: 'universal',
+      name: 'My wallet',
+      nameType: AccountNameType.CUSTOM,
+    };
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
+    db.accounts2 = [original];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]).toBe(original);
+  });
+
+  it('should not touch CUSTOM-named accounts under a non-Vault wallet and not write them back', async () => {
+    const original = {
+      id: 1,
+      walletId: 1,
+      signingType: SigningType.MULTISIG,
+      accountType: AccountType.MULTISIG,
+      name: 'My multisig',
+      nameType: AccountNameType.CUSTOM,
+    };
+    db.wallets = [{ id: 1, type: WalletType.MULTISIG }];
+    db.accounts2 = [original];
+
+    await resetVaultAccountNameType(transactionMock);
+
+    expect(db.accounts2[0]).toBe(original);
   });
 
   it('should handle empty accounts2 table', async () => {
+    db.wallets = [{ id: 1, type: WalletType.POLKADOT_VAULT }];
     db.accounts2 = [];
 
     await resetVaultAccountNameType(transactionMock);

--- a/src/renderer/shared/api/storage/migration/index.ts
+++ b/src/renderer/shared/api/storage/migration/index.ts
@@ -18,3 +18,4 @@ export { addAccountCreatedAt } from './migration-17';
 export { backupContactsBeforePKChange, migrateContactsToStringIds, restoreContactsAfterPKChange } from './migration-18';
 export { dropPersistedBackendContacts } from './migration-19';
 export { migrateWalletsHiddenReason } from './migration-20';
+export { resetVaultAccountNameType } from './migration-21';

--- a/src/renderer/shared/api/storage/migration/migration-21.ts
+++ b/src/renderer/shared/api/storage/migration/migration-21.ts
@@ -1,6 +1,6 @@
 import { type Transaction } from 'dexie';
 
-import { AccountNameType, AccountType, SigningType } from '@/shared/core';
+import { type Wallet, AccountNameType, AccountType, WalletType } from '@/shared/core';
 
 /**
  * Migration-14 stamped nameType: CUSTOM onto every pre-existing account,
@@ -9,18 +9,32 @@ import { AccountNameType, AccountType, SigningType } from '@/shared/core';
  * these — they're auto-labeled "Main" or a raw derivation path). Reset those
  * back to GENERATED so address-book resolution applies to them.
  *
+ * Vault membership is checked via the owning wallet's type rather than the
+ * account's own signingType: accounts that migrated from a pre-accounts2
+ * Multishard wallet (migration-2 -> migration-3 -> migration-6) kept their
+ * original signingType (PARITY_SIGNER, i.e. 'signing_ps') on every regrouped
+ * chain/shard account — only the synthesized BASE account was stamped
+ * POLKADOT_VAULT. Keying off wallet.type catches those legacy accounts too.
+ *
  * Deliberately excludes the BASE/universal Vault account created when a pairing
  * produces zero derived keys (`ManageVault.tsx`'s fallback) — its name is the
  * wallet name the user actually typed, so CUSTOM is correct there. Idempotent.
  */
 export async function resetVaultAccountNameType(t: Transaction): Promise<void> {
+  const wallets = await t.table<Wallet>('wallets').toArray();
+  const vaultWalletIds = new Set(
+    wallets
+      .filter((wallet) => wallet.type === WalletType.POLKADOT_VAULT || wallet.type === WalletType.SINGLE_PARITY_SIGNER)
+      .map((wallet) => wallet.id),
+  );
+
   await t
     .table('accounts2')
     .toCollection()
     .modify((account) => {
-      if (account.signingType !== SigningType.POLKADOT_VAULT) return;
-      if (account.accountType !== AccountType.CHAIN && account.accountType !== AccountType.SHARD) return;
-      if (account.nameType !== AccountNameType.CUSTOM) return;
+      if (!vaultWalletIds.has(account.walletId)) return false;
+      if (account.accountType !== AccountType.CHAIN && account.accountType !== AccountType.SHARD) return false;
+      if (account.nameType !== AccountNameType.CUSTOM) return false;
 
       account.nameType = AccountNameType.GENERATED;
     });

--- a/src/renderer/shared/api/storage/migration/migration-21.ts
+++ b/src/renderer/shared/api/storage/migration/migration-21.ts
@@ -1,0 +1,27 @@
+import { type Transaction } from 'dexie';
+
+import { AccountNameType, AccountType, SigningType } from '@/shared/core';
+
+/**
+ * Migration-14 stamped nameType: CUSTOM onto every pre-existing account,
+ * including Polkadot Vault derived keys (CHAIN/SHARD accounts) whose name was
+ * never actually chosen by the user (Vault has no per-account rename UI for
+ * these — they're auto-labeled "Main" or a raw derivation path). Reset those
+ * back to GENERATED so address-book resolution applies to them.
+ *
+ * Deliberately excludes the BASE/universal Vault account created when a pairing
+ * produces zero derived keys (`ManageVault.tsx`'s fallback) — its name is the
+ * wallet name the user actually typed, so CUSTOM is correct there. Idempotent.
+ */
+export async function resetVaultAccountNameType(t: Transaction): Promise<void> {
+  await t
+    .table('accounts2')
+    .toCollection()
+    .modify((account) => {
+      if (account.signingType !== SigningType.POLKADOT_VAULT) return;
+      if (account.accountType !== AccountType.CHAIN && account.accountType !== AccountType.SHARD) return;
+      if (account.nameType !== AccountNameType.CUSTOM) return;
+
+      account.nameType = AccountNameType.GENERATED;
+    });
+}

--- a/src/renderer/shared/api/storage/service/dexie.ts
+++ b/src/renderer/shared/api/storage/service/dexie.ts
@@ -37,6 +37,7 @@ import {
   migrateWalletsHiddenReason,
   removeDeprecatedProxiedAccounts,
   renameBlockNumberToEntropyBlockNumber,
+  resetVaultAccountNameType,
   restoreContactsAfterPKChange,
 } from '../migration';
 
@@ -178,6 +179,8 @@ class DexieStorage extends Dexie {
     this.version(51).upgrade(dropPersistedBackendContacts);
 
     this.version(52).upgrade(migrateWalletsHiddenReason);
+
+    this.version(53).upgrade(resetVaultAccountNameType);
 
     this.connections = this.table('connections');
     this.balances2 = this.table('balances2');

--- a/src/renderer/shared/ui-entities/AccountSelect/AccountSelect.tsx
+++ b/src/renderer/shared/ui-entities/AccountSelect/AccountSelect.tsx
@@ -1,9 +1,9 @@
-import { memo } from 'react';
+import { memo, useMemo, useState } from 'react';
 
 import { type Asset, type BalanceMap, type Chain, type XOR } from '@/shared/core';
-import { nonNullable, toAddress, transferableAmountBN, withdrawableAmountBN } from '@/shared/lib/utils';
+import { nonNullable, performSearch, toAddress, transferableAmountBN, withdrawableAmountBN } from '@/shared/lib/utils';
 import { Select } from '@/shared/ui-kit';
-import { type AnyAccount } from '@/domains/network';
+import { type AnyAccount, useAccountsNames } from '@/domains/network';
 import { balanceUtils } from '@/entities/balance';
 import { Address } from '../Address/Address';
 import { AssetBalance } from '../AssetBalance/AssetBalance';
@@ -24,6 +24,18 @@ type Props = {
 
 export const AccountSelect = memo(
   ({ value, onChange, chain, balances, balanceType, asset, options, placeholder, invalid, testId }: Props) => {
+    const resolvedOptions = useAccountsNames(options, chain);
+    const [query, setQuery] = useState('');
+
+    const filteredOptions = useMemo(() => {
+      return performSearch({
+        query,
+        records: resolvedOptions,
+        getMeta: account => ({ address: toAddress(account.accountId, { prefix: chain.addressPrefix }) }),
+        weights: { name: 1, address: 0.5 },
+      });
+    }, [query, resolvedOptions, chain]);
+
     const handleChange = (id: string) => {
       const account = options.find(account => account.id === id);
       if (nonNullable(account)) {
@@ -38,9 +50,10 @@ export const AccountSelect = memo(
         testId={testId}
         invalid={invalid}
         height="md"
+        onSearch={setQuery}
         onChange={handleChange}
       >
-        {options.map(account => {
+        {filteredOptions.map(account => {
           const address = toAddress(account.accountId, { prefix: chain.addressPrefix });
           const balance = balances
             ? balanceUtils.getBalance(balances, account.accountId, chain.chainId, asset.assetId)


### PR DESCRIPTION
## Description
Polkadot Vault derived accounts were flagged as "custom named" both at creation time and by a historical migration, so the address-book/identity resolution chain was always skipped for them — the transfer "From account" selector (and any other consumer of the shared name resolver) showed the raw derivation path or "Main" instead of a saved contact name, even when the same address was already in the address book. Separately, once a name was resolved and cached, it stayed stale if contacts changed while a view was still mounted — reconnecting the backend address book from an open Transfer modal required closing and reopening it to see the update.

To verify: pair a Vault wallet with multiple derived keys, add one of its addresses to the address book with a custom name, open Transfer and check the "From account" dropdown shows that name (and that typing filters the list). Then, with the modal still open, reconnect/disconnect the backend address book and confirm names update without closing the modal.

Also includes draft spec READMEs for `polkadot-vault-wallet` and `polkadot-vault-wallet-pairing` (required by the Feature Map CI check since this PR touches their account-creation code). Written from reading the code — **flagged as pending review from the feature's author** before being treated as source of truth.

## Related Issues
https://novasama-technologies.atlassian.net/browse/SPEK-698

## Changes Made
- Vault account creation (`manage-vault-model.ts`, `polkadot-vault-wallet/service.ts`) now marks newly derived keys `GENERATED` instead of relying on a `CUSTOM` default, making them eligible for address-book resolution going forward.
- New migration (`migration-21.ts`, DB v53) resets existing Vault chain/shard accounts from `CUSTOM` back to `GENERATED`, deliberately excluding the single BASE/universal account created when a pairing yields zero derived keys, since that name really was typed by the user.
- `resolveAccountName` (`service.ts`) gains a fallback tier — the account's own stored name is tried before falling back to a short address, so accounts without a contact/identity match still show "Main"/derivation path rather than a truncated address.
- `AccountSelect` (the transfer "From account" dropdown) now resolves names through the same contact/identity chain as the rest of the app, and supports search, mirroring the recipient selector's `Select` + `onSearch` pattern.
- `resource.ts` tracks which accounts/wallets currently have a resolved name cached and recomputes them whenever contacts change, so mounted views update live instead of only on remount.
- Draft spec READMEs added for `polkadot-vault-wallet` and `polkadot-vault-wallet-pairing`, and linked in the Feature Map.

### Addressed review feedback
A `CHANGES_REQUESTED` review flagged several follow-on issues in the above; all are fixed in a follow-up commit:
- `migration-21.ts` now keys off the owning wallet's type instead of the account's own `signingType` — accounts that migrated from a pre-`accounts2` Multishard wallet kept a stale `PARITY_SIGNER` signingType and were being skipped. Also fixed `.modify()`'s early-exit branches to `return false`, so untouched rows are no longer rewritten on every migration run.
- Live name recompute (`resource.ts`) now reacts to identities/accounts/chains changing, not just contacts, and merges onto the existing cache instead of replacing it wholesale; tracked params are capped to bound memory growth.
- `resolveAccountName` now uses the caller's already-known account when available instead of re-deriving it by `accountId` alone, and otherwise prefers a chain match, then a `CUSTOM`-named account, over array order — fixes a Vault key's raw derivation path being able to shadow a differently-named account that happens to share its `accountId` across wallets. The account-name cache key and `accountsNameResource`'s own request key were both extended with the same per-account identity so two accounts (or two account lists) sharing an `accountId` no longer collide on the same cache/request slot.
- `wallet-model.ts`'s `createWalletFx` now defaults `nameType` based on `accountType` (Vault `CHAIN`/`SHARD` keys → `GENERATED`, everything else keeps the existing `CUSTOM` default) instead of one blanket default, so any future Vault-derived-key creation path is correct by default without relying on every call site to remember to stamp it.

## Screenshots/Recordings
https://github.com/user-attachments/assets/f44fd5c9-cb22-4530-bc5f-c714daa8bd78

## Checklist
- [ ] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [ ] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [ ] My code follows the project's coding standards and style guidelines
