### PR TITLE
docs: specs for operation-details features

### DIFF
--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -42,7 +42,7 @@ notes.
 - `multisig-wallet`
 - `multisig-wallet-create`
 - `flexible-change-signatories`
-- `flexible-operation-details` (no spec planned)
+- [`flexible-operation-details`](./flexible-operation-details/README.md)
 - `multisig-candidates` (aggregate)
 - [`multisig-operation-description`](../aggregates/multisig-operation-description/README.md) (aggregate)
 - `selected-wallet-multisig-operations` (aggregate)
@@ -55,7 +55,7 @@ notes.
 - `proxies`
 - `proxy-add`
 - `proxy-basket`
-- `proxy-operation-details` (no spec planned)
+- [`proxy-operation-details`](./proxy-operation-details/README.md)
 - `proxy-remove`
 - [`proxy-verify`](./proxy-verify/README.md)
 - [`proxied-add-pure`](./proxied-add-pure/README.md)
@@ -71,7 +71,7 @@ notes.
 - `staking-bond-extra`
 - `staking-bond-nominate`
 - `staking-nominate`
-- `staking-operation-details` (no spec planned)
+- [`staking-operation-details`](./staking-operation-details/README.md)
 - `staking-payee`
 - `staking-restake`
 - `staking-unstake`
@@ -86,7 +86,7 @@ notes.
 - `governance`
 - `governance-navigation` (no spec planned)
 - `governance-basket`
-- `governance-operation-details` (no spec planned)
+- [`governance-operation-details`](./governance-operation-details/README.md)
 - `governance-meta-provider` (aggregate)
 
 > See also: [`dashboard-governance`](#dashboard) — governance summary on the dashboard.
@@ -117,11 +117,11 @@ notes.
 
 - `transfer`
 - `transfer-basket`
-- `transfer-operation-details` (no spec planned)
+- [`transfer-operation-details`](./transfer-operation-details/README.md)
 - `multi-transfer`
-- `multi-transfer-operation-details` (no spec planned)
+- [`multi-transfer-operation-details`](./multi-transfer-operation-details/README.md)
 - [`vested-transfer`](./vested-transfer/README.md)
-- `vested-transfer-operation-details` (no spec planned)
+- [`vested-transfer-operation-details`](./vested-transfer-operation-details/README.md)
 - [`vesting-claim`](./vesting-claim/README.md)
 - [`vesting-portfolio`](../aggregates/vesting-portfolio/README.md) (aggregate)
 - `send-to-contact`

--- a/src/renderer/features/flexible-operation-details/README.md
+++ b/src/renderer/features/flexible-operation-details/README.md
@@ -4,37 +4,81 @@
 
 ## Overview
 
-Recognizes an **"Edit flexible multisig"** operation in the [Operations view](../multisig-operations/README.md) and
-gives its row a proper title and icon instead of the raw `proxy: proxy` section/method fallback. A flexible multisig is
-a multisig that operates a proxied account; changing who controls it is executed on-chain as a proxy swap, and without
-this feature that operation would read as an anonymous proxy call.
+Covers the **"Edit flexible multisig"** operation — replacing the controller of a flexible multisig (the multisig that
+operates a proxied account) — in the [Operations view](../multisig-operations/README.md). On-chain the replacement is a
+proxy swap; without dedicated presentation it would read as an anonymous `proxy: proxy` call. The operation exists in
+**two execution variants** — **trusted** and **verified** — and the view presents each with its own card, tag, and
+details.
 
-## Who can use it / when it applies
+The primary presentation (the bespoke card and its details panel, described below) is owned by the Operations view's
+_Edit controller_ detector; this feature contributes the generic title/icon fallback for the same shape. Both are
+specified here so the edit-flexible story lives in one place.
 
-Applies automatically to any operation row whose transaction has the exact shape
-`proxy.proxy( utility.batchAll[ addProxy, removeProxy ] )` — a batch of exactly two calls, add first, remove second,
-wrapped in a proxy call. This is the shape Spektr emits when the controller of a flexible multisig is replaced. Any
-other shape (a lone add/remove proxy, a reversed pair, an unwrapped batch) is left to other operation-details features.
+## The two edit variants
+
+| Variant                   | On-chain shape                                       | What it means                                                                                                                                                                                                                        |
+| ------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| **Trusted (atomic swap)** | `proxy.proxy( batchAll[ addProxy, removeProxy ] )`   | The new controller is added **and the old one removed in the same transaction**. Requires trusting that the new controller's keys are correct upfront — there is no proof step.                                                      |
+| **Verified (add-only)**   | `proxy.proxy( batchAll[ addProxy, marker remark ] )` | **Only the new controller is added.** A `system.remark` marker in the batch records the outgoing controller. The old controller is removed later, after the new one proves access via a separate **verification operation** (below). |
+
+Accepted wrapper variations: the inner batch may be `batch` / `batchAll` / `forceBatch`; `addProxyWithDelay` counts as
+the add; and when the new controller's multisig is not known locally, the whole `proxy.proxy` may itself be wrapped in
+an outer batch alongside a `system.remarkWithEvent` carrying new-controller metadata — the detector recurses into it. A
+bare `addProxy` without the batch structure is a plain proxy addition, not an edit (see
+[`proxy-operation-details`](../proxy-operation-details/README.md)).
 
 ## What the operation row shows
 
-- **Title** — "Edit flexible multisig", with the source chain name as the subtitle.
-- **Icon** — the delegated-authorities (proxy) icon.
-- **Value** — nothing; the operation carries no displayable amount.
-- **Expanded Details panel** — this feature adds no rows of its own; the panel shows only the shared rows (depositor,
-  date/time, description).
+The edit operation renders as a bespoke card across the Operation and Value cells:
 
-## Supported wrappers
+- **old → new** identicon pair for the outgoing and incoming controller accounts;
+- title **"Edit flexible multisig"** with the chain name;
+- a variant tag with an explanatory tooltip: **"Atomic swap"** (warning-colored — _"Old proxy is removed in the same
+  transaction"_) for the trusted flow, or **"Verified swap"** (positive-colored — _"New proxy is added; the old one is
+  removed later, after verification"_) for the verified flow.
 
-The proxy wrapper is not unwrapped before matching — it is part of the matched shape itself. The `utility.batchAll` pair
-inside is the only batch shape recognized.
+No amount is displayed — the operation carries no value.
+
+## Expanded Details panel
+
+Added to the shared rows (depositor, date/time, description):
+
+- **New proxy** — the address control is transferred to, resolved to a name. When the incoming controller is a known
+  multisig candidate, its **threshold ("{n} of {m}") and signatory list** are shown under it.
+- **Old proxy** — **trusted flow only**: the outgoing controller, with the same threshold/signatories enrichment when
+  known. (In the verified flow the old controller stays in place until verification, so only the target is shown.)
+- **Execution mode** — _"Trusted (atomic): old proxy will be removed in the same transaction."_ or _"Verified
+  (add-only): old proxy will be removed later, after verification."_
+- **Open proxy details** — opens the proxied wallet's details on its Proxies tab, when the proxied account belongs to a
+  local wallet.
+
+## The verification operation (verified flow, step 2)
+
+In the verified flow the new controller must prove it can act for the proxied account before the old one is removed.
+That proof is its own multisig operation — a ping
+`proxy.proxy( real = pure proxy, system.remarkWithEvent( verify marker ) )` — presented by the Operations view's _Verify
+proxy_ card:
+
+- **Row** — title **"Verification for wallet"** with a **"Verification"** tag (tooltip: _"Signer is proving control of
+  the proxied wallet via a marker remark"_).
+- **Details** — **Verifying wallet** (the new controller whose access is being proven, named), the optional **Remark**
+  text, and **Open wallet details** (the pure proxy wallet's Proxies tab, where the delegate's verification status is
+  surfaced).
+
+The marker payload is the discriminator — an ordinary `remarkWithEvent` operation without it is not presented as a
+verification.
+
+## Fallback title and icon (this feature proper)
+
+For the exact shape `proxy.proxy( batchAll[ addProxy, removeProxy ] )` this feature registers the generic row title
+**"Edit flexible multisig"** and the delegated-authorities icon. It applies only when the bespoke detectors above do not
+claim the operation (they match a superset of shapes and take precedence), and it adds no Details rows of its own.
 
 ## Related
 
-- The Operations view carries two **bespoke cards** for proxy-shaped operations — _Edit controller_
-  (`parseProxyEditOperation`) and _Verify proxy_ (`parseVerifyProxyOperation`) — which are evaluated first and replace
-  the generic icon + title block entirely, including this feature's output. The same on-chain shape is therefore usually
-  presented by the Edit controller card (which also injects its own Details rows); this feature is the fallback
-  presentation when the bespoke detectors do not claim the operation.
-- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the transformers, and the details slot this
-  feature injects into.
+- [`multisig-operations`](../multisig-operations/README.md) — owns the bespoke _Edit controller_ / _Verify proxy_ cards,
+  their detectors, and the details panels described above.
+- **`flexible-change-signatories`** — the flow that produces edit-flexible operations and chooses between the trusted
+  and verified variants.
+- [`proxy-verify`](../proxy-verify/README.md) — builds the verification ping.
+- [`proxy-operation-details`](../proxy-operation-details/README.md) — plain (non-edit) proxy management operations.

--- a/src/renderer/features/flexible-operation-details/README.md
+++ b/src/renderer/features/flexible-operation-details/README.md
@@ -56,8 +56,26 @@ Added to the shared rows (depositor, date/time, description):
 
 In the verified flow the new controller must prove it can act for the proxied account before the old one is removed.
 That proof is its own multisig operation — a ping
-`proxy.proxy( real = pure proxy, system.remarkWithEvent( verify marker ) )` — presented by the Operations view's _Verify
-proxy_ card:
+`proxy.proxy( real = pure proxy, system.remarkWithEvent( verify marker ) )`, built by the
+[`proxy-verify`](../proxy-verify/README.md) flow and dispatched by the new controller through the pure proxy. Only proxy
+types that can dispatch a remark are verifiable this way: **Any** and **NonTransfer**.
+
+**The marker.** The `system.remarkWithEvent` body is a JSON payload
+`{ kind: "verify-proxy", delegateAccountId, pureProxyAccountId, remark? }`:
+
+- `kind` is the discriminator — an ordinary `remarkWithEvent` operation without it is never presented (or counted) as a
+  verification.
+- The `(delegate, pure proxy)` pair lets the executed operation be matched back to the exact proxy row being verified —
+  without it, _any_ executed operation through that multisig + pure-proxy pair would flip the row to verified, a false
+  positive for incidental operations.
+- `remark` is optional user text shown in the details (older pings carry it under the legacy `memo` key — still
+  accepted).
+- On-chain the remark arrives hex-encoded; local builds keep the JSON string — both are parsed. A payload whose account
+  ids don't decode is rejected, so a crafted remark can't render as a verification ping.
+- The marker is accepted at any level — bare `remarkWithEvent`, proxy-wrapped, or inside a batch — because the
+  multisig-operation domain often stores the core call with the proxy wrapper already stripped.
+
+**Presentation** (the Operations view's _Verify proxy_ card):
 
 - **Row** — title **"Verification for wallet"** with a **"Verification"** tag (tooltip: _"Signer is proving control of
   the proxied wallet via a marker remark"_).
@@ -65,14 +83,22 @@ proxy_ card:
   text, and **Open wallet details** (the pure proxy wallet's Proxies tab, where the delegate's verification status is
   surfaced).
 
-The marker payload is the discriminator — an ordinary `remarkWithEvent` operation without it is not presented as a
-verification.
+**Outcome.** When the ping executes, the wallet-details proxies model matches the emitted marker back to the
+`(delegate, pure proxy)` row and marks that controller **verified** — unblocking the removal of the old one.
+
+Note the two remark flavours are deliberately distinct: the **verify ping** uses `system.remarkWithEvent` (its execution
+must be observable on-chain), while the **old-controller marker** inside the verified edit batch is a plain
+`system.remark`; an outer `remarkWithEvent` next to the edit batch carries new-controller metadata only when the new
+multisig isn't known locally, and the detectors never conflate the three.
 
 ## Fallback title and icon (this feature proper)
 
 For the exact shape `proxy.proxy( batchAll[ addProxy, removeProxy ] )` this feature registers the generic row title
-**"Edit flexible multisig"** and the delegated-authorities icon. It applies only when the bespoke detectors above do not
-claim the operation (they match a superset of shapes and take precedence), and it adds no Details rows of its own.
+**"Edit flexible multisig"** and the delegated-authorities icon, and adds no Details rows of its own. In the operations
+table it is effectively shadowed: the domain stores a flexible-multisig operation's call with the proxy wrapper already
+stripped (so this detector's `proxy.proxy` requirement doesn't match), and the bespoke card claims the operation anyway.
+Where it does surface is the other consumers of the shared title/icon transformers — **draft rows** and **multisig
+notifications** — whose decoded calls keep the full wrapper.
 
 ## Related
 

--- a/src/renderer/features/flexible-operation-details/README.md
+++ b/src/renderer/features/flexible-operation-details/README.md
@@ -1,0 +1,40 @@
+# Flexible Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Recognizes an **"Edit flexible multisig"** operation in the [Operations view](../multisig-operations/README.md) and
+gives its row a proper title and icon instead of the raw `proxy: proxy` section/method fallback. A flexible multisig is
+a multisig that operates a proxied account; changing who controls it is executed on-chain as a proxy swap, and without
+this feature that operation would read as an anonymous proxy call.
+
+## Who can use it / when it applies
+
+Applies automatically to any operation row whose transaction has the exact shape
+`proxy.proxy( utility.batchAll[ addProxy, removeProxy ] )` — a batch of exactly two calls, add first, remove second,
+wrapped in a proxy call. This is the shape Spektr emits when the controller of a flexible multisig is replaced. Any
+other shape (a lone add/remove proxy, a reversed pair, an unwrapped batch) is left to other operation-details features.
+
+## What the operation row shows
+
+- **Title** — "Edit flexible multisig", with the source chain name as the subtitle.
+- **Icon** — the delegated-authorities (proxy) icon.
+- **Value** — nothing; the operation carries no displayable amount.
+- **Expanded Details panel** — this feature adds no rows of its own; the panel shows only the shared rows (depositor,
+  date/time, description).
+
+## Supported wrappers
+
+The proxy wrapper is not unwrapped before matching — it is part of the matched shape itself. The `utility.batchAll` pair
+inside is the only batch shape recognized.
+
+## Related
+
+- The Operations view carries two **bespoke cards** for proxy-shaped operations — _Edit controller_
+  (`parseProxyEditOperation`) and _Verify proxy_ (`parseVerifyProxyOperation`) — which are evaluated first and replace
+  the generic icon + title block entirely, including this feature's output. The same on-chain shape is therefore usually
+  presented by the Edit controller card (which also injects its own Details rows); this feature is the fallback
+  presentation when the bespoke detectors do not claim the operation.
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the transformers, and the details slot this
+  feature injects into.

--- a/src/renderer/features/governance-operation-details/README.md
+++ b/src/renderer/features/governance-operation-details/README.md
@@ -1,0 +1,56 @@
+# Governance Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents **OpenGov governance operations** in the multisig [Operations view](../multisig-operations/README.md): a human
+title and icon per governance action, the amount involved, and vote- or delegation-specific rows in the expanded Details
+panel.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is one of the governance actions:
+
+| Call            | Row title           | Amount shown                      |
+| --------------- | ------------------- | --------------------------------- |
+| vote            | "Vote"              | vote balance (without conviction) |
+| remove vote     | "Remove vote"       | —                                 |
+| unlock          | "Unlock"            | unlocked value                    |
+| delegate        | "Delegate"          | delegated balance                 |
+| undelegate      | "Revoke delegation" | —                                 |
+| edit delegation | "Edit Delegation"   | the new delegated balance         |
+
+The asset is resolved from the call's asset id. Each action carries its own icon.
+
+## Expanded Details panel
+
+Added to the shared rows, by action group:
+
+- **Votes** (vote / remove vote / unlock):
+  - **Referendum** — the referendum number (`#id`), when the call carries one.
+  - **Number of votes** — the decision ("Aye" / "Nay" / "Abstain") with the voting power: conviction-weighted balance
+    for a standard vote, the abstained balance for a split-abstain vote.
+- **Delegations** (delegate / undelegate / edit delegation):
+  - **Delegate** — the delegation target, resolved to a name. For an undelegation the target is looked up on-chain from
+    the account's current delegating state (skeleton rows while loading).
+  - **Number of votes** — the conviction-weighted voting power delegated (looked up on-chain for undelegations).
+  - **Tracks** — the governance tracks the delegation covers.
+
+## Supported wrappers
+
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching.
+- **`utility.batchAll`** — partially. The Details components and amount extraction read through governance batches
+  (edit-delegation is itself a delegate+undelegate batch; unlock ships with remove-vote), but the row **title and icon**
+  match only a direct governance call — a batch whose outer call is `batchAll` falls back to the generic
+  `section: method` title.
+
+## Confirmation step
+
+No contribution — the approve/sign confirmation shows only the shared operation summary for governance operations.
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the Details panel slot, and the fallback
+  presentation.
+- **Governance flows** (`features/governance-*`) — produce these operations.

--- a/src/renderer/features/multi-transfer-operation-details/README.md
+++ b/src/renderer/features/multi-transfer-operation-details/README.md
@@ -1,0 +1,48 @@
+# Multi Transfer Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents a **multi transfer** — a `utility.batchAll` consisting entirely of native transfers, the shape produced by
+Spektr's CSV-driven multi-transfer flow — in the multisig [Operations view](../multisig-operations/README.md): the row's
+title, icon and summed amount, a per-recipient preview in the expanded Details panel, and the total-amount block on the
+approve/sign confirmation step.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is a `utility.batchAll` where **every** inner call is
+a plain native `transfer` (one or more). A batch mixing transfers with anything else is not a multi transfer and falls
+through to the generic presentation.
+
+## What the operation row shows
+
+- **Title** — "Multi Transfer", with the source chain name as the subtitle.
+- **Icon** — the multi-transfer icon.
+- **Value** — the **sum** of all inner transfer amounts, in the chain's **native asset**.
+
+## Expanded Details panel
+
+One row is added to the shared rows: **Parsed file** with a **Preview** button. It opens a modal listing every transfer
+of the batch in a table — row number, **Recipient** (resolved to a name) and **Amount** (with fiat value and a
+raw-planks tooltip) — paged by 50 with a "Show more" control. The same preview component serves the CSV-import flow; in
+this read-only context it shows no validation issues or download action.
+
+## Confirmation step
+
+On the approve/sign flow the feature contributes the centered **total amount block** (native asset, with fiat value).
+Note: this block matches the raw transaction only — a proxy-wrapped multi transfer shows no amount here.
+
+## Supported wrappers
+
+- **`utility.batchAll`** — the matched shape itself (transfers only, inspected directly).
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching in the row title, icon, and Details
+  panel (but not on the confirmation step, see above).
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the Details panel slot, and the
+  confirmation step this feature injects into.
+- [`transfer-operation-details`](../transfer-operation-details/README.md) — single-transfer counterpart; note the asset
+  difference: multi transfer always presents the native asset, single transfers resolve the asset from the call's asset
+  id.

--- a/src/renderer/features/proxy-operation-details/README.md
+++ b/src/renderer/features/proxy-operation-details/README.md
@@ -1,0 +1,55 @@
+# Proxy Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents **proxy-management operations** — delegating and revoking on-chain authority — in the multisig
+[Operations view](../multisig-operations/README.md): a human title and icon per proxy action and the delegation-specific
+rows of the expanded Details panel.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is one of the proxy actions:
+
+| Call              | Row title                                 |
+| ----------------- | ----------------------------------------- |
+| add proxy         | "Add delegated authority (proxy)"         |
+| remove proxy      | "Revoke delegated authority (proxy)"      |
+| create pure proxy | "Create pure proxy"                       |
+| kill pure proxy   | "Revoke delegated authority (pure proxy)" |
+
+All proxy actions share the delegated-authorities icon; none displays an amount (proxy calls carry no value).
+
+**Exception:** an operation recognized as a **proxy edit** — the
+`proxy.proxy( utility.batchAll[ addProxy, removeProxy ] )` shape that swaps a flexible multisig's controller — is
+deliberately left to the Operations view's bespoke _Edit controller_ card and its own details panel; this feature
+contributes nothing for it.
+
+## Expanded Details panel
+
+Added to the shared rows, when the call carries the data:
+
+| Row             | When                       | What it shows                                |
+| --------------- | -------------------------- | -------------------------------------------- |
+| **Delegate to** | add proxy                  | the account receiving authority, named       |
+| **Revoke for**  | remove proxy               | the account losing authority, named          |
+| **Revoke for**  | kill pure proxy            | the sender (the pure proxy being dissolved)  |
+| **Access type** | add / remove / create pure | the proxy type (Any, Staking, Governance, …) |
+
+## Supported wrappers
+
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching.
+- **`utility.batchAll`** — not matched here; the add+remove pair is the proxy-edit shape handled by the bespoke card
+  (see the exception above).
+
+## Confirmation step
+
+No contribution — the approve/sign confirmation shows only the shared operation summary for proxy operations.
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row and the Details panel slot, and owns the
+  bespoke _Edit controller_ / _Verify proxy_ cards that take precedence for their shapes.
+- [`flexible-operation-details`](../flexible-operation-details/README.md) — fallback title/icon for the proxy-edit shape
+  when the bespoke detectors do not claim it.

--- a/src/renderer/features/staking-operation-details/README.md
+++ b/src/renderer/features/staking-operation-details/README.md
@@ -1,0 +1,54 @@
+# Staking Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents **staking operations** in the multisig [Operations view](../multisig-operations/README.md): a human title and
+icon per staking action, the staked amount, and staking-specific rows (reward destination, validators) in the expanded
+Details panel.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is one of the staking actions:
+
+| Call       | Row title                | Amount shown     |
+| ---------- | ------------------------ | ---------------- |
+| bond       | "Start Staking"          | bonded value     |
+| nominate   | "Change Validators"      | —                |
+| stake more | "Stake More"             | additional value |
+| unstake    | "Unstake"                | unbonded value   |
+| restake    | "Restake"                | re-bonded value  |
+| redeem     | "Withdraw Unstaked"      | withdrawn value  |
+| set payee  | "Set reward destination" | —                |
+
+The asset is resolved from the call's asset id (staking on Asset Hub is asset-based, not implicitly native). Each action
+also carries its own icon.
+
+## Expanded Details panel
+
+Added to the shared rows (depositor, date/time, description), by action:
+
+- **Rewards destination** — for bond / stake more / unstake / restake / redeem, when the call carries a payee: either
+  "Restake rewards" or the payout account resolved to a name.
+- **Validators** — for nominate (and for a bond arriving without a payee): a count button that opens the validators
+  modal, listing the selected validators (with on-chain identities) against the current validator set.
+- Set-payee operations add no rows of their own.
+
+## Supported wrappers
+
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching.
+- **`utility.batchAll`** — partially. Compound staking batches (bond + nominate, chill + unbond) resolve their
+  **amount** through the batch's representative inner call, and the Details components read payee/validators out of
+  batch entries — but the row **title and icon** match only a direct staking call, so a batch-shaped staking operation
+  falls back to the generic `section: method` title.
+
+## Confirmation step
+
+No contribution — the approve/sign confirmation shows only the shared operation summary for staking operations.
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the Details panel slot, and the fallback
+  presentation.
+- **Staking flows** (`features/staking-*`) — produce these operations; staking lives on Asset Hub chains.

--- a/src/renderer/features/transfer-operation-details/README.md
+++ b/src/renderer/features/transfer-operation-details/README.md
@@ -1,0 +1,56 @@
+# Transfer Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents **token transfer operations** — same-chain and cross-chain (XCM) — in the multisig
+[Operations view](../multisig-operations/README.md): the row's title, icon and amount, the transfer-specific rows of the
+expanded Details panel, and the amount block on the approve/sign confirmation step. Without it a transfer would render
+as a raw `section: method` line with no recipient or route information.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is:
+
+- a **direct transfer** — native transfer, transfer-all, Asset Hub asset transfer, or ORML token transfer;
+- a **cross-chain transfer** — any of the supported XCM flavours (teleport, limited/reserve transfer, `xTokens`
+  transfers, `transfer_assets_using_type_and_then`, …).
+
+## What the operation row shows
+
+- **Title** — "Transfer", "Transfer All", or "Cross-chain transfer". Shown when the transferred asset can be resolved
+  from the call's asset id; otherwise the row falls back to the generic `section: method` title.
+- **Subtitle** — the source chain name; a cross-chain transfer shows the **from → to** chain pair instead.
+- **Icon** — the transfer icon, or the cross-chain icon for XCM.
+- **Value** — the transferred amount in the resolved asset. Transfer-all shows no amount (the final amount is only known
+  at execution).
+
+## Expanded Details panel
+
+Added to the shared rows (depositor, date/time, description):
+
+| Row              | When                          | What it shows                             |
+| ---------------- | ----------------------------- | ----------------------------------------- |
+| **Recipient**    | the destination is resolvable | the recipient account, resolved to a name |
+| **Sender**       | XCM only                      | the sending account                       |
+| **From network** | XCM only                      | the source chain                          |
+| **To network**   | XCM only                      | the destination chain                     |
+
+## Confirmation step
+
+On the approve/sign flow the feature contributes the centered **amount block** — the transferred amount with its fiat
+value — when the operation is a transfer with a resolvable asset and amount.
+
+## Supported wrappers
+
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching, so a proxy-routed transfer is
+  recognized and presented as a plain transfer.
+- **`utility.batchAll`** — not handled here; a batch of transfers is presented by
+  [`multi-transfer-operation-details`](../multi-transfer-operation-details/README.md).
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the Details panel slot, and the
+  confirmation step this feature injects into.
+- [`multi-transfer-operation-details`](../multi-transfer-operation-details/README.md) — the batch counterpart.

--- a/src/renderer/features/vested-transfer-operation-details/README.md
+++ b/src/renderer/features/vested-transfer-operation-details/README.md
@@ -1,0 +1,53 @@
+# Vested Transfer Operation Details
+
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-15
+
+## Overview
+
+Presents a **vested transfer** — a transfer whose amount unlocks gradually over blocks — in the multisig
+[Operations view](../multisig-operations/README.md): the row's title, icon and amount, a vesting-schedule preview in the
+expanded Details panel, and the amount block on the approve/sign confirmation step.
+
+## Who can use it / when it applies
+
+Applies automatically to any multisig operation whose (core) call is:
+
+- a single `vesting.vestedTransfer`, or
+- a **`utility.batchAll` of `vestedTransfer` calls** — the shape Spektr's vested-transfer form emits whenever more than
+  one call is needed: multiple recipients/schedule entries, or a single schedule with a **cliff** (an amount unlocked at
+  the start block), which is encoded as two calls — the immediate unlock plus the remaining vesting.
+
+## What the operation row shows
+
+- **Title** — "Vested transfer", with the source chain name as the subtitle.
+- **Icon** — the vested-transfer icon.
+- **Value** — the locked amount in the chain's **native asset**; for a batch, the **sum** over all entries (so a cliff
+  transfer shows its full amount, not just one leg).
+
+## Expanded Details panel
+
+One row is added to the shared rows: **Parsed file** with a **Preview** button. It opens a modal listing every schedule
+entry in a table — row number, **Recipient**, **Locked** (total locked amount, with fiat and raw-planks tooltip),
+**Start block** (with a starts-on date/time tooltip once the block timestamp resolves; timeline chain used when the
+chain defines one), and **Per block** (tokens released per block). Paged by 50 with "Show more". A cliff arrives as two
+schedule rows (the immediate-unlock leg and the remaining vesting) — the dedicated "Unlocked at start" column of this
+preview component appears only in the CSV-import flow, which supplies that field.
+
+## Confirmation step
+
+On the approve/sign flow the feature contributes the centered **amount block** — the total locked amount (summed over
+batch entries) in the native asset, with fiat value. It renders only for vested-transfer operations.
+
+## Supported wrappers
+
+- **`utility.batchAll`** — recognized whenever the batch's representative inner call is a `vestedTransfer`; title, icon,
+  details and amounts all match through the batch.
+- **`proxy.proxy`** — for flexible multisigs the call is unwrapped before matching everywhere, including the
+  confirmation amount block.
+
+## Related
+
+- [`multisig-operations`](../multisig-operations/README.md) — hosts the row, the Details panel slot, and the
+  confirmation step this feature injects into.
+- **`vested-transfer`** (form feature) — produces these operations; its builder decides between the single-call and
+  batch shapes described above.


### PR DESCRIPTION
## Summary

Adds product spec READMEs for all seven `*-operation-details` features that were marked `(no spec planned)` in the Feature Map, and converts their map entries to links. Docs only — no code changes.

Each spec follows the convention in `docs/content/docs/code/style/feature-specs.md` and covers:

- what the operation is and how it surfaces in the multisig Operations view (row title, icon, value);
- what the expanded **Details** panel shows on top of the shared rows (depositor, date/time, description);
- the contribution to the approve/sign **confirmation step**, where the feature makes one;
- **supported wrappers** — `proxy.proxy` unwrapping for flexible multisigs and `utility.batchAll` shapes — including where support is partial.

## Specs added

| Feature | Covers |
| --- | --- |
| `transfer-operation-details` | direct + XCM transfers; recipient/sender/network rows; confirm amount |
| `multi-transfer-operation-details` | `batchAll` of native transfers; summed amount; parsed-file preview |
| `vested-transfer-operation-details` | `vestedTransfer` incl. cliff/multi-entry batches; schedule preview |
| `staking-operation-details` | bond/nominate/unstake/…; payee + validators rows; partial batch support |
| `governance-operation-details` | vote/delegate/unlock/…; referendum, votes, tracks rows; partial batch support |
| `proxy-operation-details` | add/remove/pure proxy; delegate/revoke/access-type rows; proxy-edit exception |
| `flexible-operation-details` | "Edit flexible multisig" title/icon; relation to bespoke cards |

Notable behaviour captured as-is (worth an owner's eye, not changed here):

- staking/governance batches (`bond+nominate`, `unlock+removeVote`) resolve amounts and details through the batch, but their row title/icon falls back to `section: method`;
- transfer titles require the asset to resolve from the call's asset id;
- multi-transfer's confirm-step amount block does not unwrap a proxy wrapper.

`pnpm check:feature-map` passes (16 documented).
