### PR TITLE
ci: move feature map check to separate workflow

### DIFF
--- a/.github/workflows/feature-map.yaml
+++ b/.github/workflows/feature-map.yaml
@@ -1,0 +1,21 @@
+name: Feature map
+
+on:
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  check-feature-map:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: ⚙️Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: 🗺️ Check feature map
+        run: node scripts/check-feature-index.mjs --changed origin/${{ github.base_ref }}

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -28,6 +28,3 @@ jobs:
 
       - name: 📝 Check by linter
         run: TIMING=1 pnpm lint
-
-      - name: 🗺️ Check feature map
-        run: pnpm check:feature-map --changed origin/${{ github.base_ref }}


### PR DESCRIPTION
## Description

The Feature Map check currently runs as the last step of the `lint` job, so when it fails the PR shows a red "lint" check even though ESLint/typescript/formatter are all fine — misleading for the author. This PR moves it into its own `Feature map` workflow so the check appears under its own name in the PR checks list.

The check script only uses node built-ins, so the new workflow skips pnpm install entirely — just checkout (full history for the merge-base diff) and `node scripts/check-feature-index.mjs`.

## Changes Made

- Added `.github/workflows/feature-map.yaml` — standalone `Feature map` check on `pull_request`, runs `check-feature-index.mjs --changed` against the PR base
- Removed the `🗺️ Check feature map` step from `lint.yaml`

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
