### PR TITLE
fix: portfolio overview vesting scope and empty states

### DIFF
--- a/src/renderer/aggregates/vesting-portfolio/README.md
+++ b/src/renderer/aggregates/vesting-portfolio/README.md
@@ -1,23 +1,23 @@
 # Vesting portfolio
 
-> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-13
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-17
 
 ## Overview
 
-Answers one question for the whole app: **what is vesting right now, across every account the user can see?** It gathers
-the live vesting schedules of every non-hidden account on every vesting-capable chain, turns them into per-account views
-and a wallet-wide summary, and — the part that carries most of the weight — decides **whether the answer can be trusted
-yet**.
+Answers one question for the whole app: **what is vesting right now, across a given set of accounts?** It gathers the
+live vesting schedules of those accounts on every vesting-capable chain, turns them into per-account views and a
+wallet-wide summary, and — the part that carries most of the weight — decides **whether the answer can be trusted yet**.
 
 The vesting block on the dashboard ([`vesting-claim`](../../features/vesting-claim/README.md)) is its only consumer
-today. That block is self-contained: it takes no account list from the page it renders in, because vesting is not a
-property of the dashboard's account selection but of the wallet.
+today. The account set is fed in from outside via `accountsScopeChanged`: the dashboard scopes vesting to its account
+filter, so the block follows the card's selection. When no scope is set the aggregate defaults to every non-hidden
+wallet account, so it stays usable standalone.
 
 ## Who / when
 
-- Covers **all non-hidden accounts**, not the dashboard's selected subset. A hidden wallet's accounts are excluded
-  entirely — a claim from one could not be confirmed, since the confirmation resolves the initiator's wallet out of the
-  visible list.
+- Covers the **scoped account set** — the dashboard's selected accounts. The subset is always ⊆ visible accounts, so a
+  hidden wallet's accounts are excluded either way — a claim from one could not be confirmed, since the confirmation
+  resolves the initiator's wallet out of the visible list.
 - A chain participates only if its **runtime** exposes `pallet_vesting` (`query.vesting.vesting` + `tx.vesting.vest`) and
   at least one account's address scheme matches it. This is discovered from the connected chain's metadata; there is no
   static list of vesting chains.
@@ -65,14 +65,14 @@ flowchart TD
     Q1 -- "yes" --> READY["ready — content, plus a spinner while chains keep reporting"]
     Q1 -- "no" --> Q2{"Every chain resolved,<br/>wallets loaded?"}
     Q2 -- "no" --> LOAD["loading — skeleton"]
-    Q2 -- "yes" --> EMPTY["empty — 'no vesting'"]
+    Q2 -- "yes" --> EMPTY["empty — nothing shown"]
 ```
 
 | State     | When it appears                                                | What the consumer shows                        |
 | --------- | -------------------------------------------------------------- | ---------------------------------------------- |
 | `loading` | Any chain may still surface a schedule, or wallets are loading  | Skeleton                                       |
 | `ready`   | At least one **row** can be shown — not awaited any further      | Content, with `loadingMore` while chains report |
-| `empty`   | Every chain resolved and none holds vesting                     | "No vesting" row                               |
+| `empty`   | Every chain resolved and none holds vesting                     | Nothing — the callout renders no row            |
 
 Two rules keep the states honest over time:
 

--- a/src/renderer/aggregates/vesting-portfolio/model.ts
+++ b/src/renderer/aggregates/vesting-portfolio/model.ts
@@ -53,12 +53,26 @@ const isSameAccountSet = (next: AnyAccount[], prev: AnyAccount[]) =>
     );
   });
 
+/**
+ * The account set vesting is read for.
+ *
+ * `null` means "every visible wallet account" — the aggregate's standalone
+ * default. A consumer that scopes vesting to a subset (the dashboard's account
+ * filter) feeds that subset here, so the block follows the card's selection
+ * rather than the whole wallet. The subset is always ⊆ visible accounts, so the
+ * hidden-wallet exclusion is preserved either way.
+ */
+const accountsScopeChanged = createEvent<AnyAccount[] | null>();
+const $accountsScope = createStore<AnyAccount[] | null>(null).on(accountsScopeChanged, (_, accounts) => accounts);
+
+const $accountsSource = combine(walletModel.$availableAccounts, $accountsScope, (all, scope) => scope ?? all);
+
 // `updateFilter` rather than a comparison inside `map`: a skipped update keeps
 // the previous value *and its reference*, which is what every derived store
 // below reads to decide whether it has anything to recompute.
 const $availableAccounts = createStore<AnyAccount[]>([], {
   updateFilter: (next, prev) => !isSameAccountSet(next, prev),
-}).on(walletModel.$availableAccounts, (_, accounts) => accounts);
+}).on($accountsSource, (_, accounts) => accounts);
 
 /** Every key of every visible wallet. Stable for as long as the account set is. */
 const $accountIds = $availableAccounts.map(accounts => [...new Set(accounts.map(account => account.accountId))].sort());
@@ -333,4 +347,5 @@ export const vestingPortfolioModel = {
 
   activated,
   deactivated,
+  accountsScopeChanged,
 };

--- a/src/renderer/features/dashboard-portfolio-overview/README.md
+++ b/src/renderer/features/dashboard-portfolio-overview/README.md
@@ -1,6 +1,6 @@
 # Portfolio Overview
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-17
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-18
 
 ## Overview
 

--- a/src/renderer/features/dashboard-portfolio-overview/README.md
+++ b/src/renderer/features/dashboard-portfolio-overview/README.md
@@ -39,6 +39,7 @@ mode, so its position is a default rather than a guarantee.
 | Fiat off             | Global "show fiat" toggle is off       | Title + "fiat disabled" hint + the injected vesting block only; no total, bars or holdings    |
 | No selection         | No accounts selected                   | Title + "Select accounts above to view your balance"                                          |
 | Loading              | Prices/currency not resolved yet       | Skeleton mirroring the final layout                                                           |
+| No tokens            | Prices resolved, selection holds nothing priced and no vesting | Title + `$0` + vesting slot + a centered "No tokens to show" message  |
 | Overview             | Data ready                             | Fiat total, Assets/Networks toggle, distribution bar + chips, vesting slot, donut + list      |
 | Balance-type filter  | A bar segment or chip clicked          | Donut and list re-scope to that balance type; scope label + color follow; "Show all" clears   |
 | Donut hover          | Pointer over a donut segment           | Center swaps to the hovered slice's value, name and share; a single holding renders as a ring |
@@ -47,6 +48,14 @@ mode, so its position is a default rather than a guarantee.
 
 The card has **no error state**: missing prices degrade into the loading / suppressed states above. The injected vesting
 callout brings its own error boundary precisely because this slot offers none.
+
+The **No tokens** state is a real "the selected accounts hold nothing" answer, told only once we are confident of it —
+not a lie flashed while balances are still arriving. Balances stream in shortly after prices resolve, and a chain that
+keeps flapping between connecting and error leaves the global "syncing" flag raised for the life of the app, so neither
+"prices ready" nor "syncing finished" is a safe cue on its own. The card therefore holds the skeleton for a short grace
+per selection, then commits to the empty message — and keeps a small "Syncing balances…" spinner on it while any chain
+is still connecting, so a late-arriving balance reads as expected rather than as the message having been wrong. The
+vesting slot stays mounted in this state, since token-denominated vesting can exist with a zero fiat total.
 
 ### Distribution by balance type
 

--- a/src/renderer/features/dashboard-portfolio-overview/index.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/index.ts
@@ -4,6 +4,7 @@ import { $features } from '@/shared/config/features';
 import { createFeature } from '@/shared/feature';
 import { accountService } from '@/domains/network';
 import { networkModel } from '@/entities/network';
+import { vestingPortfolioModel } from '@/aggregates/vesting-portfolio';
 import { balanceSubModel } from '@/features/assets-balances';
 import { dashboardWidgetsSlot } from '@/pages/Dashboard';
 import { dashboardModel } from '@/pages/Dashboard/model/dashboard-model';
@@ -22,6 +23,13 @@ sample({
   clock: dashboardModel.$selectedAccounts,
   filter: (accounts) => accounts.length > 0,
   target: balanceSubModel.fetchAccounts,
+});
+
+// Scope vesting to the card's account filter: the callout follows the selected
+// accounts rather than every non-hidden account in the wallet.
+sample({
+  clock: dashboardModel.$selectedAccounts,
+  target: vestingPortfolioModel.accountsScopeChanged,
 });
 
 sample({

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
@@ -1,10 +1,10 @@
 import { default as BigNumber } from 'bignumber.js';
-import { useCallback, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 
 import { type ChainId } from '@/shared/core';
 import { Slot, createSlot } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { BodyText, FootnoteText, SmallTitleText, TitleText } from '@/shared/ui';
+import { BodyText, FootnoteText, HelpText, Loader, SmallTitleText, TitleText } from '@/shared/ui';
 import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { useBalanceAllocation } from '../hooks/useBalanceAllocation';
@@ -27,9 +27,11 @@ type EntryLike = { accountId: string; name: string; address: string };
  * Rendered inside the Portfolio Overview card, just below the balance-type
  * distribution. The vesting-claim feature injects its callout here.
  *
- * Propless by design: vesting is shown for every non-hidden account, which the
- * injected block reads for itself — this card's account selection is none of
- * its business.
+ * The slot stays propless: vesting follows the card's account filter, but that
+ * selection is pushed to the vesting-portfolio aggregate via
+ * `accountsScopeChanged` (wired in this feature's `index.ts`) rather than
+ * threaded through the slot, so the injected block reads the scoped result for
+ * itself.
  */
 export const portfolioVestingSlot = createSlot({ name: 'portfolioVesting' });
 
@@ -44,6 +46,10 @@ const toggleButtonClass = 'cursor-pointer rounded px-4 py-1.5 text-footnote font
 const activeToggleClass = 'bg-white text-text-primary shadow-sm';
 const inactiveToggleClass = 'text-text-tertiary hover:text-text-secondary';
 
+// How long the skeleton is held for an account set that has produced nothing yet
+// before the card commits to its empty state — see the `isEmpty` branch below.
+const EMPTY_SYNC_GRACE_MS = 5000;
+
 export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const { t } = useI18n();
   const { holdings, totalFiat, fiatFlag, currency } = useHoldings(accountIds);
@@ -54,6 +60,21 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const [balanceTypeFilter, setBalanceTypeFilter] = useState<BalanceType | null>(null);
   const [selectedPriceId, setSelectedPriceId] = useState<string | null>(null);
   const [selectedChainId, setSelectedChainId] = useState<ChainId | null>(null);
+
+  // Balances stream in shortly after prices resolve, and a chain that flaps
+  // between connecting/error keeps `isSyncing` true for the life of the app —
+  // so gating the empty state on "sync finished" alone would either flash a
+  // premature "no tokens" or never show it. Hold the skeleton for a short grace
+  // per account set instead, then commit to the empty state (still flagged as
+  // syncing while any chain keeps reporting).
+  const accountKey = accountIds.join(',');
+  const [emptyGraceElapsed, setEmptyGraceElapsed] = useState(false);
+  useEffect(() => {
+    setEmptyGraceElapsed(false);
+    const id = setTimeout(() => setEmptyGraceElapsed(true), EMPTY_SYNC_GRACE_MS);
+
+    return () => clearTimeout(id);
+  }, [accountKey]);
 
   const selectedHolding = holdings.find((h) => h.priceId === selectedPriceId) ?? null;
   const selectedChainHolding = chainHoldings.find((h) => h.chainId === selectedChainId) ?? null;
@@ -142,6 +163,50 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
     return (
       <DashboardWidget>
         <PortfolioOverviewSkeleton />
+      </DashboardWidget>
+    );
+  }
+
+  // Prices resolved, but the selected accounts hold nothing priced and there is
+  // no vesting to surface either — a real, empty answer (see `useHoldings` /
+  // `useBalanceAllocation`). Distinct from a balance-type filter that scopes to
+  // zero, which reads off the raw `holdings`, not the filtered rows.
+  const isEmpty = holdings.length === 0 && !allocation;
+  if (isEmpty) {
+    // Not confident yet: still syncing and inside the grace window. Keep the
+    // skeleton rather than flash a "no tokens" we would take back once balances
+    // land.
+    if (isSyncing && !emptyGraceElapsed) {
+      return (
+        <DashboardWidget>
+          <PortfolioOverviewSkeleton />
+        </DashboardWidget>
+      );
+    }
+
+    return (
+      <DashboardWidget>
+        <FootnoteText className="text-text-tertiary">{t('dashboard.portfolioOverview.title')}</FootnoteText>
+        <TitleText className="mt-1">
+          <Price amount={totalFiat} currency={currency} />
+        </TitleText>
+
+        <Slot id={portfolioVestingSlot} />
+
+        <div className="mt-4 flex flex-col items-center gap-y-1 border-t border-divider py-8">
+          <SmallTitleText className="text-text-tertiary">
+            {t('dashboard.portfolioOverview.noTokens.title')}
+          </SmallTitleText>
+          <BodyText className="text-center text-text-tertiary">
+            {t('dashboard.portfolioOverview.noTokens.description')}
+          </BodyText>
+          {isSyncing && (
+            <span className="mt-2 flex items-center gap-1.5">
+              <Loader size={12} color="primary" />
+              <HelpText className="text-text-tertiary">{t('dashboard.portfolioOverview.syncing')}</HelpText>
+            </span>
+          )}
+        </div>
       </DashboardWidget>
     );
   }

--- a/src/renderer/features/vesting-claim/README.md
+++ b/src/renderer/features/vesting-claim/README.md
@@ -1,6 +1,6 @@
 # Vesting claim
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-13
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-17
 
 ## Overview
 
@@ -19,8 +19,9 @@ it.
 
 ## Who can use it / when it applies
 
-- Covers **every non-hidden account**, not the dashboard's selected subset — vesting belongs to the wallet, not to the
-  card's account filter. The callout therefore takes no account list from the page it sits in.
+- Follows the dashboard's **account filter** — the callout shows vesting for the accounts currently selected in the card,
+  not the whole wallet. The account set is fed to the [`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md)
+  aggregate via `accountsScopeChanged`; the callout itself stays propless and reads the scoped result.
 - A schedule counts when it sits on a **vesting-capable chain** — detected at runtime by the presence of
   `api.query.vesting.vesting` and `api.tx.vesting.vest` (this excludes `orml_vesting` chains, which use a different call
   and are out of scope).
@@ -66,15 +67,17 @@ block:
   "12m") and ticks against the wall clock. While the block time is unknown the modal falls back to the plain "Vesting" /
   "In cliff" texts.
 
-The callout's own three states — skeleton, "no vesting", and content — are governed by the
+The callout's own states — skeleton, empty (nothing), and content — are governed by the
 [`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md) readiness rule: the skeleton holds until every chain
-that could hold vesting has reported, so "no vesting" is never shown as a guess and then taken back. Content appears as
-soon as the first schedule lands, with a small spinner while the remaining chains report.
+that could hold vesting has reported, so the empty state is never shown as a guess and then taken back. Once every chain
+has reported and none holds a schedule for the selected accounts, the callout **renders nothing** — no muted "no
+vesting" row. Content appears as soon as the first schedule lands, with a small spinner while the remaining chains
+report.
 
 | State                     | When it appears                                                            | What the user sees                                                                                                                                                                                           |
 | ------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
 | Skeleton                  | A chain that could hold vesting has yet to report                          | A placeholder row where the callout will be                                                                                                                                                                  |
-| No vesting                | Every chain reported; none holds a schedule for these accounts             | A muted "no active vesting" row                                                                                                                                                                              |
+| No vesting                | Every chain reported; none holds a schedule for the selected accounts      | Nothing — the callout renders no row                                                                                                                                                                         |
 | Vested distribution slice | Any account has a vesting lock                                             | An indigo "Vested" bar in "Distribution by balance type"                                                                                                                                                     |
 | Callout                   | ≥1 active schedule                                                         | "N active vesting schedules · fully unlocks by DATE", plus a "ready" pill when claimable, and a spinner while chains still report                                                                            |
 | Schedule modal            | Callout clicked                                                            | Totals (vesting / schedules / ready-to-unlock), the average unlock rate per day, one row per account                                                                                                          |

--- a/src/renderer/features/vesting-claim/ui/VestingCallout.tsx
+++ b/src/renderer/features/vesting-claim/ui/VestingCallout.tsx
@@ -49,16 +49,10 @@ export const VestingCallout = () => {
     );
   }
 
-  // Every chain reported, and none of them holds vesting for these accounts.
+  // Every chain reported, and none of them holds vesting for these accounts —
+  // render nothing rather than a muted "no vesting" row.
   if (status === 'empty') {
-    return (
-      <div className="mt-3 flex w-full items-center gap-x-3 rounded-lg border border-divider px-3 py-2.5">
-        <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-block-background-hover">
-          <Icon name="clock" size={16} className="text-text-tertiary" />
-        </span>
-        <FootnoteText className="text-text-tertiary">{t('vesting.callout.empty')}</FootnoteText>
-      </div>
-    );
+    return null;
   }
 
   const unlockDate = summary.lastUnlockDate ? formatUnlockDate(summary.lastUnlockDate, now) : null;

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -577,6 +577,11 @@
       "byChain": "Networks",
       "balanceTypeDistribution": "Asset allocation",
       "fiatDisabledHint": "Fiat values are turned off - enable a currency in Settings to see the portfolio breakdown",
+      "syncing": "Syncing balances...",
+      "noTokens": {
+        "title": "No tokens to show",
+        "description": "The selected accounts don't hold any tokens on connected networks"
+      },
       "showAll": "Show all",
       "allAssets": "All assets",
       "allNetworks": "All networks",
@@ -3696,7 +3701,6 @@
       "unlockingRate": "Unlocking ≈ {rate}/day",
       "unlockingGradually": "Unlocking gradually",
       "subtitleWithDate": "{prefix} · fully unlocks by {date}",
-      "empty": "No active vesting schedules",
       "ready": "ready",
       "schedule": "Schedule"
     },


### PR DESCRIPTION
## Description

Fixes three issues in the Dashboard **Portfolio Overview** card and its vesting callout:

1. The vesting callout ignored the dashboard's account filter — schedules were shown for every non-hidden account even when a single account was selected in the picker.
2. When every chain had reported and no schedules were found, the callout rendered a muted "No active vesting schedules" row instead of getting out of the way.
3. When the selected accounts held no tokens, the card showed a bare `$0` with no holdings and no message, so it looked unfinished/broken.

## Changes Made

- **Vesting follows the account filter.** The `vesting-portfolio` aggregate now takes its account set from an external scope (`accountsScopeChanged`), defaulting to every non-hidden wallet account when unscoped so it stays usable standalone. The dashboard feeds `dashboardModel.$selectedAccounts` into it, so the callout reflects the card's current selection. The scope is always a subset of visible accounts, preserving the hidden-wallet exclusion.
- **Vesting empty state is hidden.** When the portfolio finishes loading across all chains and finds no schedules, the callout renders nothing instead of the muted "no active vesting" row. Removed the now-unused `vesting.callout.empty` string.
- **Portfolio Overview "No tokens" state.** Added a real empty state for a selection that holds nothing priced (and no vesting). Because there is no reliable "balances loaded" signal and a flapping chain keeps the global "syncing" flag raised, the card holds the skeleton for a short per-selection grace, then commits to a centered "No tokens to show" message — keeping a small "Syncing balances…" spinner on it while any chain is still connecting, so a late-arriving balance reads as expected rather than as the message being wrong. The vesting slot stays mounted since token-denominated vesting can exist at a zero fiat total.
- Updated the colocated spec READMEs (`dashboard-portfolio-overview`, `vesting-claim`, `vesting-portfolio`) to match the new behavior.

## Screenshots/Recordings
<!-- add before/after screenshots of the callout under a single-account filter, the hidden empty callout, and the "No tokens" card -->

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines

Made with [Cursor](https://cursor.com)