### PR TITLE
fix: keep vesting schedules in memory when the dashboard account filter changes

### DIFF
--- a/src/renderer/aggregates/vesting-portfolio/README.md
+++ b/src/renderer/aggregates/vesting-portfolio/README.md
@@ -1,6 +1,6 @@
 # Vesting portfolio
 
-> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-17
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-20
 
 ## Overview
 
@@ -9,51 +9,52 @@ live vesting schedules of those accounts on every vesting-capable chain, turns t
 wallet-wide summary, and — the part that carries most of the weight — decides **whether the answer can be trusted yet**.
 
 The vesting block on the dashboard ([`vesting-claim`](../../features/vesting-claim/README.md)) is its only consumer
-today. The account set is fed in from outside via `accountsScopeChanged`: the dashboard scopes vesting to its account
-filter, so the block follows the card's selection. When no scope is set the aggregate defaults to every non-hidden
-wallet account, so it stays usable standalone.
+today. A display scope is fed in from outside via `accountsScopeChanged`: the dashboard passes its account filter, so
+the block follows the card's selection. When no scope is set the aggregate shows every non-hidden wallet account, so it
+stays usable standalone.
 
 ## Who / when
 
-- Covers the **scoped account set** — the dashboard's selected accounts. The subset is always ⊆ visible accounts, so a
-  hidden wallet's accounts are excluded either way — a claim from one could not be confirmed, since the confirmation
-  resolves the initiator's wallet out of the visible list.
-- A chain participates only if its **runtime** exposes `pallet_vesting` (`query.vesting.vesting` + `tx.vesting.vest`) and
-  at least one account's address scheme matches it. This is discovered from the connected chain's metadata; there is no
-  static list of vesting chains.
+- **Looks up every visible wallet account; shows the scoped ones.** The lookup follows the wallet, never the card's
+  filter — see "One lookup, many views" below.
+- Hidden wallets are excluded from both: a claim from one could not be confirmed, since the confirmation resolves the
+  initiator's wallet out of the visible list.
+- A chain participates only if its **runtime** exposes `pallet_vesting` (`query.vesting.vesting` + `tx.vesting.vest`)
+  and at least one account's address scheme matches it. This is discovered from the connected chain's metadata; there is
+  no static list of vesting chains.
 
 ## States / scenarios
 
-The block has three states, and the whole point of this aggregate is that it never lies about which one it is in.
-"This wallet has no vesting" is a strong claim, and it is only made once **every chain that could have contradicted it
-has spoken**.
+The block has three states, and the whole point of this aggregate is that it never lies about which one it is in. "This
+wallet has no vesting" is a strong claim, and it is only made once **every chain that could have contradicted it has
+spoken**.
 
-A chain is *unresolved* while it might still surface a schedule, and *resolved* the moment it cannot:
+A chain is _unresolved_ while it might still surface a schedule, and _resolved_ the moment it cannot:
 
-| Chain condition                                    | Verdict                                            |
-| -------------------------------------------------- | -------------------------------------------------- |
-| Disabled                                           | not part of the question                           |
-| Still connecting (no api yet)                      | **unresolved** — its runtime is not readable yet    |
-| Failed to connect (ERROR)                          | resolved — it will never answer                    |
-| Connected, runtime has no vesting pallet           | resolved — vesting is impossible there             |
-| Connected, vesting pallet, no account addresses it | resolved — nothing of ours to look up              |
-| Connected, vesting pallet, our accounts            | resolved **only** once its schedules have arrived  |
-| Schedules arrived, timeline chain's head unknown   | **unresolved** — no figure can be read yet          |
-| Anything still outstanding after 30s               | given up on — see below                            |
+| Chain condition                                    | Verdict                                           |
+| -------------------------------------------------- | ------------------------------------------------- |
+| Disabled                                           | not part of the question                          |
+| Still connecting (no api yet)                      | **unresolved** — its runtime is not readable yet  |
+| Failed to connect (ERROR)                          | resolved — it will never answer                   |
+| Connected, runtime has no vesting pallet           | resolved — vesting is impossible there            |
+| Connected, vesting pallet, no account addresses it | resolved — nothing of ours to look up             |
+| Connected, vesting pallet, our accounts            | resolved **only** once its schedules have arrived |
+| Schedules arrived, timeline chain's head unknown   | **unresolved** — no figure can be read yet        |
+| Anything still outstanding after 30s               | given up on — see below                           |
 
 Wallets are part of the question too: while they are still being read there are no keys to look up, every chain would
 resolve trivially, and the empty state would be a lie told before the question was asked. The same goes for the network
-config: a user who has disabled *every* chain, on the other hand, has given a real (and empty) answer, and is shown it.
+config: a user who has disabled _every_ chain, on the other hand, has given a real (and empty) answer, and is shown it.
 
 **The deadline.** The app opens a connection to every enabled chain, and a chain whose RPC is down never settles — its
 socket keeps retrying, so it sits in "connecting" (or flaps between error and connecting) for the entire life of the
-app. Across dozens of chains that is the norm, not the exception. A chain that connects but never *answers* is rarer and
+app. Across dozens of chains that is the norm, not the exception. A chain that connects but never _answers_ is rarer and
 subtler — a degraded RPC that holds the socket open, a storage subscription that dies without a word — but from here the
-two are indistinguishable, and either would leave the loader spinning and, for a wallet with no vesting, the skeleton up
+two are indistinguishable, and either would leave the block unresolved — and its "loading more" spinner turning —
 permanently. So **every chain still outstanding after 30 seconds is given up on**, connected or not.
 
-The cost of the deadline being too short is a false "no vesting" — the very thing this model exists to prevent — so it is
-deliberately generous, and the cost of it being too long is only a loader that lingers. If a given-up-on chain does
+The cost of the deadline being too short is a false "no vesting" — the very thing this model exists to prevent — so it
+is deliberately generous, and the cost of it being too long is only a loader that lingers. If a given-up-on chain does
 report later and turns out to hold vesting, its schedules simply appear.
 
 The clock restarts on every activation, not just on a new account set: a timer armed on a previous visit keeps running
@@ -64,38 +65,48 @@ flowchart TD
     START["Dashboard opens"] --> Q1{"Any schedule known?"}
     Q1 -- "yes" --> READY["ready — content, plus a spinner while chains keep reporting"]
     Q1 -- "no" --> Q2{"Every chain resolved,<br/>wallets loaded?"}
-    Q2 -- "no" --> LOAD["loading — skeleton"]
+    Q2 -- "no" --> LOAD["loading — nothing shown yet"]
     Q2 -- "yes" --> EMPTY["empty — nothing shown"]
 ```
 
-| State     | When it appears                                                | What the consumer shows                        |
-| --------- | -------------------------------------------------------------- | ---------------------------------------------- |
-| `loading` | Any chain may still surface a schedule, or wallets are loading  | Skeleton                                       |
-| `ready`   | At least one **row** can be shown — not awaited any further      | Content, with `loadingMore` while chains report |
-| `empty`   | Every chain resolved and none holds vesting                     | Nothing — the callout renders no row            |
+| State     | When it appears                                                | What the consumer shows                         |
+| --------- | -------------------------------------------------------------- | ----------------------------------------------- |
+| `loading` | Any chain may still surface a schedule, or wallets are loading | Nothing yet                                     |
+| `ready`   | At least one **row** can be shown — not awaited any further    | Content, with `loadingMore` while chains report |
+| `empty`   | Every chain resolved and none holds vesting                    | Nothing — the callout renders no row            |
+
+`loading` and `empty` look identical on screen, deliberately: the consumer is an additive row under a card that carries
+its own loading state, and a placeholder shown to every user who turns out to have no vesting at all costs more than it
+buys (see [`vesting-claim`](../../features/vesting-claim/README.md)). The distinction remains this aggregate's whole job
+— it decides the moment content may appear, and keeps a half-answered question from flashing a row in and back out. What
+changed is only that nobody draws the waiting.
 
 Two rules keep the states honest over time:
 
 - **Content leads.** The first row to land flips the block to `ready`; the chains still reporting are shown as a quiet
-  "loading more" spinner rather than holding the whole block back. `ready` is read off the *rendered rows*, and the
+  "loading more" spinner rather than holding the whole block back. `ready` is read off the _rendered rows_, and the
   summary's schedule count is counted off them too: a chain whose schedules are known but whose timeline head is not can
   build no row, and a callout advertising a count the modal has no rows to back is worse than one that arrives a moment
   later.
 - **Answers latch.** Chains connect, error and reconnect for the entire life of the app. Once a terminal state has been
   shown for the current account set, a chain going unresolved again reports as `loadingMore` — it never throws a settled
-  block back to a skeleton. Changing the account set resets the latch: that is a new question.
+  block back to `loading`. Changing the **wallet's** accounts resets the latch: that is a new question. Changing the
+  _display scope_ does not — it narrows an answer already given. The latch keeps `$status` itself stable, which today's
+  consumer cannot see (it draws `loading` and `empty` the same way) but any consumer that distinguishes the two would:
+  without it, a chain flapping would flip a settled `empty` back to `loading` for the life of the app.
 
 ## The figures
 
 Two rules decide every number the consumer prints, and both exist because the obvious version of them is wrong.
 
-**Everything is timed on the schedule's own chain.** `pallet_vesting` on a migrated Asset Hub stores *relay* block
-numbers, so the current height *and* the expected block time must both be read from the **timeline chain** (`additional
-.timelineChain`, falling back to the chain itself). Pairing one chain's blocks with another's clock silently scales
-every rate and every date by the ratio between them — Kusama Asset Hub's 2s against its relay's 6s is a factor of three.
-A chain whose block time has not been fetched yet gets **no rate and no dates** rather than a plausible-looking guess,
-and one whose timeline *height* is unknown gets **no rows at all** — nothing it holds can be stated without that height
-— while staying unresolved, so the block waits on its loader instead of announcing a total it cannot itemise.
+**Everything is timed on the schedule's own chain.** `pallet_vesting` on a migrated Asset Hub stores _relay_ block
+numbers, so the current height _and_ the expected block time must both be read from the **timeline chain**
+(`additional .timelineChain`, falling back to the chain itself). Pairing one chain's blocks with another's clock
+silently scales every rate and every date by the ratio between them — Kusama Asset Hub's 2s against its relay's 6s is a
+factor of three. A chain whose block time has not been fetched yet gets **no rate and no dates** rather than a
+plausible-looking guess, and one whose timeline _height_ is unknown gets **no rows at all** — nothing it holds can be
+stated without that height — while staying unresolved, so the block waits on its loader instead of announcing a total it
+cannot itemise.
 
 **Claimability is a token fact, not a fiat one.** The summary's `hasClaim` — the callout's badge, the "Ready to unlock"
 tile — is read off the claimable BN, never off its fiat value: an asset with no price feed (a dev chain, a newly listed
@@ -109,7 +120,7 @@ reported as unlocking 4.32 KSM a day. The projection is zero while the start blo
 exceeds what the schedule still holds. An account's daily figure is simply the sum of its schedules'.
 
 A **cliff** is a schedule that releases its whole amount in one block (`perBlock ≥ locked`) — a property of its shape,
-not of where the chain has got to. A schedule whose start block merely lies in the future has *not started*; if it vests
+not of where the chain has got to. A schedule whose start block merely lies in the future has _not started_; if it vests
 gradually it is not a cliff, and saying so was the second half of the same bug.
 
 ## Lifecycle
@@ -118,25 +129,42 @@ Schedules and their `VESTING` balance locks are **live subscriptions** (one pool
 `domains/vesting`). They are held only while a consumer is on screen, and follow the chain set as it connects: a chain
 that connects late simply joins, and its schedules appear under the existing content.
 
+**One lookup, many views.** The account set that is subscribed to is always _every visible wallet account_; the
+consumer's scope is applied afterwards, as a filter over data already in memory. This is the same shape as balances,
+where one subscription covers the wallet and the dashboard's filter narrows the balance map — and it exists for the same
+reason. The subscription is keyed by chain **and** account set, so scoping the _lookup_ put the card's filter into the
+resource key: every change of selection read as a cache miss, re-subscribed the same chains for a subset of the same
+accounts, reset the latch and threw an already-answered block back to a loader — for an answer the app was holding all
+along. Narrowing the selection now costs one filter and re-renders in the same frame; widening it back costs nothing at
+all.
+
+Claim resolution deliberately stays outside the scope: the account that signs for a proxied or multisig key is resolved
+out of the **whole** wallet, and a signatory that happens to sit outside the card's filter still signs.
+
+Readiness is unscoped for the same reason — it is a property of the lookup, not of the view. One consequence is worth
+knowing: the "loading more" spinner reports chains still outstanding for **any** visible account, so under a narrowed
+selection it can turn briefly for rows the user is not looking at. The alternative — scoping readiness too — would put
+the card's filter back into the answer, and the 30-second deadline bounds the spinner either way.
+
 Because the subscriptions are live, a claim landing on-chain — its lock drops, a fully-vested schedule is pruned — flows
 back in without any refetch. So does a change made on another device.
 
 **The head is subscribed to, not polled.** The schedules almost never change — they move only when someone calls
-`vest()` or a new vested transfer lands — while *every figure derived from them* changes with the timeline chain's
+`vest()` or a new vested transfer lands — while _every figure derived from them_ changes with the timeline chain's
 current block. So the block is what has to be live, and re-fetching the (unchanged) schedules on a timer would correct
-nothing. Each timeline chain's head is therefore subscribed to for as long as the block is on screen, sharing the pooled,
-ref-counted `blockResource`: chains that share a timeline (every migrated Asset Hub points at its relay) are watched
-once, and nothing is watched at all once the block leaves the screen. The background poll behind `$currentBlock` remains
-a floor — heights only move forward, so the aggregate simply takes whichever source is further ahead, and neither a
-first frame with no head yet nor a head left over from an earlier visit can show a stale figure.
+nothing. Each timeline chain's head is therefore subscribed to for as long as the block is on screen, sharing the
+pooled, ref-counted `blockResource`: chains that share a timeline (every migrated Asset Hub points at its relay) are
+watched once, and nothing is watched at all once the block leaves the screen. The background poll behind `$currentBlock`
+remains a floor — heights only move forward, so the aggregate simply takes whichever source is further ahead, and
+neither a first frame with no head yet nor a head left over from an earlier visit can show a stale figure.
 
-This is what keeps the block honest about time: a cliff ends, a schedule starts vesting, an amount becomes claimable, and
-the UI says so within a block — with no interval, no refetch, and nothing for the user to reload.
+This is what keeps the block honest about time: a cliff ends, a schedule starts vesting, an amount becomes claimable,
+and the UI says so within a block — with no interval, no refetch, and nothing for the user to reload.
 
-Vesting figures move with every block, but most of those movements change nothing that is printed. The aggregate compares
-what *would* be displayed against what *is* displayed and drops the update when they match, so a schedule sitting in its
-cliff, or one long finished, costs nothing per block — and no update can disturb a claim mid-signature, which reads its
-own snapshot.
+Vesting figures move with every block, but most of those movements change nothing that is printed. The aggregate
+compares what _would_ be displayed against what _is_ displayed and drops the update when they match, so a schedule
+sitting in its cliff, or one long finished, costs nothing per block — and no update can disturb a claim mid-signature,
+which reads its own snapshot.
 
 ## Related
 

--- a/src/renderer/aggregates/vesting-portfolio/lib/views.test.ts
+++ b/src/renderer/aggregates/vesting-portfolio/lib/views.test.ts
@@ -6,7 +6,7 @@ import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount } from '@/domains/network';
 import { type VestingData, type VestingScheduleInfo } from '@/domains/vesting';
 
-import { computeVesting } from './views';
+import { computeVesting, filterVestingData } from './views';
 
 const ACCOUNT = '0x00'.padEnd(66, '1') as AccountId;
 
@@ -216,5 +216,53 @@ describe('computeVesting — the summary', () => {
     expect(compute({ schedules: [CLIFF, GRADUAL], lock: TOTAL_LOCK, currentBlock: START }).summary.schedulesCount).toBe(
       2,
     );
+  });
+});
+
+/**
+ * Vesting is subscribed to for every visible account, once, and the dashboard's
+ * account filter is applied to the result. That filter is this function — so it
+ * is what stands between "narrow the selection" and "show someone else's
+ * schedules", and the only thing that has to keep working for the card to stop
+ * re-fetching on every change of selection.
+ */
+describe('filterVestingData', () => {
+  const OTHER = '0x00'.padEnd(66, '2') as AccountId;
+
+  const data = (): VestingData => ({
+    schedules: {
+      [ASSET_HUB]: { [ACCOUNT]: [schedule(100, 1, 0)], [OTHER]: [schedule(200, 2, 0)] },
+      [RELAY]: { [OTHER]: [schedule(300, 3, 0)] },
+    },
+    locks: {
+      [ASSET_HUB]: { [ACCOUNT]: new BN(100), [OTHER]: new BN(200) },
+      [RELAY]: { [OTHER]: new BN(300) },
+    },
+  });
+
+  it('keeps only the scoped accounts, and drops chains left with none', () => {
+    const filtered = filterVestingData(data(), [ACCOUNT]);
+
+    expect(Object.keys(filtered.schedules)).toEqual([ASSET_HUB]);
+    expect(Object.keys(filtered.schedules[ASSET_HUB] ?? {})).toEqual([ACCOUNT]);
+    // The locks are what the claimable figure is read from — scoping the
+    // schedules without them would price a row against a stranger's lock.
+    expect(Object.keys(filtered.locks[ASSET_HUB] ?? {})).toEqual([ACCOUNT]);
+    expect(filtered.locks[RELAY]).toBeUndefined();
+  });
+
+  it('returns the data untouched when there is no scope', () => {
+    const source = data();
+
+    // Reference-identical on purpose: this runs in a `combine` that feeds the
+    // whole view computation, and rebuilding an identical copy would re-run it.
+    expect(filterVestingData(source, null)).toBe(source);
+  });
+
+  it('yields nothing for a scope that holds no vesting', () => {
+    const filtered = filterVestingData(data(), ['0x00'.padEnd(66, '3') as AccountId]);
+
+    expect(filtered.schedules).toEqual({});
+    expect(filtered.locks).toEqual({});
   });
 });

--- a/src/renderer/aggregates/vesting-portfolio/lib/views.ts
+++ b/src/renderer/aggregates/vesting-portfolio/lib/views.ts
@@ -55,6 +55,33 @@ export const collectVestingData = (
 };
 
 /**
+ * The subset of the collected data that belongs to `accountIds`.
+ *
+ * Vesting is subscribed to for every visible account, once — see the model — so
+ * narrowing the dashboard's account filter is this filter and nothing else: no
+ * new request, no cache miss, no loader. `null` means "no narrowing", and
+ * returns the data untouched rather than rebuilding an identical copy.
+ */
+export const filterVestingData = (data: VestingData, accountIds: AccountId[] | null): VestingData => {
+  if (!accountIds) return data;
+
+  const wanted = new Set(accountIds);
+
+  const pick = <T>(source: Record<ChainId, Record<AccountId, T>>): Record<ChainId, Record<AccountId, T>> => {
+    const result: Record<ChainId, Record<AccountId, T>> = {};
+
+    for (const [chainId, perChain] of Object.entries(source)) {
+      const kept = Object.entries(perChain).filter(([accountId]) => wanted.has(accountId as AccountId));
+      if (kept.length > 0) result[chainId as ChainId] = Object.fromEntries(kept) as Record<AccountId, T>;
+    }
+
+    return result;
+  };
+
+  return { schedules: pick(data.schedules), locks: pick(data.locks) };
+};
+
+/**
  * Which local account claims for each (chain, key) pair that holds schedules.
  * Kept apart from the view computation because `findSignatories` rebuilds the
  * account graph on every call, while the views below recompute on every block.

--- a/src/renderer/aggregates/vesting-portfolio/model.ts
+++ b/src/renderer/aggregates/vesting-portfolio/model.ts
@@ -4,7 +4,7 @@ import { debounce } from 'patronum';
 
 import { type Chain, type ChainId } from '@/shared/core';
 import { getTimelineChainId, nonNullable } from '@/shared/lib/utils';
-import { type BlockHeight } from '@/shared/polkadotjs-schemas';
+import { type AccountId, type BlockHeight } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount, block } from '@/domains/network';
 import { type VestingChainRequest, vestingSchedulesResource } from '@/domains/vesting';
 import { balanceModel } from '@/entities/balance';
@@ -19,6 +19,7 @@ import {
   collectVestingData,
   computeClaimResolutions,
   computeVesting,
+  filterVestingData,
   fingerprintSummary,
   fingerprintViews,
 } from './lib/views';
@@ -54,28 +55,52 @@ const isSameAccountSet = (next: AnyAccount[], prev: AnyAccount[]) =>
   });
 
 /**
- * The account set vesting is read for.
+ * The account set vesting is _displayed_ for.
  *
  * `null` means "every visible wallet account" — the aggregate's standalone
  * default. A consumer that scopes vesting to a subset (the dashboard's account
- * filter) feeds that subset here, so the block follows the card's selection
- * rather than the whole wallet. The subset is always ⊆ visible accounts, so the
- * hidden-wallet exclusion is preserved either way.
+ * filter) feeds that subset here, so the block follows the card's selection.
+ *
+ * It scopes the _view_, never the lookup: what is subscribed to is always every
+ * visible account (see `$availableAccounts`), and narrowing the scope filters
+ * data already in memory. Making the scope part of the request instead — which
+ * it used to be — put it in the resource key, so every change of the card's
+ * filter read as a cache miss and threw an already-answered block back to a
+ * loader while the same chains were re-subscribed for a subset of the same
+ * accounts. This mirrors balances, where one subscription covers the wallet and
+ * the card filters the balance map.
  */
 const accountsScopeChanged = createEvent<AnyAccount[] | null>();
 const $accountsScope = createStore<AnyAccount[] | null>(null).on(accountsScopeChanged, (_, accounts) => accounts);
-
-const $accountsSource = combine(walletModel.$availableAccounts, $accountsScope, (all, scope) => scope ?? all);
 
 // `updateFilter` rather than a comparison inside `map`: a skipped update keeps
 // the previous value *and its reference*, which is what every derived store
 // below reads to decide whether it has anything to recompute.
 const $availableAccounts = createStore<AnyAccount[]>([], {
   updateFilter: (next, prev) => !isSameAccountSet(next, prev),
-}).on($accountsSource, (_, accounts) => accounts);
+}).on(walletModel.$availableAccounts, (_, accounts) => accounts);
 
-/** Every key of every visible wallet. Stable for as long as the account set is. */
-const $accountIds = $availableAccounts.map(accounts => [...new Set(accounts.map(account => account.accountId))].sort());
+const collectIds = (accounts: AnyAccount[]) => [...new Set(accounts.map(account => account.accountId))].sort();
+
+const sameIds = (next: AccountId[] | null, prev: AccountId[] | null) =>
+  next === prev ||
+  (nonNullable(next) &&
+    nonNullable(prev) &&
+    next.length === prev.length &&
+    next.every((id, index) => id === prev[index]));
+
+/**
+ * Every key of every visible wallet — what is looked up on chain. Stable for as
+ * long as the wallet's accounts are, and deliberately independent of the
+ * display scope: this is what the resource is keyed by, and the whole point of
+ * the split is that narrowing the scope must not produce a new key.
+ */
+const $accountIds = $availableAccounts.map(collectIds);
+
+/** The keys the views are narrowed to, or `null` for "all of the above". */
+const $scopedAccountIds = createStore<AccountId[] | null>(null, {
+  updateFilter: (next, prev) => !sameIds(next, prev),
+}).on($accountsScope, (_, scope) => (scope ? collectIds(scope) : null));
 
 const $requests = combine(
   { chains: networkModel.$chains, apis: networkModel.$apis, accountIds: $accountIds },
@@ -243,16 +268,26 @@ const $fullyResolved = combine(
 
 const $data = combine($requests, vestingSchedulesResource.$cache, collectVestingData);
 
+/**
+ * What the consumer sees. Everything downstream reads this rather than `$data`,
+ * so a change of scope costs one filter over data already in hand.
+ *
+ * `$availableAccounts` below stays the _full_ set on purpose: the claim account
+ * for a proxied or multisig key is resolved out of the whole wallet, and a
+ * signatory that happens to sit outside the card's filter still signs.
+ */
+const $scopedData = combine($data, $scopedAccountIds, filterVestingData);
+
 // Views
 
 const $claimResolutions = combine(
-  { data: $data, chains: networkModel.$chains, availableAccounts: $availableAccounts },
+  { data: $scopedData, chains: networkModel.$chains, availableAccounts: $availableAccounts },
   ({ data, chains, availableAccounts }) => computeClaimResolutions(data, chains, availableAccounts),
 );
 
 const $vesting = combine(
   {
-    data: $data,
+    data: $scopedData,
     chains: networkModel.$chains,
     balances: balanceModel.$balanceMap,
     currentBlock: $blockHeights,
@@ -325,7 +360,9 @@ sample({
   target: $settledOnce,
 });
 
-// A different account set is a different question — ask it from scratch.
+// A different account set is a different question — ask it from scratch. The
+// *display scope* is not that: it narrows an answer already given, so changing
+// the card's filter must leave the latch (and the block) alone.
 sample({
   clock: $accountIds,
   fn: () => false,

--- a/src/renderer/features/vesting-claim/README.md
+++ b/src/renderer/features/vesting-claim/README.md
@@ -1,6 +1,6 @@
 # Vesting claim
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-17
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-20
 
 ## Overview
 
@@ -19,9 +19,11 @@ it.
 
 ## Who can use it / when it applies
 
-- Follows the dashboard's **account filter** — the callout shows vesting for the accounts currently selected in the card,
-  not the whole wallet. The account set is fed to the [`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md)
-  aggregate via `accountsScopeChanged`; the callout itself stays propless and reads the scoped result.
+- Follows the dashboard's **account filter** — the callout shows vesting for the accounts currently selected in the
+  card, not the whole wallet. The selection is fed to the
+  [`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md) aggregate via `accountsScopeChanged`; the callout
+  itself stays propless and reads the scoped result. Narrowing the selection is a filter over data already held, not a
+  new lookup — see the aggregate's spec — so the row updates instantly instead of falling back to a loading state.
 - A schedule counts when it sits on a **vesting-capable chain** — detected at runtime by the presence of
   `api.query.vesting.vesting` and `api.tx.vesting.vest` (this excludes `orml_vesting` chains, which use a different call
   and are out of scope).
@@ -67,28 +69,29 @@ block:
   "12m") and ticks against the wall clock. While the block time is unknown the modal falls back to the plain "Vesting" /
   "In cliff" texts.
 
-The callout's own states — skeleton, empty (nothing), and content — are governed by the
-[`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md) readiness rule: the skeleton holds until every chain
-that could hold vesting has reported, so the empty state is never shown as a guess and then taken back. Once every chain
-has reported and none holds a schedule for the selected accounts, the callout **renders nothing** — no muted "no
-vesting" row. Content appears as soon as the first schedule lands, with a small spinner while the remaining chains
-report.
+**The callout shows nothing until there is something to show.** It is an additive row under a card that carries its own
+loading state, and most wallets have no vesting at all — a placeholder here would be a row that appears, holds for as
+long as the slowest chain takes to answer, and then vanishes again, for every user who was never going to see it. So
+"still looking" and "nothing found" look identical on screen: empty. The
+[`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md) readiness rule still decides _when_ content may
+appear — a schedule that lands makes the row fade in, and the remaining chains report behind a small spinner — it just
+no longer has a placeholder to govern. Any loading the user needs to see is the card's own, on the balance distribution
+row.
 
-| State                     | When it appears                                                            | What the user sees                                                                                                                                                                                           |
-| ------------------------- | -------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Skeleton                  | A chain that could hold vesting has yet to report                          | A placeholder row where the callout will be                                                                                                                                                                  |
-| No vesting                | Every chain reported; none holds a schedule for the selected accounts      | Nothing — the callout renders no row                                                                                                                                                                         |
-| Vested distribution slice | Any account has a vesting lock                                             | An indigo "Vested" bar in "Distribution by balance type"                                                                                                                                                     |
-| Callout                   | ≥1 active schedule                                                         | "N active vesting schedules · fully unlocks by DATE", plus a "ready" pill when claimable, and a spinner while chains still report                                                                            |
-| Schedule modal            | Callout clicked                                                            | Totals (vesting / schedules / ready-to-unlock), the average unlock rate per day, one row per account                                                                                                          |
+| State                     | When it appears                                                            | What the user sees                                                                                                                                                                                               |
+| ------------------------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Looking / no vesting      | Chains are still reporting, or all reported and none holds a schedule      | Nothing — the callout renders no row                                                                                                                                                                             |
+| Vested distribution slice | Any account has a vesting lock                                             | An indigo "Vested" bar in "Distribution by balance type"                                                                                                                                                         |
+| Callout                   | ≥1 active schedule                                                         | Fades in: "N active vesting schedules · fully unlocks by DATE", plus a "ready" pill when claimable, and a spinner while chains still report                                                                      |
+| Schedule modal            | Callout clicked                                                            | Totals (vesting / schedules / ready-to-unlock), the average unlock rate per day, one row per account                                                                                                             |
 | Account modal             | "See schedule" clicked                                                     | Account totals with "Claim all", an "Unlocking ≈ $X per day" line, and per-schedule cards: asset icon, "Schedule N · SYMBOL", per-schedule "≈ rate / day · fiat", progress bar, "Fully unlocks DATE · in 3h 20m" |
-| Schedule ready            | A schedule's attributed ready amount > 0                                   | Below a separator: "X TOKEN / $Y ready to claim" — informational only; claiming happens via the account-level "Claim all"                                                                                    |
-| Fully unlocked schedule   | `lockedNow == 0` for a schedule                                            | "Fully unlocked" replaces the unlock-date text, in the same muted style                                                                                                                                      |
-| Cliff                     | `perBlock ≥ locked` — the schedule releases everything in a single block   | "In cliff", and below a separator "Cliff until DATE — nothing to unlock yet"; no per-day rate is shown (a lump sum has none) and no claim is offered                                                          |
-| Not started               | `now < startingBlock` on a schedule that vests gradually                   | "Vesting starts DATE · in 2h 10m". **Not a cliff** — a gradual schedule that has yet to begin. Its "fully unlocks" date is shown as usual, since it is known                                                  |
-| Claim unavailable         | Vested tokens are ready, but no local account signs for them on this chain | A muted reason where "Claim all" would sit ("Your wallet can't sign on this network"); schedules stay visible                                                                                                |
-| Confirm                   | "Claim all" pressed                                                        | Signing route, "Unlocks now" + "Keeps vesting", network fee (and multisig deposit), then Sign & submit                                                                                                       |
-| Claim unaffordable        | The signer cannot cover the fee, or cannot reserve the multisig deposit    | The confirm explains which, and **Sign is blocked**. Switching the signing route re-checks it                                                                                                                |
+| Schedule ready            | A schedule's attributed ready amount > 0                                   | Below a separator: "X TOKEN / $Y ready to claim" — informational only; claiming happens via the account-level "Claim all"                                                                                        |
+| Fully unlocked schedule   | `lockedNow == 0` for a schedule                                            | "Fully unlocked" replaces the unlock-date text, in the same muted style                                                                                                                                          |
+| Cliff                     | `perBlock ≥ locked` — the schedule releases everything in a single block   | "In cliff", and below a separator "Cliff until DATE — nothing to unlock yet"; no per-day rate is shown (a lump sum has none) and no claim is offered                                                             |
+| Not started               | `now < startingBlock` on a schedule that vests gradually                   | "Vesting starts DATE · in 2h 10m". **Not a cliff** — a gradual schedule that has yet to begin. Its "fully unlocks" date is shown as usual, since it is known                                                     |
+| Claim unavailable         | Vested tokens are ready, but no local account signs for them on this chain | A muted reason where "Claim all" would sit ("Your wallet can't sign on this network"); schedules stay visible                                                                                                    |
+| Confirm                   | "Claim all" pressed                                                        | Signing route, "Unlocks now" + "Keeps vesting", network fee (and multisig deposit), then Sign & submit                                                                                                           |
+| Claim unaffordable        | The signer cannot cover the fee, or cannot reserve the multisig deposit    | The confirm explains which, and **Sign is blocked**. Switching the signing route re-checks it                                                                                                                    |
 
 ## Lifecycle
 
@@ -112,7 +115,7 @@ flowchart TD
 
 **The confirm opens on the click, not on the data.** Everything it leads with — the amount unlocking, the amount that
 keeps vesting, the account, the chain — is already in hand when the button is pressed. The wrapped transaction, the fee
-and the validation each cost a round trip to the node, so they are *not* awaited: the modal opens immediately and they
+and the validation each cost a round trip to the node, so they are _not_ awaited: the modal opens immediately and they
 stream in behind their own loaders, with the sign button disabled until they land. Changing the signing route re-runs
 them in place. On submit the on-chain vesting lock drops and the freed amount becomes transferable (unless a larger
 staking/vote lock still dominates `frozen`).
@@ -120,15 +123,16 @@ staking/vote lock still dominates `frozen`).
 ### Can the claim actually be paid for?
 
 Worth spelling out, because a vesting account is the one account most likely to look like it cannot pay. On Polkadot and
-Kusama `UnvestedFundsAllowedWithdrawReasons` is `except(TRANSFER | RESERVE)`, so pallet_vesting's lock blocks exactly two
-things: **transfers and reserves**. It does *not* block transaction payment. So an account whose entire balance is still
-vesting can pay its own claim fee out of that locked balance, down to the existential deposit — no chicken-and-egg.
+Kusama `UnvestedFundsAllowedWithdrawReasons` is `except(TRANSFER | RESERVE)`, so pallet_vesting's lock blocks exactly
+two things: **transfers and reserves**. It does _not_ block transaction payment. So an account whose entire balance is
+still vesting can pay its own claim fee out of that locked balance, down to the existential deposit — no
+chicken-and-egg.
 
 Two cases do fail, and both are checked before signing:
 
-- **The multisig deposit is a reserve**, which the vesting lock *does* block. A signatory whose balance is vesting-locked
-  cannot back a multisig claim, however large that balance is.
-- **A co-existing staking or conviction-vote lock** carries `WithdrawReasons::all()`, which *does* cover fees. Such an
+- **The multisig deposit is a reserve**, which the vesting lock _does_ block. A signatory whose balance is
+  vesting-locked cannot back a multisig claim, however large that balance is.
+- **A co-existing staking or conviction-vote lock** carries `WithdrawReasons::all()`, which _does_ cover fees. Such an
   account can be unable to pay even though its vesting lock alone would have allowed it.
 
 Both surface on the confirm screen and block the sign button rather than failing on-chain.
@@ -144,8 +148,8 @@ lands, and for changes made from another device. On a failed submit both modals 
 
 - [`vesting-portfolio`](../../aggregates/vesting-portfolio/README.md) — what is vesting, and when that answer may be
   trusted; owns the live subscriptions this feature renders from.
-- `domains/vesting` — the live schedule/lock subscription (`vestingSchedulesResource`) and the pure `vestingClaimService`
-  math.
+- `domains/vesting` — the live schedule/lock subscription (`vestingSchedulesResource`) and the pure
+  `vestingClaimService` math.
 - `dashboard-portfolio-overview` — hosts the callout slot and renders the new "Vested" allocation category.
 - `vested-transfer` — the inverse operation (creating vesting); shares the `vesting` pallet and confirm/sign infra.
 - `operations/OperationSign`, `operations/OperationSubmit`, `shared/transactions` — the reused signing/submission stack.

--- a/src/renderer/features/vesting-claim/ui/VestingCallout.tsx
+++ b/src/renderer/features/vesting-claim/ui/VestingCallout.tsx
@@ -4,7 +4,6 @@ import { useI18n } from '@/shared/i18n';
 import { useClock } from '@/shared/lib/hooks';
 import { formatFiatBalance } from '@/shared/lib/utils';
 import { FootnoteText, HelpText, Icon, Loader } from '@/shared/ui';
-import { Skeleton } from '@/shared/ui-kit';
 import { currencySelect } from '@/aggregates/currency-select';
 import { type VestingSummary, vestingPortfolioModel } from '@/aggregates/vesting-portfolio';
 import { FiatBalance } from '@/widgets/price';
@@ -33,25 +32,14 @@ export const VestingCallout = () => {
       : t('price.withCode', { code: currency?.code ?? '', amount });
   };
 
-  // Not every chain that could hold vesting has reported yet, so nothing may be
-  // said about the absence of it — hold the skeleton rather than claim an empty
-  // wallet we would have to take back a second later.
-  if (status === 'loading') {
-    return (
-      <div className="mt-3 flex w-full items-center gap-x-3 rounded-lg border border-divider px-3 py-2.5">
-        <Skeleton width="32px" height="32px" />
-        <div className="flex flex-1 flex-col gap-y-1.5">
-          <Skeleton width="180px" height="12px" />
-          <Skeleton width="120px" height="10px" />
-        </div>
-        <Skeleton width="72px" height="20px" />
-      </div>
-    );
-  }
-
-  // Every chain reported, and none of them holds vesting for these accounts —
-  // render nothing rather than a muted "no vesting" row.
-  if (status === 'empty') {
+  // Nothing is drawn until there is something to draw. The row is additive — it
+  // sits under a card that carries its own loading state — and most wallets have
+  // no vesting at all, so a placeholder here is a row that appears, holds for as
+  // long as the slowest chain takes to answer, and then vanishes again, for
+  // every user who was never going to see it. `loading` and `empty` are the same
+  // absence on screen; the distinction still matters to the model, which is what
+  // keeps the row from flashing in on a half-answered question.
+  if (status !== 'ready') {
     return null;
   }
 
@@ -66,10 +54,12 @@ export const VestingCallout = () => {
     ? t('vesting.callout.subtitleWithDate', { prefix: unlockingPrefix, date: unlockDate })
     : unlockingPrefix;
 
+  // The row lands after the card is already on screen — chains answer at their
+  // own pace — so it fades in rather than snapping into place.
   return (
     <button
       type="button"
-      className="mt-3 flex w-full cursor-pointer items-center gap-x-3 rounded-lg border border-badge-background-hover bg-secondary-button-background px-3 py-2.5 text-left"
+      className="mt-3 flex w-full cursor-pointer items-center gap-x-3 rounded-lg border border-badge-background-hover bg-secondary-button-background px-3 py-2.5 text-left duration-300 animate-in fade-in slide-in-from-top-1"
       onClick={() => modalModel.scheduleModalOpened()}
     >
       <span className="flex size-8 shrink-0 items-center justify-center rounded-lg bg-badge-background">


### PR DESCRIPTION
## Description

Two problems with the vesting row in the dashboard's Portfolio Overview card, both rooted in the same place — the account set was part of the vesting lookup rather than of the view.

**Changing the account filter re-fetched from the network.** `vestingSchedulesResource` is keyed by chain **and** account set, and the dashboard fed its selection straight into that key. So narrowing "all accounts" → "some accounts" read as a cache miss: the same chains were re-subscribed for a subset of the same accounts, the settled latch reset, the 30-second grace restarted, and an already-answered block fell back to a loader — for data the app was holding all along.

The fix mirrors balances: **subscribe once for every visible wallet account, filter in memory.** `$accountIds` (what is looked up, what the resource is keyed by) now follows the wallet and is deliberately independent of the display scope; `$scopedAccountIds` narrows the result via a new `filterVestingData` pass. Switching selection is now one filter and a re-render in the same frame — no request, no cache miss, no loader. Claim resolution stays deliberately unscoped: the account that signs for a proxied or multisig key is resolved out of the whole wallet, so a signatory outside the card's filter still signs.

**The skeleton showed to users with no vesting at all.** The callout held a placeholder row until every enabled chain reported — up to the full 30-second grace. For the majority of wallets, which have no vesting, that is a row that appears, lingers, and then vanishes, having said nothing. It now renders nothing until there is something to render, and fades in when a schedule lands. Loading is the card's own job, on the balance-distribution row.

The `loading` / `empty` distinction stays in the aggregate — it is what keeps the row from flashing in on a half-answered question — it just no longer has a placeholder to govern.

## Related Issues

<!-- fill in -->

## Changes Made

- `aggregates/vesting-portfolio/model.ts` — split the subscribed account set from the displayed one; scope now filters `$data` in memory (`$scopedData`) instead of feeding `$requests`. The settled latch and the grace period key off the wallet's accounts, so a change of selection no longer resets them.
- `aggregates/vesting-portfolio/lib/views.ts` — new `filterVestingData`, filtering schedules **and** locks (the claimable figure is read from the lock, so scoping one without the other would price a row against a stranger's).
- `features/vesting-claim/ui/VestingCallout.tsx` — dropped the skeleton branch; the row renders only when `ready`, with a `fade-in / slide-in-from-top` appearance.
- Specs updated (`vesting-portfolio`, `vesting-claim`): the new lookup/view split, the revised state table, and one consequence worth knowing — readiness stays unscoped, so the small "loading more" spinner can briefly turn for chains outside the current selection.
- Tests: 3 cases for `filterVestingData` (narrowing with empty-chain pruning, reference identity on an unset scope, empty result for a scope with no vesting).

## Screenshots/Recordings

<!-- before/after of switching the account filter with vesting present -->

## Test steps

1. Wallet **with** vesting, dashboard open, Portfolio Overview card:
   - Select **all accounts** → the vesting row fades in once schedules land.
   - Narrow to **some accounts** (still including a vesting account) → the row updates instantly. No skeleton, no spinner restart, no network activity for `vesting.vesting` (check the RPC traffic in devtools).
   - Widen back to all accounts → instant, no re-fetch.
   - Narrow to accounts **without** vesting → the row disappears immediately; widening restores it immediately.
2. Wallet **without** any vesting: no placeholder row appears at any point during startup — the card shows only its own loading state on the balance-distribution row.
3. Claim path unchanged: with a **multisig** vesting account, narrow the selection so the signatory is *not* selected → the row still offers "Claim all" and the confirm screen resolves the correct signing wallet.
4. Verify a claim landing on-chain still updates the row live (subscriptions are unchanged).

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
