### PR TITLE
fix: hold portfolio overview skeleton until balances arrive on cold start

### DIFF
--- a/src/renderer/features/dashboard-portfolio-overview/README.md
+++ b/src/renderer/features/dashboard-portfolio-overview/README.md
@@ -1,6 +1,6 @@
 # Portfolio Overview
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-18
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-20
 
 ## Overview
 
@@ -34,28 +34,40 @@ mode, so its position is a default rather than a guarantee.
 
 ## States / scenarios
 
-| State                | When it appears                        | What the user sees                                                                            |
-| -------------------- | -------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Fiat off             | Global "show fiat" toggle is off       | Title + "fiat disabled" hint + the injected vesting block only; no total, bars or holdings    |
-| No selection         | No accounts selected                   | Title + "Select accounts above to view your balance"                                          |
-| Loading              | Prices/currency not resolved yet       | Skeleton mirroring the final layout                                                           |
-| No tokens            | Prices resolved, selection holds nothing priced and no vesting | Title + `$0` + vesting slot + a centered "No tokens to show" message  |
-| Overview             | Data ready                             | Fiat total, Assets/Networks toggle, distribution bar + chips, vesting slot, donut + list      |
-| Balance-type filter  | A bar segment or chip clicked          | Donut and list re-scope to that balance type; scope label + color follow; "Show all" clears   |
-| Donut hover          | Pointer over a donut segment           | Center swaps to the hovered slice's value, name and share; a single holding renders as a ring |
-| Asset / chain detail | A holdings row is clicked              | Modal with a per-address (asset view) or per-asset (chain view) breakdown                     |
-| Syncing              | Any selected chain is still connecting | A small spinner beside the distribution label; the numbers keep updating as balances arrive   |
+| State                | When it appears                                                   | What the user sees                                                                            |
+| -------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
+| Fiat off             | Global "show fiat" toggle is off                                  | Title + "fiat disabled" hint + the injected vesting block only; no total, bars or holdings    |
+| No selection         | No accounts selected                                              | Title + "Select accounts above to view your balance"                                          |
+| Loading              | Prices/currency not resolved, or no balance record has landed yet | Skeleton mirroring the final layout                                                           |
+| No tokens            | Prices resolved, selection holds nothing priced and no vesting    | Title + `$0` + vesting slot + a centered "No tokens to show" message                          |
+| Overview             | Data ready                                                        | Fiat total, Assets/Networks toggle, distribution bar + chips, vesting slot, donut + list      |
+| Balance-type filter  | A bar segment or chip clicked                                     | Donut and list re-scope to that balance type; scope label + color follow; "Show all" clears   |
+| Donut hover          | Pointer over a donut segment                                      | Center swaps to the hovered slice's value, name and share; a single holding renders as a ring |
+| Asset / chain detail | A holdings row is clicked                                         | Modal with a per-address (asset view) or per-asset (chain view) breakdown                     |
+| Syncing              | Any selected chain is still connecting                            | A small spinner beside the distribution label; the numbers keep updating as balances arrive   |
 
 The card has **no error state**: missing prices degrade into the loading / suppressed states above. The injected vesting
 callout brings its own error boundary precisely because this slot offers none.
 
 The **No tokens** state is a real "the selected accounts hold nothing" answer, told only once we are confident of it —
-not a lie flashed while balances are still arriving. Balances stream in shortly after prices resolve, and a chain that
-keeps flapping between connecting and error leaves the global "syncing" flag raised for the life of the app, so neither
-"prices ready" nor "syncing finished" is a safe cue on its own. The card therefore holds the skeleton for a short grace
-per selection, then commits to the empty message — and keeps a small "Syncing balances…" spinner on it while any chain
-is still connecting, so a late-arriving balance reads as expected rather than as the message having been wrong. The
-vesting slot stays mounted in this state, since token-denominated vesting can exist with a zero fiat total.
+not a lie flashed while balances are still arriving.
+
+Zero holdings is not evidence on its own. A balance of **zero** produces no holding and no allocation, exactly like a
+balance that has not been read yet, so the rendered emptiness is identical in both cases. What separates them is the
+**presence of a balance record**: the subscription writes one for every (account, chain, asset) pair it queries, zero
+balances included, so the first record landing is the moment "nothing to show" becomes a statement about the accounts
+rather than about the app's own progress. Until then the card shows its skeleton — the same rule the Portfolio page
+shimmers on, where a row with no record renders a skeleton and never a zero.
+
+This replaced a short wall-clock grace measured from mount, which on a cold start expired long before balances arrived
+and told users with substantial holdings that they had none, while the Portfolio page was still shimmering for the very
+same accounts.
+
+A **backstop** remains, at 30s per selection, because a chain whose RPC is down keeps retrying for the life of the app
+and its records never arrive; without a bound the skeleton would never resolve. It bounds the wait rather than deciding
+the answer. Once the empty message is shown, a small "Syncing balances…" spinner stays on it while any chain is still
+connecting, so a late-arriving balance reads as expected rather than as the message having been wrong. The vesting slot
+stays mounted in this state, since token-denominated vesting can exist with a zero fiat total.
 
 ### Distribution by balance type
 

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useBalancesArrived.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useBalancesArrived.ts
@@ -1,0 +1,17 @@
+import { useStoreMap } from 'effector-react';
+
+import { balanceModel } from '@/entities/balance';
+import { hasBalanceRecords } from '../lib/balanceRecords';
+
+/**
+ * True once the balance store holds anything at all for the selected accounts —
+ * see {@link hasBalanceRecords}. Until then the card cannot honestly say the
+ * accounts hold nothing.
+ */
+export const useBalancesArrived = (accountIds: string[]): boolean => {
+  return useStoreMap({
+    store: balanceModel.$balanceMap,
+    keys: [accountIds],
+    fn: (balanceMap, [ids]) => hasBalanceRecords(balanceMap, ids),
+  });
+};

--- a/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/balanceRecords.test.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/balanceRecords.test.ts
@@ -1,0 +1,35 @@
+import { type Balance } from '@/shared/core';
+import { hasBalanceRecords } from '../balanceRecords';
+
+const record = (accountId: string): Balance => ({ accountId }) as unknown as Balance;
+
+/**
+ * The signal that separates "not looked yet" from "looked, nothing there". The
+ * card commits to its empty state on it, so a false positive is a premature "no
+ * tokens" shown to a user who has plenty.
+ */
+describe('hasBalanceRecords', () => {
+  test('reports nothing before any balance has landed', () => {
+    expect(hasBalanceRecords({}, ['0x01'])).toEqual(false);
+  });
+
+  test('reports a record as soon as one exists for a selected account', () => {
+    expect(hasBalanceRecords({ a: record('0x01') }, ['0x01'])).toEqual(true);
+  });
+
+  test('counts a zero balance as having been read', () => {
+    // The whole point: a zero balance produces no holding, so only the presence
+    // of the record itself distinguishes an empty wallet from an unread one.
+    expect(hasBalanceRecords({ a: record('0x01') }, ['0x01', '0x02'])).toEqual(true);
+  });
+
+  test('ignores records belonging to accounts outside the selection', () => {
+    // Narrowing the dashboard filter to an account with no balances yet must
+    // read as "not looked", not inherit the previous selection's evidence.
+    expect(hasBalanceRecords({ a: record('0x02'), b: record('0x03') }, ['0x01'])).toEqual(false);
+  });
+
+  test('reports nothing for an empty selection', () => {
+    expect(hasBalanceRecords({ a: record('0x01') }, [])).toEqual(false);
+  });
+});

--- a/src/renderer/features/dashboard-portfolio-overview/lib/balanceRecords.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/balanceRecords.ts
@@ -1,0 +1,27 @@
+import { type Balance } from '@/shared/core';
+
+/**
+ * Whether the balance store holds _any_ record for these accounts.
+ *
+ * The distinction this exists to draw is "we have not looked yet" versus "we
+ * looked and there is nothing". Both render as zero holdings, because a balance
+ * of zero produces no holding and no allocation — so emptiness alone cannot
+ * tell them apart, and the card used to guess with a timer.
+ *
+ * A record is written for every (account, chain, asset) pair the subscription
+ * queries, zero balances included, so the first record arriving is the moment
+ * "nothing to show" becomes a statement about the accounts rather than about
+ * the app's own progress. This is the same signal the Portfolio page shimmers
+ * on — there, per row: a row with no record renders a skeleton, never a zero.
+ */
+export function hasBalanceRecords(balanceMap: Record<string, Balance>, accountIds: string[]): boolean {
+  if (accountIds.length === 0) return false;
+
+  const wanted = new Set(accountIds);
+
+  for (const balance of Object.values(balanceMap)) {
+    if (wanted.has(balance.accountId)) return true;
+  }
+
+  return false;
+}

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
@@ -8,6 +8,7 @@ import { BodyText, FootnoteText, HelpText, Loader, SmallTitleText, TitleText } f
 import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { useBalanceAllocation } from '../hooks/useBalanceAllocation';
+import { useBalancesArrived } from '../hooks/useBalancesArrived';
 import { useBalancesSyncing } from '../hooks/useBalancesSyncing';
 import { type ChainHolding, useChainHoldings } from '../hooks/useChainHoldings';
 import { type Holding, useHoldings } from '../hooks/useHoldings';
@@ -46,9 +47,18 @@ const toggleButtonClass = 'cursor-pointer rounded px-4 py-1.5 text-footnote font
 const activeToggleClass = 'bg-white text-text-primary shadow-sm';
 const inactiveToggleClass = 'text-text-tertiary hover:text-text-secondary';
 
-// How long the skeleton is held for an account set that has produced nothing yet
-// before the card commits to its empty state — see the `isEmpty` branch below.
-const EMPTY_SYNC_GRACE_MS = 5000;
+/**
+ * Backstop for an account set whose balances never arrive at all.
+ *
+ * Not the mechanism that decides emptiness — that is `balancesArrived`, below.
+ * This only bounds the wait, because a chain whose RPC is down keeps retrying
+ * for the life of the app and would otherwise pin the skeleton forever. Long on
+ * purpose: the cost of it being short is the very bug it replaced — a "no
+ * tokens" shown to a user who has plenty, while the Portfolio page is still
+ * shimmering for the same accounts. Matches the deadline the vesting aggregate
+ * gives chains for the same reason.
+ */
+const EMPTY_BACKSTOP_MS = 30_000;
 
 export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const { t } = useI18n();
@@ -56,22 +66,19 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
   const { chainHoldings } = useChainHoldings(accountIds);
   const allocation = useBalanceAllocation(accountIds);
   const isSyncing = useBalancesSyncing();
+  const balancesArrived = useBalancesArrived(accountIds);
   const [viewMode, setViewMode] = useState<ViewMode>('asset');
   const [balanceTypeFilter, setBalanceTypeFilter] = useState<BalanceType | null>(null);
   const [selectedPriceId, setSelectedPriceId] = useState<string | null>(null);
   const [selectedChainId, setSelectedChainId] = useState<ChainId | null>(null);
 
-  // Balances stream in shortly after prices resolve, and a chain that flaps
-  // between connecting/error keeps `isSyncing` true for the life of the app —
-  // so gating the empty state on "sync finished" alone would either flash a
-  // premature "no tokens" or never show it. Hold the skeleton for a short grace
-  // per account set instead, then commit to the empty state (still flagged as
-  // syncing while any chain keeps reporting).
+  // Re-armed per account set: a new selection is a new question, and its
+  // balances may not be in the store yet even though the previous one's were.
   const accountKey = accountIds.join(',');
-  const [emptyGraceElapsed, setEmptyGraceElapsed] = useState(false);
+  const [backstopElapsed, setBackstopElapsed] = useState(false);
   useEffect(() => {
-    setEmptyGraceElapsed(false);
-    const id = setTimeout(() => setEmptyGraceElapsed(true), EMPTY_SYNC_GRACE_MS);
+    setBackstopElapsed(false);
+    const id = setTimeout(() => setBackstopElapsed(true), EMPTY_BACKSTOP_MS);
 
     return () => clearTimeout(id);
   }, [accountKey]);
@@ -173,10 +180,12 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
   // zero, which reads off the raw `holdings`, not the filtered rows.
   const isEmpty = holdings.length === 0 && !allocation;
   if (isEmpty) {
-    // Not confident yet: still syncing and inside the grace window. Keep the
-    // skeleton rather than flash a "no tokens" we would take back once balances
-    // land.
-    if (isSyncing && !emptyGraceElapsed) {
+    // Nothing has been read for these accounts yet, so there is nothing to be
+    // empty about — shimmer, exactly as the Portfolio page does for a row whose
+    // balance has not landed. Zero holdings is not evidence on its own: a
+    // balance of zero produces none either, so the two are indistinguishable
+    // until the first record arrives.
+    if (!balancesArrived && !backstopElapsed) {
       return (
         <DashboardWidget>
           <PortfolioOverviewSkeleton />


### PR DESCRIPTION
## Description

On a cold start the Portfolio Overview card announced **"No tokens to show"** to users holding plenty — while the
Portfolio page was still shimmering for the very same accounts.

**Why.** The card held its skeleton for `EMPTY_SYNC_GRACE_MS = 5000`, measured from mount. A cold start needs far longer
than that: chains connect, metadata loads, storage subscriptions open, and `$balanceMap` is buffered on top. The timer
expired first, the card saw zero holdings, and committed to the empty state.

**The real problem is that zero holdings was never evidence.** A balance of **zero** produces no holding and no
allocation — exactly like a balance that has not been read yet. The two are indistinguishable from the rendered result,
so the card was guessing, and a wall-clock timer is what a guess looks like in code.

**What separates them is the presence of a balance record.** The subscription writes one for every (account, chain,
asset) pair it queries, zero balances included, so the first record landing is the moment "nothing to show" becomes a
statement about the accounts rather than about the app's own progress. This is exactly the rule the **Portfolio page**
already shimmers on — there, per row: a row with no record renders a skeleton, never a zero. The card now uses the same
signal.

The timer stays, at **30s**, demoted to a pure backstop: a chain whose RPC is down keeps retrying for the life of the
app and its records never arrive, so the wait still needs a bound — it just no longer decides the answer. Same reasoning
and same deadline as the vesting aggregate's.

## Related Issues

<!-- fill in -->

## Changes Made

- `lib/balanceRecords.ts` — new `hasBalanceRecords(balanceMap, accountIds)`: does the store hold anything at all for
  this selection.
- `hooks/useBalancesArrived.ts` — `useStoreMap` over `balanceModel.$balanceMap`, keyed on the account set, so narrowing
  the dashboard filter to an account with no balances yet correctly reads as "not looked" instead of inheriting the
  previous selection's evidence.
- `ui/PortfolioOverviewWidget.tsx` — the empty branch now gates on `!balancesArrived` instead of
  `isSyncing && !graceElapsed`; `EMPTY_SYNC_GRACE_MS` (5s) → `EMPTY_BACKSTOP_MS` (30s), re-armed per selection.
  `isSyncing` keeps its other job: the "Syncing balances…" spinner shown *on* the empty state.
- Spec updated: the "No tokens" section now states the record-presence rule and why zero holdings alone cannot support
  the claim; the states table's Loading row covers the new condition.
- 5 tests for `hasBalanceRecords`, including the two that matter: a zero balance counts as read, and records for
  accounts outside the selection do not.

## Screenshots/Recordings

<!-- cold start: skeleton instead of "No tokens to show" -->

## Test steps

1. **Cold start (the bug).** Clear the app's IndexedDB (or use a fresh profile) so no balances are cached, then open the
   Dashboard with a wallet that holds tokens.
   - Before: after ~5s the card flips to "No tokens to show" and `$0`, while the Portfolio page still shimmers.
   - After: the card keeps its skeleton and goes straight to the real numbers once balances land — no empty state at any
     point.
2. **Genuinely empty wallet.** An account that really holds nothing: the card still reaches "No tokens to show" —
   shortly after its balance records arrive, not after a fixed wait.
3. **Warm start.** Reopen with balances already in IndexedDB: content appears immediately, no added skeleton time
   (hydration populates `$balanceMap` before the first render that matters).
4. **Switching selection.** Narrow the account filter to an account whose balances have not been fetched: skeleton, not
   a premature empty; widen back: instant.
5. **Dead chain backstop.** With every chain unreachable, the card resolves to the empty state after 30s rather than
   shimmering forever.

## Notes for the reviewer

Verified in the browser against this branch by mounting the widget with an account id that has no balance records —
the changed branch renders the skeleton (no "No tokens" text). The 30s backstop was confirmed firing by its render at
+31s. The real app was reloaded afterwards and behaves normally.

Touches the same spec file as #5963 but a different section, so the two should merge cleanly.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
