### PR TITLE
feat: remember last used account for address book pairing

### DIFF
--- a/src/renderer/aggregates/backend/README.md
+++ b/src/renderer/aggregates/backend/README.md
@@ -1,6 +1,6 @@
 # Address book backend connection & authentication
 
-> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-06-22
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-28
 
 ## Overview
 
@@ -23,6 +23,16 @@ or network issues.
 | Connected         | Session is live and the URL is unchanged       | Connected account with a disconnect action                                                  |
 | Error             | Challenge or signature verification failed     | Error alert with a "try again" action                                                       |
 | Session expired   | Background health check loses the session      | Toast with a reconnect shortcut                                                             |
+
+### Account preselection
+
+The account select preselects, in order: the currently authenticated account, the account of the last live session, or
+the account used for the last successful sign-in on this device.
+
+- The device-level preference survives disconnects and sign-outs — reconnecting preselects the account the user signed
+  in with before, instead of the first account in the list; it only changes when a later sign-in succeeds with a
+  different account.
+- If the remembered account is no longer signable in the app, the selector falls back to the first account in the list.
 
 ### Signing network selection
 
@@ -50,7 +60,7 @@ flowchart TD
 ```
 
 A successful sign-in stores the session, remembers the account and network for next time, and closes the modal. Clearing
-the URL disconnects, logs out, and forgets the remembered account (the network preference is kept).
+the URL disconnects and logs out; the remembered account and network preferences are kept for the next pairing.
 
 ## Related
 

--- a/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
+++ b/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
@@ -1,9 +1,13 @@
 import { allSettled, createWatch, fork } from 'effector';
 import { describe, expect, it, vi } from 'vitest';
 
-import { type ChainId } from '@/shared/core';
+import { type ChainId, type VaultBaseAccount, AccountType, CryptoType, SigningType, WalletType } from '@/shared/core';
+import { TEST_ACCOUNTS } from '@/shared/lib/utils';
 import { polkadotChain } from '@/shared/mocks';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { accounts } from '@/domains/network';
 import { networkModel } from '@/entities/network';
+import { walletModel } from '@/entities/wallet';
 import { messageSignModel } from '@/features/operations/OperationMessageSign';
 import { DEFAULT_AUTH_CHAIN_ID } from '../../lib/auth-chain';
 import { authModel } from '../auth-model';
@@ -112,5 +116,81 @@ describe('authModel — persisted default chain', () => {
     await allSettled(authModel.events.signOutClicked, { scope });
 
     expect(scope.getState(authModel.__test.$defaultAuthChainId)).toBe(KUSAMA);
+  });
+});
+
+describe('authModel — persisted default account', () => {
+  const vaultWallet = { id: 1, type: WalletType.SINGLE_PARITY_SIGNER, name: 'Vault' };
+
+  const createVaultAccount = (id: string, accountId: AccountId): VaultBaseAccount => ({
+    id,
+    type: 'universal',
+    accountType: AccountType.BASE,
+    name: `Account ${id}`,
+    walletId: 1,
+    accountId,
+    cryptoType: CryptoType.SR25519,
+    signingType: SigningType.POLKADOT_VAULT,
+    createdAt: 0,
+  });
+
+  it('preselects the persisted default account on modal open', async () => {
+    const scope = fork({
+      values: [
+        [walletModel.__test.$rawWallets, [vaultWallet]],
+        [accounts.__test.$list, [createVaultAccount('1', TEST_ACCOUNTS[0]), createVaultAccount('2', TEST_ACCOUNTS[1])]],
+        [authModel.__test.$defaultAuthAccountId, TEST_ACCOUNTS[1]],
+      ],
+    });
+
+    await allSettled(backendConfigurationModel.events.modalOpened, { scope });
+
+    expect(scope.getState(authModel.$selectedAccountId)).toBe(TEST_ACCOUNTS[1]);
+  });
+
+  it('falls back to the first account when the saved account is gone', async () => {
+    const scope = fork({
+      values: [
+        [walletModel.__test.$rawWallets, [vaultWallet]],
+        [accounts.__test.$list, [createVaultAccount('1', TEST_ACCOUNTS[0]), createVaultAccount('2', TEST_ACCOUNTS[1])]],
+        [authModel.__test.$defaultAuthAccountId, TEST_ACCOUNTS[2]],
+      ],
+    });
+
+    await allSettled(backendConfigurationModel.events.modalOpened, { scope });
+
+    expect(scope.getState(authModel.$selectedAccountId)).toBe(TEST_ACCOUNTS[0]);
+  });
+
+  it('saves the account used for a successful sign-in as the new default', async () => {
+    const scope = fork({
+      values: [[authModel.$selectedAccountId, TEST_ACCOUNTS[1]]],
+      handlers: [[authModel.__test.verifySignatureFx, () => ({ permissions: [] })]],
+    });
+
+    // sessionHealthCheck (5 min interval) starts on verifySignatureFx.done and keeps the
+    // scope busy, so allSettled never resolves — poll the store instead of awaiting it.
+    void allSettled(authModel.__test.verifySignatureFx, {
+      scope,
+      params: { baseUrl: 'https://backend.test', accountId: '0x00', challengeId: 'challenge', signature: '0x01' },
+    });
+
+    await vi.waitFor(() => {
+      expect(scope.getState(authModel.__test.$defaultAuthAccountId)).toBe(TEST_ACCOUNTS[1]);
+    });
+  });
+
+  it('keeps the default account after sign-out', async () => {
+    const scope = fork({
+      values: [
+        [authModel.__test.$defaultAuthAccountId, TEST_ACCOUNTS[0]],
+        [backendConfigurationModel.$backendUrl, 'https://backend.test'],
+      ],
+      handlers: [[authModel.__test.logoutFx, () => undefined]],
+    });
+
+    await allSettled(authModel.events.signOutClicked, { scope });
+
+    expect(scope.getState(authModel.__test.$defaultAuthAccountId)).toBe(TEST_ACCOUNTS[0]);
   });
 });

--- a/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
+++ b/src/renderer/aggregates/backend/model/__tests__/auth-model.test.ts
@@ -134,14 +134,18 @@ describe('authModel — persisted default account', () => {
     createdAt: 0,
   });
 
-  it('preselects the persisted default account on modal open', async () => {
-    const scope = fork({
+  const createScopeWithAccounts = (defaultAccountId: AccountId) => {
+    return fork({
       values: [
         [walletModel.__test.$rawWallets, [vaultWallet]],
         [accounts.__test.$list, [createVaultAccount('1', TEST_ACCOUNTS[0]), createVaultAccount('2', TEST_ACCOUNTS[1])]],
-        [authModel.__test.$defaultAuthAccountId, TEST_ACCOUNTS[1]],
+        [authModel.__test.$defaultAuthAccountId, defaultAccountId],
       ],
     });
+  };
+
+  it('preselects the persisted default account on modal open', async () => {
+    const scope = createScopeWithAccounts(TEST_ACCOUNTS[1]);
 
     await allSettled(backendConfigurationModel.events.modalOpened, { scope });
 
@@ -149,13 +153,7 @@ describe('authModel — persisted default account', () => {
   });
 
   it('falls back to the first account when the saved account is gone', async () => {
-    const scope = fork({
-      values: [
-        [walletModel.__test.$rawWallets, [vaultWallet]],
-        [accounts.__test.$list, [createVaultAccount('1', TEST_ACCOUNTS[0]), createVaultAccount('2', TEST_ACCOUNTS[1])]],
-        [authModel.__test.$defaultAuthAccountId, TEST_ACCOUNTS[2]],
-      ],
-    });
+    const scope = createScopeWithAccounts(TEST_ACCOUNTS[2]);
 
     await allSettled(backendConfigurationModel.events.modalOpened, { scope });
 

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -62,6 +62,11 @@ $selectedChainId.on(chainSelected, (_, chainId) => chainId);
 const $defaultAuthChainId = createStore<ChainId>(DEFAULT_AUTH_CHAIN_ID);
 persistLocal({ store: $defaultAuthChainId, key: 'address-book-default-auth-chain-id', sync: true });
 
+// Account of the last successful sign-in. Unlike $lastAuthedAccountId it survives sign-out
+// and source disconnect, so reconnecting preselects the account the user used before.
+const $defaultAuthAccountId = createStore<AccountId | null>(null);
+persistLocal({ store: $defaultAuthAccountId, key: 'address-book-default-auth-account-id', sync: true });
+
 const $lastAuthedAccountId = createStore<AccountId | null>(null);
 persist({ store: $lastAuthedAccountId, key: 'address-book-last-authed-account-id' });
 
@@ -174,10 +179,11 @@ sample({
     selectedId: $selectedAccountId,
     authState: $authState,
     lastAuthedId: $lastAuthedAccountId,
+    defaultAccountId: $defaultAuthAccountId,
   },
   filter: ({ accounts, selectedId }) => accounts.length > 0 && selectedId === null,
-  fn: ({ accounts, authState, lastAuthedId }) => {
-    const priorId = authState?.accountId ?? lastAuthedId;
+  fn: ({ accounts, authState, lastAuthedId, defaultAccountId }) => {
+    const priorId = authState?.accountId ?? lastAuthedId ?? defaultAccountId;
     const prior = priorId ? accounts.find(a => a.accountId === priorId) : undefined;
 
     return (prior ?? accounts[0]!).accountId;
@@ -293,12 +299,20 @@ sample({
   target: $authState,
 });
 
-// Must stay declared before the connectCompleted sample below — it has to read
-// $selectedChainId before the connectCompleted-triggered reset overwrites it.
+// Both samples must stay declared before the connectCompleted sample below — they have to
+// read $selectedChainId / $selectedAccountId before the connectCompleted-triggered reset
+// overwrites them.
 sample({
   clock: verifySignatureFx.done,
   source: $selectedChainId,
   target: $defaultAuthChainId,
+});
+
+sample({
+  clock: verifySignatureFx.done,
+  source: $selectedAccountId,
+  filter: nonNullable,
+  target: $defaultAuthAccountId,
 });
 
 const signInSucceeded = createEvent();
@@ -498,5 +512,6 @@ export const authModel = {
     checkSessionFx,
     verifySignatureFx,
     $defaultAuthChainId,
+    $defaultAuthAccountId,
   },
 };

--- a/src/renderer/aggregates/backend/model/auth-model.ts
+++ b/src/renderer/aggregates/backend/model/auth-model.ts
@@ -64,6 +64,8 @@ persistLocal({ store: $defaultAuthChainId, key: 'address-book-default-auth-chain
 
 // Account of the last successful sign-in. Unlike $lastAuthedAccountId it survives sign-out
 // and source disconnect, so reconnecting preselects the account the user used before.
+// A separate store is required: $lastAuthedAccountId must keep resetting on logout because
+// the session-expiry heuristic reads it (session check returns null + non-null id → expired).
 const $defaultAuthAccountId = createStore<AccountId | null>(null);
 persistLocal({ store: $defaultAuthAccountId, key: 'address-book-default-auth-account-id', sync: true });
 


### PR DESCRIPTION
## Description
The account select in the address book connect modal preselects the previously used account, but the store backing it also acts as the session-expiry detector and is cleared on sign-out and on source disconnect. As a result, every reconnect started with the first account in the list and the right one had to be picked from the dropdown again.

**Before:** after a sign-out or disconnect, the connect modal preselects the first signable account.

**After:** the account of the last successful sign-in is remembered on the device (localStorage, alongside the remembered signing network) and preselected on every later pairing; if it is no longer signable, the selector falls back to the first account.

## Related Issues

## Changes Made
- Added persisted `$defaultAuthAccountId` (`address-book-default-auth-account-id`), written on successful sign-in and never cleared
- Preselection order: authenticated account → last session account → device default → first in the list
- Unit tests for save, preselect, fallback and sign-out survival
- Updated the aggregate spec README

## Screenshots/Recordings

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
