### PR TITLE
fix: derive live multisig completion status only from terminal events

### DIFF
--- a/src/renderer/domains/network/multisig-operation/service.test.ts
+++ b/src/renderer/domains/network/multisig-operation/service.test.ts
@@ -2,6 +2,7 @@ import { type DecodedTransaction, CryptoType } from '@/shared/core';
 import { toAccountId } from '@/shared/lib/utils';
 
 import { multisigOperationService } from './service';
+import { type MultisigEvent, type MultisigOperation } from './types';
 
 const PROXIED_ACCOUNT = '0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef';
 
@@ -186,6 +187,76 @@ describe('multisig operation service', () => {
         call: makeDecodedTransaction('proxy', 'proxy', { real: PROXIED_ACCOUNT }),
       });
       expect(multisigOperationService.extractProxiedAccountId(tx)).toBeUndefined();
+    });
+  });
+
+  describe('mergeMultisigOperations', () => {
+    const makeEvent = (id: string, blockCreated: number): MultisigEvent =>
+      ({
+        id,
+        accountId: '0x00',
+        status: 'approve',
+        blockCreated,
+        indexCreated: 0,
+        timestamp: 0,
+      }) as unknown as MultisigEvent;
+
+    const makeOperation = (overrides: Partial<MultisigOperation> = {}): MultisigOperation =>
+      ({
+        id: 'op-1',
+        status: 'pending',
+        callHash: '0xhash',
+        callData: null,
+        transaction: null,
+        section: null,
+        method: null,
+        blockCreated: 100,
+        indexCreated: 0,
+        events: [],
+        timestamp: 0,
+        ...overrides,
+      }) as unknown as MultisigOperation;
+
+    it('unions events from both sides on merge', () => {
+      // Indexer knows the initiation and the executor's approval; the live
+      // snapshot knows the initiation and a middle approval the indexer lost.
+      const offChain = makeOperation({
+        status: 'executed',
+        events: [makeEvent('e-init', 100), makeEvent('e-exec', 300)],
+      });
+      const live = makeOperation({ events: [makeEvent('e-init', 100), makeEvent('e-middle', 200)] });
+
+      const [merged] = multisigOperationService.mergeMultisigOperations([offChain], [live]);
+
+      expect(merged?.events.map(e => e.id).sort()).toEqual(['e-exec', 'e-init', 'e-middle']);
+    });
+
+    it('does not let a pending live version shadow a resolved one', () => {
+      const offChain = makeOperation({ status: 'executed', events: [makeEvent('e-init', 100)] });
+      const live = makeOperation({ events: [makeEvent('e-init', 100), makeEvent('e-middle', 200)] });
+
+      const [merged] = multisigOperationService.mergeMultisigOperations([offChain], [live]);
+
+      expect(merged?.status).toBe('executed');
+    });
+
+    it('keeps the updated side status when it is resolved', () => {
+      const offChain = makeOperation({ status: 'executed' });
+      const live = makeOperation({ status: 'cancelled' });
+
+      const [merged] = multisigOperationService.mergeMultisigOperations([offChain], [live]);
+
+      expect(merged?.status).toBe('cancelled');
+    });
+
+    it('prefers the old-side event content on id collision (real per-event block over storage-derived)', () => {
+      const offChain = makeOperation({ status: 'executed', events: [makeEvent('e-middle', 200)] });
+      const live = makeOperation({ events: [makeEvent('e-middle', 100)] });
+
+      const [merged] = multisigOperationService.mergeMultisigOperations([offChain], [live]);
+
+      expect(merged?.events).toHaveLength(1);
+      expect(merged?.events[0]?.blockCreated).toBe(200);
     });
   });
 });

--- a/src/renderer/domains/network/multisig-operation/service.ts
+++ b/src/renderer/domains/network/multisig-operation/service.ts
@@ -3,6 +3,7 @@ import { type GenericExtrinsic } from '@polkadot/types';
 import { type AnyTuple } from '@polkadot/types/types';
 import { u8aToHex } from '@polkadot/util';
 import { createKeyMulti } from '@polkadot/util-crypto';
+import { uniqBy } from 'lodash';
 
 import {
   type CallHash,
@@ -146,6 +147,17 @@ const mergeMultisigOperations = (
     sort: (a, b) => a.blockCreated - b.blockCreated,
     merge: (a, b) => ({
       ...b,
+      // A still-pending version must not shadow one that already knows how the
+      // operation resolved — either side can lag the other (live storage
+      // snapshot vs indexer catching up).
+      status: b.status === 'pending' && a.status !== 'pending' ? a.status : b.status,
+      // Union: each side can know approvals the other lacks — the live path has
+      // storage-derived approvals the indexer hasn't indexed yet, the indexer
+      // has the executor's approval when the live event was missed. On an id
+      // collision the a-side (indexer) event wins: it carries the real per-event
+      // block and timestamp, while storage-derived events reuse the creation
+      // timepoint.
+      events: uniqBy([...a.events, ...b.events], event => event.id),
       callData: b.callData ?? a.callData,
       callHash: b.callHash ?? a.callHash,
       transaction: b.transaction ?? a.transaction,

--- a/src/renderer/domains/network/multisig-operation/store.test.ts
+++ b/src/renderer/domains/network/multisig-operation/store.test.ts
@@ -271,5 +271,30 @@ describe('multisigOperation store', () => {
     it('marks a MultisigCancelled as cancelled, taking precedence over a failed execution', async () => {
       expect(await deriveStatus([completion(rejectEvent, null), completion(approveEvent, 'error')])).toBe('cancelled');
     });
+
+    it('does not resolve a removed operation when only an approval was caught', async () => {
+      // A MultisigApproval carries no executionResult — the entry vanished from
+      // storage, but whether it executed or was cancelled is unknown here.
+      expect(await deriveStatus([completion(approveEvent, null)])).toBeUndefined();
+    });
+
+    it('does not resolve a removed operation when no completion event was caught', async () => {
+      expect(await deriveStatus([])).toBeUndefined();
+    });
+
+    it('appends the executor approval to the storage-derived events', async () => {
+      const storageEvent: MultisigEvent = { id: 'e-storage', status: 'approve' } as unknown as MultisigEvent;
+      const opWithEvents = { ...baseOp, events: [storageEvent] };
+
+      const scope = fork({
+        values: new Map<any, any>([
+          [multisigOperation.__test.$removedFromChainStorageOperations, [opWithEvents]],
+          [$completionEvents, [completion(approveEvent, 'success')]],
+        ]),
+      });
+
+      const [derived] = scope.getState(multisigOperation.__test.$completedLiveOperations);
+      expect(derived?.events.map(e => e.id).sort()).toEqual(['e-approve', 'e-storage']);
+    });
   });
 });

--- a/src/renderer/domains/network/multisig-operation/store.ts
+++ b/src/renderer/domains/network/multisig-operation/store.ts
@@ -14,7 +14,7 @@ import {
   AccountType,
 } from '@/shared/core';
 import { series } from '@/shared/effector';
-import { entries, groupBy, keys, nonNullable } from '@/shared/lib/utils';
+import { entries, groupBy, keys, nonNullable, nullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type ResourceRequestKey } from '@/shared/query/types';
 import { networkModel } from '@/entities/network';
@@ -336,24 +336,30 @@ const $completedLiveOperations = combine(
     removedOperations: $removedFromChainStorageOperations,
   },
   ({ completionEvents, removedOperations }) => {
-    if (!completionEvents.length || !removedOperations.length) return [];
+    if (!removedOperations.length) return [];
 
     const eventsByOperationId = groupBy(completionEvents, event => event.operationId);
-    return removedOperations.map(op => {
-      const events = eventsByOperationId[op.id];
+    const completed: MultisigOperation[] = [];
 
-      if (!events || events.length === 0) return op;
+    for (const op of removedOperations) {
+      const events = eventsByOperationId[op.id] ?? [];
+
+      // The status must come from a terminal on-chain event: a caught rejection,
+      // or a MultisigExecuted (the only event carrying an executionResult). A
+      // storage entry that disappeared while only approvals were caught did
+      // resolve, but we don't know how — labeling it "executed" would mislabel a
+      // missed cancellation and hide the executor's signature. Leave it out and
+      // let the indexer report the outcome.
+      const isRejected = events.some(e => e.event.status === 'reject');
+      const executionResult = events.find(e => nonNullable(e.executionResult))?.executionResult;
+      if (!isRejected && nullable(executionResult)) continue;
 
       const newEvents = uniqBy(op.events.concat(events.map(e => e.event)), e => e.id);
-      // A reject event ⇒ cancelled; a MultisigExecuted with a failed inner call ⇒ error;
-      // otherwise executed. Keeps parity with the indexer's error status on the live path.
-      const newStatus = newEvents.find(e => e.status === 'reject')
-        ? 'cancelled'
-        : events.some(e => e.executionResult === 'error')
-          ? 'error'
-          : 'executed';
-      return { ...op, events: newEvents, status: newStatus };
-    }) satisfies MultisigOperation[];
+      const newStatus = isRejected ? 'cancelled' : executionResult === 'error' ? 'error' : 'executed';
+      completed.push({ ...op, events: newEvents, status: newStatus });
+    }
+
+    return completed;
   },
 );
 


### PR DESCRIPTION
## Description

The live completion path for multisig operations (`$completedLiveOperations`) pairs operations that disappeared from `multisig.multisigs` storage with system events caught by the events subscription, and previously labeled such an operation `executed` whenever *any* event for it had been caught — a plain `MultisigApproval` was enough. Two consequences:

1. If the subscription caught an intermediate approval but missed the final `MultisigExecuted` (WebSocket reconnect between the two), the operation surfaced as `executed` while carrying only the pending-snapshot events — the executor's signature never appeared, and the signatory panel showed fewer signed entries than the threshold requires. A missed `MultisigCancelled` was mislabeled the same way.
2. Because storage-derived events reuse the operation's creation timepoint and the merge in `$liveOperations` let the live side win wholesale, this incorrect record kept shadowing the correct indexer version for the rest of the session — the periodic off-chain refetch could not repair it.

Separately, when *no* completion event was caught, a removed-from-storage operation stayed `pending` in the merged list, shadowing the indexer's resolved version the same way.

## Related Issues

—

## Changes Made

- `store.ts` — `$completedLiveOperations` now resolves a status only from a terminal event: a caught rejection ⇒ `cancelled`, a `MultisigExecuted` ⇒ `executed`/`error` (it is the only event carrying an `executionResult`). A storage entry that vanished with only approvals caught is excluded from the completed list — it did resolve, but how is unknown until the indexer reports it.
- `service.ts` — `mergeMultisigOperations` now unions events from both sides by event id (each side can know approvals the other lacks; on collision the indexer-side event wins since it carries the real per-event block/timestamp), and a still-`pending` version no longer overrides a side that already knows the resolved status.
- Tests: terminal-only status derivation and event union in `store.test.ts`; merge status precedence and event union in `service.test.ts`.

## Screenshots/Recordings

—

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines