### PR TITLE
fix: apply balance type filter to portfolio detail modals

### DIFF
--- a/src/renderer/features/dashboard-portfolio-overview/README.md
+++ b/src/renderer/features/dashboard-portfolio-overview/README.md
@@ -1,6 +1,6 @@
 # Portfolio Overview
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-21
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-29
 
 ## Overview
 
@@ -34,17 +34,17 @@ mode, so its position is a default rather than a guarantee.
 
 ## States / scenarios
 
-| State                | When it appears                                                   | What the user sees                                                                            |
-| -------------------- | ----------------------------------------------------------------- | --------------------------------------------------------------------------------------------- |
-| Fiat off             | Global "show fiat" toggle is off                                  | Title + "fiat disabled" hint + the injected vesting block only; no total, bars or holdings    |
-| No selection         | No accounts selected                                              | Title + "Select accounts above to view your balance"                                          |
-| Loading              | Prices/currency not resolved, or no balance record has landed yet | Skeleton mirroring the final layout                                                           |
-| No tokens            | Prices resolved, selection holds nothing priced and no vesting    | Title + `$0` + vesting slot + a centered "No tokens to show" message                          |
-| Overview             | Data ready                                                        | Fiat total, Assets/Networks toggle, distribution bar + chips, vesting slot, donut + list      |
-| Balance-type filter  | A bar segment or chip clicked                                     | Donut and list re-scope to that balance type; scope label + color follow; "Show all" clears   |
-| Donut hover          | Pointer over a donut segment                                      | Center swaps to the hovered slice's value, name and share; a single holding renders as a ring |
-| Asset / chain detail | A holdings row is clicked                                         | Modal with a per-address (asset view) or per-asset (chain view) breakdown                     |
-| Syncing              | Any selected chain is still connecting                            | A small spinner beside the distribution label; the numbers keep updating as balances arrive   |
+| State                | When it appears                                                   | What the user sees                                                                                         |
+| -------------------- | ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| Fiat off             | Global "show fiat" toggle is off                                  | Title + "fiat disabled" hint + the injected vesting block only; no total, bars or holdings                 |
+| No selection         | No accounts selected                                              | Title + "Select accounts above to view your balance"                                                       |
+| Loading              | Prices/currency not resolved, or no balance record has landed yet | Skeleton mirroring the final layout                                                                        |
+| No tokens            | Prices resolved, selection holds nothing priced and no vesting    | Title + `$0` + vesting slot + a centered "No tokens to show" message                                       |
+| Overview             | Data ready                                                        | Fiat total, Assets/Networks toggle, distribution bar + chips, vesting slot, donut + list                   |
+| Balance-type filter  | A bar segment or chip clicked                                     | Donut, list and detail modals re-scope to that balance type; scope label + color follow; "Show all" clears |
+| Donut hover          | Pointer over a donut segment                                      | Center swaps to the hovered slice's value, name and share; a single holding renders as a ring              |
+| Asset / chain detail | A holdings row is clicked                                         | Modal with a per-address (asset view) or per-asset (chain view) breakdown                                  |
+| Syncing              | Any selected chain is still connecting                            | A small spinner beside the distribution label; the numbers keep updating as balances arrive                |
 
 The card has **no error state**: missing prices degrade into the loading / suppressed states above. The injected vesting
 callout brings its own error boundary precisely because this slot offers none.
@@ -157,6 +157,11 @@ Clicking a holdings row opens a breakdown modal:
   fallback. Each row shows its amount, fiat value, and share, plus a **per-row allocation bar with a legend** breaking
   that address's holding into the same four categories (transferable / reserved / locked / vested).
 - **Chain detail** (from the By Chain view) lists one row **per asset** on that chain.
+- The modals **inherit the active balance-type filter**: rows carry only that type's amount and fiat (through the same
+  `splitBalanceForHoldings` buckets the lists are filtered by), addresses/assets holding none of it are dropped, shares
+  are recomputed against the scoped sum, and the header shows the scoped total with a colored dot + type label next to
+  the row count. The per-row allocation bar keeps showing the full four-category split — under a filter it is what
+  explains the rest of that address's holding.
 - Shares inside the modals are **rounded down** to one decimal, so a column can visibly sum to slightly under 100%.
 
 ## Lifecycle

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/__tests__/useChainBreakdown.test.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/__tests__/useChainBreakdown.test.ts
@@ -1,0 +1,85 @@
+import { BN } from '@polkadot/util';
+
+import { type Asset, type Balance, type Chain, type ChainId } from '@/shared/core';
+import { type PriceObject } from '@/domains/price';
+import { computeChainBreakdown } from '../useChainBreakdown';
+
+const CURRENCY = { coingeckoId: 'usd' };
+
+const makeBalance = (params: {
+  accountId: string;
+  chainId: string;
+  assetId: number;
+  free: number;
+  reserved?: number;
+  frozen?: number;
+}): Balance => {
+  // structural balance fixture, matching the fields computeChainBreakdown +
+  // splitBalanceForHoldings read (legacy transferable mode)
+  const balance = {
+    accountId: params.accountId,
+    chainId: params.chainId,
+    assetId: params.assetId,
+    free: new BN(params.free),
+    reserved: new BN(params.reserved ?? 0),
+    frozen: new BN(params.frozen ?? 0),
+    locked: [],
+    transferableMode: 'legacy',
+  };
+
+  return balance as unknown as Balance;
+};
+
+const makeAsset = (assetId: number, priceId?: string): Asset => {
+  return { assetId, priceId, precision: 0, symbol: `T${assetId}`, name: `Token${assetId}` } as unknown as Asset;
+};
+
+const makeChain = (chainId: string, assets: Asset[]): Chain => {
+  return { chainId, assets } as unknown as Chain;
+};
+
+// both assets priced at 1 unit / token so fiat === raw tokens
+const PRICES: PriceObject = { dot: { usd: { price: 1, change: 0 } }, usdt: { usd: { price: 1, change: 0 } } };
+const CHAIN_ID = 'polkadot' as ChainId;
+const CHAINS = { polkadot: makeChain('polkadot', [makeAsset(1, 'dot'), makeAsset(2, 'usdt')]) };
+
+const compute = (balances: Balance[], balanceType: Parameters<typeof computeChainBreakdown>[0]['balanceType']) =>
+  computeChainBreakdown({
+    chainId: CHAIN_ID,
+    accountIds: ['a'],
+    balanceType,
+    balanceMap: Object.fromEntries(balances.map((b, i) => [String(i), b])),
+    chains: CHAINS,
+    prices: PRICES,
+    currency: CURRENCY,
+  });
+
+describe('computeChainBreakdown', () => {
+  test('without a filter rows carry full totals per asset', () => {
+    const result = compute(
+      [
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 1, free: 600, reserved: 200 }),
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 2, free: 200 }),
+      ],
+      null,
+    );
+
+    expect(result.rows).toHaveLength(2);
+    expect(result.rows[0]).toMatchObject({ assetId: 1, rawAmount: '800', sharePercent: 80 });
+    expect(result.rows[1]).toMatchObject({ assetId: 2, rawAmount: '200', sharePercent: 20 });
+  });
+
+  test('drops assets holding none of the filtered balance type and re-scopes amounts', () => {
+    const result = compute(
+      [
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 1, free: 600, reserved: 200 }),
+        // asset 2 has nothing reserved
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 2, free: 900 }),
+      ],
+      'reserved',
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ assetId: 1, rawAmount: '200', sharePercent: 100 });
+  });
+});

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/__tests__/useHoldingBreakdown.test.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/__tests__/useHoldingBreakdown.test.ts
@@ -1,0 +1,136 @@
+import { BN } from '@polkadot/util';
+
+import { type Asset, type Balance, type Chain, LockTypes } from '@/shared/core';
+import { type PriceObject } from '@/domains/price';
+import { computeHoldingBreakdown } from '../useHoldingBreakdown';
+
+type AssetLock = Balance['locked'][number];
+
+const CURRENCY = { coingeckoId: 'usd' };
+
+const makeLock = (type: LockTypes, amount: number): AssetLock => ({ type, amount: new BN(amount) });
+
+const makeBalance = (params: {
+  accountId: string;
+  chainId: string;
+  assetId: number;
+  free: number;
+  reserved?: number;
+  frozen?: number;
+  locks?: AssetLock[];
+  mode?: 'legacy' | 'holdAndFreezes';
+}): Balance => {
+  // structural balance fixture, matching the fields computeHoldingBreakdown +
+  // splitBalanceForHoldings read
+  const balance = {
+    accountId: params.accountId,
+    chainId: params.chainId,
+    assetId: params.assetId,
+    free: new BN(params.free),
+    reserved: new BN(params.reserved ?? 0),
+    frozen: new BN(params.frozen ?? 0),
+    locked: params.locks ?? [],
+    transferableMode: params.mode ?? 'legacy',
+  };
+
+  return balance as unknown as Balance;
+};
+
+const makeAsset = (assetId: number, priceId?: string): Asset => {
+  return { assetId, priceId, precision: 0, symbol: `T${assetId}`, name: `Token${assetId}` } as unknown as Asset;
+};
+
+const makeChain = (chainId: string, assets: Asset[]): Chain => {
+  return { chainId, assets } as unknown as Chain;
+};
+
+// a single priced asset priced at 1 unit / token so fiat === raw tokens
+const PRICES: PriceObject = { dot: { usd: { price: 1, change: 0 } } };
+const CHAINS = { polkadot: makeChain('polkadot', [makeAsset(1, 'dot')]) };
+const ENTRIES = [
+  { accountId: 'a', name: 'Alice', address: 'addrA' },
+  { accountId: 'b', name: 'Bob', address: 'addrB' },
+];
+
+const compute = (balances: Balance[], balanceType: Parameters<typeof computeHoldingBreakdown>[0]['balanceType']) =>
+  computeHoldingBreakdown({
+    priceId: 'dot',
+    accountIds: ['a', 'b'],
+    allEntries: ENTRIES,
+    balanceType,
+    balanceMap: Object.fromEntries(balances.map((b, i) => [String(i), b])),
+    chains: CHAINS,
+    prices: PRICES,
+    currency: CURRENCY,
+  });
+
+describe('computeHoldingBreakdown', () => {
+  test('without a filter rows carry full totals and shares of the grand total', () => {
+    const result = compute(
+      [
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 1, free: 600, reserved: 200 }),
+        makeBalance({ accountId: 'b', chainId: 'polkadot', assetId: 1, free: 200 }),
+      ],
+      null,
+    );
+
+    expect(result.rows).toHaveLength(2);
+    // sorted by fiat desc, names resolved from entries
+    expect(result.rows[0]).toMatchObject({ accountId: 'a', name: 'Alice', rawAmount: '800', sharePercent: 80 });
+    expect(result.rows[1]).toMatchObject({ accountId: 'b', name: 'Bob', rawAmount: '200', sharePercent: 20 });
+  });
+
+  test('drops accounts holding none of the filtered balance type', () => {
+    const result = compute(
+      [
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 1, free: 600, reserved: 200 }),
+        // b holds plenty, but nothing reserved
+        makeBalance({ accountId: 'b', chainId: 'polkadot', assetId: 1, free: 900 }),
+      ],
+      'reserved',
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ accountId: 'a', rawAmount: '200', sharePercent: 100 });
+  });
+
+  test('recomputes shares against the scoped sum, not the full totals', () => {
+    // transferable (legacy) = free − frozen: a → 400, b → 600
+    const result = compute(
+      [
+        makeBalance({ accountId: 'a', chainId: 'polkadot', assetId: 1, free: 1000, frozen: 600 }),
+        makeBalance({ accountId: 'b', chainId: 'polkadot', assetId: 1, free: 600 }),
+      ],
+      'transferable',
+    );
+
+    expect(result.rows).toHaveLength(2);
+    // b leads under the filter even though a's full balance is larger
+    expect(result.rows[0]).toMatchObject({ accountId: 'b', rawAmount: '600', sharePercent: 60 });
+    expect(result.rows[1]).toMatchObject({ accountId: 'a', rawAmount: '400', sharePercent: 40 });
+  });
+
+  test('vested filter counts a lock riding on reserved funds', () => {
+    // holdAndFreezes staker: the 100 vesting lock is fully covered by the 800
+    // held, so the partition reports zero vested — but the holdings buckets
+    // (splitBalanceForHoldings) must still select this account under Vested.
+    const result = compute(
+      [
+        makeBalance({
+          accountId: 'a',
+          chainId: 'polkadot',
+          assetId: 1,
+          free: 200,
+          reserved: 800,
+          frozen: 100,
+          locks: [makeLock(LockTypes.VESTING, 100)],
+          mode: 'holdAndFreezes',
+        }),
+      ],
+      'vested',
+    );
+
+    expect(result.rows).toHaveLength(1);
+    expect(result.rows[0]).toMatchObject({ accountId: 'a', rawAmount: '100' });
+  });
+});

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
@@ -3,11 +3,12 @@ import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
 import { type ChainId } from '@/shared/core';
-import { getRoundedValue, totalAmount, totalAmountBN } from '@/shared/lib/utils';
+import { getRoundedValue, totalAmountBN } from '@/shared/lib/utils';
 import { useAssetsPrices } from '@/domains/price';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { currencySelect } from '@/aggregates/currency-select';
+import { type BalanceType, splitBalanceForHoldings } from '../lib/balanceTypes';
 
 export type ChainAssetRow = {
   assetId: number;
@@ -28,7 +29,11 @@ export type ChainBreakdownData = {
   rows: ChainAssetRow[];
 };
 
-export const useChainBreakdown = (chainId: ChainId, accountIds: string[]): ChainBreakdownData => {
+export const useChainBreakdown = (
+  chainId: ChainId,
+  accountIds: string[],
+  balanceType: BalanceType | null,
+): ChainBreakdownData => {
   const balanceMap = useUnit(balanceModel.$balanceMap);
   const chains = useUnit(networkModel.$chains);
   const currency = useUnit(currencySelect.$activeCurrency);
@@ -65,8 +70,10 @@ export const useChainBreakdown = (chainId: ChainId, accountIds: string[]): Chain
       const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
       if (!priceItem) continue;
 
-      const rawBN = totalAmountBN(balance);
-      const fiat = getRoundedValue(totalAmount(balance), priceItem.price, asset.precision);
+      // Same buckets the holdings list is filtered by, so the assets shown
+      // here are exactly the ones contributing to the scoped list row.
+      const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
+      const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
 
       const existing = groupMap.get(asset.assetId);
       if (existing) {
@@ -118,5 +125,5 @@ export const useChainBreakdown = (chainId: ChainId, accountIds: string[]): Chain
     }
 
     return { rows };
-  }, [chainId, accountIds, balanceMap, chains, prices, currency]);
+  }, [chainId, accountIds, balanceMap, chains, prices, currency, balanceType]);
 };

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useChainBreakdown.ts
@@ -2,9 +2,9 @@ import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { type ChainId } from '@/shared/core';
+import { type Balance, type Chain, type ChainId } from '@/shared/core';
 import { getRoundedValue, totalAmountBN } from '@/shared/lib/utils';
-import { useAssetsPrices } from '@/domains/price';
+import { type PriceObject, useAssetsPrices } from '@/domains/price';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { currencySelect } from '@/aggregates/currency-select';
@@ -29,6 +29,108 @@ export type ChainBreakdownData = {
   rows: ChainAssetRow[];
 };
 
+type ChainBreakdownParams = {
+  chainId: ChainId;
+  accountIds: string[];
+  balanceType: BalanceType | null;
+  balanceMap: Record<string, Balance>;
+  chains: Record<string, Chain>;
+  prices: PriceObject;
+  currency: { coingeckoId: string };
+};
+
+/**
+ * Pure computation behind {@link useChainBreakdown}. Split out from the hook so
+ * the per-asset grouping and balance-type scoping are testable without a
+ * store/React harness.
+ */
+export function computeChainBreakdown(params: ChainBreakdownParams): ChainBreakdownData {
+  const { chainId, accountIds, balanceType, balanceMap, chains, prices, currency } = params;
+
+  const accountIdSet = new Set(accountIds);
+  const chain = chains[chainId];
+  if (!chain) return { rows: [] };
+
+  const groupMap = new Map<
+    number,
+    {
+      priceId: string;
+      symbol: string;
+      name: string;
+      icon: { monochrome: string; colored: string };
+      precision: number;
+      totalRaw: BigNumber;
+      fiatValue: BigNumber;
+    }
+  >();
+
+  for (const balance of Object.values(balanceMap)) {
+    if (!accountIdSet.has(balance.accountId)) continue;
+    if (balance.chainId !== chainId) continue;
+
+    const asset = chain.assets.find((a) => a.assetId === balance.assetId);
+    if (!asset?.priceId) continue;
+
+    const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
+    if (!priceItem) continue;
+
+    // Same buckets the holdings list is filtered by, so the assets shown
+    // here are exactly the ones contributing to the scoped list row.
+    const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
+    const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
+
+    const existing = groupMap.get(asset.assetId);
+    if (existing) {
+      existing.totalRaw = existing.totalRaw.plus(rawBN.toString());
+      existing.fiatValue = existing.fiatValue.plus(fiat);
+    } else {
+      groupMap.set(asset.assetId, {
+        priceId: asset.priceId,
+        symbol: asset.symbol,
+        name: asset.name,
+        icon: asset.icon,
+        precision: asset.precision,
+        totalRaw: new BigNumber(rawBN.toString()),
+        fiatValue: new BigNumber(fiat),
+      });
+    }
+  }
+
+  let totalFiat = new BigNumber(0);
+  for (const group of groupMap.values()) {
+    totalFiat = totalFiat.plus(group.fiatValue);
+  }
+
+  const rows: ChainAssetRow[] = Array.from(groupMap.entries())
+    .filter(([, g]) => g.totalRaw.gt(0))
+    .map(([assetId, group]) => {
+      const fiatNum = group.fiatValue.toNumber();
+      const share = totalFiat.gt(0) ? group.fiatValue.div(totalFiat).times(100).toNumber() : 0;
+
+      return {
+        assetId,
+        priceId: group.priceId,
+        symbol: group.symbol,
+        name: group.name,
+        icon: group.icon,
+        precision: group.precision,
+        rawAmount: group.totalRaw.toFixed(0),
+        rawAmountNum: group.totalRaw.toNumber(),
+        fiatValue: group.fiatValue.toString(),
+        fiatValueNum: fiatNum,
+        sharePercent: share,
+        colorIndex: 0,
+      };
+    })
+    .sort((a, b) => b.fiatValueNum - a.fiatValueNum);
+
+  for (let i = 0; i < rows.length; i++) {
+    rows[i]!.colorIndex = i;
+  }
+
+  return { rows };
+}
+
 export const useChainBreakdown = (
   chainId: ChainId,
   accountIds: string[],
@@ -43,87 +145,6 @@ export const useChainBreakdown = (
   return useMemo(() => {
     if (!prices || !currency) return { rows: [] };
 
-    const accountIdSet = new Set(accountIds);
-    const chain = chains[chainId];
-    if (!chain) return { rows: [] };
-
-    const groupMap = new Map<
-      number,
-      {
-        priceId: string;
-        symbol: string;
-        name: string;
-        icon: { monochrome: string; colored: string };
-        precision: number;
-        totalRaw: BigNumber;
-        fiatValue: BigNumber;
-      }
-    >();
-
-    for (const balance of Object.values(balanceMap)) {
-      if (!accountIdSet.has(balance.accountId)) continue;
-      if (balance.chainId !== chainId) continue;
-
-      const asset = chain.assets.find((a) => a.assetId === balance.assetId);
-      if (!asset?.priceId) continue;
-
-      const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
-      if (!priceItem) continue;
-
-      // Same buckets the holdings list is filtered by, so the assets shown
-      // here are exactly the ones contributing to the scoped list row.
-      const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
-      const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
-
-      const existing = groupMap.get(asset.assetId);
-      if (existing) {
-        existing.totalRaw = existing.totalRaw.plus(rawBN.toString());
-        existing.fiatValue = existing.fiatValue.plus(fiat);
-      } else {
-        groupMap.set(asset.assetId, {
-          priceId: asset.priceId,
-          symbol: asset.symbol,
-          name: asset.name,
-          icon: asset.icon,
-          precision: asset.precision,
-          totalRaw: new BigNumber(rawBN.toString()),
-          fiatValue: new BigNumber(fiat),
-        });
-      }
-    }
-
-    let totalFiat = new BigNumber(0);
-    for (const group of groupMap.values()) {
-      totalFiat = totalFiat.plus(group.fiatValue);
-    }
-
-    const rows: ChainAssetRow[] = Array.from(groupMap.entries())
-      .filter(([, g]) => g.totalRaw.gt(0))
-      .map(([assetId, group]) => {
-        const fiatNum = group.fiatValue.toNumber();
-        const share = totalFiat.gt(0) ? group.fiatValue.div(totalFiat).times(100).toNumber() : 0;
-
-        return {
-          assetId,
-          priceId: group.priceId,
-          symbol: group.symbol,
-          name: group.name,
-          icon: group.icon,
-          precision: group.precision,
-          rawAmount: group.totalRaw.toFixed(0),
-          rawAmountNum: group.totalRaw.toNumber(),
-          fiatValue: group.fiatValue.toString(),
-          fiatValueNum: fiatNum,
-          sharePercent: share,
-          colorIndex: 0,
-        };
-      })
-      .sort((a, b) => b.fiatValueNum - a.fiatValueNum);
-
-    for (let i = 0; i < rows.length; i++) {
-      rows[i]!.colorIndex = i;
-    }
-
-    return { rows };
+    return computeChainBreakdown({ chainId, accountIds, balanceType, balanceMap, chains, prices, currency });
   }, [chainId, accountIds, balanceMap, chains, prices, currency, balanceType]);
 };

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
@@ -2,8 +2,9 @@ import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
+import { type Balance, type Chain } from '@/shared/core';
 import { getRoundedValue, totalAmountBN } from '@/shared/lib/utils';
-import { useAssetsPrices } from '@/domains/price';
+import { type PriceObject, useAssetsPrices } from '@/domains/price';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { currencySelect } from '@/aggregates/currency-select';
@@ -29,6 +30,108 @@ export type BreakdownData = {
 
 type EntryLike = { accountId: string; name: string; address: string };
 
+type HoldingBreakdownParams = {
+  priceId: string;
+  accountIds: string[];
+  allEntries: EntryLike[];
+  balanceType: BalanceType | null;
+  balanceMap: Record<string, Balance>;
+  chains: Record<string, Chain>;
+  prices: PriceObject;
+  currency: { coingeckoId: string };
+};
+
+/**
+ * Pure computation behind {@link useHoldingBreakdown}. Split out from the hook
+ * so the per-address grouping and balance-type scoping are testable without a
+ * store/React harness.
+ */
+export function computeHoldingBreakdown(params: HoldingBreakdownParams): BreakdownData {
+  const { priceId, accountIds, allEntries, balanceType, balanceMap, chains, prices, currency } = params;
+
+  const accountIdSet = new Set(accountIds);
+
+  const entryMap = new Map<string, { name: string; address: string }>();
+  for (const entry of allEntries) {
+    entryMap.set(entry.accountId, { name: entry.name, address: entry.address });
+  }
+
+  const groupMap = new Map<
+    string,
+    {
+      totalRaw: BigNumber;
+      fiatValue: BigNumber;
+      precision: number;
+      symbol: string;
+    }
+  >();
+
+  for (const balance of Object.values(balanceMap)) {
+    if (!accountIdSet.has(balance.accountId)) continue;
+
+    const chain = chains[balance.chainId];
+    if (!chain) continue;
+
+    const asset = chain.assets.find((a) => a.assetId === balance.assetId);
+    if (!asset?.priceId || asset.priceId !== priceId) continue;
+
+    const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
+    if (!priceItem) continue;
+
+    // Same buckets the holdings list is filtered by, so the accounts shown
+    // here are exactly the ones contributing to the scoped list row.
+    const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
+    const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
+
+    const existing = groupMap.get(balance.accountId);
+    if (existing) {
+      existing.totalRaw = existing.totalRaw.plus(rawBN.toString());
+      existing.fiatValue = existing.fiatValue.plus(fiat);
+    } else {
+      groupMap.set(balance.accountId, {
+        totalRaw: new BigNumber(rawBN.toString()),
+        fiatValue: new BigNumber(fiat),
+        precision: asset.precision,
+        symbol: asset.symbol,
+      });
+    }
+  }
+
+  let totalFiat = new BigNumber(0);
+  for (const group of groupMap.values()) {
+    totalFiat = totalFiat.plus(group.fiatValue);
+  }
+
+  const rows: BreakdownRow[] = Array.from(groupMap.entries())
+    .filter(([, g]) => g.totalRaw.gt(0))
+    .map(([accountId, group]) => {
+      const entry = entryMap.get(accountId);
+      const fiatNum = group.fiatValue.toNumber();
+      const share = totalFiat.gt(0) ? group.fiatValue.div(totalFiat).times(100).toNumber() : 0;
+
+      return {
+        accountId,
+        name: entry?.name ?? '',
+        address: entry?.address ?? '',
+        rawAmount: group.totalRaw.toFixed(0),
+        rawAmountNum: group.totalRaw.toNumber(),
+        fiatValue: group.fiatValue.toString(),
+        fiatValueNum: fiatNum,
+        sharePercent: share,
+        precision: group.precision,
+        symbol: group.symbol,
+        colorIndex: 0,
+      };
+    })
+    .sort((a, b) => b.fiatValueNum - a.fiatValueNum);
+
+  for (let i = 0; i < rows.length; i++) {
+    rows[i]!.colorIndex = i;
+  }
+
+  return { rows };
+}
+
 export const useHoldingBreakdown = (
   priceId: string,
   accountIds: string[],
@@ -44,86 +147,15 @@ export const useHoldingBreakdown = (
   return useMemo(() => {
     if (!prices || !currency) return { rows: [] };
 
-    const accountIdSet = new Set(accountIds);
-
-    const entryMap = new Map<string, { name: string; address: string }>();
-    for (const entry of allEntries) {
-      entryMap.set(entry.accountId, { name: entry.name, address: entry.address });
-    }
-
-    const groupMap = new Map<
-      string,
-      {
-        totalRaw: BigNumber;
-        fiatValue: BigNumber;
-        precision: number;
-        symbol: string;
-      }
-    >();
-
-    for (const balance of Object.values(balanceMap)) {
-      if (!accountIdSet.has(balance.accountId)) continue;
-
-      const chain = chains[balance.chainId];
-      if (!chain) continue;
-
-      const asset = chain.assets.find((a) => a.assetId === balance.assetId);
-      if (!asset?.priceId || asset.priceId !== priceId) continue;
-
-      const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
-      if (!priceItem) continue;
-
-      // Same buckets the holdings list is filtered by, so the accounts shown
-      // here are exactly the ones contributing to the scoped list row.
-      const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
-      const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
-
-      const existing = groupMap.get(balance.accountId);
-      if (existing) {
-        existing.totalRaw = existing.totalRaw.plus(rawBN.toString());
-        existing.fiatValue = existing.fiatValue.plus(fiat);
-      } else {
-        groupMap.set(balance.accountId, {
-          totalRaw: new BigNumber(rawBN.toString()),
-          fiatValue: new BigNumber(fiat),
-          precision: asset.precision,
-          symbol: asset.symbol,
-        });
-      }
-    }
-
-    let totalFiat = new BigNumber(0);
-    for (const group of groupMap.values()) {
-      totalFiat = totalFiat.plus(group.fiatValue);
-    }
-
-    const rows: BreakdownRow[] = Array.from(groupMap.entries())
-      .filter(([, g]) => g.totalRaw.gt(0))
-      .map(([accountId, group]) => {
-        const entry = entryMap.get(accountId);
-        const fiatNum = group.fiatValue.toNumber();
-        const share = totalFiat.gt(0) ? group.fiatValue.div(totalFiat).times(100).toNumber() : 0;
-
-        return {
-          accountId,
-          name: entry?.name ?? '',
-          address: entry?.address ?? '',
-          rawAmount: group.totalRaw.toFixed(0),
-          rawAmountNum: group.totalRaw.toNumber(),
-          fiatValue: group.fiatValue.toString(),
-          fiatValueNum: fiatNum,
-          sharePercent: share,
-          precision: group.precision,
-          symbol: group.symbol,
-          colorIndex: 0,
-        };
-      })
-      .sort((a, b) => b.fiatValueNum - a.fiatValueNum);
-
-    for (let i = 0; i < rows.length; i++) {
-      rows[i]!.colorIndex = i;
-    }
-
-    return { rows };
+    return computeHoldingBreakdown({
+      priceId,
+      accountIds,
+      allEntries,
+      balanceType,
+      balanceMap,
+      chains,
+      prices,
+      currency,
+    });
   }, [priceId, accountIds, balanceMap, chains, prices, currency, allEntries, balanceType]);
 };

--- a/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/hooks/useHoldingBreakdown.ts
@@ -2,11 +2,12 @@ import { default as BigNumber } from 'bignumber.js';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { getRoundedValue, totalAmount, totalAmountBN } from '@/shared/lib/utils';
+import { getRoundedValue, totalAmountBN } from '@/shared/lib/utils';
 import { useAssetsPrices } from '@/domains/price';
 import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { currencySelect } from '@/aggregates/currency-select';
+import { type BalanceType, splitBalanceForHoldings } from '../lib/balanceTypes';
 
 export type BreakdownRow = {
   accountId: string;
@@ -28,7 +29,12 @@ export type BreakdownData = {
 
 type EntryLike = { accountId: string; name: string; address: string };
 
-export const useHoldingBreakdown = (priceId: string, accountIds: string[], allEntries: EntryLike[]): BreakdownData => {
+export const useHoldingBreakdown = (
+  priceId: string,
+  accountIds: string[],
+  allEntries: EntryLike[],
+  balanceType: BalanceType | null,
+): BreakdownData => {
   const balanceMap = useUnit(balanceModel.$balanceMap);
   const chains = useUnit(networkModel.$chains);
   const currency = useUnit(currencySelect.$activeCurrency);
@@ -67,8 +73,10 @@ export const useHoldingBreakdown = (priceId: string, accountIds: string[], allEn
       const priceItem = prices[asset.priceId]?.[currency.coingeckoId];
       if (!priceItem) continue;
 
-      const rawBN = totalAmountBN(balance);
-      const fiat = getRoundedValue(totalAmount(balance), priceItem.price, asset.precision);
+      // Same buckets the holdings list is filtered by, so the accounts shown
+      // here are exactly the ones contributing to the scoped list row.
+      const rawBN = balanceType ? splitBalanceForHoldings(balance)[balanceType] : totalAmountBN(balance);
+      const fiat = getRoundedValue(rawBN.toString(), priceItem.price, asset.precision);
 
       const existing = groupMap.get(balance.accountId);
       if (existing) {
@@ -117,5 +125,5 @@ export const useHoldingBreakdown = (priceId: string, accountIds: string[], allEn
     }
 
     return { rows };
-  }, [priceId, accountIds, balanceMap, chains, prices, currency, allEntries]);
+  }, [priceId, accountIds, balanceMap, chains, prices, currency, allEntries, balanceType]);
 };

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
@@ -5,7 +5,6 @@ import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { pjsSchema } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HelpText } from '@/shared/ui';
-import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
 import { type Column, Modal, Table } from '@/shared/ui-kit';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
@@ -19,6 +18,7 @@ import { type BalanceType } from '../lib/balanceTypes';
 import { type RowAllocation, computeAssetRowAllocations } from '../lib/computeRowAllocations';
 
 import { AllocationBarWithLegend } from './AllocationBarWithLegend';
+import { BalanceTypeBadge } from './BalanceTypeBadge';
 import { Price } from './Price';
 import { PriceChangeIndicator } from './PriceChangeIndicator';
 
@@ -134,17 +134,7 @@ export const AssetDetailModal = memo(({ holding, accountIds, allEntries, balance
               <FootnoteText className="text-text-tertiary">
                 {t('dashboard.portfolioOverview.assetDetail.addressCount', { count: addressCount })}
               </FootnoteText>
-              {balanceType && (
-                <span className="flex items-center gap-1">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: ALLOCATION_COLORS[balanceType] }}
-                  />
-                  <FootnoteText className="text-text-tertiary">
-                    {t(`dashboard.portfolioOverview.balanceType.${balanceType}`)}
-                  </FootnoteText>
-                </span>
-              )}
+              {balanceType && <BalanceTypeBadge type={balanceType} />}
             </div>
           </div>
           <div className="shrink-0">

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AssetDetailModal.tsx
@@ -5,6 +5,7 @@ import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { pjsSchema } from '@/shared/polkadotjs-schemas';
 import { FootnoteText, HelpText } from '@/shared/ui';
+import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
 import { type Column, Modal, Table } from '@/shared/ui-kit';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
@@ -14,6 +15,7 @@ import { currencySelect } from '@/aggregates/currency-select';
 import { NamedAccount } from '@/widgets/NameResolver';
 import { type BreakdownRow, useHoldingBreakdown } from '../hooks/useHoldingBreakdown';
 import { type Holding } from '../hooks/useHoldings';
+import { type BalanceType } from '../lib/balanceTypes';
 import { type RowAllocation, computeAssetRowAllocations } from '../lib/computeRowAllocations';
 
 import { AllocationBarWithLegend } from './AllocationBarWithLegend';
@@ -28,13 +30,14 @@ type Props = {
   holding: Holding;
   accountIds: string[];
   allEntries: EntryLike[];
+  balanceType: BalanceType | null;
   currency: CurrencyItem | null;
   onClose: () => void;
 };
 
-export const AssetDetailModal = memo(({ holding, accountIds, allEntries, currency, onClose }: Props) => {
+export const AssetDetailModal = memo(({ holding, accountIds, allEntries, balanceType, currency, onClose }: Props) => {
   const { t } = useI18n();
-  const { rows } = useHoldingBreakdown(holding.priceId, accountIds, allEntries);
+  const { rows } = useHoldingBreakdown(holding.priceId, accountIds, allEntries, balanceType);
   const addressCount = rows.length;
   const { formatted, suffix } = formatBalance(holding.totalRaw, holding.precision);
 
@@ -127,9 +130,22 @@ export const AssetDetailModal = memo(({ holding, accountIds, allEntries, currenc
           <AssetIcon asset={holding} size={32} />
           <div className="min-w-0 flex-1">
             <FootnoteText className="font-bold">{holding.symbol}</FootnoteText>
-            <FootnoteText className="text-text-tertiary">
-              {t('dashboard.portfolioOverview.assetDetail.addressCount', { count: addressCount })}
-            </FootnoteText>
+            <div className="flex items-center gap-1.5">
+              <FootnoteText className="text-text-tertiary">
+                {t('dashboard.portfolioOverview.assetDetail.addressCount', { count: addressCount })}
+              </FootnoteText>
+              {balanceType && (
+                <span className="flex items-center gap-1">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: ALLOCATION_COLORS[balanceType] }}
+                  />
+                  <FootnoteText className="text-text-tertiary">
+                    {t(`dashboard.portfolioOverview.balanceType.${balanceType}`)}
+                  </FootnoteText>
+                </span>
+              )}
+            </div>
           </div>
           <div className="shrink-0">
             <FootnoteText align="right" className="font-bold tabular-nums">

--- a/src/renderer/features/dashboard-portfolio-overview/ui/BalanceTypeBadge.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/BalanceTypeBadge.tsx
@@ -1,0 +1,23 @@
+import { useI18n } from '@/shared/i18n';
+import { FootnoteText } from '@/shared/ui';
+import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
+import { type BalanceType } from '../lib/balanceTypes';
+
+type Props = {
+  type: BalanceType;
+};
+
+/**
+ * Colored dot + localized balance-type name. Shown in the detail-modal headers
+ * to mark that the breakdown is scoped to the active cross-filter.
+ */
+export const BalanceTypeBadge = ({ type }: Props) => {
+  const { t } = useI18n();
+
+  return (
+    <span className="flex items-center gap-1">
+      <span className="h-2 w-2 shrink-0 rounded-full" style={{ backgroundColor: ALLOCATION_COLORS[type] }} />
+      <FootnoteText className="text-text-tertiary">{t(`dashboard.portfolioOverview.balanceType.${type}`)}</FootnoteText>
+    </span>
+  );
+};

--- a/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
@@ -4,7 +4,6 @@ import { memo, useMemo } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { FootnoteText, HelpText } from '@/shared/ui';
-import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
 import { type Column, Modal, Table } from '@/shared/ui-kit';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
@@ -17,6 +16,7 @@ import { type BalanceType } from '../lib/balanceTypes';
 import { type RowAllocation, computeChainRowAllocations } from '../lib/computeRowAllocations';
 
 import { AllocationBarWithLegend } from './AllocationBarWithLegend';
+import { BalanceTypeBadge } from './BalanceTypeBadge';
 import { Price } from './Price';
 
 type ChainTableRow = ChainAssetRow & { allocation: RowAllocation | null };
@@ -125,17 +125,7 @@ export const ChainDetailModal = memo(({ chainHolding, accountIds, balanceType, c
               <FootnoteText className="text-text-tertiary">
                 {t('dashboard.portfolioOverview.chainDetail.assetCount', { count: chainHolding.assetCount })}
               </FootnoteText>
-              {balanceType && (
-                <span className="flex items-center gap-1">
-                  <span
-                    className="h-2 w-2 shrink-0 rounded-full"
-                    style={{ backgroundColor: ALLOCATION_COLORS[balanceType] }}
-                  />
-                  <FootnoteText className="text-text-tertiary">
-                    {t(`dashboard.portfolioOverview.balanceType.${balanceType}`)}
-                  </FootnoteText>
-                </span>
-              )}
+              {balanceType && <BalanceTypeBadge type={balanceType} />}
             </div>
           </div>
           <div className="shrink-0">

--- a/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/ChainDetailModal.tsx
@@ -4,6 +4,7 @@ import { memo, useMemo } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { FootnoteText, HelpText } from '@/shared/ui';
+import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
 import { AssetIcon } from '@/shared/ui-entities';
 import { type Column, Modal, Table } from '@/shared/ui-kit';
 import { type CurrencyItem, useAssetsPrices } from '@/domains/price';
@@ -12,6 +13,7 @@ import { networkModel } from '@/entities/network';
 import { currencySelect } from '@/aggregates/currency-select';
 import { type ChainAssetRow, useChainBreakdown } from '../hooks/useChainBreakdown';
 import { type ChainHolding } from '../hooks/useChainHoldings';
+import { type BalanceType } from '../lib/balanceTypes';
 import { type RowAllocation, computeChainRowAllocations } from '../lib/computeRowAllocations';
 
 import { AllocationBarWithLegend } from './AllocationBarWithLegend';
@@ -22,13 +24,14 @@ type ChainTableRow = ChainAssetRow & { allocation: RowAllocation | null };
 type Props = {
   chainHolding: ChainHolding;
   accountIds: string[];
+  balanceType: BalanceType | null;
   currency: CurrencyItem | null;
   onClose: () => void;
 };
 
-export const ChainDetailModal = memo(({ chainHolding, accountIds, currency, onClose }: Props) => {
+export const ChainDetailModal = memo(({ chainHolding, accountIds, balanceType, currency, onClose }: Props) => {
   const { t } = useI18n();
-  const { rows } = useChainBreakdown(chainHolding.chainId, accountIds);
+  const { rows } = useChainBreakdown(chainHolding.chainId, accountIds, balanceType);
 
   const balanceMap = useUnit(balanceModel.$balanceMap);
   const chains = useUnit(networkModel.$chains);
@@ -118,9 +121,22 @@ export const ChainDetailModal = memo(({ chainHolding, accountIds, currency, onCl
           <img src={chainHolding.chainIcon} alt={chainHolding.chainName} width={32} height={32} className="shrink-0" />
           <div className="min-w-0 flex-1">
             <FootnoteText className="font-bold">{chainHolding.chainName}</FootnoteText>
-            <FootnoteText className="text-text-tertiary">
-              {t('dashboard.portfolioOverview.chainDetail.assetCount', { count: chainHolding.assetCount })}
-            </FootnoteText>
+            <div className="flex items-center gap-1.5">
+              <FootnoteText className="text-text-tertiary">
+                {t('dashboard.portfolioOverview.chainDetail.assetCount', { count: chainHolding.assetCount })}
+              </FootnoteText>
+              {balanceType && (
+                <span className="flex items-center gap-1">
+                  <span
+                    className="h-2 w-2 shrink-0 rounded-full"
+                    style={{ backgroundColor: ALLOCATION_COLORS[balanceType] }}
+                  />
+                  <FootnoteText className="text-text-tertiary">
+                    {t(`dashboard.portfolioOverview.balanceType.${balanceType}`)}
+                  </FootnoteText>
+                </span>
+              )}
+            </div>
           </div>
           <div className="shrink-0">
             <FootnoteText align="right" className="font-bold tabular-nums">

--- a/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/PortfolioOverviewWidget.tsx
@@ -83,9 +83,6 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
     return () => clearTimeout(id);
   }, [accountKey]);
 
-  const selectedHolding = holdings.find((h) => h.priceId === selectedPriceId) ?? null;
-  const selectedChainHolding = chainHoldings.find((h) => h.chainId === selectedChainId) ?? null;
-
   const switchToAssetView = useCallback(() => setViewMode('asset'), []);
   const switchToChainView = useCallback(() => setViewMode('chain'), []);
   const toggleBalanceType = useCallback((type: BalanceType) => {
@@ -140,6 +137,12 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
 
     return { chainRows: rows, chainScopeTotal: scopeTotal.toString() };
   }, [chainHoldings, balanceTypeFilter]);
+
+  // Resolved against the scoped rows, not the raw holdings: with a filter
+  // active the modal header must show the same amounts as the row that was
+  // clicked, and its breakdown is scoped to the same balance type.
+  const selectedHolding = assetRows.find((h) => h.priceId === selectedPriceId) ?? null;
+  const selectedChainHolding = chainRows.find((h) => h.chainId === selectedChainId) ?? null;
 
   // fiat display is off — the fiat-driven breakdown (total, allocation, donut)
   // has nothing to show, but the injected vesting block is token-denominated
@@ -296,6 +299,7 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
           holding={selectedHolding}
           accountIds={accountIds}
           allEntries={allEntries}
+          balanceType={balanceTypeFilter}
           currency={currency}
           onClose={closeAssetDetail}
         />
@@ -305,6 +309,7 @@ export const PortfolioOverviewWidget = ({ accountIds, allEntries }: Props) => {
         <ChainDetailModal
           chainHolding={selectedChainHolding}
           accountIds={accountIds}
+          balanceType={balanceTypeFilter}
           currency={currency}
           onClose={closeChainDetail}
         />


### PR DESCRIPTION
## Description

In Portfolio Overview the asset-allocation cross-filter (Transferable / Reserved / Locked / Vested) scoped only the holdings lists. Opening a detail modal ignored the filter: it listed every address/asset with full totals, so a row opened from a filtered list showed numbers that didn't match it.

The detail modals now inherit the active filter. Rows are computed from the same `splitBalanceForHoldings` buckets the lists are filtered by, so addresses/assets holding none of the selected type are dropped, amounts and shares are re-scoped, and the modal header shows the scoped total with a colored dot + type label next to the row count. The per-row allocation bar keeps the full four-category split — under a filter it explains the rest of that address's holding.

## Related Issues

—

## Changes Made

- `useHoldingBreakdown` / `useChainBreakdown` accept the active `BalanceType` and scope row amounts through `splitBalanceForHoldings`
- `AssetDetailModal` / `ChainDetailModal` receive the filter, and show a dot + type label in the header when it's active
- `PortfolioOverviewWidget` resolves the selected holding from the already-scoped rows, so the modal header matches the clicked row
- Feature spec README updated (detail-modals section + reviewed date)
- Breakdown computation extracted into pure `computeHoldingBreakdown` / `computeChainBreakdown` (same pattern as `computeBalanceAllocation`) with unit tests covering the balance-type scoping
- Scope indicator extracted into a shared `BalanceTypeBadge` component

## Screenshots/Recordings

Verified in the running renderer: with the **Reserved** filter active, the DOT asset modal shows `0.20152 DOT / $0.15385` (instead of the full `1.13794 DOT`) with the "Reserved" label in the header; the Polkadot Asset Hub chain modal shows the same scoped figures. Without a filter both modals are unchanged.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
