### PR TITLE
fix: show vesting overlap in detail modal allocation bars

### DIFF
--- a/scripts/check-feature-index.mjs
+++ b/scripts/check-feature-index.mjs
@@ -162,8 +162,10 @@ if (changedFlagIndex !== -1) {
       layer: match[1],
       name: match[2],
       codeChanged: false,
+      specChanged: false,
     };
     if (match[3] !== 'README.md') module.codeChanged = true;
+    else module.specChanged = true;
     changedModules.set(key, module);
   }
 
@@ -187,7 +189,11 @@ if (changedFlagIndex !== -1) {
     if (!module.codeChanged) continue;
 
     // code changed → the spec must be re-reviewed: its "Last reviewed" date
-    // must move past the date in the merge base (a new spec always passes)
+    // must move past the date in the merge base (a new spec always passes).
+    // Same-day exception: a follow-up landing the day the base was already
+    // reviewed cannot move a day-granular date, so an equal date passes when
+    // the spec file itself was edited in this change — the edit is the
+    // evidence of the re-review the date can no longer carry.
     let baseReadme = null;
     try {
       baseReadme = execFileSync('git', ['show', `${mergeBase}:src/renderer/${module.layer}/${module.name}/README.md`], {
@@ -200,11 +206,15 @@ if (changedFlagIndex !== -1) {
     }
     const baseDate = baseReadme?.match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
     const currentDate = readFileSync(readmePath, 'utf8').match(REVIEWED_DATE_PATTERN)?.[1] ?? null;
-    if (baseDate !== null && (currentDate === null || currentDate <= baseDate)) {
-      errors.push(
-        `${module.layer}/${module.name} code changed but the spec's "Last reviewed" date was not bumped — ` +
-          `run the feature-specs skill to review the spec and bump the date`,
-      );
+    if (baseDate !== null) {
+      const dateBumped =
+        currentDate !== null && (currentDate > baseDate || (currentDate === baseDate && module.specChanged));
+      if (!dateBumped) {
+        errors.push(
+          `${module.layer}/${module.name} code changed but the spec's "Last reviewed" date was not bumped — ` +
+            `run the feature-specs skill to review the spec and bump the date`,
+        );
+      }
     }
   }
 }

--- a/src/renderer/features/dashboard-portfolio-overview/README.md
+++ b/src/renderer/features/dashboard-portfolio-overview/README.md
@@ -162,6 +162,10 @@ Clicking a holdings row opens a breakdown modal:
   are recomputed against the scoped sum, and the header shows the scoped total with a colored dot + type label next to
   the row count. The per-row allocation bar keeps showing the full four-category split — under a filter it is what
   explains the rest of that address's holding.
+- The per-row bars give **"vesting that has no slice"** the same treatment as the distribution bar: vesting riding on
+  reserved funds joins no segment but is drawn as a hatched marker (with the same 6px visibility floor) across the
+  segments it covers, and the legend's Vested entry — hatch-swatched under overlap — prints the **whole** vesting lock,
+  so its figure matches the row amount the Vested filter selected rather than the partition's capped slice.
 - Shares inside the modals are **rounded down** to one decimal, so a column can visibly sum to slightly under 100%.
 
 ## Lifecycle

--- a/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/computeOverlapBarLayout.test.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/computeOverlapBarLayout.test.ts
@@ -1,0 +1,89 @@
+import { computeOverlapBarLayout } from '../computeOverlapBarLayout';
+
+const makeTypes = (pcts: { transferable?: number; reserved?: number; locked?: number; vested?: number }) => ({
+  transferable: pcts.transferable ?? 0,
+  reserved: pcts.reserved ?? 0,
+  locked: pcts.locked ?? 0,
+  vested: pcts.vested ?? 0,
+});
+
+describe('computeOverlapBarLayout', () => {
+  test('without overlap renders vested as a plain segment and no marker', () => {
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ transferable: 60, locked: 10, vested: 30 }),
+      overlapPct: 0,
+      hasOverlap: false,
+    });
+
+    expect(layout.segments).toEqual([
+      { type: 'transferable', pct: 60 },
+      { type: 'locked', pct: 10 },
+      { type: 'vested', pct: 30 },
+    ]);
+    expect(layout.overlapSpan).toBeNull();
+  });
+
+  test('drops zero-share segments', () => {
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ transferable: 100 }),
+      overlapPct: 0,
+      hasOverlap: false,
+    });
+
+    expect(layout.segments).toEqual([{ type: 'transferable', pct: 100 }]);
+  });
+
+  test('with overlap folds vested into locked and spans the marker across both', () => {
+    // T=50, R=20, L=10, V=15, overlap=5
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ transferable: 50, reserved: 20, locked: 10, vested: 15 }),
+      overlapPct: 5,
+      hasOverlap: true,
+    });
+
+    expect(layout.segments).toEqual([
+      { type: 'transferable', pct: 50 },
+      { type: 'reserved', pct: 20 },
+      { type: 'locked', pct: 25 },
+    ]);
+    // reaches left into reserved by the overlap, right into locked by vested
+    expect(layout.overlapSpan).toEqual({ left: 65, width: 20 });
+  });
+
+  test('with overlap fully covered by reserved the marker sits inside reserved', () => {
+    // staking wallet: vesting rides entirely on the hold, partition vested = 0
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ transferable: 10, reserved: 90 }),
+      overlapPct: 5,
+      hasOverlap: true,
+    });
+
+    expect(layout.segments).toEqual([
+      { type: 'transferable', pct: 10 },
+      { type: 'reserved', pct: 90 },
+    ]);
+    expect(layout.overlapSpan).toEqual({ left: 95, width: 5 });
+  });
+
+  test('clamps the marker inside the bar', () => {
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ reserved: 40, vested: 70 }),
+      overlapPct: 50,
+      hasOverlap: true,
+    });
+
+    expect(layout.overlapSpan!.left).toBe(0);
+    expect(layout.overlapSpan!.width).toBe(100);
+  });
+
+  test('dust overlap (zero pct) still folds and yields a zero-width span for the min-px floor', () => {
+    const layout = computeOverlapBarLayout({
+      types: makeTypes({ transferable: 30, reserved: 70 }),
+      overlapPct: 0,
+      hasOverlap: true,
+    });
+
+    expect(layout.segments.find((s) => s.type === 'vested')).toBeUndefined();
+    expect(layout.overlapSpan).toEqual({ left: 100, width: 0 });
+  });
+});

--- a/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/computeRowAllocations.test.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/__tests__/computeRowAllocations.test.ts
@@ -111,12 +111,12 @@ describe('computeAssetRowAllocations', () => {
 
     expect(result.size).toBe(1);
     const alloc = result.get('acc1')!;
-    expect(alloc.transferable.pct).toBeCloseTo(75, 0); // 900/1200 * 100
-    expect(alloc.transferable.raw).toBe('900');
-    expect(alloc.reserved.pct).toBeCloseTo(16.67, 0); // 200/1200 * 100
-    expect(alloc.reserved.fiat).toBe('200');
-    expect(alloc.locked.pct).toBeCloseTo(8.33, 0); // 100/1200 * 100
-    expect(alloc.vested.pct).toBe(0);
+    expect(alloc.types.transferable.pct).toBeCloseTo(75, 0); // 900/1200 * 100
+    expect(alloc.types.transferable.raw).toBe('900');
+    expect(alloc.types.reserved.pct).toBeCloseTo(16.67, 0); // 200/1200 * 100
+    expect(alloc.types.reserved.fiat).toBe('200');
+    expect(alloc.types.locked.pct).toBeCloseTo(8.33, 0); // 100/1200 * 100
+    expect(alloc.types.vested.pct).toBe(0);
   });
 
   test('carves the vesting lock out of the locked amount', () => {
@@ -147,11 +147,11 @@ describe('computeAssetRowAllocations', () => {
     });
 
     const alloc = result.get('acc1')!;
-    expect(alloc.vested.raw).toBe('300');
-    expect(alloc.vested.fiat).toBe('300');
-    expect(alloc.vested.pct).toBeCloseTo(30, 0);
-    expect(alloc.locked.raw).toBe('100');
-    expect(alloc.locked.pct).toBeCloseTo(10, 0);
+    expect(alloc.types.vested.raw).toBe('300');
+    expect(alloc.types.vested.fiat).toBe('300');
+    expect(alloc.types.vested.pct).toBeCloseTo(30, 0);
+    expect(alloc.types.locked.raw).toBe('100');
+    expect(alloc.types.locked.pct).toBeCloseTo(10, 0);
   });
 
   test('caps vested by the locked amount', () => {
@@ -181,9 +181,9 @@ describe('computeAssetRowAllocations', () => {
     });
 
     const alloc = result.get('acc1')!;
-    expect(alloc.vested.raw).toBe('100');
-    expect(alloc.locked.raw).toBe('0');
-    expect(alloc.locked.pct).toBe(0);
+    expect(alloc.types.vested.raw).toBe('100');
+    expect(alloc.types.locked.raw).toBe('0');
+    expect(alloc.types.locked.pct).toBe(0);
   });
 
   test('returns 100% transferable when no locks or reserves', () => {
@@ -204,10 +204,10 @@ describe('computeAssetRowAllocations', () => {
     });
 
     const alloc = result.get('acc1')!;
-    expect(alloc.transferable.pct).toBeCloseTo(100, 0);
-    expect(alloc.locked.pct).toBe(0);
-    expect(alloc.reserved.pct).toBe(0);
-    expect(alloc.vested.pct).toBe(0);
+    expect(alloc.types.transferable.pct).toBeCloseTo(100, 0);
+    expect(alloc.types.locked.pct).toBe(0);
+    expect(alloc.types.reserved.pct).toBe(0);
+    expect(alloc.types.vested.pct).toBe(0);
   });
 
   test('omits accounts with zero balance from result', () => {
@@ -256,10 +256,144 @@ describe('computeAssetRowAllocations', () => {
     // chain2: transferable = 400, reserved = 0, total = 400
     // combined: transferable = 900, reserved = 100, total = 1100, locked = 100
     const alloc = result.get('acc1')!;
-    expect(alloc.transferable.pct).toBeCloseTo(81.8, 0);
-    expect(alloc.transferable.raw).toBe('900');
-    expect(alloc.reserved.pct).toBeCloseTo(9.1, 0);
-    expect(alloc.locked.pct).toBeCloseTo(9.1, 0);
+    expect(alloc.types.transferable.pct).toBeCloseTo(81.8, 0);
+    expect(alloc.types.transferable.raw).toBe('900');
+    expect(alloc.types.reserved.pct).toBeCloseTo(9.1, 0);
+    expect(alloc.types.locked.pct).toBeCloseTo(9.1, 0);
+  });
+});
+
+describe('vesting overlap (vesting lock riding on reserved funds)', () => {
+  test('reports vesting fully covered by a hold as overlap, not as a partition slice', () => {
+    // staking wallet on a holdAndFreezes chain: reserved (hold) covers the whole
+    // vesting lock. transferable = 1000 - max(0, 500-10000) = 1000, total = 11000,
+    // locked = 0 -> partition vested = 0, overlap = 500
+    const balances = [
+      makeBalance({
+        accountId: 'acc1',
+        chainId: 'chain1',
+        assetId: 0,
+        free: 1000,
+        reserved: 10000,
+        frozen: 500,
+        vestingLock: 500,
+      }),
+    ];
+    const balanceMap = Object.fromEntries(balances.map((b) => [b.id, b]));
+    const chains = makeChains([{ chainId: 'chain1', assetId: 0, priceId: 'polkadot', symbol: 'DOT', precision: 0 }]);
+    const prices = makePrices([{ priceId: 'polkadot', coingeckoId: 'usd', price: 1 }]);
+
+    const result = computeAssetRowAllocations({
+      accountIds: ['acc1'],
+      priceId: 'polkadot',
+      balanceMap: balanceMap as any,
+      chains: chains as any,
+      prices,
+      currency: makeCurrency(),
+    });
+
+    const alloc = result.get('acc1')!;
+    expect(alloc.types.vested.pct).toBe(0);
+    expect(alloc.vestedOverlap.raw).toBe('500');
+    expect(alloc.vestedOverlap.fiat).toBe('500');
+    expect(alloc.vestedOverlap.pct).toBeCloseTo((500 / 11000) * 100, 1);
+    expect(alloc.vestedTotal).toEqual({ raw: '500', fiat: '500' });
+  });
+
+  test('splits vesting between the partition slice and the overlap', () => {
+    // transferable = 1000 - max(0, 600-200) = 600, total = 1200
+    // locked total = 1200 - 600 - 200 = 400 -> partition vested = min(600, 400) = 400
+    // vested total = min(600, 1200) = 600 -> overlap = 200
+    const balances = [
+      makeBalance({
+        accountId: 'acc1',
+        chainId: 'chain1',
+        assetId: 0,
+        free: 1000,
+        reserved: 200,
+        frozen: 600,
+        vestingLock: 600,
+      }),
+    ];
+    const balanceMap = Object.fromEntries(balances.map((b) => [b.id, b]));
+    const chains = makeChains([{ chainId: 'chain1', assetId: 0, priceId: 'polkadot', symbol: 'DOT', precision: 0 }]);
+    const prices = makePrices([{ priceId: 'polkadot', coingeckoId: 'usd', price: 1 }]);
+
+    const result = computeAssetRowAllocations({
+      accountIds: ['acc1'],
+      priceId: 'polkadot',
+      balanceMap: balanceMap as any,
+      chains: chains as any,
+      prices,
+      currency: makeCurrency(),
+    });
+
+    const alloc = result.get('acc1')!;
+    expect(alloc.types.vested.raw).toBe('400');
+    expect(alloc.vestedOverlap.raw).toBe('200');
+    expect(alloc.vestedTotal).toEqual({ raw: '600', fiat: '600' });
+  });
+
+  test('reports zero overlap when the vesting lock fits in locked', () => {
+    const balances = [
+      makeBalance({
+        accountId: 'acc1',
+        chainId: 'chain1',
+        assetId: 0,
+        free: 1000,
+        reserved: 0,
+        frozen: 400,
+        vestingLock: 300,
+      }),
+    ];
+    const balanceMap = Object.fromEntries(balances.map((b) => [b.id, b]));
+    const chains = makeChains([{ chainId: 'chain1', assetId: 0, priceId: 'polkadot', symbol: 'DOT', precision: 0 }]);
+    const prices = makePrices([{ priceId: 'polkadot', coingeckoId: 'usd', price: 1 }]);
+
+    const result = computeAssetRowAllocations({
+      accountIds: ['acc1'],
+      priceId: 'polkadot',
+      balanceMap: balanceMap as any,
+      chains: chains as any,
+      prices,
+      currency: makeCurrency(),
+    });
+
+    const alloc = result.get('acc1')!;
+    expect(alloc.vestedOverlap.pct).toBe(0);
+    expect(alloc.vestedTotal).toEqual({ raw: '300', fiat: '300' });
+  });
+
+  test('chain rows carry the overlap too', () => {
+    const balances = [
+      makeBalance({
+        accountId: 'acc1',
+        chainId: 'chain1',
+        assetId: 0,
+        free: 1000,
+        reserved: 10000,
+        frozen: 500,
+        vestingLock: 500,
+      }),
+    ];
+    const balanceMap = Object.fromEntries(balances.map((b) => [b.id, b]));
+    const chains = makeChains([{ chainId: 'chain1', assetId: 0, priceId: 'polkadot', symbol: 'DOT', precision: 0 }]);
+    const prices = makePrices([{ priceId: 'polkadot', coingeckoId: 'usd', price: 1 }]);
+
+    const result = computeChainRowAllocations({
+      assetIds: [0],
+      chainId: 'chain1' as any,
+      accountIds: ['acc1'],
+      balanceMap: balanceMap as any,
+      chains: chains as any,
+      prices,
+      currency: makeCurrency(),
+    });
+
+    const alloc = result.get(0)!;
+    expect(alloc.types.vested.pct).toBe(0);
+    expect(alloc.vestedOverlap.raw).toBe('500');
+    expect(alloc.vestedTotal).toEqual({ raw: '500', fiat: '500' });
   });
 });
 
@@ -287,9 +421,9 @@ describe('computeChainRowAllocations', () => {
     // acc2: transferable=500, reserved=0, total=500
     // combined: transferable=1400, reserved=200, total=1700, locked=100
     const alloc = result.get(0)!;
-    expect(alloc.transferable.pct).toBeCloseTo(82.4, 0);
-    expect(alloc.reserved.pct).toBeCloseTo(11.8, 0);
-    expect(alloc.locked.pct).toBeCloseTo(5.9, 0);
+    expect(alloc.types.transferable.pct).toBeCloseTo(82.4, 0);
+    expect(alloc.types.reserved.pct).toBeCloseTo(11.8, 0);
+    expect(alloc.types.locked.pct).toBeCloseTo(5.9, 0);
   });
 
   test('carves the vesting lock out of the locked amount', () => {
@@ -321,10 +455,10 @@ describe('computeChainRowAllocations', () => {
     });
 
     const alloc = result.get(0)!;
-    expect(alloc.vested).toEqual({ pct: 30, raw: '300', fiat: '300' });
-    expect(alloc.locked).toEqual({ pct: 10, raw: '100', fiat: '100' });
-    expect(alloc.transferable).toEqual({ pct: 60, raw: '600', fiat: '600' });
-    expect(alloc.reserved.pct).toBe(0);
+    expect(alloc.types.vested).toEqual({ pct: 30, raw: '300', fiat: '300' });
+    expect(alloc.types.locked).toEqual({ pct: 10, raw: '100', fiat: '100' });
+    expect(alloc.types.transferable).toEqual({ pct: 60, raw: '600', fiat: '600' });
+    expect(alloc.types.reserved.pct).toBe(0);
   });
 
   test('omits assets with zero balance', () => {

--- a/src/renderer/features/dashboard-portfolio-overview/lib/computeOverlapBarLayout.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/computeOverlapBarLayout.ts
@@ -1,0 +1,50 @@
+import { type BalanceType, BALANCE_TYPES } from './balanceTypes';
+
+export type OverlapBarLayout = {
+  segments: { type: BalanceType; pct: number }[];
+  /** `null` when there is no overlap — the bar needs no marker */
+  overlapSpan: { left: number; width: number } | null;
+};
+
+/**
+ * Geometry shared by the distribution bar and the detail-modal row bars: how a
+ * four-type partition is rendered when part of the vesting rides on reserved
+ * funds (see `vestingOverlapBN`).
+ *
+ * With an overlap the vested amount stops being a slice: it sits on top of
+ * reserved, and of whatever it froze inside locked. So it folds back into the
+ * segments it covers — keeping the bar a true partition — and is reported as a
+ * span to draw a marker across instead. The span is contiguous and straddles
+ * the reserved/locked boundary: it reaches left into reserved by the overlap,
+ * and right into locked by the part that did freeze free funds. Clamped to the
+ * bar; the caller still applies its own min-width floor, which percentages
+ * alone don't know about.
+ *
+ * `hasOverlap` is the caller's presence test (it may know the raw amount is
+ * non-zero even when the fiat share rounds to zero); a dust overlap then still
+ * folds and yields a zero-width span for the floor to keep visible.
+ */
+export function computeOverlapBarLayout(params: {
+  types: Record<BalanceType, number>;
+  overlapPct: number;
+  hasOverlap: boolean;
+}): OverlapBarLayout {
+  const { types, overlapPct, hasOverlap } = params;
+
+  const segments = BALANCE_TYPES.flatMap((type) => {
+    if (hasOverlap && type === 'vested') return [];
+
+    const pct = hasOverlap && type === 'locked' ? types.locked + types.vested : types[type];
+
+    return pct > 0 ? [{ type, pct }] : [];
+  });
+
+  const overlapSpan = hasOverlap
+    ? {
+        left: Math.max(0, types.transferable + types.reserved - overlapPct),
+        width: Math.min(100, overlapPct + types.vested),
+      }
+    : null;
+
+  return { segments, overlapSpan };
+}

--- a/src/renderer/features/dashboard-portfolio-overview/lib/computeRowAllocations.ts
+++ b/src/renderer/features/dashboard-portfolio-overview/lib/computeRowAllocations.ts
@@ -4,7 +4,7 @@ import { type Balance, type Chain, type ChainId } from '@/shared/core';
 import { getRoundedValue } from '@/shared/lib/utils';
 import { type PriceObject } from '@/domains/price';
 
-import { type BalanceType, BALANCE_TYPES, makeByType, splitBalanceByType } from './balanceTypes';
+import { type BalanceType, BALANCE_TYPES, makeByType, splitBalanceByType, vestingOverlapBN } from './balanceTypes';
 
 export type AllocationSegment = {
   pct: number;
@@ -12,7 +12,22 @@ export type AllocationSegment = {
   fiat: string;
 };
 
-export type RowAllocation = Record<BalanceType, AllocationSegment>;
+export type RowAllocation = {
+  types: Record<BalanceType, AllocationSegment>;
+  /**
+   * Vesting that rides on reserved funds — see {@link vestingOverlapBN}. Same
+   * contract as `AllocationData.vestedOverlap`: not one of `types` (those sum
+   * to the row total and drive the bar's geometry), `pct` is expressed against
+   * the same total so it can be drawn as a marker over the segments it covers.
+   */
+  vestedOverlap: AllocationSegment;
+  /**
+   * Everything under a vesting schedule — `types.vested` plus the overlap. What
+   * the legend prints, so the figure matches the holdings row the Vested filter
+   * selected.
+   */
+  vestedTotal: { raw: string; fiat: string };
+};
 
 type AssetAllocParams = {
   accountIds: string[];
@@ -33,33 +48,59 @@ type ChainAllocParams = {
   currency: { coingeckoId: string };
 };
 
-type ByTypeAccumulator = Record<BalanceType, { raw: BigNumber; fiat: BigNumber }>;
+type Amounts = { raw: BigNumber; fiat: BigNumber };
 
-const makeAccumulator = (): ByTypeAccumulator => makeByType(() => ({ raw: new BigNumber(0), fiat: new BigNumber(0) }));
+type RowAccumulator = {
+  types: Record<BalanceType, Amounts>;
+  overlap: Amounts;
+};
 
-function accumulate(acc: ByTypeAccumulator, balance: Balance, price: number, precision: number) {
+const makeAmounts = (): Amounts => ({ raw: new BigNumber(0), fiat: new BigNumber(0) });
+
+const makeAccumulator = (): RowAccumulator => ({ types: makeByType(makeAmounts), overlap: makeAmounts() });
+
+function addAmounts(amounts: Amounts, raw: string, price: number, precision: number) {
+  amounts.raw = amounts.raw.plus(raw);
+  amounts.fiat = amounts.fiat.plus(getRoundedValue(raw, price, precision));
+}
+
+function accumulate(acc: RowAccumulator, balance: Balance, price: number, precision: number) {
   const split = splitBalanceByType(balance);
   for (const type of BALANCE_TYPES) {
     if (split[type].isZero()) continue;
 
-    const raw = split[type].toString();
-    acc[type].raw = acc[type].raw.plus(raw);
-    acc[type].fiat = acc[type].fiat.plus(getRoundedValue(raw, price, precision));
+    addAmounts(acc.types[type], split[type].toString(), price, precision);
+  }
+
+  const overlap = vestingOverlapBN(balance);
+  if (!overlap.isZero()) {
+    addAmounts(acc.overlap, overlap.toString(), price, precision);
   }
 }
 
-function toAllocation(acc: ByTypeAccumulator): RowAllocation | null {
+function toAllocation(acc: RowAccumulator): RowAllocation | null {
+  // The overlap stays out of the total: it doubles funds already counted under
+  // `reserved`/`locked`, adding it would inflate every percentage.
   let totalFiat = new BigNumber(0);
   for (const type of BALANCE_TYPES) {
-    totalFiat = totalFiat.plus(acc[type].fiat);
+    totalFiat = totalFiat.plus(acc.types[type].fiat);
   }
   if (totalFiat.isZero()) return null;
 
-  return makeByType((type) => ({
-    pct: acc[type].fiat.div(totalFiat).multipliedBy(100).toNumber(),
-    raw: acc[type].raw.toFixed(0),
-    fiat: acc[type].fiat.toString(),
-  }));
+  const toSegment = (amounts: Amounts): AllocationSegment => ({
+    pct: amounts.fiat.div(totalFiat).multipliedBy(100).toNumber(),
+    raw: amounts.raw.toFixed(0),
+    fiat: amounts.fiat.toString(),
+  });
+
+  return {
+    types: makeByType((type) => toSegment(acc.types[type])),
+    vestedOverlap: toSegment(acc.overlap),
+    vestedTotal: {
+      raw: acc.types.vested.raw.plus(acc.overlap.raw).toFixed(0),
+      fiat: acc.types.vested.fiat.plus(acc.overlap.fiat).toString(),
+    },
+  };
 }
 
 export function computeAssetRowAllocations(params: AssetAllocParams): Map<string, RowAllocation> {
@@ -69,7 +110,7 @@ export function computeAssetRowAllocations(params: AssetAllocParams): Map<string
   const accountIdSet = new Set(accountIds);
 
   // Group balances by accountId, filtering to matching priceId
-  const grouped = new Map<string, ByTypeAccumulator>();
+  const grouped = new Map<string, RowAccumulator>();
 
   for (const balance of Object.values(balanceMap)) {
     if (!accountIdSet.has(balance.accountId)) continue;
@@ -108,7 +149,7 @@ export function computeChainRowAllocations(params: ChainAllocParams): Map<number
   const chain = chains[chainId];
   if (!chain) return result;
 
-  const grouped = new Map<number, ByTypeAccumulator>();
+  const grouped = new Map<number, RowAccumulator>();
 
   for (const balance of Object.values(balanceMap)) {
     if (!accountIdSet.has(balance.accountId)) continue;

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBarWithLegend.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBarWithLegend.tsx
@@ -1,11 +1,12 @@
 import { memo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { formatBalance } from '@/shared/lib/utils';
+import { cnTw, formatBalance } from '@/shared/lib/utils';
 import { HelpText } from '@/shared/ui';
-import { ALLOCATION_COLORS, VESTED_HATCH } from '@/shared/ui/chart-constants';
+import { ALLOCATION_COLORS, ALLOCATION_MARKER_MIN_PX, VESTED_HATCH } from '@/shared/ui/chart-constants';
 import { type CurrencyItem } from '@/domains/price';
-import { type BalanceType, BALANCE_TYPES } from '../lib/balanceTypes';
+import { type BalanceType, BALANCE_TYPES, makeByType } from '../lib/balanceTypes';
+import { computeOverlapBarLayout } from '../lib/computeOverlapBarLayout';
 import { type RowAllocation } from '../lib/computeRowAllocations';
 
 import { Price } from './Price';
@@ -17,40 +18,23 @@ type Props = {
   currency: CurrencyItem | null;
 };
 
-// Same floor `BalanceTypeBar` gives its marker: a trace of vesting inside a
-// large reserved balance is a sub-pixel span nobody can find otherwise.
-const MARKER_MIN_PX = 6;
-
 export const AllocationBarWithLegend = memo(({ allocation, symbol, precision, currency }: Props) => {
   const { t } = useI18n();
 
   const { types, vestedOverlap, vestedTotal } = allocation;
 
-  // Vesting that rides on reserved funds. It has a fiat value but no slice of
-  // its own — see `vestingOverlapBN`.
-  const hasOverlap = vestedOverlap.pct > 0;
+  // Vesting that rides on reserved funds — see `vestingOverlapBN`. Presence is
+  // judged by the raw amount: a dust overlap whose fiat share rounds to zero
+  // must still hatch the legend and print the whole vesting.
+  const hasOverlap = vestedOverlap.raw !== '0';
 
   const visibleTypes = BALANCE_TYPES.filter((type) => types[type].pct > 0 || (type === 'vested' && hasOverlap));
 
-  // Same fold `BalanceTypeBar` does: with an overlap the vested amount stops
-  // being a slice, so it merges into the segments it covers and is drawn as a
-  // marker across them instead.
-  const barSegments = BALANCE_TYPES.flatMap((type) => {
-    if (hasOverlap && type === 'vested') return [];
-
-    const pct = hasOverlap && type === 'locked' ? types.locked.pct + types.vested.pct : types[type].pct;
-
-    return pct > 0 ? [{ type, pct }] : [];
+  const { segments: barSegments, overlapSpan } = computeOverlapBarLayout({
+    types: makeByType((type) => types[type].pct),
+    overlapPct: vestedOverlap.pct,
+    hasOverlap,
   });
-
-  // Contiguous span straddling the reserved/locked boundary: left into reserved
-  // by the overlap, right into locked by the part that did freeze free funds.
-  const overlapSpan = hasOverlap
-    ? {
-        left: Math.max(0, types.transferable.pct + types.reserved.pct - vestedOverlap.pct),
-        width: Math.min(100, vestedOverlap.pct + types.vested.pct),
-      }
-    : null;
 
   return (
     <div className="w-full">
@@ -66,9 +50,9 @@ export const AllocationBarWithLegend = memo(({ allocation, symbol, precision, cu
             aria-hidden
             className="pointer-events-none absolute inset-y-0 rounded-[2px]"
             style={{
-              left: `min(${overlapSpan.left}%, calc(100% - ${MARKER_MIN_PX}px))`,
+              left: `min(${overlapSpan.left}%, calc(100% - ${ALLOCATION_MARKER_MIN_PX}px))`,
               width: `${overlapSpan.width}%`,
-              minWidth: `${MARKER_MIN_PX}px`,
+              minWidth: `${ALLOCATION_MARKER_MIN_PX}px`,
               backgroundImage: VESTED_HATCH,
             }}
           />
@@ -117,8 +101,10 @@ const LegendItem = ({ type, raw, fiat, hatched, symbol, precision, currency, lab
 
   return (
     <div className="flex items-start gap-1.5">
+      {/* hatched swatch is a square, same as the distribution bar's chip — the
+          stripes are illegible on a dot this size */}
       <span
-        className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full"
+        className={cnTw('mt-1 h-1.5 w-1.5 shrink-0', hatched ? 'rounded-[2px]' : 'rounded-full')}
         style={hatched ? { backgroundImage: VESTED_HATCH } : { backgroundColor: ALLOCATION_COLORS[type] }}
       />
       <div className="min-w-0">

--- a/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBarWithLegend.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/AllocationBarWithLegend.tsx
@@ -3,7 +3,7 @@ import { memo } from 'react';
 import { useI18n } from '@/shared/i18n';
 import { formatBalance } from '@/shared/lib/utils';
 import { HelpText } from '@/shared/ui';
-import { ALLOCATION_COLORS } from '@/shared/ui/chart-constants';
+import { ALLOCATION_COLORS, VESTED_HATCH } from '@/shared/ui/chart-constants';
 import { type CurrencyItem } from '@/domains/price';
 import { type BalanceType, BALANCE_TYPES } from '../lib/balanceTypes';
 import { type RowAllocation } from '../lib/computeRowAllocations';
@@ -17,35 +17,85 @@ type Props = {
   currency: CurrencyItem | null;
 };
 
+// Same floor `BalanceTypeBar` gives its marker: a trace of vesting inside a
+// large reserved balance is a sub-pixel span nobody can find otherwise.
+const MARKER_MIN_PX = 6;
+
 export const AllocationBarWithLegend = memo(({ allocation, symbol, precision, currency }: Props) => {
   const { t } = useI18n();
 
-  const visibleTypes = BALANCE_TYPES.filter((type) => allocation[type].pct > 0);
+  const { types, vestedOverlap, vestedTotal } = allocation;
+
+  // Vesting that rides on reserved funds. It has a fiat value but no slice of
+  // its own — see `vestingOverlapBN`.
+  const hasOverlap = vestedOverlap.pct > 0;
+
+  const visibleTypes = BALANCE_TYPES.filter((type) => types[type].pct > 0 || (type === 'vested' && hasOverlap));
+
+  // Same fold `BalanceTypeBar` does: with an overlap the vested amount stops
+  // being a slice, so it merges into the segments it covers and is drawn as a
+  // marker across them instead.
+  const barSegments = BALANCE_TYPES.flatMap((type) => {
+    if (hasOverlap && type === 'vested') return [];
+
+    const pct = hasOverlap && type === 'locked' ? types.locked.pct + types.vested.pct : types[type].pct;
+
+    return pct > 0 ? [{ type, pct }] : [];
+  });
+
+  // Contiguous span straddling the reserved/locked boundary: left into reserved
+  // by the overlap, right into locked by the part that did freeze free funds.
+  const overlapSpan = hasOverlap
+    ? {
+        left: Math.max(0, types.transferable.pct + types.reserved.pct - vestedOverlap.pct),
+        width: Math.min(100, vestedOverlap.pct + types.vested.pct),
+      }
+    : null;
 
   return (
     <div className="w-full">
-      <div className="flex h-[7px] w-full overflow-hidden rounded-full">
-        {visibleTypes.map((type) => (
-          <div
-            key={type}
-            className="h-full"
-            style={{ width: `${allocation[type].pct}%`, backgroundColor: ALLOCATION_COLORS[type] }}
+      <div className="relative">
+        <div className="flex h-[7px] w-full overflow-hidden rounded-full">
+          {barSegments.map(({ type, pct }) => (
+            <div key={type} className="h-full" style={{ width: `${pct}%`, backgroundColor: ALLOCATION_COLORS[type] }} />
+          ))}
+        </div>
+
+        {overlapSpan && (
+          <span
+            aria-hidden
+            className="pointer-events-none absolute inset-y-0 rounded-[2px]"
+            style={{
+              left: `min(${overlapSpan.left}%, calc(100% - ${MARKER_MIN_PX}px))`,
+              width: `${overlapSpan.width}%`,
+              minWidth: `${MARKER_MIN_PX}px`,
+              backgroundImage: VESTED_HATCH,
+            }}
           />
-        ))}
+        )}
       </div>
 
       <div className="mt-1.5 flex flex-wrap gap-x-4 gap-y-1">
-        {visibleTypes.map((type) => (
-          <LegendItem
-            key={type}
-            type={type}
-            allocation={allocation}
-            symbol={symbol}
-            precision={precision}
-            currency={currency}
-            labelText={t(`dashboard.portfolioOverview.balanceType.${type}`)}
-          />
-        ))}
+        {visibleTypes.map((type) => {
+          // With an overlap the legend prints the whole vesting — partition
+          // slice plus the part riding on reserved — so the figure matches the
+          // holdings row the Vested filter selected.
+          const amounts = type === 'vested' && hasOverlap ? vestedTotal : types[type];
+
+          return (
+            <LegendItem
+              key={type}
+              type={type}
+              raw={amounts.raw}
+              fiat={amounts.fiat}
+              hatched={type === 'vested' && hasOverlap}
+              symbol={symbol}
+              precision={precision}
+              currency={currency}
+              labelText={t(`dashboard.portfolioOverview.balanceType.${type}`)}
+            />
+          );
+        })}
       </div>
     </div>
   );
@@ -53,19 +103,24 @@ export const AllocationBarWithLegend = memo(({ allocation, symbol, precision, cu
 
 type LegendItemProps = {
   type: BalanceType;
-  allocation: RowAllocation;
+  raw: string;
+  fiat: string;
+  hatched: boolean;
   symbol: string;
   precision: number;
   currency: CurrencyItem | null;
   labelText: string;
 };
 
-const LegendItem = ({ type, allocation, symbol, precision, currency, labelText }: LegendItemProps) => {
-  const { formatted, suffix } = formatBalance(allocation[type].raw, precision);
+const LegendItem = ({ type, raw, fiat, hatched, symbol, precision, currency, labelText }: LegendItemProps) => {
+  const { formatted, suffix } = formatBalance(raw, precision);
 
   return (
     <div className="flex items-start gap-1.5">
-      <span className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full" style={{ backgroundColor: ALLOCATION_COLORS[type] }} />
+      <span
+        className="mt-1 h-1.5 w-1.5 shrink-0 rounded-full"
+        style={hatched ? { backgroundImage: VESTED_HATCH } : { backgroundColor: ALLOCATION_COLORS[type] }}
+      />
       <div className="min-w-0">
         <span
           className="block text-help-text font-medium text-text-primary tabular-nums"
@@ -75,7 +130,7 @@ const LegendItem = ({ type, allocation, symbol, precision, currency, labelText }
           {suffix} {symbol}
         </span>
         <HelpText className="text-text-tertiary">
-          {labelText} · <Price amount={allocation[type].fiat} currency={currency} />
+          {labelText} · <Price amount={fiat} currency={currency} />
         </HelpText>
       </div>
     </div>

--- a/src/renderer/features/dashboard-portfolio-overview/ui/BalanceTypeBar.tsx
+++ b/src/renderer/features/dashboard-portfolio-overview/ui/BalanceTypeBar.tsx
@@ -4,10 +4,11 @@ import { TEST_IDS } from '@/shared/constants';
 import { useI18n } from '@/shared/i18n';
 import { cnTw, formatAsset } from '@/shared/lib/utils';
 import { FootnoteText, HelpText, Icon, Loader } from '@/shared/ui';
-import { ALLOCATION_COLORS, VESTED_HATCH } from '@/shared/ui/chart-constants';
+import { ALLOCATION_COLORS, ALLOCATION_MARKER_MIN_PX, VESTED_HATCH } from '@/shared/ui/chart-constants';
 import { type CurrencyItem } from '@/domains/price';
 import { type AllocationData } from '../hooks/useBalanceAllocation';
-import { type BalanceType, BALANCE_TYPES } from '../lib/balanceTypes';
+import { type BalanceType, BALANCE_TYPES, makeByType } from '../lib/balanceTypes';
+import { computeOverlapBarLayout } from '../lib/computeOverlapBarLayout';
 
 import { Price } from './Price';
 
@@ -19,10 +20,6 @@ type Props = {
   onToggleType: (type: BalanceType) => void;
   onClear: () => void;
 };
-
-// Same floor the bar's segments use, so a trace of vesting stays visible instead
-// of collapsing to a sub-pixel span nobody can find.
-const MARKER_MIN_PX = 6;
 
 export const BalanceTypeBar = memo(({ allocation, currency, syncing, selectedType, onToggleType, onClear }: Props) => {
   const { t } = useI18n();
@@ -44,36 +41,12 @@ export const BalanceTypeBar = memo(({ allocation, currency, syncing, selectedTyp
   // figure on the chip. Only a chip with no priced rows behind it cannot filter.
   const isFilterable = (type: BalanceType) => allocation.types[type].pct > 0 || (type === 'vested' && hasOverlap);
 
-  /**
-   * With an overlap the vested amount stops being a slice: it sits on top of
-   * reserved, and of whatever it froze inside locked. So it folds back into the
-   * segments it covers — keeping the bar a true partition — and is drawn as a
-   * marker across them instead.
-   */
-  const barSegments = BALANCE_TYPES.flatMap((type) => {
-    if (hasOverlap && type === 'vested') return [];
-
-    const pct =
-      hasOverlap && type === 'locked'
-        ? allocation.types.locked.pct + allocation.types.vested.pct
-        : allocation.types[type].pct;
-
-    return pct > 0 ? [{ type, pct }] : [];
+  // Fold + marker-span geometry shared with the detail modals' row bars.
+  const { segments: barSegments, overlapSpan } = computeOverlapBarLayout({
+    types: makeByType((type) => allocation.types[type].pct),
+    overlapPct: allocation.vestedOverlap.pct,
+    hasOverlap,
   });
-
-  // The vesting span is contiguous and straddles the reserved/locked boundary:
-  // it reaches left into reserved by the overlap, and right into locked by the
-  // part that did freeze unreserved funds. Clamped, since the segments carry a
-  // 6px floor that percentages alone don't know about.
-  const overlapSpan = hasOverlap
-    ? {
-        left: Math.max(
-          0,
-          allocation.types.transferable.pct + allocation.types.reserved.pct - allocation.vestedOverlap.pct,
-        ),
-        width: Math.min(100, allocation.vestedOverlap.pct + allocation.types.vested.pct),
-      }
-    : null;
 
   const renderChipValue = (type: BalanceType) => {
     if (type !== 'vested') {
@@ -160,9 +133,9 @@ export const BalanceTypeBar = memo(({ allocation, currency, syncing, selectedTyp
                 // (the span itself is bounded by the total), so clamping the
                 // start by exactly that floor keeps the marker inside the bar
                 // instead of hanging past its rounded end.
-                left: `min(${overlapSpan.left}%, calc(100% - ${MARKER_MIN_PX}px))`,
+                left: `min(${overlapSpan.left}%, calc(100% - ${ALLOCATION_MARKER_MIN_PX}px))`,
                 width: `${overlapSpan.width}%`,
-                minWidth: `${MARKER_MIN_PX}px`,
+                minWidth: `${ALLOCATION_MARKER_MIN_PX}px`,
                 backgroundImage: VESTED_HATCH,
               }}
             />

--- a/src/renderer/shared/ui/chart-constants.ts
+++ b/src/renderer/shared/ui/chart-constants.ts
@@ -57,3 +57,10 @@ export const ALLOCATION_COLORS = {
  * segment's own colour stays legible underneath in both themes.
  */
 export const VESTED_HATCH = `repeating-linear-gradient(135deg, ${ALLOCATION_COLORS.vested}d9 0 3px, #ffffff59 3px 6px)`;
+
+/**
+ * Floor for the {@link VESTED_HATCH} marker (and the segments it sits over): a
+ * trace of vesting inside a large balance would otherwise collapse to a
+ * sub-pixel span nobody can find.
+ */
+export const ALLOCATION_MARKER_MIN_PX = 6;


### PR DESCRIPTION
## Description

Follow-up to #5971. The per-row **Asset Allocation** bars in the portfolio detail modals (asset detail and chain detail) did not show vested tokens when the vesting lock rides on reserved funds — the normal case for anyone who both stakes and vests on Asset Hub: the staking hold satisfies the freeze, so the strict partition (`splitBalanceByType`) reports vested as zero and the vested segment/legend never appeared, even when the modal was opened from the Vested filter.

The main distribution bar already solves this (`vestingOverlapBN` + hatched marker); this PR mirrors that treatment in the per-row bars:

- the bar stays an exact partition — the overlapping vesting joins no segment and is drawn as a hatched marker (same 6px visibility floor) across the segments it covers;
- the legend's Vested entry gets the hatched swatch and prints the **whole** vesting lock, so the figure matches the row amount the Vested filter selected.

## Related Issues

Related to #5971

## Changes Made

- `computeRowAllocations`: `RowAllocation` restructured to `{ types, vestedOverlap, vestedTotal }` — overlap computed per balance and kept outside the partition (does not inflate percentages or understate reserved)
- `AllocationBarWithLegend`: hatched overlap marker over the bar + vested legend total, mirroring `BalanceTypeBar`
- Feature README: documented the overlap treatment in detail modals
- Tests: 4 new cases covering full/partial/zero overlap for asset and chain rows

## Screenshots/Recordings

N/A

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
