### PR TITLE
fix: read staking apy from realized era rewards after the dap reform

### DIFF
--- a/src/renderer/domains/staking/apy/__tests__/networkApy.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkApy.test.ts
@@ -16,29 +16,22 @@ vi.mock('@/shared/pallet/staking', () => ({
 const consts = vi.mocked(stakingPallet.consts);
 const storage = vi.mocked(stakingPallet.storage);
 
-// Polkadot Asset Hub-like figures (observed onchain): a fixed per-era staker mint
-// of 130 162 DOT over a 24h era, against ~873.9M DOT staked → ~5.44% APR.
+// Polkadot Asset Hub-like figures: a per-era staker reward of 130 162 DOT over
+// a 24h era, against ~873.9M DOT staked → ~5.44% APR.
 const TO_STAKERS = '1301621489239150';
 const TOTAL_STAKED = '8739307348715573817';
 
 type ApiOverrides = {
-  toStakers?: string | number | null;
-  withInflationApi?: boolean;
   totalIssuance?: string | null;
+  predictionCall?: ReturnType<typeof vi.fn>;
 };
 
-const mockApi = ({ toStakers = TO_STAKERS, withInflationApi = true, totalIssuance = null }: ApiOverrides = {}) => {
-  const inflation = withInflationApi
-    ? {
-        experimentalIssuancePredictionInfo: vi.fn().mockResolvedValue({
-          toJSON: () => ({ issuance: '0x0', nextMint: [toStakers, '229697909865732'] }),
-        }),
-      }
-    : undefined;
-
+const mockApi = ({ totalIssuance = null, predictionCall }: ApiOverrides = {}) => {
   const balances = totalIssuance
     ? { totalIssuance: vi.fn().mockResolvedValue({ toString: () => totalIssuance }) }
     : undefined;
+
+  const inflation = predictionCall ? { experimentalIssuancePredictionInfo: predictionCall } : undefined;
 
   return { call: { inflation }, query: { balances } } as unknown as ApiPromise;
 };
@@ -63,10 +56,10 @@ describe('getNetworkApy', () => {
     vi.clearAllMocks();
     consts.sessionsPerEra.mockReturnValue(6);
     storage.erasTotalStake.mockResolvedValue(new BN(TOTAL_STAKED));
-    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
+    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: new BN(TO_STAKERS) }]);
   });
 
-  test('annualises the per-era staker mint over the era duration', async () => {
+  test('annualises the last completed era staker reward over the era duration', async () => {
     const apy = await apyService.getNetworkApy({
       api: mockApi(),
       timelineApi: relayApi(),
@@ -76,6 +69,7 @@ describe('getNetworkApy', () => {
     });
 
     // 1301621489239150 × 365.25 / 8739307348715573817 × 100
+    expect(storage.erasValidatorReward).toHaveBeenCalledWith(expect.anything(), [99]);
     expect(apy).toEqual('5.44');
   });
 
@@ -92,18 +86,21 @@ describe('getNetworkApy', () => {
     expect(apy).toEqual('4.90');
   });
 
-  test('falls back to the last completed era reward when the inflation API is missing', async () => {
-    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: new BN(TO_STAKERS) }]);
+  test('ignores the issuance prediction API whose nextMint is the total era emission since the DAP reform', async () => {
+    const predictionCall = vi.fn().mockResolvedValue({
+      // ~2.21× the staker reward - the pre-DAP interpretation would overstate APY.
+      toJSON: () => ({ issuance: '0x0', nextMint: ['2879160367447112', '0'] }),
+    });
 
     const apy = await apyService.getNetworkApy({
-      api: mockApi({ withInflationApi: false }),
+      api: mockApi({ predictionCall }),
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
       validators: validators(0),
     });
 
-    expect(storage.erasValidatorReward).toHaveBeenCalledWith(expect.anything(), [99]);
+    expect(predictionCall).not.toHaveBeenCalled();
     expect(apy).toEqual('5.44');
   });
 
@@ -133,8 +130,10 @@ describe('getNetworkApy', () => {
   });
 
   test('falls back to the NPoS curve when the chain reports no era reward at all', async () => {
+    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
+
     const apy = await apyService.getNetworkApy({
-      api: mockApi({ withInflationApi: false, totalIssuance: '17478614697431147634' }),
+      api: mockApi({ totalIssuance: '17478614697431147634' }),
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
@@ -146,8 +145,10 @@ describe('getNetworkApy', () => {
   });
 
   test('returns null when no staker reward can be resolved', async () => {
+    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
+
     const apy = await apyService.getNetworkApy({
-      api: mockApi({ withInflationApi: false }),
+      api: mockApi(),
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,

--- a/src/renderer/domains/staking/apy/__tests__/networkApy.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkApy.test.ts
@@ -144,6 +144,21 @@ describe('getNetworkApy', () => {
     expect(apy).toEqual('15.00');
   });
 
+  test('leaves the apy unknown when the era reward query fails instead of guessing via the curve', async () => {
+    storage.erasValidatorReward.mockRejectedValue(new Error('disconnected'));
+
+    const apy = await apyService.getNetworkApy({
+      // Issuance is available, so the curve fallback would produce a value if reached.
+      api: mockApi({ totalIssuance: '17478614697431147634' }),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(apy).toBeNull();
+  });
+
   test('returns null when no staker reward can be resolved', async () => {
     storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
 

--- a/src/renderer/domains/staking/apy/__tests__/validatorsApy.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/validatorsApy.test.ts
@@ -19,7 +19,7 @@ const storage = vi.mocked(stakingPallet.storage);
 
 const polkadotAh = { chainId: AssetHubChains.POLKADOT_AH } as Chain;
 
-// 10% pool reward rate: 1000 minted per era × 365.25 eras/year against 3_652_500 staked.
+// 10% pool reward rate: 1000 paid to stakers per era × 365.25 eras/year against 3_652_500 staked.
 const TOTAL_STAKED = 3_652_500;
 const ERA_REWARD = 1000;
 

--- a/src/renderer/domains/staking/apy/__tests__/validatorsApy.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/validatorsApy.test.ts
@@ -23,19 +23,7 @@ const polkadotAh = { chainId: AssetHubChains.POLKADOT_AH } as Chain;
 const TOTAL_STAKED = 3_652_500;
 const ERA_REWARD = 1000;
 
-const mockApi = (withReward = true): ApiPromise =>
-  ({
-    call: {
-      inflation: withReward
-        ? {
-            experimentalIssuancePredictionInfo: vi
-              .fn()
-              .mockResolvedValue({ toJSON: () => ({ nextMint: [String(ERA_REWARD), '0'] }) }),
-          }
-        : undefined,
-    },
-    query: {},
-  }) as unknown as ApiPromise;
+const mockApi = (): ApiPromise => ({ call: {}, query: {} }) as unknown as ApiPromise;
 
 const alice = '0x01' as AccountId;
 const bob = '0x02' as AccountId;
@@ -46,7 +34,7 @@ describe('getValidatorsApy', () => {
     vi.clearAllMocks();
     consts.sessionsPerEra.mockReturnValue(6);
     storage.erasTotalStake.mockResolvedValue(new BN(TOTAL_STAKED));
-    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
+    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: new BN(ERA_REWARD) }]);
   });
 
   test('pays a higher rate to validators holding less than the average stake', async () => {
@@ -82,8 +70,10 @@ describe('getValidatorsApy', () => {
   });
 
   test('returns an empty map when the chain reports no reward data', async () => {
+    storage.erasValidatorReward.mockResolvedValue([{ era: 99, reward: null }]);
+
     const apy = await apyService.getValidatorsApy({
-      api: mockApi(false),
+      api: mockApi(),
       timelineApi: null,
       chain: polkadotAh,
       era: 100,

--- a/src/renderer/domains/staking/apy/calculator.ts
+++ b/src/renderer/domains/staking/apy/calculator.ts
@@ -8,9 +8,9 @@ const PERBILL = 1_000_000_000;
 /**
  * Yearly inflation predicted by the classic NPoS reward curve.
  *
- * Only used as a fallback when the chain exposes neither the inflation runtime
- * API nor a realized era payout - chains with a fixed inflation model (Polkadot
- * after ref. 1139) are not described by this curve.
+ * Only used as a fallback when the chain reports no realized era payout -
+ * chains with a fixed inflation model (Polkadot after ref. 1139) are not
+ * described by this curve.
  */
 export function calculateYearlyInflation(stakedPortion: number): number {
   const calculatedInflation =

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -39,12 +39,6 @@ export const apyService = {
   getValidatorsApy,
 };
 
-type IssuancePredictionCall = () => Promise<{ toJSON: () => unknown }>;
-
-function hasKey<K extends string>(value: unknown, key: K): value is Record<K, unknown> {
-  return typeof value === 'object' && value !== null && key in value;
-}
-
 /**
  * Era duration in milliseconds.
  *
@@ -70,63 +64,18 @@ function getEraDurationMs(api: ApiPromise, timelineApi: ApiPromise | null | unde
   return FALLBACK_ERA_DURATION_MS[chain.chainId] ?? DEFAULT_ERA_DURATION_MS;
 }
 
-function parsePlanck(value: unknown): BigNumber | null {
-  if (typeof value === 'number') return new BigNumber(value);
-  if (typeof value === 'string') {
-    const parsed = value.startsWith('0x') ? new BigNumber(value.slice(2), 16) : new BigNumber(value);
-
-    return parsed.isFinite() ? parsed : null;
-  }
-
-  return null;
-}
-
-// Reads `nextMint = [toStakers, toTreasury]` from the inflation prediction result.
-function readStakersMint(json: unknown): BigNumber | null {
-  if (!hasKey(json, 'nextMint')) return null;
-
-  const { nextMint } = json;
-  if (!Array.isArray(nextMint) || nextMint.length === 0) return null;
-
-  return parsePlanck(nextMint[0]);
-}
-
-// Resolves the `inflation.experimentalIssuancePredictionInfo` runtime call if the chain exposes it.
-function getIssuancePredictionCall(api: ApiPromise): IssuancePredictionCall | null {
-  if (!hasKey(api.call, 'inflation')) return null;
-
-  const { inflation } = api.call;
-  if (!hasKey(inflation, 'experimentalIssuancePredictionInfo')) return null;
-
-  const predict = inflation.experimentalIssuancePredictionInfo;
-
-  // The signature cannot be inferred from the dynamically-typed runtime api.
-  return typeof predict === 'function' ? (predict as IssuancePredictionCall) : null;
-}
-
 /**
- * Per-era reward minted to stakers (validators + nominators), before
- * commission.
+ * Per-era reward paid to stakers (validators + nominators), before commission.
  *
- * Uses the `inflation.experimentalIssuancePredictionInfo` runtime API, which
- * the runtime documents as the recommended source over re-deriving the onchain
- * logic and which reflects the chain's real inflation model (fixed on Polkadot,
- * curve-based on Kusama). Falls back to the last completed era's realized
- * payout when the runtime API is unavailable.
+ * Reads the last completed era's realized payout (`erasValidatorReward`) - the
+ * exact budget nominator payouts draw from. The
+ * `inflation.experimentalIssuancePredictionInfo` runtime API is deliberately
+ * not used: since the Dynamic Allocation Pool reform (fellows-runtimes v2.3.0,
+ * 2026-06) its `nextMint` reports the total era emission on Polkadot, of which
+ * stakers only receive the DAP staker allocation (~45%) - treating it as the
+ * staker reward overstates APY ~2.2×.
  */
 async function getStakersEraReward(api: ApiPromise, era: EraIndex): Promise<BigNumber | null> {
-  const predict = getIssuancePredictionCall(api);
-
-  if (predict) {
-    try {
-      const info = await predict();
-      const toStakers = readStakersMint(info.toJSON());
-      if (toStakers && toStakers.isGreaterThan(0)) return toStakers;
-    } catch (error) {
-      console.warn('inflation prediction API failed, falling back to era reward', error);
-    }
-  }
-
   try {
     const [entry] = await stakingPallet.storage.erasValidatorReward(api, [Math.max(era - 1, 0)]);
     if (entry?.reward) return new BigNumber(entry.reward.toString());

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -74,16 +74,15 @@ function getEraDurationMs(api: ApiPromise, timelineApi: ApiPromise | null | unde
  * 2026-06) its `nextMint` reports the total era emission on Polkadot, of which
  * stakers only receive the DAP staker allocation (~45%) - treating it as the
  * staker reward overstates APY ~2.2×.
+ *
+ * Returns `null` when the chain genuinely reports no reward for the era; throws
+ * when the query fails, so a transient error is never mistaken for a chain
+ * without era payouts.
  */
 async function getStakersEraReward(api: ApiPromise, era: EraIndex): Promise<BigNumber | null> {
-  try {
-    const [entry] = await stakingPallet.storage.erasValidatorReward(api, [Math.max(era - 1, 0)]);
-    if (entry?.reward) return new BigNumber(entry.reward.toString());
-  } catch (error) {
-    console.warn(error);
-  }
+  const [entry] = await stakingPallet.storage.erasValidatorReward(api, [Math.max(era - 1, 0)]);
 
-  return null;
+  return entry?.reward ? new BigNumber(entry.reward.toString()) : null;
 }
 
 async function getTotalStaked(api: ApiPromise, era: EraIndex): Promise<BigNumber | null> {
@@ -131,14 +130,24 @@ type AvgRewardPercentParams = {
  * length (`reward × erasPerYear / totalStaked`), which is correct for both the
  * legacy NPoS inflation curve (Kusama) and the fixed inflation model (Polkadot,
  * ref. 1139). The curve is only re-derived when the chain reports no era reward
- * at all.
+ * at all; a failed reward query leaves the APY unknown instead - on Polkadot
+ * the curve is known to overstate ~2.7×, and a wrong value would be cached for
+ * the rest of the era.
  */
 async function getAvgRewardPercent(params: AvgRewardPercentParams): Promise<number | null> {
   const { api, timelineApi, chain, era, totalStaked } = params;
 
   if (!totalStaked.isFinite() || totalStaked.isLessThanOrEqualTo(0)) return null;
 
-  const stakersEraReward = await getStakersEraReward(api, era);
+  let stakersEraReward: BigNumber | null;
+  try {
+    stakersEraReward = await getStakersEraReward(api, era);
+  } catch (error) {
+    console.warn('era reward query failed, leaving the apy unknown', error);
+
+    return null;
+  }
+
   if (stakersEraReward?.isGreaterThan(0)) {
     const erasPerYear = MILLISECONDS_PER_YEAR / getEraDurationMs(api, timelineApi, chain);
 

--- a/src/renderer/domains/staking/validators/__tests__/eraValidators.test.ts
+++ b/src/renderer/domains/staking/validators/__tests__/eraValidators.test.ts
@@ -37,7 +37,7 @@ const bob = '0x02' as AccountId;
 const CHAIN_ID = AssetHubChains.POLKADOT_AH;
 const ERA = 100;
 
-// 10% pool reward rate: 1000 minted per 24h era against 3_652_500 staked.
+// 10% pool reward rate: 1000 paid to stakers per 24h era against 3_652_500 staked.
 const TOTAL_STAKED = 3_652_500;
 const VALIDATOR_STAKE = String(TOTAL_STAKED / 2);
 

--- a/src/renderer/domains/staking/validators/__tests__/eraValidators.test.ts
+++ b/src/renderer/domains/staking/validators/__tests__/eraValidators.test.ts
@@ -41,13 +41,9 @@ const ERA = 100;
 const TOTAL_STAKED = 3_652_500;
 const VALIDATOR_STAKE = String(TOTAL_STAKED / 2);
 
-const mockApi = (withReward = true): ApiPromise =>
+const mockApi = (): ApiPromise =>
   ({
-    call: {
-      inflation: withReward
-        ? { experimentalIssuancePredictionInfo: vi.fn().mockResolvedValue({ toJSON: () => ({ nextMint: ['1000'] }) }) }
-        : undefined,
-    },
+    call: {},
     query: {},
     genesisHash: { toHex: () => CHAIN_ID },
   }) as unknown as ApiPromise;
@@ -91,7 +87,7 @@ describe('validatorsService.getEraValidators', () => {
     storage.unappliedSlashKeys.mockResolvedValue([]);
     storage.slashingSpans.mockResolvedValue([]);
     storage.erasTotalStake.mockResolvedValue(new BN(TOTAL_STAKED));
-    storage.erasValidatorReward.mockResolvedValue([{ era: ERA - 1, reward: null }]);
+    storage.erasValidatorReward.mockResolvedValue([{ era: ERA - 1, reward: new BN(1000) }]);
   });
 
   test('should compose exposure, preferences and reward points into an era validator', async () => {
@@ -231,7 +227,9 @@ describe('validatorsService.getEraValidators', () => {
   });
 
   test('should leave the apy unknown when the chain reports no reward data', async () => {
-    const result = await getEraValidators({ api: mockApi(false), overviews: overviews([[alice, {}]]) });
+    storage.erasValidatorReward.mockResolvedValue([{ era: ERA - 1, reward: null }]);
+
+    const result = await getEraValidators({ api: mockApi(), overviews: overviews([[alice, {}]]) });
 
     expect(result[alice]?.apy).toBeNull();
   });


### PR DESCRIPTION
## Description

Polkadot Asset Hub staking APY was shown as 8+% while the real staker return is ~2.9%. Since the Dynamic Allocation Pool (DAP) reform (fellows-runtimes v2.3.0, 2026-06-05) the `inflation.experimentalIssuancePredictionInfo` runtime API reports the **total era emission** in `nextMint[0]` (~153,132 DOT/day), while stakers only receive the DAP staker allocation (45.2% ≈ 69,216 DOT/day) — treating the mint as the staker reward overstates APY ~2.2×, further amplified by the per-validator boost.

The fix drops the prediction API entirely and derives the reward rate from the last completed era's realized payout (`erasValidatorReward`) — the exact budget nominator payouts draw from. This mirrors nova-wallet-ios (novasamatech/nova-wallet-ios#1837), which switched to the staking pallet's `era_reward_allocation` view function that returns the same value. The NPoS-curve fallback for chains reporting no era reward stays untouched.

Verified against live chains: PAH realized 69,216 DOT/era → 2.87% gross (prediction API would give 6.34%); KAH 907 KSM/era → 15.40% (prediction and realized agree, so Kusama output is unchanged).

## Related Issues

Related to the staking dashboard rework (`feat/staking-dashboard-rework`).

## Changes Made

- `apy/service.ts`: `getStakersEraReward` reads only the realized `erasValidatorReward(era - 1)`; removed the issuance-prediction call and its parsing helpers
- `apy/calculator.ts`: updated the NPoS-curve fallback comment
- Tests: reward is now mocked through `erasValidatorReward`; added a regression test asserting the prediction API is ignored even when the chain exposes it

## Screenshots/Recordings

N/A — numbers verified against live chain RPC (see description).

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
