### PR TITLE
feat: dashboard improvements

### DIFF
--- a/src/renderer/aggregates/account-presets/model.ts
+++ b/src/renderer/aggregates/account-presets/model.ts
@@ -10,10 +10,17 @@ import {
   type BackendContactSeed,
   type LocalContactSeed,
   type WalletEntrySeed,
+  applyPresetFilter,
   buildMergedEntries,
   matchPreset,
 } from './lib';
-import { type AccountEntry, type AccountPreset, type PresetFilterCriteria, type PresetType } from './types';
+import {
+  type AccountEntry,
+  type AccountPreset,
+  type PresetFilterCriteria,
+  type PresetType,
+  EMPTY_FILTERS,
+} from './types';
 
 const MAX_SEGMENTS = 3;
 const PRESETS_KEY = 'account_presets';
@@ -226,16 +233,49 @@ type MatchedSource = {
 const resolveMatched = ({ activeId, byPresetId, all }: MatchedSource) =>
   activeId ? (byPresetId[activeId] ?? all) : all;
 
+const resolveMatchedWithQuickFilter = ({
+  quickFilter,
+  ...source
+}: MatchedSource & { quickFilter: PresetFilterCriteria }) => applyPresetFilter(quickFilter, resolveMatched(source));
+
+/**
+ * An ad-hoc narrowing on top of whichever preset is active.
+ *
+ * Deliberately **not persisted**: a saved preset is a decision the user made
+ * and named, a quick filter is a look they are taking right now, and a look
+ * that survived a restart would silently scope the whole dashboard to something
+ * nobody remembers choosing. "Save as preset" is how a look becomes a
+ * decision.
+ */
+const $dashboardQuickFilter = createStore<PresetFilterCriteria>(EMPTY_FILTERS);
+const $operationsQuickFilter = createStore<PresetFilterCriteria>(EMPTY_FILTERS);
+
+const dashboardQuickFilterChanged = createEvent<PresetFilterCriteria>();
+const operationsQuickFilterChanged = createEvent<PresetFilterCriteria>();
+
+$dashboardQuickFilter.on(dashboardQuickFilterChanged, (_, filters) => filters);
+$operationsQuickFilter.on(operationsQuickFilterChanged, (_, filters) => filters);
+
 const $matchedDashboardEntriesRaw = combine(
-  { activeId: $activeDashboardPresetId, byPresetId: $entriesByPresetId, all: $allEntries },
-  resolveMatched,
+  {
+    activeId: $activeDashboardPresetId,
+    byPresetId: $entriesByPresetId,
+    all: $allEntries,
+    quickFilter: $dashboardQuickFilter,
+  },
+  resolveMatchedWithQuickFilter,
 );
 const $matchedDashboardEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
 $matchedDashboardEntries.on($matchedDashboardEntriesRaw, (_, next) => next);
 
 const $matchedOperationsEntriesRaw = combine(
-  { activeId: $activeOperationsPresetId, byPresetId: $entriesByPresetId, all: $allEntries },
-  resolveMatched,
+  {
+    activeId: $activeOperationsPresetId,
+    byPresetId: $entriesByPresetId,
+    all: $allEntries,
+    quickFilter: $operationsQuickFilter,
+  },
+  resolveMatchedWithQuickFilter,
 );
 const $matchedOperationsEntries = createStore<AccountEntry[]>([], { updateFilter: matchedEntriesFilter });
 $matchedOperationsEntries.on($matchedOperationsEntriesRaw, (_, next) => next);
@@ -250,10 +290,12 @@ export const accountPresetsModel = {
   $activeDashboardPresetId,
   $activeDashboardPreset,
   $matchedDashboardEntries,
+  $dashboardQuickFilter,
 
   $activeOperationsPresetId,
   $activeOperationsPreset,
   $matchedOperationsEntries,
+  $operationsQuickFilter,
 
   presetCreated,
   presetUpdated,
@@ -263,4 +305,6 @@ export const accountPresetsModel = {
 
   dashboardPresetActivated,
   operationsPresetActivated,
+  dashboardQuickFilterChanged,
+  operationsQuickFilterChanged,
 };

--- a/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
+++ b/src/renderer/features/account-selector/ui/AccountSelectorSwitcher.tsx
@@ -6,8 +6,10 @@ import { useI18n } from '@/shared/i18n';
 import { cnTw, includes } from '@/shared/lib/utils';
 import { Counter, FootnoteText, Icon, IconButton } from '@/shared/ui';
 import { Popover, SearchInput, Tabs, Tooltip } from '@/shared/ui-kit';
-import { type AccountEntry, accountPresetsModel } from '@/aggregates/account-presets';
+import { type AccountEntry, type PresetFilterCriteria, accountPresetsModel } from '@/aggregates/account-presets';
 import { PresetManagementModal, SourceBreakdownBar } from '@/widgets/PresetManagementModal';
+
+import { QuickFilterPopover } from './QuickFilterPopover';
 
 type TabCounterProps = {
   label: string;
@@ -36,6 +38,8 @@ const ALL_VALUE = '__all__';
 type Props = {
   $activePresetId: Store<string | null>;
   onActivate: (id: string | null) => void;
+  $quickFilters: Store<PresetFilterCriteria>;
+  onQuickFiltersChange: (filters: PresetFilterCriteria) => void;
 };
 
 /**
@@ -46,7 +50,12 @@ type Props = {
  * break the slot call path (`TypeError: render is not a function`). Memoize
  * child components instead if needed.
  */
-export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) => {
+export const AccountSelectorSwitcher = ({
+  $activePresetId,
+  onActivate,
+  $quickFilters,
+  onQuickFiltersChange,
+}: Props) => {
   const { t } = useI18n();
   const activePresetId = useUnit($activePresetId);
   const segmentPresets = useUnit(accountPresetsModel.$segmentPresets);
@@ -162,6 +171,8 @@ export const AccountSelectorSwitcher = ({ $activePresetId, onActivate }: Props) 
         ) : (
           <IconButton name="settingsLite" onClick={handleOpenSettings} />
         )}
+
+        <QuickFilterPopover $filters={$quickFilters} onChange={onQuickFiltersChange} />
       </div>
       <PresetManagementModal isOpen={modalOpen} onClose={handleCloseModal} />
     </>

--- a/src/renderer/features/account-selector/ui/DashboardAccountSelector.tsx
+++ b/src/renderer/features/account-selector/ui/DashboardAccountSelector.tsx
@@ -5,6 +5,8 @@ import { AccountSelectorSwitcher } from './AccountSelectorSwitcher';
 export const DashboardAccountSelector = () => (
   <AccountSelectorSwitcher
     $activePresetId={accountPresetsModel.$activeDashboardPresetId}
+    $quickFilters={accountPresetsModel.$dashboardQuickFilter}
+    onQuickFiltersChange={accountPresetsModel.dashboardQuickFilterChanged}
     onActivate={accountPresetsModel.dashboardPresetActivated}
   />
 );

--- a/src/renderer/features/account-selector/ui/OperationsAccountSelector.tsx
+++ b/src/renderer/features/account-selector/ui/OperationsAccountSelector.tsx
@@ -5,6 +5,8 @@ import { AccountSelectorSwitcher } from './AccountSelectorSwitcher';
 export const OperationsAccountSelector = () => (
   <AccountSelectorSwitcher
     $activePresetId={accountPresetsModel.$activeOperationsPresetId}
+    $quickFilters={accountPresetsModel.$operationsQuickFilter}
+    onQuickFiltersChange={accountPresetsModel.operationsQuickFilterChanged}
     onActivate={accountPresetsModel.operationsPresetActivated}
   />
 );

--- a/src/renderer/features/account-selector/ui/QuickFilterPopover.tsx
+++ b/src/renderer/features/account-selector/ui/QuickFilterPopover.tsx
@@ -88,6 +88,9 @@ export const QuickFilterPopover = ({ $filters, onChange }: Props) => {
 
   const active = countActive(filters);
 
+  /** Criteria that only address-book contacts carry values for. */
+  const addressBookScoped = filters.chainIds.length > 0 || filters.fields.length > 0;
+
   const toggleChain = (chainId: string) => {
     const next = filters.chainIds.includes(chainId)
       ? filters.chainIds.filter((id) => id !== chainId)
@@ -173,6 +176,14 @@ export const QuickFilterPopover = ({ $filters, onChange }: Props) => {
               }}
             />
           ))}
+
+          {addressBookScoped && (
+            /* `applyPresetFilter` answers network and field criteria from
+               address-book metadata, so a row without it cannot match one.
+               Saying so beats letting the user combine `Source: Wallet` with a
+               network chip and read the empty result as a bug. */
+            <FootnoteText className="text-text-tertiary">{t('presets.quickFilter.addressBookOnly')}</FootnoteText>
+          )}
 
           {active > 0 && (
             <button

--- a/src/renderer/features/account-selector/ui/QuickFilterPopover.tsx
+++ b/src/renderer/features/account-selector/ui/QuickFilterPopover.tsx
@@ -1,0 +1,224 @@
+import { type Store } from 'effector';
+import { useUnit } from 'effector-react';
+import { useMemo, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { Counter, FootnoteText, Icon } from '@/shared/ui';
+import { Popover } from '@/shared/ui-kit';
+import { contactModel } from '@/entities/contact';
+import {
+  type AccountSource,
+  type FieldCriterion,
+  type PresetFilterCriteria,
+  EMPTY_FILTERS,
+} from '@/aggregates/account-presets';
+
+type Props = {
+  $filters: Store<PresetFilterCriteria>;
+  onChange: (filters: PresetFilterCriteria) => void;
+};
+
+const SOURCE_OPTIONS: { id: AccountSource; labelKey: string }[] = [
+  { id: 'wallet', labelKey: 'dashboard.presets.sources.wallet' },
+  { id: 'local-contact', labelKey: 'dashboard.presets.sources.localContact' },
+  { id: 'backend-contact', labelKey: 'dashboard.presets.sources.backendContact' },
+];
+
+const countActive = (filters: PresetFilterCriteria): number =>
+  filters.sources.length +
+  filters.chainIds.length +
+  filters.fields.reduce((total, criterion) => total + criterion.options.length, 0);
+
+/**
+ * Ad-hoc narrowing on top of the active preset, applied from the selector
+ * itself.
+ *
+ * The management modal is where a scope becomes a **decision** — named, saved,
+ * shared between surfaces. This is where the user takes a look: filter by a
+ * network or an address-book field for as long as they are looking at it, then
+ * drop it. It is intentionally not persisted, so nothing survives a restart to
+ * silently scope the dashboard to something nobody remembers choosing.
+ *
+ * The groups are derived from the synced contacts exactly as the management
+ * modal's editor derives them — offering a network or a field option that no
+ * contact carries would be a chip that can only ever empty the list.
+ */
+export const QuickFilterPopover = ({ $filters, onChange }: Props) => {
+  const { t } = useI18n();
+  const filters = useUnit($filters);
+  const backendContacts = useUnit(contactModel.$backendContacts);
+  const [open, setOpen] = useState(false);
+
+  const { chainOptions, fieldGroups } = useMemo(() => {
+    const chainNamesById = new Map<string, string>();
+    const groups = new Map<string, { fieldName: string; options: Map<string, string> }>();
+
+    for (const contact of backendContacts) {
+      if (contact.chainId) {
+        chainNamesById.set(contact.chainId, contact.chainName ?? contact.chainId);
+      }
+      for (const field of contact.fields) {
+        let group = groups.get(field.fieldId);
+        if (!group) {
+          group = { fieldName: field.fieldName, options: new Map() };
+          groups.set(field.fieldId, group);
+        }
+        for (const optionValue of field.values) {
+          group.options.set(optionValue.optionId, optionValue.value);
+        }
+      }
+    }
+
+    return {
+      chainOptions: Array.from(chainNamesById.entries())
+        .map(([chainId, chainName]) => ({ id: chainId, label: chainName }))
+        .sort((a, b) => a.label.localeCompare(b.label)),
+      fieldGroups: Array.from(groups.entries())
+        .map(([fieldId, group]) => ({
+          fieldId,
+          fieldName: group.fieldName,
+          options: Array.from(group.options.entries())
+            .map(([id, value]) => ({ id, value }))
+            .sort((a, b) => a.value.localeCompare(b.value)),
+        }))
+        .sort((a, b) => a.fieldName.localeCompare(b.fieldName)),
+    };
+  }, [backendContacts]);
+
+  const active = countActive(filters);
+
+  const toggleChain = (chainId: string) => {
+    const next = filters.chainIds.includes(chainId)
+      ? filters.chainIds.filter((id) => id !== chainId)
+      : [...filters.chainIds, chainId];
+
+    onChange({ ...filters, chainIds: next });
+  };
+
+  const toggleSource = (source: AccountSource) => {
+    const next = filters.sources.includes(source)
+      ? filters.sources.filter((s) => s !== source)
+      : [...filters.sources, source];
+
+    onChange({ ...filters, sources: next });
+  };
+
+  /**
+   * A criterion is stored per field, so toggling the last option of a field
+   * drops the whole criterion rather than leaving an empty one behind — an
+   * empty option list constrains nothing, and keeping it would make the badge
+   * count a filter the user has just cleared.
+   */
+  const toggleFieldOption = (group: { fieldId: string; fieldName: string }, option: { id: string; value: string }) => {
+    const criterion = filters.fields.find((c) => c.fieldId === group.fieldId);
+    const selected = criterion?.options ?? [];
+    const nextOptions = selected.some((o) => o.id === option.id)
+      ? selected.filter((o) => o.id !== option.id)
+      : [...selected, option];
+
+    const others = filters.fields.filter((c) => c.fieldId !== group.fieldId);
+    const nextFields: FieldCriterion[] =
+      nextOptions.length === 0
+        ? others
+        : [...others, { fieldId: group.fieldId, fieldName: group.fieldName, options: nextOptions }];
+
+    onChange({ ...filters, fields: nextFields });
+  };
+
+  const isFieldOptionActive = (fieldId: string, optionId: string) =>
+    filters.fields.some((c) => c.fieldId === fieldId && c.options.some((o) => o.id === optionId));
+
+  return (
+    <Popover open={open} align="end" side="bottom" onToggle={setOpen}>
+      <Popover.Trigger>
+        <button
+          type="button"
+          aria-label={t('presets.quickFilter.title')}
+          className={cnTw(
+            'flex items-center gap-x-1.5 rounded-md px-2 py-1.5 transition-colors hover:bg-action-background-hover',
+            active > 0 ? 'text-icon-accent' : 'text-icon-default',
+          )}
+        >
+          <Icon name="settingsLite" size={14} className="text-inherit" />
+          {active > 0 ? <Counter variant="waiting">{active}</Counter> : null}
+        </button>
+      </Popover.Trigger>
+
+      <Popover.Content>
+        <div className="flex max-h-[420px] w-[260px] flex-col gap-y-3 overflow-y-auto p-3">
+          <ChipGroup
+            title={t('presets.quickFilter.network')}
+            options={chainOptions}
+            isActive={(id) => filters.chainIds.includes(id)}
+            onToggle={toggleChain}
+          />
+
+          <ChipGroup
+            title={t('presets.quickFilter.source')}
+            options={SOURCE_OPTIONS.map((option) => ({ id: option.id, label: t(option.labelKey) }))}
+            isActive={(id) => filters.sources.includes(id)}
+            onToggle={toggleSource}
+          />
+
+          {fieldGroups.map((group) => (
+            <ChipGroup
+              key={group.fieldId}
+              title={group.fieldName}
+              options={group.options.map((option) => ({ id: option.id, label: option.value }))}
+              isActive={(id) => isFieldOptionActive(group.fieldId, id)}
+              onToggle={(id) => {
+                const option = group.options.find((o) => o.id === id);
+                if (option) toggleFieldOption(group, option);
+              }}
+            />
+          ))}
+
+          {active > 0 && (
+            <button
+              type="button"
+              className="self-start rounded px-1 py-0.5 transition-colors hover:bg-action-background-hover"
+              onClick={() => onChange(EMPTY_FILTERS)}
+            >
+              <FootnoteText className="text-text-tertiary">{t('presets.quickFilter.clear')}</FootnoteText>
+            </button>
+          )}
+        </div>
+      </Popover.Content>
+    </Popover>
+  );
+};
+
+type ChipGroupProps<T extends string> = {
+  title: string;
+  options: { id: T; label: string }[];
+  isActive: (id: T) => boolean;
+  onToggle: (id: T) => void;
+};
+
+const ChipGroup = <T extends string>({ title, options, isActive, onToggle }: ChipGroupProps<T>) => {
+  if (options.length === 0) return null;
+
+  return (
+    <div className="flex flex-col gap-y-1.5">
+      <FootnoteText className="text-text-tertiary">{title}</FootnoteText>
+      <div className="flex flex-wrap gap-1.5">
+        {options.map((option) => (
+          <button
+            key={option.id}
+            type="button"
+            className={cnTw(
+              'max-w-full truncate rounded-full px-2.5 py-1 text-footnote transition-colors',
+              isActive(option.id)
+                ? 'bg-icon-accent text-white'
+                : 'border border-filter-border text-text-secondary hover:bg-action-background-hover',
+            )}
+            onClick={() => onToggle(option.id)}
+          >
+            {option.label}
+          </button>
+        ))}
+      </div>
+    </div>
+  );
+};

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -211,6 +211,10 @@ unclaimed era has left, and the positions table badges expiry per row, coloured 
 most people have never heard of the claim window until a reward silently expires. Eras are converted to days through the
 chain's own era duration.
 
+The claim modal additionally names the **dates**: `earned 2 Jul, expires 24 Sep`. "Era 1,704" means nothing to anyone
+reading that line, and the same fact in the unit people hold money in does. Both are derived from the chain's era anchor
+and are simply **absent** when it has not arrived — a guessed date about money that disappears is worse than no date.
+
 ### Drill-downs
 
 - **Est. APY** opens the donut breakdown: one segment per position, hover-linked in both directions — the donut centre

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -154,11 +154,40 @@ Three rules keep a hover-driven screen with a `NamedAccount` in every row from r
 scoping the request to the filters would re-download a year of history on every filter click and cache a separate copy
 per combination. Only the **period** changes a request, because it changes which eras are attributed.
 
+## Rewards by Account
+
+A fifth widget shipped from this folder — a full-width table answering the question the claim drill-down cannot: **which
+of my addresses earned what, and what is that worth annualised**. One row per (account × chain), with Network, Chain,
+Account, Address, Type, Total staked, Rewards in period and APY %.
+
+It is a separate table rather than a mode of the validator view because the two have different units. A payout is
+`payout_stakers_by_page(validator, era, page)`, so the claim view is organised by validator and every row can express
+one call; an account row cannot, and putting a Claim button on it would invite the same call to be submitted twice.
+
+- **Rewards** come from the indexer's **raw payout rows** — received amounts with a timestamp — so an arbitrary date
+  range applies to them exactly. This is deliberately not the drill-down's "earned" figure, which is **accrued** by era
+  replay; the two are different facts and are never mixed.
+- **APY %** is simple, non-compounding annualisation: `rewards / staked × 365 / days`. The denominator is the stake **as
+  it is now**, because the ledger only reports today's bond and reconstructing yesterday's would cost an `erasStakers`
+  read per era in the range. A position that changed size mid-window is therefore not adjusted for, which the tooltip
+  says in words rather than leaving the reader to assume otherwise.
+- Under each figure sits the **network's own current reward rate**, as a benchmark. It is labelled as the network's and
+  is the _current_ rate, not one recomputed over the chosen window — a forward-looking figure next to a realised one,
+  never presented as the same kind of number.
+- A position that stakes nothing shows `—`, not `0%`: a yield over nothing is not zero, it does not exist.
+
 ### The period tabs
 
-`7d / 30d / All time` sit on the rewards drill-down and move **two** things: the earned attribution window (the donut
-and the Earned column), and the CSV export. They deliberately do **not** filter the claim: a payout expires by **era**,
-not by date, and hiding part of what is still claimable behind a date filter hides money.
+`7d / 30d / All time / Custom` sit on the rewards drill-down and on the Rewards by Account table, and move **two**
+things: the earned attribution window (the donut, the Earned column and the table's rows), and the CSV export. They
+deliberately do **not** filter the validator table or the claim: a payout expires by **era**, not by date, and hiding
+part of what is still claimable behind a date filter hides money.
+
+**Custom** opens a date-range picker, and only then — a date field sitting next to "30d" invites the user to set both
+and wonder which one won. Both ends of the range are inclusive of the whole day, so 1 Jul – 31 Jul is 31 days, and a
+half-picked range is a real state: nothing is reported until the second end lands, because annualising over a length
+nobody chose would be an invented number. A range that ends in the past still costs the eras since it **started** — eras
+are counted backwards from the active one, so a July window looked at in September replays September's eras too.
 
 There is deliberately **no "received in period" figure** next to the tabs. Received (actual payouts, on the indexer's
 timestamps) and earned (the eras' arithmetic) are different facts on different clocks — old eras claimed inside the

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useAccountRewardRows.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useAccountRewardRows.ts
@@ -1,0 +1,133 @@
+import { useUnit } from 'effector-react';
+import { useMemo } from 'react';
+
+import { type Address, type ChainId } from '@/shared/core';
+import { getRelaychainAsset, nullable, toAccountId, toAddress } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { networkModel } from '@/entities/network';
+import { useStakingPositions } from '@/aggregates/staking-positions';
+import { type PositionRole, derivePositionRole } from '@/features/dashboard-staking-positions';
+import { sumPlanck } from '../lib/amounts';
+import { realisedApy } from '../lib/realised-apy';
+import { type RewardWindow, isWindowReady, windowBounds, windowDays } from '../lib/reward-period';
+import { filterPositionsByAccounts } from '../lib/summary';
+
+import { useNetworkApys } from './useNetworkApys';
+import { useRawRewardPayouts } from './useRawRewardPayouts';
+
+export type AccountRewardRow = {
+  /** `${chainId}-${accountId}`. */
+  id: string;
+  accountId: AccountId;
+  chainId: ChainId;
+  networkName: string;
+  chainName: string;
+  address: Address;
+  role: PositionRole;
+  symbol: string;
+  precision: number;
+  /** Bonded ledger total, planck. */
+  totalStaked: string;
+  /** Payouts the indexer recorded inside the window, planck. */
+  rewards: string;
+  /** Annualised realised yield in percent, `null` when it cannot be stated. */
+  apy: number | null;
+  /** Current network reward rate in percent, as a benchmark. */
+  networkApy: number | null;
+};
+
+export type AccountRewardRowsResult = {
+  rows: AccountRewardRow[];
+  /** Days the window spans — what the annualisation divides by. */
+  days: number | null;
+  /** A custom range with only one end picked: nothing to report yet. */
+  ready: boolean;
+};
+
+/**
+ * One row per (account × chain): what it has staked, what it earned inside the
+ * window, and what that is worth annualised — beside the network's own rate.
+ *
+ * Rewards come from the indexer's raw payout rows, which are **received**
+ * amounts with a timestamp, so a date range can be applied to them exactly. The
+ * validator drill-down's "earned" figure is a different fact — accrued by era
+ * replay — and the two are deliberately not mixed.
+ */
+export const useAccountRewardRows = (accountIds: string[], window: RewardWindow): AccountRewardRowsResult => {
+  const { positions } = useStakingPositions();
+  const chains = useUnit(networkModel.$chains);
+
+  const scoped = useMemo(() => filterPositionsByAccounts(positions, accountIds), [positions, accountIds]);
+
+  const payoutRequests = useMemo(() => {
+    const byChain = new Map<ChainId, AccountId[]>();
+    for (const position of scoped) {
+      const accounts = byChain.get(position.chainId) ?? [];
+      if (!accounts.includes(position.accountId)) accounts.push(position.accountId);
+      byChain.set(position.chainId, accounts);
+    }
+
+    return [...byChain.entries()].map(([chainId, ids]) => ({ chainId, accountIds: ids.sort() }));
+  }, [scoped]);
+
+  const rawPayouts = useRawRewardPayouts(payoutRequests);
+  const chainIds = useMemo(() => payoutRequests.map((request) => request.chainId), [payoutRequests]);
+  const networkApys = useNetworkApys(chainIds);
+
+  const bounds = windowBounds(window);
+  const days = windowDays(window);
+  const ready = isWindowReady(window);
+
+  const rewardsByKey = useMemo(() => {
+    const byKey = new Map<string, string[]>();
+    if (!ready) return byKey;
+
+    for (const payout of rawPayouts) {
+      if (bounds.from !== null && payout.timestamp < bounds.from) continue;
+      if (bounds.to !== null && payout.timestamp > bounds.to) continue;
+
+      // The indexer speaks addresses; a row is keyed by account id.
+      const key = `${payout.chainId}-${toAccountId(payout.address)}`;
+      byKey.set(key, [...(byKey.get(key) ?? []), payout.amount]);
+    }
+
+    return byKey;
+  }, [rawPayouts, bounds.from, bounds.to, ready]);
+
+  const rows = useMemo(() => {
+    const result: AccountRewardRow[] = [];
+
+    for (const position of scoped) {
+      const chain = chains[position.chainId];
+      if (nullable(chain)) continue;
+
+      const asset = getRelaychainAsset(chain.assets);
+      if (nullable(asset)) continue;
+
+      const key = `${position.chainId}-${position.accountId}`;
+      const rewards = sumPlanck(rewardsByKey.get(key) ?? []);
+      const parent = chain.parentId ? chains[chain.parentId] : undefined;
+
+      result.push({
+        id: key,
+        accountId: position.accountId,
+        chainId: position.chainId,
+        networkName: parent?.name ?? chain.name,
+        chainName: chain.name,
+        address: toAddress(position.accountId, { prefix: chain.addressPrefix }),
+        role: derivePositionRole(position),
+        symbol: asset.symbol,
+        precision: asset.precision,
+        totalStaked: position.stake.active,
+        rewards,
+        apy: ready ? realisedApy(rewards, position.stake.active, days) : null,
+        networkApy: networkApys[position.chainId] ?? null,
+      });
+    }
+
+    // Biggest earner first — the row people open the table to find.
+    return result.sort((a, b) => Number(b.rewards) - Number(a.rewards));
+  }, [scoped, chains, rewardsByKey, networkApys, days, ready]);
+
+  return { rows, days, ready };
+};

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useAccountRewardRows.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useAccountRewardRows.ts
@@ -1,10 +1,12 @@
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { type Address, type ChainId } from '@/shared/core';
+import { type Address, type Chain, type ChainId, type Wallet } from '@/shared/core';
 import { getRelaychainAsset, nullable, toAccountId, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { accounts } from '@/domains/network';
 import { networkModel } from '@/entities/network';
+import { walletModel, walletUtils } from '@/entities/wallet';
 import { useStakingPositions } from '@/aggregates/staking-positions';
 import { type PositionRole, derivePositionRole } from '@/features/dashboard-staking-positions';
 import { sumPlanck } from '../lib/amounts';
@@ -13,7 +15,7 @@ import { type RewardWindow, isWindowReady, windowBounds, windowDays } from '../l
 import { filterPositionsByAccounts } from '../lib/summary';
 
 import { useNetworkApys } from './useNetworkApys';
-import { useRawRewardPayouts } from './useRawRewardPayouts';
+import { useRawPayoutsSince, useRawRewardPayouts } from './useRawRewardPayouts';
 
 export type AccountRewardRow = {
   /** `${chainId}-${accountId}`. */
@@ -22,11 +24,19 @@ export type AccountRewardRow = {
   chainId: ChainId;
   networkName: string;
   chainName: string;
+  /** The chain itself — the account cell resolves names against it. */
+  chain: Chain;
   address: Address;
+  /** Wallet the account belongs to, `null` for a foreign / contact address. */
+  wallet: Wallet | null;
   role: PositionRole;
   symbol: string;
   precision: number;
-  /** Bonded ledger total, planck. */
+  /**
+   * Ledger total — bonded plus everything still unbonding, planck. The same
+   * figure the positions table's Staked column prints, so the two tables cannot
+   * disagree about one row.
+   */
   totalStaked: string;
   /** Payouts the indexer recorded inside the window, planck. */
   rewards: string;
@@ -42,6 +52,12 @@ export type AccountRewardRowsResult = {
   days: number | null;
   /** A custom range with only one end picked: nothing to report yet. */
   ready: boolean;
+  /**
+   * Whether the payout history reaches back far enough to answer the window.
+   * `false` for a custom range that starts before the fetched year — the rows
+   * are still listed, but their APY is `null` rather than a confident `0.00%`.
+   */
+  covered: boolean;
 };
 
 /**
@@ -56,6 +72,21 @@ export type AccountRewardRowsResult = {
 export const useAccountRewardRows = (accountIds: string[], window: RewardWindow): AccountRewardRowsResult => {
   const { positions } = useStakingPositions();
   const chains = useUnit(networkModel.$chains);
+  const wallets = useUnit(walletModel.$wallets);
+  const allAccounts = useUnit(accounts.$list);
+
+  const walletByAccountId = useMemo(() => {
+    const map = new Map<string, Wallet>();
+
+    for (const account of allAccounts) {
+      if (map.has(account.accountId)) continue;
+
+      const wallet = walletUtils.getWalletById(wallets, account.walletId);
+      if (wallet) map.set(account.accountId, wallet);
+    }
+
+    return map;
+  }, [allAccounts, wallets]);
 
   const scoped = useMemo(() => filterPositionsByAccounts(positions, accountIds), [positions, accountIds]);
 
@@ -71,12 +102,25 @@ export const useAccountRewardRows = (accountIds: string[], window: RewardWindow)
   }, [scoped]);
 
   const rawPayouts = useRawRewardPayouts(payoutRequests);
+  const payoutsSince = useRawPayoutsSince();
   const chainIds = useMemo(() => payoutRequests.map((request) => request.chainId), [payoutRequests]);
   const networkApys = useNetworkApys(chainIds);
 
   const bounds = windowBounds(window);
   const days = windowDays(window);
   const ready = isWindowReady(window);
+
+  /**
+   * Whether the indexer rows actually span the requested window.
+   *
+   * The payout history is fetched from the first of the month twelve months
+   * back, but the Custom picker accepts any past date. A range that starts
+   * before that has no rows to sum, and reporting the resulting `0` as a
+   * realised APY would state a confident `0.00%` about a period nobody looked
+   * at — the same "not read is not zero" rule the rest of this feature
+   * follows.
+   */
+  const covered = ready && (bounds.from === null || bounds.from >= payoutsSince);
 
   const rewardsByKey = useMemo(() => {
     const byKey = new Map<string, string[]>();
@@ -114,20 +158,22 @@ export const useAccountRewardRows = (accountIds: string[], window: RewardWindow)
         chainId: position.chainId,
         networkName: parent?.name ?? chain.name,
         chainName: chain.name,
+        chain,
         address: toAddress(position.accountId, { prefix: chain.addressPrefix }),
+        wallet: walletByAccountId.get(position.accountId) ?? null,
         role: derivePositionRole(position),
         symbol: asset.symbol,
         precision: asset.precision,
-        totalStaked: position.stake.active,
+        totalStaked: position.stake.total,
         rewards,
-        apy: ready ? realisedApy(rewards, position.stake.active, days) : null,
+        apy: covered ? realisedApy(rewards, position.stake.total, days) : null,
         networkApy: networkApys[position.chainId] ?? null,
       });
     }
 
     // Biggest earner first — the row people open the table to find.
     return result.sort((a, b) => Number(b.rewards) - Number(a.rewards));
-  }, [scoped, chains, rewardsByKey, networkApys, days, ready]);
+  }, [scoped, chains, walletByAccountId, rewardsByKey, networkApys, days, covered]);
 
-  return { rows, days, ready };
+  return { rows, days, ready, covered };
 };

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useChainEras.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useChainEras.ts
@@ -6,6 +6,7 @@ import { keys } from '@/shared/lib/utils';
 import { stakingPallet } from '@/shared/pallet/staking';
 import { era } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
+import { type EraTimeAnchor } from '../lib/expiry';
 
 /**
  * Active era per chain. The subscription itself is owned by the
@@ -14,6 +15,27 @@ import { networkModel } from '@/entities/network';
  */
 export const useChainEras = (): Record<ChainId, EraIndex> => {
   return useUnit(era.eraResource.$cache);
+};
+
+/**
+ * Everything needed to turn an era index into a date, per chain: the active era
+ * and when it started. `null` for a chain whose anchor has not arrived — a date
+ * is then simply not shown, never estimated.
+ */
+export const useEraAnchors = (): Record<ChainId, EraTimeAnchor | null> => {
+  const cache = useUnit(era.eraProgressResource.$cache);
+
+  return useMemo(() => {
+    const anchors: Record<ChainId, EraTimeAnchor | null> = {};
+    for (const chainId of keys(cache)) {
+      const progress = cache[chainId];
+      anchors[chainId] = progress
+        ? { activeEra: progress.era, eraStartMs: progress.eraStartMs, eraDurationMs: progress.eraDurationMs }
+        : null;
+    }
+
+    return anchors;
+  }, [cache]);
 };
 
 /**

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
@@ -12,7 +12,7 @@ import {
   rewardsService,
 } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
-import { type RewardPeriod, erasInPeriod } from '../lib/reward-period';
+import { type RewardWindow, erasInWindow } from '../lib/reward-period';
 
 import { useChainEras, useEraDurations } from './useChainEras';
 import { useResourcePool } from './useResourcePool';
@@ -45,7 +45,7 @@ export type ValidatorRewardsResult = {
  * The era range is what keeps that affordable, which is why the window is a
  * parameter of the fetch rather than a filter over a fetched year.
  */
-export const useValidatorRewards = (positions: StakingPosition[], period: RewardPeriod): ValidatorRewardsResult => {
+export const useValidatorRewards = (positions: StakingPosition[], window: RewardWindow): ValidatorRewardsResult => {
   const chains = useUnit(networkModel.$chains);
   const apis = useUnit(networkModel.$apis);
   const eras = useChainEras();
@@ -79,7 +79,7 @@ export const useValidatorRewards = (positions: StakingPosition[], period: Reward
 
       // The active era has not paid anything yet — its arithmetic is not final.
       const eraTo = activeEra - 1;
-      const eraFrom = Math.max(0, eraTo - erasInPeriod(period, eraDurations[chainId] ?? null, historyDepth) + 1);
+      const eraFrom = Math.max(0, eraTo - erasInWindow(window, eraDurations[chainId] ?? null, historyDepth) + 1);
       if (eraTo < eraFrom) continue;
 
       byChain.set(chainId, {
@@ -94,7 +94,7 @@ export const useValidatorRewards = (positions: StakingPosition[], period: Reward
 
     // Sorted so the cache key of a selection does not depend on row order.
     return [...byChain.values()].map((request) => ({ ...request, stashes: [...request.stashes].sort() }));
-  }, [positions, chains, apis, eras, eraDurations, period]);
+  }, [positions, chains, apis, eras, eraDurations, window]);
 
   useResourcePool(eraRewardsResource, requests);
 

--- a/src/renderer/features/dashboard-staking-kpi/index.ts
+++ b/src/renderer/features/dashboard-staking-kpi/index.ts
@@ -7,6 +7,7 @@ import { dashboardStakingSlot } from '@/pages/Dashboard';
 import { dashboardStakingKpiActions } from './model/actions';
 import { ApyWidget } from './ui/ApyWidget';
 import { NominationsWidget } from './ui/NominationsWidget';
+import { RewardsTableWidget } from './ui/RewardsTableWidget';
 import { RewardsWidget } from './ui/RewardsWidget';
 import { TotalStakedWidget } from './ui/TotalStakedWidget';
 
@@ -55,6 +56,16 @@ export const dashboardStakingRewardsFeature = createFeature({
   enable,
 });
 
+/**
+ * Rewards seen from the account rather than from the validator — a full-width
+ * table, so its own feature: it belongs below the cards, not between them.
+ */
+export const dashboardStakingRewardsTableFeature = createFeature({
+  name: 'dashboard/staking-rewards-table',
+  input: createStore({}),
+  enable,
+});
+
 // A KPI card is one figure with a subline — extra height would only add blank
 // card, so growth is capped at double width and the default height.
 const KPI_SIZE = { defaultSize: { w: 1, h: 2 }, minSize: { w: 1, h: 2 }, maxSize: { w: 2, h: 2 } };
@@ -63,3 +74,12 @@ dashboardStakingTotalStakedFeature.inject(dashboardStakingSlot, { order: 0, rend
 dashboardStakingApyFeature.inject(dashboardStakingSlot, { order: 1, render: ApyWidget, ...KPI_SIZE });
 dashboardStakingNominationsFeature.inject(dashboardStakingSlot, { order: 2, render: NominationsWidget, ...KPI_SIZE });
 dashboardStakingRewardsFeature.inject(dashboardStakingSlot, { order: 3, render: RewardsWidget, ...KPI_SIZE });
+dashboardStakingRewardsTableFeature.inject(dashboardStakingSlot, {
+  // Below the positions table (10), above the chart (20) — orders on this tab
+  // are spaced by ten, see `dashboard-staking-positions`.
+  order: 15,
+  render: RewardsTableWidget,
+  // A table sized like the other full-width ones on this tab.
+  defaultSize: { w: 4, h: 5 },
+  minSize: { w: 2, h: 3 },
+});

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/realised-apy.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/realised-apy.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, test } from 'vitest';
+
+import { realisedApy } from '../realised-apy';
+
+describe('realisedApy', () => {
+  test('reproduces the annualisation the figure is expected to match', () => {
+    // 3333 earned on 1,000,000 staked over 1–31 July: 3.9243%.
+    expect(realisedApy('3333', '1000000', 31)).toBeCloseTo(3.92433871, 6);
+    expect(realisedApy('3000', '1000000', 31)).toBeCloseTo(3.532258065, 6);
+    // A validator's own 30,000 earning 300 over the same window: 11.774%.
+    expect(realisedApy('300', '30000', 31)).toBeCloseTo(11.77419355, 6);
+  });
+
+  test('a yield over nothing staked does not exist', () => {
+    expect(realisedApy('100', '0', 30)).toBeNull();
+  });
+
+  test('a window of no length cannot be annualised', () => {
+    expect(realisedApy('100', '1000', null)).toBeNull();
+    expect(realisedApy('100', '1000', 0)).toBeNull();
+  });
+
+  test('earning nothing is a real zero', () => {
+    expect(realisedApy('0', '1000', 30)).toBe(0);
+  });
+});

--- a/src/renderer/features/dashboard-staking-kpi/lib/expiry.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/expiry.ts
@@ -53,3 +53,40 @@ export function oldestPayoutEra(eras: number[]): number | null {
 
   return Math.min(...eras);
 }
+
+/** The era anchor a date is derived from — when the active era started. */
+export type EraTimeAnchor = {
+  activeEra: number;
+  eraStartMs: number;
+  eraDurationMs: number;
+};
+
+/**
+ * When an era **started**, in unix ms, walked back from the active era's own
+ * start.
+ *
+ * "Era 1,704" means nothing to anyone reading a card; "earned around 2 July" is
+ * the same fact in the unit people actually hold money in. Derived, never
+ * guessed: without an anchor the caller gets `null` and prints the era count it
+ * already had.
+ */
+export function eraStartedAt(era: number, anchor: EraTimeAnchor | null): number | null {
+  if (!anchor || anchor.eraDurationMs <= 0) return null;
+
+  return anchor.eraStartMs - (anchor.activeEra - era) * anchor.eraDurationMs;
+}
+
+/**
+ * When an era's payout stops being claimable — the moment it falls out of the
+ * `historyDepth` window.
+ *
+ * The window is inclusive of its oldest era (see {@link erasUntilExpiry}), so
+ * the deadline is the start of the era that finally pushes it out.
+ */
+export function eraExpiresAt(
+  era: number,
+  anchor: EraTimeAnchor | null,
+  historyDepth: number = DEFAULT_CLAIM_WINDOW_ERAS,
+): number | null {
+  return eraStartedAt(era + historyDepth + 1, anchor);
+}

--- a/src/renderer/features/dashboard-staking-kpi/lib/realised-apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/realised-apy.ts
@@ -1,0 +1,34 @@
+import { default as BigNumber } from 'bignumber.js';
+
+const DAYS_PER_YEAR = 365;
+
+/**
+ * What a position actually earned over a window, annualised.
+ *
+ * Simple, non-compounding annualisation — `rewards / staked × 365 / days` — the
+ * formula the figure is expected to match, and the one a spreadsheet reproduces
+ * without knowing anything about compounding conventions.
+ *
+ * **The denominator is the stake as it is now**, not a time-weighted average
+ * over the window: the ledger only reports today's bond, and reconstructing
+ * yesterday's would cost an `erasStakers` read per era in the range. The number
+ * is therefore right for a position that was bonded throughout and overstates —
+ * or understates — one that changed size mid-window, which is why the column
+ * says "realised" and carries the assumption in its tooltip rather than being
+ * printed next to the forward-looking network APY as if they were the same kind
+ * of number.
+ *
+ * `null` when there is nothing to divide by, or no window to annualise over: a
+ * yield over an unstaked position is not zero, it does not exist.
+ */
+export function realisedApy(rewardsPlanck: string, stakedPlanck: string, days: number | null): number | null {
+  if (days === null || days <= 0) return null;
+
+  const staked = new BigNumber(stakedPlanck);
+  if (!staked.isFinite() || staked.lte(0)) return null;
+
+  const rewards = new BigNumber(rewardsPlanck);
+  if (!rewards.isFinite()) return null;
+
+  return rewards.div(staked).multipliedBy(DAYS_PER_YEAR).div(days).multipliedBy(100).toNumber();
+}

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -1,19 +1,105 @@
+import { type DateRange } from '@/shared/ui-kit';
 import { getErasInDays } from '@/domains/staking';
 
 /** Windows the rewards drill-down can be looked at through. */
-export const REWARD_PERIODS = ['7d', '30d', 'all'] as const;
+export const REWARD_PERIODS = ['7d', '30d', 'all', 'custom'] as const;
 
 export type RewardPeriod = (typeof REWARD_PERIODS)[number];
 
 export const DEFAULT_REWARD_PERIOD: RewardPeriod = '30d';
 
-const DAYS_BY_PERIOD: Record<RewardPeriod, number | null> = { '7d': 7, '30d': 30, all: null };
+/**
+ * A period plus, for `custom`, the dates behind it.
+ *
+ * The two travel together because every consumer needs both: the tab decides
+ * how the window is described, the range decides where it starts and ends, and
+ * a `custom` period with no range yet is a real state — the picker is open and
+ * nothing has been chosen.
+ */
+export type RewardWindow = {
+  period: RewardPeriod;
+  /**
+   * Inclusive day bounds, local time. Only meaningful for `custom`, and
+   * half-filled while the user is still picking — `react-day-picker` reports
+   * the first click as `{ from }` alone.
+   */
+  range: DateRange | null;
+};
+
+export const DEFAULT_REWARD_WINDOW: RewardWindow = { period: DEFAULT_REWARD_PERIOD, range: null };
+
+const DAYS_BY_PERIOD: Record<RewardPeriod, number | null> = { '7d': 7, '30d': 30, all: null, custom: null };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Days the period covers, `null` for "everything there is". */
 export function periodDays(period: RewardPeriod): number | null {
   return DAYS_BY_PERIOD[period];
+}
+
+/**
+ * Unix **seconds** the window covers — the unit the indexer stamps payouts with
+ * — both bounds inclusive of the whole day the user picked: someone asking for
+ * "1 Jul – 31 Jul" means the 31st, not the instant it began.
+ *
+ * `null` bounds mean "unbounded that way", which is what `all` is, and what a
+ * half-picked custom range is until its other end lands.
+ */
+export function windowBounds(window: RewardWindow, now = new Date()): { from: number | null; to: number | null } {
+  if (window.period === 'custom') {
+    const { from, to } = window.range ?? {};
+
+    return {
+      from: from ? Math.floor(startOfDayMs(from) / 1000) : null,
+      to: to ? Math.floor((startOfDayMs(to) + DAY_MS - 1) / 1000) : null,
+    };
+  }
+
+  const start = periodStart(window.period, now);
+
+  return { from: start ?? null, to: null };
+}
+
+function startOfDayMs(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+/**
+ * Days the window spans, used to annualise what it earned. A custom range
+ * counts both end days, so 1 Jul – 31 Jul is 31 days rather than 30.
+ */
+export function windowDays(window: RewardWindow): number | null {
+  if (window.period !== 'custom') return periodDays(window.period);
+
+  const { from, to } = window.range ?? {};
+  if (!from || !to) return null;
+
+  return Math.max(1, Math.round((startOfDayMs(to) - startOfDayMs(from)) / DAY_MS) + 1);
+}
+
+/** Whether the window is fully specified — a half-picked range is not. */
+export function isWindowReady(window: RewardWindow): boolean {
+  return window.period !== 'custom' || Boolean(window.range?.from && window.range.to);
+}
+
+/** Short label for a file name: `30d`, `all`, or `2026-07-01_2026-07-31`. */
+export function windowSlug(window: RewardWindow): string {
+  if (window.period !== 'custom') return window.period;
+
+  const { from, to } = window.range ?? {};
+  if (!from || !to) return 'custom';
+
+  return `${toIsoDay(from)}_${toIsoDay(to)}`;
+}
+
+function toIsoDay(date: Date): string {
+  // Built from the local parts on purpose: `toISOString` would shift the day
+  // for anyone east or west of UTC, and the name has to match the days the
+  // picker showed.
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${date.getFullYear()}-${month}-${day}`;
 }
 
 /**
@@ -41,8 +127,35 @@ export function periodStart(period: RewardPeriod, now = new Date()): number | un
  * walk that can only come back empty.
  */
 export function erasInPeriod(period: RewardPeriod, eraDurationMs: number | null, historyDepth: number): number {
-  const days = periodDays(period);
-  if (days === null || !eraDurationMs || eraDurationMs <= 0) return historyDepth;
+  return erasInWindow({ period, range: null }, eraDurationMs, historyDepth);
+}
+
+/**
+ * Same, for a window that may be a custom range.
+ *
+ * A range that ends in the past still has to be replayed from **now** back to
+ * its start — eras are counted backwards from the active one, so a July window
+ * looked at in September costs the eras since July, not the eras inside it.
+ */
+export function erasInWindow(
+  window: RewardWindow,
+  eraDurationMs: number | null,
+  historyDepth: number,
+  now = Date.now(),
+): number {
+  if (!eraDurationMs || eraDurationMs <= 0) return historyDepth;
+
+  if (window.period === 'custom') {
+    const from = window.range?.from;
+    if (!from) return historyDepth;
+
+    const span = Math.max(DAY_MS, now - startOfDayMs(from));
+
+    return Math.min(historyDepth, Math.max(1, Math.ceil(span / eraDurationMs)));
+  }
+
+  const days = periodDays(window.period);
+  if (days === null) return historyDepth;
 
   return Math.min(historyDepth, getErasInDays(days, eraDurationMs));
 }

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -315,7 +315,13 @@ export const ClaimModal = memo(
     }, [claimable]);
 
     /**
-     * The oldest unclaimed era, as dates rather than as an era index.
+     * The unclaimed payout closest to expiring, as dates rather than era
+     * indices.
+     *
+     * Ranked by eras **left**, not by era number: indices are per-chain and
+     * unrelated — Kusama runs about four times Polkadot's — so taking the
+     * numerically smallest across a mixed selection always picked Polkadot and
+     * could contradict the "expires in N days" line right beside it.
      *
      * "Era 1,704" means nothing to anyone reading this line; "earned 2 Jul,
      * expires 24 Sep" is the same fact in the unit people hold money in. Both
@@ -324,26 +330,30 @@ export const ClaimModal = memo(
      * date.
      */
     const oldestUnclaimed = useMemo(() => {
-      let oldest: { chainId: ChainId; era: number } | null = null;
+      let closest: { chainId: ChainId; era: number; erasLeft: number } | null = null;
 
       for (const row of claimable) {
+        const activeEra = eras[row.chainId];
+        if (activeEra === undefined) continue;
+
         for (const payoutEra of row.eras) {
-          if (!oldest || payoutEra < oldest.era) {
-            oldest = { chainId: row.chainId, era: payoutEra };
+          const erasLeft = erasUntilExpiry(payoutEra, activeEra, historyDepths[row.chainId] ?? undefined);
+          if (!closest || erasLeft < closest.erasLeft) {
+            closest = { chainId: row.chainId, era: payoutEra, erasLeft };
           }
         }
       }
 
-      if (!oldest) return null;
+      if (!closest) return null;
 
-      const anchor = eraAnchors[oldest.chainId] ?? null;
-      const historyDepth = historyDepths[oldest.chainId] ?? undefined;
+      const anchor = eraAnchors[closest.chainId] ?? null;
+      const historyDepth = historyDepths[closest.chainId] ?? undefined;
 
       return {
-        earnedAt: eraStartedAt(oldest.era, anchor),
-        expiresAt: eraExpiresAt(oldest.era, anchor, historyDepth ?? undefined),
+        earnedAt: eraStartedAt(closest.era, anchor),
+        expiresAt: eraExpiresAt(closest.era, anchor, historyDepth ?? undefined),
       };
-    }, [claimable, eraAnchors, historyDepths]);
+    }, [claimable, eras, eraAnchors, historyDepths]);
 
     /**
      * Following a slice with the eye is useless if its row is fifty pixels

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -22,7 +22,7 @@ import { formatAssetAmountExact, sumFiat } from '../lib/amounts';
 import { csvFileName, rawPayoutCsvColumns } from '../lib/csv';
 import { DEFAULT_CLAIM_WINDOW_ERAS, daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
 import { formatFiat } from '../lib/format-fiat';
-import { type RewardPeriod, DEFAULT_REWARD_PERIOD, periodStart } from '../lib/reward-period';
+import { type RewardWindow, DEFAULT_REWARD_WINDOW, windowBounds, windowSlug } from '../lib/reward-period';
 import { DEFAULT_REWARD_SORT, isRewardSortColumn, sortRewardRows } from '../lib/reward-sorting';
 import { type ClaimRow } from '../lib/types';
 import {
@@ -98,7 +98,7 @@ export const ClaimModal = memo(
     const signableChains = useSignableChains();
     const blockedChains = useUnit(dashboardStakingKpiActions.$blockedClaimChains);
 
-    const [period, setPeriod] = useState<RewardPeriod>(DEFAULT_REWARD_PERIOD);
+    const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
     const [chainFilter, setChainFilter] = useState<ChainId | null>(null);
     const [nominatorFilter, setNominatorFilter] = useState<AccountId | null>(null);
     const [tableSort, setTableSort] = useState<TableSort>(DEFAULT_REWARD_SORT);
@@ -106,7 +106,7 @@ export const ClaimModal = memo(
     const hoveredId = hovered?.id ?? null;
     const listRef = useRef<HTMLDivElement>(null);
 
-    const { rewards, pendingChains } = useValidatorRewards(positions, period);
+    const { rewards, pendingChains } = useValidatorRewards(positions, rewardWindow);
     const pendingChainSet = useMemo(() => new Set(pendingChains), [pendingChains]);
 
     /**
@@ -345,17 +345,18 @@ export const ClaimModal = memo(
 
     const rawPayouts = useRawRewardPayouts(payoutRequests);
 
-    const windowStart = periodStart(period);
+    const bounds = windowBounds(rewardWindow);
     const windowedPayouts = useMemo(
       () =>
         rawPayouts.filter(
           (payout) =>
-            (windowStart === undefined || payout.timestamp >= windowStart) &&
+            (bounds.from === null || payout.timestamp >= bounds.from) &&
+            (bounds.to === null || payout.timestamp <= bounds.to) &&
             (chainFilter === null || payout.chainId === chainFilter) &&
             // The indexer speaks addresses; the filter speaks account ids.
             (nominatorFilter === null || toAccountId(payout.address) === nominatorFilter),
         ),
-      [rawPayouts, windowStart, chainFilter, nominatorFilter],
+      [rawPayouts, bounds.from, bounds.to, chainFilter, nominatorFilter],
     );
 
     /**
@@ -389,8 +390,11 @@ export const ClaimModal = memo(
       const network =
         chainFilter === null ? 'all-networks' : (networks.find((n) => n.chainId === chainFilter)?.chainName ?? '');
 
-      downloadCsv(csvFileName('reward-payouts', { parts: [network, period] }), buildCsv(columns, windowedPayouts));
-    }, [windowedPayouts, scopedClaimRows, chainFilter, networks, period, t]);
+      downloadCsv(
+        csvFileName('reward-payouts', { parts: [network, windowSlug(rewardWindow)] }),
+        buildCsv(columns, windowedPayouts),
+      );
+    }, [windowedPayouts, scopedClaimRows, chainFilter, networks, rewardWindow, t]);
 
     const handleClaimRow = useCallback(
       (row: ValidatorRewardRow) => claimRequested({ requests: toClaimRequests([row], signableChains) }),
@@ -610,7 +614,7 @@ export const ClaimModal = memo(
                 slightly different number (actual payouts land on their own
                 clock) read as a discrepancy rather than a different fact. */}
               <div className="flex items-center justify-end gap-4">
-                <PeriodTabs value={period} onChange={setPeriod} />
+                <PeriodTabs value={rewardWindow} onChange={setRewardWindow} />
               </div>
 
               {/* One network is not a choice — the filter appears with the second. */}

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -1,3 +1,4 @@
+import { format } from 'date-fns';
 import { useUnit } from 'effector-react';
 import { memo, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 
@@ -14,13 +15,21 @@ import { type CurrencyItem } from '@/domains/price';
 import { type StakingPosition } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
 import { NamedAccount } from '@/widgets/NameResolver';
+import { useEraAnchors } from '../hooks/useChainEras';
 import { useRawRewardPayouts } from '../hooks/useRawRewardPayouts';
 import { useSignableChains } from '../hooks/useSignableChains';
 import { useStakingChainAssets } from '../hooks/useStakingChainAssets';
 import { useValidatorRewards } from '../hooks/useValidatorRewards';
 import { formatAssetAmountExact, sumFiat } from '../lib/amounts';
 import { csvFileName, rawPayoutCsvColumns } from '../lib/csv';
-import { DEFAULT_CLAIM_WINDOW_ERAS, daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
+import {
+  DEFAULT_CLAIM_WINDOW_ERAS,
+  daysUntilExpiry,
+  eraExpiresAt,
+  eraStartedAt,
+  erasUntilExpiry,
+  oldestPayoutEra,
+} from '../lib/expiry';
 import { formatFiat } from '../lib/format-fiat';
 import { type RewardWindow, DEFAULT_REWARD_WINDOW, windowBounds, windowSlug } from '../lib/reward-period';
 import { DEFAULT_REWARD_SORT, isRewardSortColumn, sortRewardRows } from '../lib/reward-sorting';
@@ -56,6 +65,9 @@ type Props = {
 };
 
 type DisplayRow = ValidatorRewardRow & { color: string; accruedFiat: string; expiryDays: number | null };
+
+/** `2 Jul` — a day, without a year nobody needs inside an 84-era window. */
+const formatDay = (timestampMs: number): string => format(new Date(timestampMs), 'd MMM');
 
 /** A segmented-control button, styled like `Tabs.Trigger` without its panels. */
 const FilterChip = ({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) => (
@@ -95,6 +107,7 @@ export const ClaimModal = memo(
     const claimEnabled = enabledActions.includes('claim');
     const claimRequested = useUnit(dashboardStakingKpiActions.claimRequested);
     const { toFiat } = useStakingChainAssets();
+    const eraAnchors = useEraAnchors();
     const signableChains = useSignableChains();
     const blockedChains = useUnit(dashboardStakingKpiActions.$blockedClaimChains);
 
@@ -300,6 +313,37 @@ export const ClaimModal = memo(
 
       return values.length > 0 ? Math.min(...values) : null;
     }, [claimable]);
+
+    /**
+     * The oldest unclaimed era, as dates rather than as an era index.
+     *
+     * "Era 1,704" means nothing to anyone reading this line; "earned 2 Jul,
+     * expires 24 Sep" is the same fact in the unit people hold money in. Both
+     * are derived from the chain's era anchor and are simply absent when it has
+     * not arrived — a guessed date about money that disappears is worse than no
+     * date.
+     */
+    const oldestUnclaimed = useMemo(() => {
+      let oldest: { chainId: ChainId; era: number } | null = null;
+
+      for (const row of claimable) {
+        for (const payoutEra of row.eras) {
+          if (!oldest || payoutEra < oldest.era) {
+            oldest = { chainId: row.chainId, era: payoutEra };
+          }
+        }
+      }
+
+      if (!oldest) return null;
+
+      const anchor = eraAnchors[oldest.chainId] ?? null;
+      const historyDepth = historyDepths[oldest.chainId] ?? undefined;
+
+      return {
+        earnedAt: eraStartedAt(oldest.era, anchor),
+        expiresAt: eraExpiresAt(oldest.era, anchor, historyDepth ?? undefined),
+      };
+    }, [claimable, eraAnchors, historyDepths]);
 
     /**
      * Following a slice with the eye is useless if its row is fifty pixels
@@ -776,6 +820,12 @@ export const ClaimModal = memo(
                         soonestExpiry === null
                           ? null
                           : t('dashboard.staking.kpi.rewards.oldestExpires', { count: soonestExpiry }),
+                        oldestUnclaimed?.earnedAt && oldestUnclaimed.expiresAt
+                          ? t('dashboard.staking.kpi.rewards.oldestDates', {
+                              earned: formatDay(oldestUnclaimed.earnedAt),
+                              expires: formatDay(oldestUnclaimed.expiresAt),
+                            })
+                          : null,
                       ]
                         .filter(Boolean)
                         .join(' · ')}

--- a/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
@@ -1,10 +1,11 @@
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
-import { type RewardPeriod, REWARD_PERIODS } from '../lib/reward-period';
+import { DateRangePicker } from '@/shared/ui-kit';
+import { type RewardWindow, REWARD_PERIODS } from '../lib/reward-period';
 
 type Props = {
-  value: RewardPeriod;
-  onChange: (period: RewardPeriod) => void;
+  value: RewardWindow;
+  onChange: (window: RewardWindow) => void;
 };
 
 /** The window everything time-bounded on the rewards screen is read through. */
@@ -12,22 +13,38 @@ export const PeriodTabs = ({ value, onChange }: Props) => {
   const { t } = useI18n();
 
   return (
-    <div className="flex w-fit shrink-0 items-center gap-x-1 rounded-md bg-tab-background p-0.5">
-      {REWARD_PERIODS.map((period) => (
-        <button
-          key={period}
-          type="button"
-          className={cnTw(
-            'cursor-pointer rounded-sm px-3 py-1 text-button-small transition-all duration-100',
-            value === period
-              ? 'bg-white text-text-primary shadow-card-shadow'
-              : 'text-text-secondary hover:text-text-primary',
-          )}
-          onClick={() => onChange(period)}
-        >
-          {t(`dashboard.staking.kpi.rewards.period.${period}`)}
-        </button>
-      ))}
+    <div className="flex shrink-0 items-center gap-x-2">
+      <div className="flex w-fit items-center gap-x-1 rounded-md bg-tab-background p-0.5">
+        {REWARD_PERIODS.map((period) => (
+          <button
+            key={period}
+            type="button"
+            className={cnTw(
+              'cursor-pointer rounded-sm px-3 py-1 text-button-small transition-all duration-100',
+              value.period === period
+                ? 'bg-white text-text-primary shadow-card-shadow'
+                : 'text-text-secondary hover:text-text-primary',
+            )}
+            onClick={() => onChange({ period, range: period === 'custom' ? value.range : null })}
+          >
+            {t(`dashboard.staking.kpi.rewards.period.${period}`)}
+          </button>
+        ))}
+      </div>
+
+      {/*
+        The picker appears only under the Custom tab: a date field sitting next
+        to "30d" invites the user to set both and wonder which one won.
+      */}
+      {value.period === 'custom' && (
+        <div className="w-[160px]">
+          <DateRangePicker
+            value={value.range ?? undefined}
+            placeholder={t('dashboard.staking.kpi.rewards.period.pickDates')}
+            onChange={(range) => onChange({ period: 'custom', range: range ?? null })}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/features/dashboard-staking-kpi/ui/RewardsTableWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/RewardsTableWidget.tsx
@@ -1,10 +1,11 @@
 import { useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { formatBalance } from '@/shared/lib/utils';
+import { formatBalance, formatBalanceExact } from '@/shared/lib/utils';
 import { pjsSchema } from '@/shared/polkadotjs-schemas';
 import { BodyText, FootnoteText, HelpText, SmallTitleText } from '@/shared/ui';
 import { type DataTableColumn, type DataTableFilterState, DataTable, Tooltip } from '@/shared/ui-kit';
+import { comparePlanck } from '@/features/dashboard-staking-positions';
 import { NamedAccount } from '@/widgets/NameResolver';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { type AccountRewardRow, useAccountRewardRows } from '../hooks/useAccountRewardRows';
@@ -30,7 +31,7 @@ const MIN_WIDTH = 1180;
 export const RewardsTableWidget = ({ accountIds }: Props) => {
   const { t } = useI18n();
   const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
-  const { rows, days, ready } = useAccountRewardRows(accountIds, rewardWindow);
+  const { rows, days, ready, covered } = useAccountRewardRows(accountIds, rewardWindow);
 
   const columns = useMemo<DataTableColumn<AccountRewardRow>[]>(() => {
     const amount = (
@@ -43,23 +44,21 @@ export const RewardsTableWidget = ({ accountIds }: Props) => {
       width,
       sortable: true,
       filter: 'range',
-      text: (row) => {
-        const formatted = formatBalance(pick(row), row.precision);
-
-        return `${formatted.formatted}${formatted.suffix} ${row.symbol}`;
-      },
-      exportValue: (row) => formatBalance(pick(row), row.precision, { keepPrecision: true }).formatted,
-      value: (row) => Number(formatBalance(pick(row), row.precision, { keepPrecision: true }).value),
-      render: (row) => {
-        const formatted = formatBalance(pick(row), row.precision);
-
-        return (
-          <FootnoteText className="tabular-nums">
-            {formatted.formatted}
-            {formatted.suffix} {row.symbol}
-          </FootnoteText>
-        );
-      },
+      // `formatted` already carries the shorthand suffix; appending `suffix`
+      // again printed `2MM DOT`. Sorting, the range filter and the export read
+      // the un-abbreviated amount instead — a `value` divided by its own
+      // shorthand makes 2M DOT compare as smaller than 900K.
+      text: (row) => `${formatBalance(pick(row), row.precision).formatted} ${row.symbol}`,
+      exportValue: (row) => formatBalanceExact(pick(row), row.precision),
+      value: (row) => Number(formatBalanceExact(pick(row), row.precision)),
+      // Planck amounts run past `Number.MAX_SAFE_INTEGER`, so the order is
+      // settled on the raw integers rather than on `value`.
+      compare: (a, b) => comparePlanck(pick(a), pick(b)),
+      render: (row) => (
+        <FootnoteText className="tabular-nums">
+          {formatBalance(pick(row), row.precision).formatted} {row.symbol}
+        </FootnoteText>
+      ),
     });
 
     return [
@@ -85,10 +84,15 @@ export const RewardsTableWidget = ({ accountIds }: Props) => {
         id: 'account',
         title: t('dashboard.staking.rewardsTable.columns.account'),
         width: '18%',
+        // The chain and the wallet are what make the resolver run the full
+        // chain (custom name → contact → identity → wallet name); without them
+        // the cell prints a generic-prefix address next to the chain-prefixed
+        // one in the Address column.
         render: (row) => (
           <NamedAccount
             accountId={pjsSchema.helpers.toAccountId(row.accountId)}
-            chain={undefined}
+            chain={row.chain}
+            wallet={row.wallet ?? undefined}
             variant="short"
             iconSize={20}
             hideExplorers
@@ -174,7 +178,11 @@ export const RewardsTableWidget = ({ accountIds }: Props) => {
         <BodyText className="text-text-tertiary">{t('dashboard.staking.rewardsTable.pickRange')}</BodyText>
       )}
 
-      {ready && days !== null ? (
+      {ready && !covered ? (
+        // Rows still list what is staked; the earnings column simply has no
+        // data to report over a range older than the fetched history.
+        <HelpText className="mt-2 text-text-tertiary">{t('dashboard.staking.rewardsTable.outOfHistory')}</HelpText>
+      ) : ready && days !== null ? (
         <HelpText className="mt-2 text-text-tertiary">
           {t('dashboard.staking.rewardsTable.windowHint', { days })}
         </HelpText>

--- a/src/renderer/features/dashboard-staking-kpi/ui/RewardsTableWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/RewardsTableWidget.tsx
@@ -1,0 +1,190 @@
+import { useMemo, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { formatBalance } from '@/shared/lib/utils';
+import { pjsSchema } from '@/shared/polkadotjs-schemas';
+import { BodyText, FootnoteText, HelpText, SmallTitleText } from '@/shared/ui';
+import { type DataTableColumn, type DataTableFilterState, DataTable, Tooltip } from '@/shared/ui-kit';
+import { NamedAccount } from '@/widgets/NameResolver';
+import { DashboardWidget } from '@/pages/Dashboard';
+import { type AccountRewardRow, useAccountRewardRows } from '../hooks/useAccountRewardRows';
+import { type RewardWindow, DEFAULT_REWARD_WINDOW, windowSlug } from '../lib/reward-period';
+
+import { PeriodTabs } from './PeriodTabs';
+
+type Props = {
+  accountIds: string[];
+};
+
+const MIN_WIDTH = 1180;
+
+/**
+ * Rewards seen from the **account**, over a window the user picks.
+ *
+ * The claim drill-down is organised by validator, because that is the unit a
+ * payout call takes. This is the other question — "which of my addresses earned
+ * what, and what is that worth annualised" — and it is a different table rather
+ * than a mode of the same one: mixing the two would put a Claim button on a row
+ * that cannot express one call.
+ */
+export const RewardsTableWidget = ({ accountIds }: Props) => {
+  const { t } = useI18n();
+  const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
+  const { rows, days, ready } = useAccountRewardRows(accountIds, rewardWindow);
+
+  const columns = useMemo<DataTableColumn<AccountRewardRow>[]>(() => {
+    const amount = (
+      id: string,
+      width: string,
+      pick: (row: AccountRewardRow) => string,
+    ): DataTableColumn<AccountRewardRow> => ({
+      id,
+      title: t(`dashboard.staking.rewardsTable.columns.${id}`),
+      width,
+      sortable: true,
+      filter: 'range',
+      text: (row) => {
+        const formatted = formatBalance(pick(row), row.precision);
+
+        return `${formatted.formatted}${formatted.suffix} ${row.symbol}`;
+      },
+      exportValue: (row) => formatBalance(pick(row), row.precision, { keepPrecision: true }).formatted,
+      value: (row) => Number(formatBalance(pick(row), row.precision, { keepPrecision: true }).value),
+      render: (row) => {
+        const formatted = formatBalance(pick(row), row.precision);
+
+        return (
+          <FootnoteText className="tabular-nums">
+            {formatted.formatted}
+            {formatted.suffix} {row.symbol}
+          </FootnoteText>
+        );
+      },
+    });
+
+    return [
+      {
+        id: 'network',
+        title: t('dashboard.staking.rewardsTable.columns.network'),
+        width: '10%',
+        sortable: true,
+        filter: 'enum',
+        text: (row) => row.networkName,
+        render: (row) => <FootnoteText className="truncate">{row.networkName}</FootnoteText>,
+      },
+      {
+        id: 'chain',
+        title: t('dashboard.staking.rewardsTable.columns.chain'),
+        width: '12%',
+        sortable: true,
+        filter: 'enum',
+        text: (row) => row.chainName,
+        render: (row) => <FootnoteText className="truncate text-text-secondary">{row.chainName}</FootnoteText>,
+      },
+      {
+        id: 'account',
+        title: t('dashboard.staking.rewardsTable.columns.account'),
+        width: '18%',
+        render: (row) => (
+          <NamedAccount
+            accountId={pjsSchema.helpers.toAccountId(row.accountId)}
+            chain={undefined}
+            variant="short"
+            iconSize={20}
+            hideExplorers
+          />
+        ),
+      },
+      {
+        id: 'address',
+        title: t('dashboard.staking.rewardsTable.columns.address'),
+        width: '11%',
+        filter: 'text',
+        text: (row) => row.address,
+        render: (row) => <HelpText className="truncate text-text-tertiary">{row.address}</HelpText>,
+      },
+      {
+        id: 'role',
+        title: t('dashboard.staking.rewardsTable.columns.role'),
+        width: '9%',
+        sortable: true,
+        filter: 'enum',
+        text: (row) => t(`dashboard.staking.positions.role.${row.role}`),
+        render: (row) => (
+          <FootnoteText className="text-text-secondary">
+            {t(`dashboard.staking.positions.role.${row.role}`)}
+          </FootnoteText>
+        ),
+      },
+      amount('totalStaked', '13%', (row) => row.totalStaked),
+      amount('rewards', '13%', (row) => row.rewards),
+      {
+        id: 'apy',
+        title: t('dashboard.staking.rewardsTable.columns.apy'),
+        width: '14%',
+        sortable: true,
+        filter: 'range',
+        text: (row) => (row.apy === null ? t('dashboard.staking.positions.noValue') : `${row.apy.toFixed(2)}%`),
+        value: (row) => row.apy,
+        render: (row) => (
+          <div className="flex flex-col">
+            {row.apy === null ? (
+              <FootnoteText className="text-text-tertiary">{t('dashboard.staking.positions.noValue')}</FootnoteText>
+            ) : (
+              <Tooltip>
+                <Tooltip.Trigger>
+                  <FootnoteText className="text-text-positive tabular-nums">{row.apy.toFixed(2)}%</FootnoteText>
+                </Tooltip.Trigger>
+                <Tooltip.Content>{t('dashboard.staking.rewardsTable.apyHint')}</Tooltip.Content>
+              </Tooltip>
+            )}
+
+            {row.networkApy === null ? null : (
+              <HelpText className="text-text-tertiary tabular-nums">
+                {t('dashboard.staking.rewardsTable.networkAverage', { value: row.networkApy.toFixed(2) })}
+              </HelpText>
+            )}
+          </div>
+        ),
+      },
+    ];
+  }, [t]);
+
+  return (
+    <DashboardWidget>
+      <div className="mb-3 flex items-center justify-between gap-x-4">
+        <SmallTitleText>{t('dashboard.staking.rewardsTable.title')}</SmallTitleText>
+        <PeriodTabs value={rewardWindow} onChange={setRewardWindow} />
+      </div>
+
+      {accountIds.length === 0 ? (
+        <BodyText className="text-text-tertiary">{t('dashboard.staking.rewardsTable.noSelection')}</BodyText>
+      ) : ready ? (
+        <DataTable
+          columns={columns}
+          rows={rows}
+          getRowId={(row) => row.id}
+          minWidth={MIN_WIDTH}
+          searchPlaceholder={t('dashboard.staking.rewardsTable.searchPlaceholder')}
+          emptyMessage={t('dashboard.staking.rewardsTable.empty')}
+          exportFileName={(context: { filters: DataTableFilterState }) => exportName(context, rewardWindow)}
+        />
+      ) : (
+        // A half-picked range would annualise over a length nobody chose.
+        <BodyText className="text-text-tertiary">{t('dashboard.staking.rewardsTable.pickRange')}</BodyText>
+      )}
+
+      {ready && days !== null ? (
+        <HelpText className="mt-2 text-text-tertiary">
+          {t('dashboard.staking.rewardsTable.windowHint', { days })}
+        </HelpText>
+      ) : null}
+    </DashboardWidget>
+  );
+};
+
+const exportName = (context: { filters: DataTableFilterState }, rewardWindow: RewardWindow): string => {
+  const parts = (context.filters.enum['network'] ?? []).map((part) => part.toLowerCase().replaceAll(/\s+/g, '-'));
+
+  return `nova-spektr-staking-account-rewards-${[...parts, windowSlug(rewardWindow)].join('-')}.csv`;
+};

--- a/src/renderer/features/dashboard-staking-positions/README.md
+++ b/src/renderer/features/dashboard-staking-positions/README.md
@@ -61,13 +61,33 @@ flowchart TD
 
 ### The table
 
-Columns, in order: **Account · Staked · Share · Status · APY · Validators · Unclaimed · actions**. Sorted by staked
-descending by default, and clearing the sort returns to that default rather than to the aggregate's arbitrary order.
+Columns, in order: **Network · Chain · Account · Address · Type · Total balance · Nominating stake · Self stake · Staked
+· Share · Status · APY · Validators · Unclaimed · actions**. Sorted by staked descending by default, and clearing the
+sort returns to that default rather than to the aggregate's arbitrary order.
+
+Fifteen columns do not fit a laptop, so the card **scrolls sideways** below ~1720px rather than squeezing: every amount
+crushed into an ellipsis defeats the point of a table people compare numbers in.
+
+Every column carries its own filter — a tick-list on Network, Chain, Type and Status, a substring on Address, a numeric
+range on every amount — plus one search box across the whole row, all through the shared `ui-kit/DataTable`. Filters,
+search and the CSV export run over the **strings the cells render**, never the underlying record, and the export's
+filename carries the network and type filters that produced it.
 
 - **Account** — the resolved name, the address, the chain, and everything about the account that changes what can be
   done with it: the multisig threshold and the count of pending drafts this very account already initiated on this very
   chain. A validator position adds a `Validator` chip here (with a tooltip) — the one glance-level marker that the rest
-  of the row reads differently.
+  of the row reads differently, and the one that survives the **Type** column being scrolled out of view. It is also the
+  one column with **no filter**: the name it prints is resolved inside the cell (custom name → contact → on-chain
+  identity → wallet), so a filter here could only match a raw field the user is not looking at. **Address** beside it is
+  the searchable identity.
+- **Type** — `Validator` / `Nominator` / `Idle` / `Unknown`. A stash is a validator or a nominator on `pallet_staking`,
+  never both, so the position's kind answers it first. `Idle` is a bonded stash that nominates nothing; `Unknown` is the
+  era validator set still being unread, which is a statement about what the app has looked at rather than about the
+  chain.
+- **Total balance / Nominating stake / Self stake** — what the address holds on the chain, what its bond backs for other
+  people, and what a validating stash puts behind itself. A validator's bond is not nominating stake, so that column
+  reads `0` there; self stake is the **era's** snapshot and can lag a bond placed after the election, and reads `—`
+  rather than `0` while the exposure is unread.
 - **Share** — a share of what the user is _looking at_. Under the dashboard's account filter the denominator is the
   visible chain total, so the column always adds up to 100%.
 - **Status** — `Active` / `Waiting` / `Inactive` / `Bonded`, each with the reason behind it. The reason is the point:

--- a/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
+++ b/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
@@ -2,12 +2,12 @@ import { BN, BN_ZERO } from '@polkadot/util';
 import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
-import { type ChainId } from '@/shared/core';
+import { type AssetId, type ChainId } from '@/shared/core';
 import { getRelaychainAsset, nonNullable, nullable, toAccountId, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accounts } from '@/domains/network';
 import { type EraValidatorMap, type StakingPosition, validators as validatorsStore } from '@/domains/staking';
-import { balanceModel } from '@/entities/balance';
+import { balanceModel, balanceUtils } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { useStakingPositions } from '@/aggregates/staking-positions';
@@ -60,6 +60,18 @@ function derivePositionApy(position: StakingPosition, eraValidators: EraValidato
  * Nothing here starts a subscription: `aggregates/staking-positions` already
  * drives every read this needs, so the widget only joins the caches it filled.
  */
+/** `free + reserved` of one (account, chain, asset), `null` when unread. */
+function totalBalanceOf(
+  balanceMap: Parameters<typeof balanceUtils.getBalance>[0],
+  accountId: AccountId,
+  chainId: ChainId,
+  assetId: AssetId,
+): string | null {
+  const balance = balanceUtils.getBalance(balanceMap, accountId, chainId, assetId);
+
+  return balance ? balance.free.add(balance.reserved).toString() : null;
+}
+
 export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
   const { positions, pending } = useStakingPositions();
   const chains = useUnit(networkModel.$chains);
@@ -68,20 +80,6 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
   const eraValidators = useUnit(validatorsStore.validatorsResource.$cache);
   const balanceMap = useUnit(balanceModel.$balanceMap);
   const { drafts, available: draftsAvailable } = useVisibleDrafts();
-
-  // Keyed by (chain, account, asset) so a row can find the one balance that
-  // belongs to it without walking the whole map per row.
-  const balanceByKey = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const balance of Object.values(balanceMap)) {
-      map.set(
-        `${balance.chainId}-${balance.accountId}-${balance.assetId}`,
-        balance.free.add(balance.reserved).toString(),
-      );
-    }
-
-    return map;
-  }, [balanceMap]);
 
   const selectedIds = useMemo(() => {
     if (accountIds.length === 0) return null;
@@ -166,7 +164,10 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
         // The era's snapshot, so it can lag a bond placed after the election —
         // and it stays `null` until that exposure is read.
         selfStake: position.validator?.ownStake ?? null,
-        totalBalance: balanceByKey.get(`${position.chainId}-${position.accountId}-${asset.assetId}`) ?? null,
+        // `$balanceMap` is already keyed by (account, chain, asset), so the row
+        // reads its one balance straight out of it — re-indexing the whole map
+        // on every subscription tick bought nothing.
+        totalBalance: totalBalanceOf(balanceMap, position.accountId, position.chainId, asset.assetId),
         sharePercent: calculateSharePercent(
           position.stake.total,
           (chainTotals.get(position.chainId) ?? BN_ZERO).toString(),
@@ -187,7 +188,7 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
     signerAccountIds,
     accountByAccountId,
     eraValidators,
-    balanceByKey,
+    balanceMap,
     draftCountByKey,
     pending,
     draftsAvailable,

--- a/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
+++ b/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
@@ -3,15 +3,23 @@ import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
 import { type ChainId } from '@/shared/core';
-import { getRelaychainAsset, nonNullable, nullable, toAccountId } from '@/shared/lib/utils';
+import { getRelaychainAsset, nonNullable, nullable, toAccountId, toAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accounts } from '@/domains/network';
 import { type EraValidatorMap, type StakingPosition, validators as validatorsStore } from '@/domains/staking';
+import { balanceModel } from '@/entities/balance';
 import { networkModel } from '@/entities/network';
 import { walletModel, walletUtils } from '@/entities/wallet';
 import { useStakingPositions } from '@/aggregates/staking-positions';
 import { useVisibleDrafts } from '@/features/drafts';
-import { type PositionRow, averageApy, calculateSharePercent, getAccessMode, getMultisigThreshold } from '../lib';
+import {
+  type PositionRow,
+  averageApy,
+  calculateSharePercent,
+  derivePositionRole,
+  getAccessMode,
+  getMultisigThreshold,
+} from '../lib';
 
 import { useSignerAccountIds } from './useSignerAccountIds';
 
@@ -58,7 +66,22 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
   const wallets = useUnit(walletModel.$wallets);
   const allAccounts = useUnit(accounts.$list);
   const eraValidators = useUnit(validatorsStore.validatorsResource.$cache);
+  const balanceMap = useUnit(balanceModel.$balanceMap);
   const { drafts, available: draftsAvailable } = useVisibleDrafts();
+
+  // Keyed by (chain, account, asset) so a row can find the one balance that
+  // belongs to it without walking the whole map per row.
+  const balanceByKey = useMemo(() => {
+    const map = new Map<string, string>();
+    for (const balance of Object.values(balanceMap)) {
+      map.set(
+        `${balance.chainId}-${balance.accountId}-${balance.assetId}`,
+        balance.free.add(balance.reserved).toString(),
+      );
+    }
+
+    return map;
+  }, [balanceMap]);
 
   const selectedIds = useMemo(() => {
     if (accountIds.length === 0) return null;
@@ -134,7 +157,16 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
         accessMode: getAccessMode(account, wallets, signerAccountIds),
         multisig: getMultisigThreshold(account),
         status: position.status,
+        networkName: (chain.parentId ? chains[chain.parentId]?.name : undefined) ?? chain.name,
+        address: toAddress(position.accountId, { prefix: chain.addressPrefix }),
         staked: position.stake.total,
+        role: derivePositionRole(position),
+        // A validator's bond backs itself, not somebody else's set.
+        nominatingStake: position.kind === 'validator' ? '0' : position.stake.active,
+        // The era's snapshot, so it can lag a bond placed after the election —
+        // and it stays `null` until that exposure is read.
+        selfStake: position.validator?.ownStake ?? null,
+        totalBalance: balanceByKey.get(`${position.chainId}-${position.accountId}-${asset.assetId}`) ?? null,
         sharePercent: calculateSharePercent(
           position.stake.total,
           (chainTotals.get(position.chainId) ?? BN_ZERO).toString(),
@@ -155,6 +187,7 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
     signerAccountIds,
     accountByAccountId,
     eraValidators,
+    balanceByKey,
     draftCountByKey,
     pending,
     draftsAvailable,

--- a/src/renderer/features/dashboard-staking-positions/index.ts
+++ b/src/renderer/features/dashboard-staking-positions/index.ts
@@ -6,8 +6,15 @@ import { dashboardStakingSlot } from '@/pages/Dashboard';
 
 import { PositionsWidget } from './ui/PositionsWidget';
 
-export type { CountdownParts, MultisigThreshold, PositionAccessMode, PositionRow } from './lib';
-export { canAct, getAccessMode, getCountdownParts, getMultisigThreshold, getUnbondingCountdown } from './lib';
+export type { CountdownParts, MultisigThreshold, PositionAccessMode, PositionRole, PositionRow } from './lib';
+export {
+  canAct,
+  derivePositionRole,
+  getAccessMode,
+  getCountdownParts,
+  getMultisigThreshold,
+  getUnbondingCountdown,
+} from './lib';
 export type {
   ClaimPayload,
   NominationsChangePayload,

--- a/src/renderer/features/dashboard-staking-positions/index.ts
+++ b/src/renderer/features/dashboard-staking-positions/index.ts
@@ -9,6 +9,7 @@ import { PositionsWidget } from './ui/PositionsWidget';
 export type { CountdownParts, MultisigThreshold, PositionAccessMode, PositionRole, PositionRow } from './lib';
 export {
   canAct,
+  comparePlanck,
   derivePositionRole,
   getAccessMode,
   getCountdownParts,

--- a/src/renderer/features/dashboard-staking-positions/lib/index.ts
+++ b/src/renderer/features/dashboard-staking-positions/lib/index.ts
@@ -18,7 +18,8 @@ export {
   getExpiryUrgency,
   sortByStake,
 } from './position-metrics';
-export { type PositionSortColumn, DEFAULT_SORT, isSortColumn, sortPositionRows } from './position-sorting';
+export { type PositionRole, derivePositionRole } from './position-role';
+export { DEFAULT_SORT } from './position-sorting';
 export { buildNominationRows, countNominations } from './nominations';
 export {
   type NominationSortColumn,

--- a/src/renderer/features/dashboard-staking-positions/lib/position-role.ts
+++ b/src/renderer/features/dashboard-staking-positions/lib/position-role.ts
@@ -1,0 +1,26 @@
+import { type StakingPosition } from '@/domains/staking';
+
+/**
+ * What the stash does with its bond, as the table's Type column says it.
+ *
+ * - `validator` — registered as a validator (elected, or elected-and-chilled);
+ * - `nominator` — nominates somebody;
+ * - `idle` — bonded and doing neither;
+ * - `unknown` — the era validator set has not been read, so an idle-looking
+ *   ledger cannot yet be told from a validating one.
+ *
+ * This is a view concern rather than a domain one: the domain answers the two
+ * questions the chain actually has facts about — `kind` (validator or
+ * nominator) and `status` (what that bond is doing this era) — and the column
+ * folds them into the one word a user scans for. `unknown` is the same
+ * anti-flicker rule the status pill follows: it says the app has not looked,
+ * never that the chain said "nothing".
+ */
+export type PositionRole = 'validator' | 'nominator' | 'idle' | 'unknown';
+
+export function derivePositionRole(position: StakingPosition): PositionRole {
+  if (position.kind === 'validator') return 'validator';
+  if (position.nominations.length > 0) return 'nominator';
+
+  return position.status === 'unknown' ? 'unknown' : 'idle';
+}

--- a/src/renderer/features/dashboard-staking-positions/lib/position-sorting.ts
+++ b/src/renderer/features/dashboard-staking-positions/lib/position-sorting.ts
@@ -1,73 +1,9 @@
-import { type PositionStatus } from '@/domains/staking';
-
-import { comparePlanck } from './position-metrics';
-import { type PositionRow } from './types';
-
-/** Columns the header can sort by, keyed exactly as the table's columns are. */
-export type PositionSortColumn = 'staked' | 'sharePercent' | 'status' | 'apy' | 'activeValidatorCount';
-
-export const DEFAULT_SORT = { column: 'staked', direction: 'desc' } as const;
-
 /**
- * Earning first, dead last — the order a user scanning for problems wants.
+ * Largest stake first — the order the table opens in, and the one it returns to
+ * when a user clicks a header a third time to clear their own sort.
  *
- * `unknown` sorts next to `active` rather than beside the problems: a position
- * whose exposures are still loading is far more often earning than not, and
- * parking it at the bottom would make rows jump the length of the table the
- * moment the read lands.
+ * The comparators themselves live on the columns (`ui/PositionsTable`), where
+ * `DataTable` reads them: a planck amount runs past `Number.MAX_SAFE_INTEGER`,
+ * so those columns compare as big integers rather than as numbers.
  */
-const STATUS_RANK: Record<PositionStatus, number> = {
-  active: 0,
-  unknown: 1,
-  waiting: 2,
-  inactive: 3,
-  bonded: 4,
-};
-
-/**
- * `null` APY always sinks to the bottom, in both directions: an unknown value
- * is not a small one, and floating it to the top of a descending sort would put
- * the least informative rows where the most interesting ones belong.
- */
-function compareNullableNumber(a: number | null, b: number | null): number {
-  if (a === null && b === null) return 0;
-  if (a === null) return 1;
-  if (b === null) return -1;
-
-  return a - b;
-}
-
-export function sortPositionRows(rows: PositionRow[], column: PositionSortColumn, direction: 'asc' | 'desc') {
-  const sign = direction === 'desc' ? -1 : 1;
-
-  const compare = (a: PositionRow, b: PositionRow): number => {
-    switch (column) {
-      case 'staked':
-        return sign * comparePlanck(a.staked, b.staked);
-      case 'sharePercent':
-        return sign * (a.sharePercent - b.sharePercent);
-      case 'status':
-        return sign * (STATUS_RANK[a.status] - STATUS_RANK[b.status]);
-      case 'activeValidatorCount':
-        return sign * (a.activeValidatorCount - b.activeValidatorCount);
-      case 'apy': {
-        const result = compareNullableNumber(a.apy, b.apy);
-
-        // The null sentinel is direction-independent; only real values flip.
-        return a.apy === null || b.apy === null ? result : sign * result;
-      }
-    }
-  };
-
-  return [...rows].sort(compare);
-}
-
-export function isSortColumn(value: string): value is PositionSortColumn {
-  return (
-    value === 'staked' ||
-    value === 'sharePercent' ||
-    value === 'status' ||
-    value === 'apy' ||
-    value === 'activeValidatorCount'
-  );
-}
+export const DEFAULT_SORT = { column: 'staked', direction: 'desc' } as const;

--- a/src/renderer/features/dashboard-staking-positions/lib/types.ts
+++ b/src/renderer/features/dashboard-staking-positions/lib/types.ts
@@ -1,7 +1,9 @@
-import { type Asset, type Chain, type Wallet } from '@/shared/core';
+import { type Address, type Asset, type Chain, type Wallet } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type AnyAccount } from '@/domains/network';
 import { type NominationStatus, type PositionStatus, type StakingPosition } from '@/domains/staking';
+
+import { type PositionRole } from './position-role';
 
 /**
  * How the user can act on the account behind a position.
@@ -41,8 +43,30 @@ export type PositionRow = {
   multisig: MultisigThreshold | null;
   /** Mirrors `position.status` — the table needs it as a sortable column key. */
   status: PositionStatus;
+  /** The relay this chain belongs to — Polkadot for Polkadot Asset Hub. */
+  networkName: string;
+  /** Address in the chain's own prefix — the string the row prints. */
+  address: Address;
   /** Ledger total — bonded plus everything still unbonding, in planck. */
   staked: string;
+  /** What the stash does with its bond. */
+  role: PositionRole;
+  /**
+   * Stake behind other people's validators, planck. A validator's own bond is
+   * not nominating stake, so it reads `0` there.
+   */
+  nominatingStake: string;
+  /**
+   * A validating stash's own stake in the active era, planck. `null` for every
+   * other role and while the era exposure is unread — never `0`, which would
+   * claim the chain said something it has not.
+   */
+  selfStake: string | null;
+  /**
+   * `free + reserved` of the staking asset on this chain, planck. `null` until
+   * a balance record for the pair has landed.
+   */
+  totalBalance: string | null;
   /** Share of the chain's visible total, in percent. */
   sharePercent: number;
   /**

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { formatBalance } from '@/shared/lib/utils';
+import { formatBalance, formatBalanceExact } from '@/shared/lib/utils';
 import { CaptionText, FootnoteText, HelpText, Icon } from '@/shared/ui';
 import { AssetBalance } from '@/shared/ui-entities';
 import { type DataTableColumn, type DataTableFilterState, DataTable } from '@/shared/ui-kit';
@@ -49,23 +49,26 @@ export const PositionsTable = ({ rows, onRowClick }: Props) => {
     const planck = (pick: (row: PositionRow) => string | null): ColumnBody => ({
       sortable: true,
       filter: 'range',
+      // `formatted` already carries the shorthand suffix — appending `suffix`
+      // again printed (and searched, and exported) `2MM DOT`.
       text: (row) => {
         const value = pick(row);
         if (value === null) return noValue;
 
-        const formatted = formatBalance(value, row.asset.precision);
-
-        return `${formatted.formatted}${formatted.suffix} ${row.asset.symbol}`;
+        return `${formatBalance(value, row.asset.precision).formatted} ${row.asset.symbol}`;
       },
+      // Export and range-filter read the un-abbreviated amount: `formatted`
+      // would put `2M` in a CSV cell, and a `value` divided by its own
+      // shorthand makes 2M DOT compare as smaller than 900K.
       exportValue: (row) => {
         const value = pick(row);
 
-        return value === null ? '' : formatBalance(value, row.asset.precision, { keepPrecision: true }).formatted;
+        return value === null ? '' : formatBalanceExact(value, row.asset.precision);
       },
       value: (row) => {
         const value = pick(row);
 
-        return value === null ? null : Number(formatBalance(value, row.asset.precision, { keepPrecision: true }).value);
+        return value === null ? null : Number(formatBalanceExact(value, row.asset.precision));
       },
       compare: (a, b) => {
         const left = pick(a);

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
@@ -1,126 +1,252 @@
-import { type ReactNode, useMemo } from 'react';
+import { useMemo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { CaptionText, FootnoteText, Icon } from '@/shared/ui';
+import { formatBalance } from '@/shared/lib/utils';
+import { CaptionText, FootnoteText, HelpText, Icon } from '@/shared/ui';
 import { AssetBalance } from '@/shared/ui-entities';
-import { type Column, type TableSort, Table } from '@/shared/ui-kit';
+import { type DataTableColumn, type DataTableFilterState, DataTable } from '@/shared/ui-kit';
 import { AssetFiatBalance } from '@/widgets/price';
-import { type PositionRow } from '../lib';
+import { type PositionRow, DEFAULT_SORT, comparePlanck } from '../lib';
 
 import { PositionAccountCell } from './PositionAccountCell';
 import { PositionStatusPill } from './PositionStatusPill';
 import { UnclaimedCell } from './UnclaimedCell';
-import { type PositionColumnKey, POSITION_COLUMNS } from './columnLayout';
+import { type PositionColumnId, POSITIONS_MIN_WIDTH, POSITION_COLUMNS } from './columnLayout';
 
 /**
  * Past this many rows the card would grow taller than the dashboard grid, so
  * the body becomes the scroll container instead of the page.
  */
 export const SCROLL_THRESHOLD = 20;
-/**
- * Eight rows plus the header — enough to compare without hiding the widgets
- * below.
- */
-const SCROLL_MAX_HEIGHT = 448;
+
+/** Everything a column contributes beyond its identity, width and header. */
+type ColumnBody = Omit<DataTableColumn<PositionRow>, 'id' | 'title' | 'width'>;
 
 type Props = {
   rows: PositionRow[];
-  sort: TableSort;
-  onSortChange: (sort: TableSort | null) => void;
   onRowClick: (row: PositionRow) => void;
 };
 
-export const PositionsTable = ({ rows, sort, onSortChange, onRowClick }: Props) => {
+const exportName = (context: { filters: DataTableFilterState }, isoDate: string): string => {
+  const parts = [...(context.filters.enum['network'] ?? []), ...(context.filters.enum['role'] ?? [])].map((part) =>
+    part.toLowerCase().replaceAll(/\s+/g, '-'),
+  );
+
+  return `nova-spektr-staking-positions-${[...parts, isoDate].join('-')}.csv`;
+};
+
+export const PositionsTable = ({ rows, onRowClick }: Props) => {
   const { t } = useI18n();
 
-  const columns = useMemo<Column<PositionRow>[]>(() => {
-    const renderers: Record<PositionColumnKey, (row: PositionRow) => ReactNode> = {
-      accountId: (row) => <PositionAccountCell row={row} />,
+  const columns = useMemo<DataTableColumn<PositionRow>[]>(() => {
+    const noValue = t('dashboard.staking.positions.noValue');
 
-      staked: (row) => (
-        <div className="flex flex-col">
-          <AssetBalance value={row.staked} asset={row.asset} className="text-footnote" />
-          <AssetFiatBalance asset={row.asset} amount={row.staked} />
-        </div>
-      ),
+    /**
+     * A planck column: rendered as a token amount, filtered by a numeric range,
+     * and sorted as a big integer — the amounts run well past
+     * `Number.MAX_SAFE_INTEGER`, so `value` alone would mis-order large bonds.
+     */
+    const planck = (pick: (row: PositionRow) => string | null): ColumnBody => ({
+      sortable: true,
+      filter: 'range',
+      text: (row) => {
+        const value = pick(row);
+        if (value === null) return noValue;
 
-      sharePercent: (row) => (
-        <FootnoteText className="text-text-secondary">
-          {t('assetBalance.number', { value: row.sharePercent.toFixed(1), maximumFractionDigits: 1 })}%
-        </FootnoteText>
-      ),
+        const formatted = formatBalance(value, row.asset.precision);
 
-      status: (row) => (
-        <PositionStatusPill
-          status={row.position.status}
-          statusReason={row.position.statusReason}
-          kind={row.position.kind}
-        />
-      ),
+        return `${formatted.formatted}${formatted.suffix} ${row.asset.symbol}`;
+      },
+      exportValue: (row) => {
+        const value = pick(row);
 
-      apy: (row) =>
-        row.apy === null ? (
-          <FootnoteText className="text-text-tertiary">{t('dashboard.staking.positions.noValue')}</FootnoteText>
+        return value === null ? '' : formatBalance(value, row.asset.precision, { keepPrecision: true }).formatted;
+      },
+      value: (row) => {
+        const value = pick(row);
+
+        return value === null ? null : Number(formatBalance(value, row.asset.precision, { keepPrecision: true }).value);
+      },
+      compare: (a, b) => {
+        const left = pick(a);
+        const right = pick(b);
+
+        // Unknown sinks in both directions: it says "not read", not "small".
+        if (left === null && right === null) return 0;
+        if (left === null) return 1;
+        if (right === null) return -1;
+
+        return comparePlanck(left, right);
+      },
+      render: (row) => {
+        const value = pick(row);
+
+        return value === null ? (
+          <FootnoteText className="text-text-tertiary">{noValue}</FootnoteText>
         ) : (
-          // The column header already says APY — a bare percent keeps the cell
-          // on one line (same format as the nominations table).
-          <FootnoteText className="text-text-positive">{`${row.apy.toFixed(1)}%`}</FootnoteText>
+          <AssetBalance value={value} asset={row.asset} className="text-footnote" />
+        );
+      },
+    });
+
+    const bodies: Record<PositionColumnId, ColumnBody> = {
+      network: {
+        sortable: true,
+        filter: 'enum',
+        text: (row) => row.networkName,
+        render: (row) => <FootnoteText className="truncate">{row.networkName}</FootnoteText>,
+      },
+
+      chain: {
+        sortable: true,
+        filter: 'enum',
+        text: (row) => row.chain.name,
+        render: (row) => <FootnoteText className="truncate text-text-secondary">{row.chain.name}</FootnoteText>,
+      },
+
+      // No filter on the account: the name this cell prints is resolved inside
+      // it (custom name → contact → on-chain identity → wallet), so a filter
+      // here could only match a raw field the user is not looking at. The
+      // Address column beside it is the searchable identity.
+      account: { render: (row) => <PositionAccountCell row={row} /> },
+
+      address: {
+        filter: 'text',
+        text: (row) => row.address,
+        render: (row) => <HelpText className="truncate text-text-tertiary">{row.address}</HelpText>,
+      },
+
+      role: {
+        sortable: true,
+        filter: 'enum',
+        text: (row) => t(`dashboard.staking.positions.role.${row.role}`),
+        render: (row) => (
+          <FootnoteText className="text-text-secondary">
+            {t(`dashboard.staking.positions.role.${row.role}`)}
+          </FootnoteText>
         ),
+      },
 
-      activeValidatorCount: (row) => (
-        <FootnoteText className="text-text-secondary">
-          {row.position.kind === 'validator'
-            ? row.position.validator?.nominatorCount == null
-              ? t('dashboard.staking.positions.noValue')
-              : t('dashboard.staking.positions.nominatorsValue', { count: row.position.validator.nominatorCount })
-            : t('dashboard.staking.positions.validatorsValue', {
-                active: row.activeValidatorCount,
-                total: row.nominationCount,
-              })}
-        </FootnoteText>
-      ),
+      totalBalance: planck((row) => row.totalBalance),
+      nominatingStake: planck((row) => row.nominatingStake),
+      selfStake: planck((row) => row.selfStake),
 
-      asset: (row) => <UnclaimedCell row={row} />,
+      staked: {
+        ...planck((row) => row.staked),
+        render: (row) => (
+          <div className="flex flex-col">
+            <AssetBalance value={row.staked} asset={row.asset} className="text-footnote" />
+            <AssetFiatBalance asset={row.asset} amount={row.staked} />
+          </div>
+        ),
+      },
 
-      accessMode: (row) => (
-        <div className="flex items-center justify-end gap-x-1.5">
-          {row.accessMode === 'draft' ? <Icon name="edit" size={14} className="text-text-tertiary" /> : null}
-          {row.accessMode === 'watchOnly' ? (
-            <CaptionText className="text-text-tertiary">{t('dashboard.staking.positions.viewOnly')}</CaptionText>
-          ) : null}
-          <Icon name="right" size={14} className="text-text-tertiary" />
-        </div>
-      ),
+      sharePercent: {
+        sortable: true,
+        filter: 'range',
+        text: (row) => `${row.sharePercent.toFixed(1)}%`,
+        value: (row) => row.sharePercent,
+        render: (row) => (
+          <FootnoteText className="text-text-secondary">
+            {t('assetBalance.number', { value: row.sharePercent.toFixed(1), maximumFractionDigits: 1 })}%
+          </FootnoteText>
+        ),
+      },
+
+      status: {
+        sortable: true,
+        filter: 'enum',
+        text: (row) => t(`dashboard.staking.positions.status.${row.status}`),
+        render: (row) => (
+          <PositionStatusPill
+            status={row.position.status}
+            statusReason={row.position.statusReason}
+            kind={row.position.kind}
+          />
+        ),
+      },
+
+      apy: {
+        sortable: true,
+        filter: 'range',
+        text: (row) => (row.apy === null ? noValue : `${row.apy.toFixed(1)}%`),
+        value: (row) => row.apy,
+        render: (row) =>
+          row.apy === null ? (
+            <FootnoteText className="text-text-tertiary">{noValue}</FootnoteText>
+          ) : (
+            // The column header already says APY — a bare percent keeps the
+            // cell on one line (same format as the nominations table).
+            <FootnoteText className="text-text-positive">{`${row.apy.toFixed(1)}%`}</FootnoteText>
+          ),
+      },
+
+      // A validating stash has nominators rather than nominations, so the
+      // column reads the other side of the relation for it. Sorting and the
+      // range filter stay on the nominator count either way: both are "how
+      // many validators/nominators does this row involve".
+      activeValidatorCount: {
+        sortable: true,
+        filter: 'range',
+        text: (row) =>
+          row.position.kind === 'validator'
+            ? (row.position.validator?.nominatorCount?.toString() ?? noValue)
+            : `${row.activeValidatorCount}/${row.nominationCount}`,
+        value: (row) =>
+          row.position.kind === 'validator'
+            ? (row.position.validator?.nominatorCount ?? null)
+            : row.activeValidatorCount,
+        render: (row) => (
+          <FootnoteText className="text-text-secondary">
+            {row.position.kind === 'validator'
+              ? row.position.validator?.nominatorCount == null
+                ? noValue
+                : t('dashboard.staking.positions.nominatorsValue', { count: row.position.validator.nominatorCount })
+              : t('dashboard.staking.positions.validatorsValue', {
+                  active: row.activeValidatorCount,
+                  total: row.nominationCount,
+                })}
+          </FootnoteText>
+        ),
+      },
+
+      // The amount is resolved by a per-row hook inside the cell, so it is not
+      // in the row and cannot be sorted, filtered or exported from here.
+      unclaimed: { decorative: true, render: (row) => <UnclaimedCell row={row} /> },
+
+      accessMode: {
+        decorative: true,
+        render: (row) => (
+          <div className="flex items-center justify-end gap-x-1.5">
+            {row.accessMode === 'draft' ? <Icon name="edit" size={14} className="text-text-tertiary" /> : null}
+            {row.accessMode === 'watchOnly' ? (
+              <CaptionText className="text-text-tertiary">{t('dashboard.staking.positions.viewOnly')}</CaptionText>
+            ) : null}
+            <Icon name="right" size={14} className="text-text-tertiary" />
+          </div>
+        ),
+      },
     };
 
     return POSITION_COLUMNS.map((column) => ({
-      key: column.key,
+      id: column.id,
       title: column.titleKey ? t(`dashboard.staking.positions.${column.titleKey}`) : '',
-      sortable: column.sortable,
       width: column.width,
-      render: (_value, row) => renderers[column.key](row),
+      ...bodies[column.id],
     }));
   }, [t]);
 
-  const scrolls = rows.length > SCROLL_THRESHOLD;
-
   return (
-    <div
-      className={scrolls ? 'overflow-y-auto' : undefined}
-      style={scrolls ? { maxHeight: SCROLL_MAX_HEIGHT } : undefined}
-    >
-      {/* Always sticky: below the row threshold the nearest scrollport is the
-          widget shell, and the header must survive scrolling there too — not
-          only inside the table's own scroller. */}
-      <Table
-        columns={columns}
-        data={rows}
-        sort={sort}
-        stickyHeader
-        getRowKey={(row) => row.id}
-        onSortChange={onSortChange}
-        onRowClick={onRowClick}
-      />
-    </div>
+    <DataTable
+      columns={columns}
+      rows={rows}
+      getRowId={(row) => row.id}
+      defaultSort={DEFAULT_SORT}
+      minWidth={POSITIONS_MIN_WIDTH}
+      scrollThreshold={SCROLL_THRESHOLD}
+      searchPlaceholder={t('dashboard.staking.positions.searchPlaceholder')}
+      exportFileName={(context) => exportName(context, new Date().toISOString().slice(0, 10))}
+      onRowClick={onRowClick}
+    />
   );
 };

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTableSkeleton.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTableSkeleton.tsx
@@ -1,64 +1,43 @@
 import { useMemo } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { type Column, Skeleton, Table } from '@/shared/ui-kit';
+import { type DataTableColumn, DataTable, Skeleton } from '@/shared/ui-kit';
 
-import { type PositionColumnKey, POSITION_COLUMNS } from './columnLayout';
+import { POSITIONS_MIN_WIDTH, POSITION_COLUMNS } from './columnLayout';
 
 const SKELETON_ROWS = 5;
 
-/** Placeholder row — one field per column, so the table types line up. */
-type SkeletonRow = Record<PositionColumnKey, null> & { id: string };
-
-const PLACEHOLDER_WIDTH: Record<PositionColumnKey, string> = {
-  accountId: '180px',
-  staked: '80px',
-  sharePercent: '36px',
-  status: '56px',
-  apy: '40px',
-  activeValidatorCount: '52px',
-  asset: '88px',
-  accessMode: '16px',
-};
+type SkeletonRow = { id: string };
 
 /**
  * The loaded table's own header and column widths, with the cells blanked.
  *
- * Reusing `Table` rather than drawing a stand-in grid is what removes the jump:
- * the row height, the paddings and the widths are literally the same code, so
- * there is nothing left to drift.
+ * Reusing `DataTable` rather than drawing a stand-in grid is what removes the
+ * jump: the row height, the paddings and the widths are literally the same
+ * code, so there is nothing left to drift. Its toolbar stays off — there is
+ * nothing to search or export yet.
  */
 export const PositionsTableSkeleton = () => {
   const { t } = useI18n();
 
   const rows = useMemo<SkeletonRow[]>(
-    () =>
-      Array.from({ length: SKELETON_ROWS }, (_, index) => ({
-        id: `skeleton-${index}`,
-        accountId: null,
-        staked: null,
-        sharePercent: null,
-        status: null,
-        apy: null,
-        activeValidatorCount: null,
-        asset: null,
-        accessMode: null,
-      })),
+    () => Array.from({ length: SKELETON_ROWS }, (_, index) => ({ id: `skeleton-${index}` })),
     [],
   );
 
-  const columns = useMemo<Column<SkeletonRow>[]>(
+  const columns = useMemo<DataTableColumn<SkeletonRow>[]>(
     () =>
       POSITION_COLUMNS.map((column) => ({
-        key: column.key,
+        id: column.id,
         title: column.titleKey ? t(`dashboard.staking.positions.${column.titleKey}`) : '',
         width: column.width,
-        render: () => <Skeleton width={PLACEHOLDER_WIDTH[column.key]} height="20px" />,
+        decorative: true,
+        render: () => <Skeleton width={column.placeholder} height="20px" />,
       })),
     [t],
   );
 
-  // Same stickiness as the loaded table — the header must not gain a divider
-  // and start pinning only when the data lands.
-  return <Table columns={columns} data={rows} getRowKey={(row) => row.id} stickyHeader />;
+  // Same minimum width as the loaded table — the columns must not reflow the
+  // moment the data lands.
+  return <DataTable columns={columns} rows={rows} getRowId={(row) => row.id} minWidth={POSITIONS_MIN_WIDTH} />;
 };

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsWidget.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsWidget.tsx
@@ -2,18 +2,18 @@ import { useUnit } from 'effector-react';
 import { useCallback, useMemo, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
-import { Button, CaptionText, CountChip, Icon, SmallTitleText } from '@/shared/ui';
-import { type TableSort, Tooltip } from '@/shared/ui-kit';
+import { Button, CountChip, Icon, SmallTitleText } from '@/shared/ui';
+import { Tooltip } from '@/shared/ui-kit';
 import { ValidatorSelectionModal } from '@/features/validator-selection';
 import { DashboardWidget } from '@/pages/Dashboard';
 import { usePositionRows } from '../hooks/usePositionRows';
 import { useTrackedAddressBookAccounts } from '../hooks/useTrackedAddressBookAccounts';
-import { type PositionRow, DEFAULT_SORT, isSortColumn, sortPositionRows } from '../lib';
+import { type PositionRow } from '../lib';
 import { positionActions } from '../model/position-actions';
 
 import { PositionDetailDrawer } from './PositionDetailDrawer';
 import { PositionsEmptyState } from './PositionsEmptyState';
-import { PositionsTable, SCROLL_THRESHOLD } from './PositionsTable';
+import { PositionsTable } from './PositionsTable';
 import { PositionsTableSkeleton } from './PositionsTableSkeleton';
 
 type Props = {
@@ -24,9 +24,9 @@ type Props = {
 /**
  * The staking tab's main surface: one row per (account × chain) position.
  *
- * Sorting is controlled rather than left to the table, because "largest stake
- * first" has to hold over planck strings no `Number` can compare — see
- * `lib/position-metrics`.
+ * Sorting and filtering live in the table itself: `DataTable` reads the
+ * comparators declared on each column, so "largest stake first" holds over
+ * planck strings no `Number` can compare — see `lib/position-metrics`.
  *
  * This is also where the dashboard's address-book selection is handed to
  * `aggregates/staking-positions`, once for the whole staking tab.
@@ -38,30 +38,14 @@ export const PositionsWidget = ({ accountIds }: Props) => {
   const wiredActions = useUnit(positionActions.$wiredActions);
   const changeValidatorsTarget = useUnit(positionActions.$changeValidatorsTarget);
 
-  const [sort, setSort] = useState<TableSort>(DEFAULT_SORT);
   const [openRowId, setOpenRowId] = useState<string | null>(null);
-
-  const sortedRows = useMemo(() => {
-    if (!isSortColumn(sort.column)) return rows;
-
-    return sortPositionRows(rows, sort.column, sort.direction);
-  }, [rows, sort]);
 
   // A row is looked up rather than stored: the position keeps updating while the
   // drawer is open, and a snapshot taken at click time would go stale on screen.
   const openRow = useMemo<PositionRow | null>(
-    () => sortedRows.find((row) => row.id === openRowId) ?? null,
-    [sortedRows, openRowId],
+    () => rows.find((row) => row.id === openRowId) ?? null,
+    [rows, openRowId],
   );
-
-  const handleSortChange = useCallback((next: TableSort | null) => {
-    // Clearing the sort would leave the rows in aggregate order, which means
-    // nothing to the user. `Table` cycles asc → desc → null, so `null` is folded
-    // back onto the same column as ascending: sending it to `DEFAULT_SORT` made
-    // the third click on the Staked column - the default one - land on the state
-    // it was already in, so Staked could never be sorted ascending at all.
-    setSort((current) => next ?? { column: current.column, direction: 'asc' });
-  }, []);
 
   const startStakingWired = wiredActions.includes('startStaking');
 
@@ -102,17 +86,7 @@ export const PositionsWidget = ({ accountIds }: Props) => {
         <PositionsEmptyState startStakingWired={startStakingWired} onStartStaking={startStaking} />
       ) : null}
 
-      {rows.length > 0 ? (
-        <>
-          <PositionsTable rows={sortedRows} sort={sort} onSortChange={handleSortChange} onRowClick={handleRowClick} />
-
-          {rows.length > SCROLL_THRESHOLD ? (
-            <CaptionText className="px-3 pt-2 text-text-tertiary">
-              {t('dashboard.staking.positions.scrollHint', { count: rows.length })}
-            </CaptionText>
-          ) : null}
-        </>
-      ) : null}
+      {rows.length > 0 ? <PositionsTable rows={rows} onRowClick={handleRowClick} /> : null}
 
       <PositionDetailDrawer row={openRow} onClose={closeDrawer} />
 

--- a/src/renderer/features/dashboard-staking-positions/ui/__tests__/PositionDetailDrawer.test.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/__tests__/PositionDetailDrawer.test.tsx
@@ -4,6 +4,7 @@ import { Provider } from 'effector-react';
 
 import { type Wallet, CryptoType, SigningType, WalletType } from '@/shared/core';
 import { I18Provider } from '@/shared/i18n';
+import { toAddress } from '@/shared/lib/utils';
 import { createAccountId, dotAsset, polkadotAssetHubChain } from '@/shared/mocks';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { ThemeProvider } from '@/shared/ui-kit';
@@ -66,7 +67,13 @@ const row: PositionRow = {
   accessMode: 'direct',
   multisig: null,
   status: 'active',
+  networkName: 'Polkadot',
+  address: toAddress(accountId, { prefix: polkadotAssetHubChain.addressPrefix }),
   staked: '1000000000000',
+  role: 'nominator',
+  nominatingStake: '1000000000000',
+  selfStake: null,
+  totalBalance: null,
   sharePercent: 100,
   apy: null,
   activeValidatorCount: 0,

--- a/src/renderer/features/dashboard-staking-positions/ui/columnLayout.ts
+++ b/src/renderer/features/dashboard-staking-positions/ui/columnLayout.ts
@@ -1,5 +1,3 @@
-import { type PositionRow } from '../lib';
-
 /**
  * The one description of the table's shape.
  *
@@ -9,19 +7,33 @@ import { type PositionRow } from '../lib';
  * hand.
  */
 export const POSITION_COLUMNS = [
-  { key: 'accountId', titleKey: 'columns.account', width: '30%', sortable: false },
-  { key: 'staked', titleKey: 'columns.staked', width: '14%', sortable: true },
-  { key: 'sharePercent', titleKey: 'columns.share', width: '8%', sortable: true },
-  { key: 'status', titleKey: 'columns.status', width: '11%', sortable: true },
-  { key: 'apy', titleKey: 'columns.apy', width: '8%', sortable: true },
-  { key: 'activeValidatorCount', titleKey: 'columns.validators', width: '10%', sortable: true },
-  { key: 'asset', titleKey: 'columns.unclaimed', width: '15%', sortable: false },
-  { key: 'accessMode', titleKey: null, width: '4%', sortable: false },
+  { id: 'network', titleKey: 'columns.network', width: '7%', placeholder: '56px' },
+  { id: 'chain', titleKey: 'columns.chain', width: '9%', placeholder: '72px' },
+  { id: 'account', titleKey: 'columns.account', width: '16%', placeholder: '180px' },
+  { id: 'address', titleKey: 'columns.address', width: '9%', placeholder: '72px' },
+  { id: 'role', titleKey: 'columns.role', width: '7%', placeholder: '56px' },
+  { id: 'totalBalance', titleKey: 'columns.totalBalance', width: '9%', placeholder: '72px' },
+  { id: 'nominatingStake', titleKey: 'columns.nominatingStake', width: '9%', placeholder: '72px' },
+  { id: 'selfStake', titleKey: 'columns.selfStake', width: '8%', placeholder: '64px' },
+  { id: 'staked', titleKey: 'columns.staked', width: '10%', placeholder: '80px' },
+  { id: 'sharePercent', titleKey: 'columns.share', width: '6%', placeholder: '36px' },
+  { id: 'status', titleKey: 'columns.status', width: '8%', placeholder: '56px' },
+  { id: 'apy', titleKey: 'columns.apy', width: '5%', placeholder: '40px' },
+  { id: 'activeValidatorCount', titleKey: 'columns.validators', width: '6%', placeholder: '52px' },
+  { id: 'unclaimed', titleKey: 'columns.unclaimed', width: '9%', placeholder: '88px' },
+  { id: 'accessMode', titleKey: null, width: '4%', placeholder: '16px' },
 ] as const satisfies readonly {
-  key: keyof PositionRow;
+  id: string;
   titleKey: string | null;
   width: string;
-  sortable: boolean;
+  placeholder: string;
 }[];
 
-export type PositionColumnKey = (typeof POSITION_COLUMNS)[number]['key'];
+export type PositionColumnId = (typeof POSITION_COLUMNS)[number]['id'];
+
+/**
+ * Fifteen columns do not fit a laptop. Squeezing them would turn every amount
+ * into an ellipsis, which defeats the point of a table people compare numbers
+ * in, so the card scrolls sideways instead.
+ */
+export const POSITIONS_MIN_WIDTH = 1720;

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -553,7 +553,9 @@
         "typeCustom": "Custom Selection",
         "selectAll": "Select All",
         "deselectAll": "Deselect All",
-        "selectedCount": "{count} selected"
+        "selectedCount": "{count} selected",
+        "network": "Network",
+        "anyNetwork": "Any network"
       },
       "sources": {
         "wallet": "Wallet",
@@ -3261,6 +3263,12 @@
       "overlap_one": "{count} account appears in multiple categories",
       "overlap_other": "{count} accounts appear in multiple categories",
       "empty": "No accounts match this filter"
+    },
+    "quickFilter": {
+      "title": "Filter accounts",
+      "network": "Network",
+      "source": "Source",
+          "clear": "Clear filters"
     }
   },
   "price": {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -965,13 +965,21 @@
           "status": "Status",
           "apy": "APY",
           "validators": "Validators",
-          "unclaimed": "Unclaimed"
+          "unclaimed": "Unclaimed",
+          "network": "Network",
+          "chain": "Chain",
+          "address": "Address",
+          "role": "Type",
+          "totalBalance": "Total balance",
+          "nominatingStake": "Nominating stake",
+          "selfStake": "Self stake"
         },
         "status": {
           "active": "Active",
           "waiting": "Waiting",
           "inactive": "Inactive",
-          "bonded": "Bonded"
+          "bonded": "Bonded",
+          "unknown": "Unknown"
         },
         "statusHint": {
           "active": "Backed by elected validators this era — this stake is earning.",
@@ -995,8 +1003,6 @@
           "expiring": "expires now",
           "hint": "Unclaimed rewards are lost once their era leaves the chain's history."
         },
-        "scrollHint_one": "{count} position",
-        "scrollHint_other": "{count} positions · scroll for more",
         "empty": {
           "title": "No staking positions yet",
           "description": "Stake DOT and KSM directly from your accounts — including multisig and Address Book accounts via drafts.",
@@ -1056,7 +1062,14 @@
             "footer": "{total} nominations · {active} active, {waiting} waiting, {dropped} dropped out",
             "empty": "This account nominates no validators yet."
           }
-        }
+        },
+        "role": {
+          "validator": "Validator",
+          "nominator": "Nominator",
+          "idle": "Idle",
+          "unknown": "—"
+        },
+        "searchPlaceholder": "Search network, chain or address"
       }
     }
   },

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -487,6 +487,17 @@
     "walletsTab": "Your wallets",
     "yourAccounts": "Your accounts"
   },
+  "dataTable": {
+    "clearFilters": "Clear filters",
+    "clearColumn": "Clear this filter",
+    "export": "Export CSV",
+    "filterColumn": "Filter column",
+    "containsPlaceholder": "Contains…",
+    "min": "Min",
+    "max": "Max",
+    "noMatches": "No rows match the current filters",
+    "rowCount": "Showing {visible} of {total}"
+  },
   "dateRangePicker": {
     "lastMonth": "Last month",
     "lastWeek": "Last week",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -911,7 +911,8 @@
             "all": "All time",
             "custom": "Custom",
             "pickDates": "Pick dates"
-          }
+          },
+          "oldestDates": "earned {earned}, expires {expires}"
         },
         "positions": {
           "detailTitle": "Staking positions",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1083,6 +1083,7 @@
         "pickRange": "Pick both ends of the date range to see rewards for it",
         "searchPlaceholder": "Search network, chain or address",
         "windowHint": "Yield is annualised from {days} days at the current bonded amount",
+        "outOfHistory": "Reward history only reaches back 12 months — APY is not reported for an earlier range",
         "apyHint": "Rewards received in the window, annualised over the amount staked today. A position that changed size mid-window is not adjusted for.",
         "networkAverage": "network {value}%",
         "columns": {
@@ -3269,7 +3270,8 @@
       "title": "Filter accounts",
       "network": "Network",
       "source": "Source",
-          "clear": "Clear filters"
+          "addressBookOnly": "Network and address-book filters match address-book contacts only",
+      "clear": "Clear filters"
     }
   },
   "price": {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -906,7 +906,9 @@
           "period": {
             "7d": "7d",
             "30d": "30d",
-            "all": "All time"
+            "all": "All time",
+            "custom": "Custom",
+            "pickDates": "Pick dates"
           }
         },
         "positions": {
@@ -1070,6 +1072,26 @@
           "unknown": "—"
         },
         "searchPlaceholder": "Search network, chain or address"
+      },
+      "rewardsTable": {
+        "title": "Rewards by Account",
+        "noSelection": "Select accounts above to see their rewards",
+        "empty": "No rewards were paid to the selected accounts in this window",
+        "pickRange": "Pick both ends of the date range to see rewards for it",
+        "searchPlaceholder": "Search network, chain or address",
+        "windowHint": "Yield is annualised from {days} days at the current bonded amount",
+        "apyHint": "Rewards received in the window, annualised over the amount staked today. A position that changed size mid-window is not adjusted for.",
+        "networkAverage": "network {value}%",
+        "columns": {
+          "network": "Network",
+          "chain": "Chain",
+          "account": "Account",
+          "address": "Address",
+          "role": "Type",
+          "totalStaked": "Total staked",
+          "rewards": "Rewards in period",
+          "apy": "APY %"
+        }
       }
     }
   },

--- a/src/renderer/shared/lib/utils/balance.ts
+++ b/src/renderer/shared/lib/utils/balance.ts
@@ -129,6 +129,24 @@ export const formatBalance = (
   };
 };
 
+/**
+ * The amount as a plain decimal string in whole tokens — no `K`/`M`/`B`/`T`
+ * shorthand, full precision, no group separators.
+ *
+ * `formatBalance().value` is divided by whichever shorthand it picked, so `2M
+ * DOT` yields `"2"` while `900K DOT` yields `"900000"`. That is fine for a
+ * label printed next to its own suffix, and wrong for anything that compares,
+ * filters or exports the number: sorting would put the 2M position below the
+ * 900k one, and a CSV cell would read `2M` instead of an amount a spreadsheet
+ * can sum. This is the form to use for all three.
+ */
+export const formatBalanceExact = (balance: string | BN = '0', precision = 0): string => {
+  return formatBalance(balance, precision, {
+    shorthands: { K: false, M: false, B: false, T: false },
+    keepPrecision: true,
+  }).value;
+};
+
 export const formatAsset = (value: BN | string, asset: Asset, config?: FormatBalanceConfig) => {
   return `${formatBalance(value, asset.precision, config).formatted} ${asset.symbol}`;
 };

--- a/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
+++ b/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
@@ -112,8 +112,11 @@ export const DataTable = <T,>({
       if (prev?.column !== column.id) return { column: column.id, direction: 'asc' };
       if (prev.direction === 'asc') return { column: column.id, direction: 'desc' };
 
-      // Third click clears the sort and returns to the caller's default order.
-      return defaultSort;
+      // Third click folds back onto the same column as ascending rather than
+      // onto `defaultSort`: on the default column those are the same state, so
+      // the header would look dead and that column could never be sorted the
+      // other way at all.
+      return { column: column.id, direction: 'asc' };
     });
   };
 
@@ -170,7 +173,7 @@ export const DataTable = <T,>({
       )}
 
       <div
-        className={cnTw(minWidth && 'overflow-x-auto', scrolls && SCROLL_CLASS)}
+        className={cnTw(minWidth && 'overflow-x-auto [&_.table-container]:overflow-visible', scrolls && SCROLL_CLASS)}
         style={scrolls ? { maxHeight: scrollMaxHeight } : undefined}
       >
         <div className="table-container">

--- a/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
+++ b/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
@@ -47,6 +47,12 @@ type Props<T> = {
   scrollThreshold?: number;
   scrollMaxHeight?: number;
   /**
+   * Width below which the table scrolls sideways instead of squeezing. A table
+   * with a dozen columns cannot fit a laptop, and columns crushed to an
+   * ellipsis are worse than a scrollbar.
+   */
+  minWidth?: number;
+  /**
    * Enables the export button. Receives the filters that produced the file, so
    * the name can carry them — a folder of exports is unreadable when three of
    * them differ only by a filter nobody wrote down.
@@ -77,6 +83,7 @@ export const DataTable = <T,>({
   searchPlaceholder,
   scrollThreshold = DEFAULT_SCROLL_THRESHOLD,
   scrollMaxHeight = DEFAULT_SCROLL_MAX_HEIGHT,
+  minWidth,
   exportFileName,
   emptyMessage,
   toolbar,
@@ -162,9 +169,12 @@ export const DataTable = <T,>({
         </div>
       )}
 
-      <div className={scrolls ? SCROLL_CLASS : undefined} style={scrolls ? { maxHeight: scrollMaxHeight } : undefined}>
+      <div
+        className={cnTw(minWidth && 'overflow-x-auto', scrolls && SCROLL_CLASS)}
+        style={scrolls ? { maxHeight: scrollMaxHeight } : undefined}
+      >
         <div className="table-container">
-          <table className="table">
+          <table className="table" style={minWidth ? { minWidth } : undefined}>
             <thead className="table-header">
               <tr>
                 {columns.map(column => {

--- a/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
+++ b/src/renderer/shared/ui-kit/DataTable/DataTable.tsx
@@ -1,0 +1,257 @@
+import { type ReactNode, useMemo, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { type CsvColumn, buildCsv, downloadCsv } from '@/shared/lib/csv';
+import { cnTw } from '@/shared/lib/utils';
+import { Button, CaptionText, FootnoteText } from '@/shared/ui';
+import { SearchInput } from '../SearchInput/SearchInput';
+import { type TableRowProps, type TableSort } from '../Table';
+import '../Table/Table.css';
+
+import { DataTableFilterPopover } from './DataTableFilterPopover';
+import { countActiveFilters, emptyFilterState, filterRows, isColumnFiltered, searchRows, sortRows } from './filtering';
+import { type DataTableColumn, type DataTableFilterState } from './types';
+
+/**
+ * Past this many rows the card would grow taller than the dashboard grid, so
+ * the body becomes the scroll container instead of the page.
+ */
+const DEFAULT_SCROLL_THRESHOLD = 20;
+/** Eight rows plus the header. */
+const DEFAULT_SCROLL_MAX_HEIGHT = 448;
+
+/**
+ * Keeps the sticky header working: `.table-container` is `overflow: hidden`,
+ * which would make it the sticky ancestor and pin the header to a box that
+ * never scrolls. Handing the scroll to the wrapper and letting the header cells
+ * stick is what actually holds the columns in place.
+ */
+const SCROLL_CLASS = [
+  'overflow-y-auto',
+  '[&_.table-container]:overflow-visible',
+  '[&_.table-header-cell]:sticky',
+  '[&_.table-header-cell]:top-0',
+  '[&_.table-header-cell]:z-1',
+  '[&_.table-header-cell]:bg-white',
+].join(' ');
+
+type Props<T> = {
+  columns: DataTableColumn<T>[];
+  rows: T[];
+  getRowId: (row: T) => string;
+  defaultSort?: TableSort | null;
+  rowProps?: (row: T) => TableRowProps;
+  onRowClick?: (row: T) => void;
+  /** Shows the search box when provided. */
+  searchPlaceholder?: string;
+  scrollThreshold?: number;
+  scrollMaxHeight?: number;
+  /**
+   * Enables the export button. Receives the filters that produced the file, so
+   * the name can carry them — a folder of exports is unreadable when three of
+   * them differ only by a filter nobody wrote down.
+   */
+  exportFileName?: (context: { query: string; filters: DataTableFilterState }) => string;
+  emptyMessage?: ReactNode;
+  /** Extra controls rendered at the left of the toolbar. */
+  toolbar?: ReactNode;
+  className?: string;
+};
+
+/**
+ * A dashboard table that owns its own sort, per-column filters, search and CSV
+ * export.
+ *
+ * Every one of those runs over the **display strings the columns render**, not
+ * over the underlying record: a query typed from what is on screen has to match
+ * what is on screen, and a filter that offers an option the table cannot show
+ * is a bug in both directions.
+ */
+export const DataTable = <T,>({
+  columns,
+  rows,
+  getRowId,
+  defaultSort = null,
+  rowProps,
+  onRowClick,
+  searchPlaceholder,
+  scrollThreshold = DEFAULT_SCROLL_THRESHOLD,
+  scrollMaxHeight = DEFAULT_SCROLL_MAX_HEIGHT,
+  exportFileName,
+  emptyMessage,
+  toolbar,
+  className,
+}: Props<T>) => {
+  const { t } = useI18n();
+
+  const [sort, setSort] = useState<TableSort | null>(defaultSort);
+  const [filters, setFilters] = useState<DataTableFilterState>(emptyFilterState);
+  const [query, setQuery] = useState('');
+
+  const visibleRows = useMemo(() => {
+    const filtered = filterRows(rows, columns, filters);
+    const searched = searchRows(filtered, columns, query);
+
+    return sortRows(searched, columns, sort);
+  }, [rows, columns, filters, query, sort]);
+
+  const activeFilters = countActiveFilters(filters);
+  const narrowed = activeFilters > 0 || query.trim() !== '';
+
+  const handleSort = (column: DataTableColumn<T>) => {
+    if (!column.sortable) return;
+
+    setSort(prev => {
+      if (prev?.column !== column.id) return { column: column.id, direction: 'asc' };
+      if (prev.direction === 'asc') return { column: column.id, direction: 'desc' };
+
+      // Third click clears the sort and returns to the caller's default order.
+      return defaultSort;
+    });
+  };
+
+  const handleExport = () => {
+    if (!exportFileName) return;
+
+    const csvColumns: CsvColumn<T>[] = columns
+      .filter(column => !column.decorative && (column.exportValue || column.text))
+      .map(column => ({
+        header: typeof column.title === 'string' ? column.title : column.id,
+        cell: (row: T) => column.exportValue?.(row) ?? column.text?.(row) ?? '',
+      }));
+
+    downloadCsv(exportFileName({ query, filters }), buildCsv(csvColumns, visibleRows));
+  };
+
+  const scrolls = visibleRows.length > scrollThreshold;
+
+  const hasToolbar = Boolean(searchPlaceholder || toolbar || exportFileName || narrowed);
+
+  return (
+    <div className={cnTw('flex flex-col gap-y-3', className)}>
+      {hasToolbar && (
+        <div className="flex items-center gap-x-2">
+          {toolbar}
+
+          {searchPlaceholder && (
+            <div className="w-56">
+              <SearchInput value={query} placeholder={searchPlaceholder} onChange={setQuery} />
+            </div>
+          )}
+
+          <div className="ml-auto flex items-center gap-x-2">
+            {narrowed && (
+              <Button
+                variant="text"
+                size="sm"
+                onClick={() => {
+                  setFilters(emptyFilterState());
+                  setQuery('');
+                }}
+              >
+                {t('dataTable.clearFilters')}
+              </Button>
+            )}
+
+            {exportFileName && (
+              <Button variant="text" size="sm" disabled={visibleRows.length === 0} onClick={handleExport}>
+                {t('dataTable.export')}
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+
+      <div className={scrolls ? SCROLL_CLASS : undefined} style={scrolls ? { maxHeight: scrollMaxHeight } : undefined}>
+        <div className="table-container">
+          <table className="table">
+            <thead className="table-header">
+              <tr>
+                {columns.map(column => {
+                  const isActive = sort?.column === column.id;
+
+                  return (
+                    <th
+                      key={column.id}
+                      className={cnTw('table-header-cell', {
+                        'table-header-cell--sortable': column.sortable,
+                        'table-header-cell--active': isActive,
+                      })}
+                      style={{ width: column.width }}
+                      onClick={() => handleSort(column)}
+                    >
+                      <div className="table-header-content">
+                        <span className="truncate">{column.title}</span>
+
+                        <div className="flex shrink-0 items-center gap-x-1">
+                          {column.sortable && (
+                            <div className="table-sort-indicator">
+                              {/* eslint-disable-next-line i18next/no-literal-string */}
+                              {isActive && sort.direction === 'asc' && <span className="text-xs">▴</span>}
+                              {/* eslint-disable-next-line i18next/no-literal-string */}
+                              {isActive && sort.direction === 'desc' && <span className="text-xs">▾</span>}
+                              {/* eslint-disable-next-line i18next/no-literal-string */}
+                              {!isActive && <span className="text-xs opacity-30">⇅</span>}
+                            </div>
+                          )}
+
+                          {column.filter && (
+                            <DataTableFilterPopover
+                              column={column}
+                              rows={rows}
+                              filters={filters}
+                              active={isColumnFiltered(filters, column)}
+                              onFiltersChange={setFilters}
+                            />
+                          )}
+                        </div>
+                      </div>
+                    </th>
+                  );
+                })}
+              </tr>
+            </thead>
+
+            <tbody className="table-body">
+              {visibleRows.map(row => {
+                const { disabled = false, selected = false } = rowProps?.(row) ?? {};
+
+                return (
+                  <tr
+                    key={getRowId(row)}
+                    className={cnTw('table-row', {
+                      'table-row--disabled': disabled,
+                      'table-row--selected': selected,
+                      'cursor-pointer': Boolean(onRowClick) && !disabled,
+                    })}
+                    onClick={onRowClick && !disabled ? () => onRowClick(row) : undefined}
+                  >
+                    {columns.map(column => (
+                      <td key={column.id} className="table-cell align-middle">
+                        {column.render(row)}
+                      </td>
+                    ))}
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      </div>
+
+      {visibleRows.length === 0 && (
+        <div className="flex justify-center py-6">
+          <FootnoteText className="text-text-tertiary">
+            {narrowed ? t('dataTable.noMatches') : emptyMessage}
+          </FootnoteText>
+        </div>
+      )}
+
+      {visibleRows.length > 0 && (scrolls || narrowed) && (
+        <CaptionText className="text-text-tertiary">
+          {t('dataTable.rowCount', { visible: visibleRows.length, total: rows.length })}
+        </CaptionText>
+      )}
+    </div>
+  );
+};

--- a/src/renderer/shared/ui-kit/DataTable/DataTableFilterPopover.tsx
+++ b/src/renderer/shared/ui-kit/DataTable/DataTableFilterPopover.tsx
@@ -1,0 +1,142 @@
+import { type MouseEvent, useState } from 'react';
+
+import { useI18n } from '@/shared/i18n';
+import { cnTw } from '@/shared/lib/utils';
+import { FootnoteText } from '@/shared/ui';
+import { Checkbox } from '../Checkbox/Checkbox';
+import { Input } from '../Input/Input';
+import { Popover } from '../Popover/Popover';
+
+import { enumOptions } from './filtering';
+import { type DataTableColumn, type DataTableFilterState } from './types';
+
+type Props<T> = {
+  column: DataTableColumn<T>;
+  rows: T[];
+  filters: DataTableFilterState;
+  active: boolean;
+  onFiltersChange: (next: DataTableFilterState) => void;
+};
+
+const parseBound = (raw: string): number | null => {
+  const trimmed = raw.trim();
+  if (trimmed === '') return null;
+
+  const parsed = Number(trimmed);
+
+  return Number.isFinite(parsed) ? parsed : null;
+};
+
+/**
+ * The funnel on a column header.
+ *
+ * The trigger stops propagation: the whole header cell is the sort target, so a
+ * click meant for the filter would otherwise re-sort the table underneath the
+ * popover the user just opened.
+ */
+export const DataTableFilterPopover = <T,>({ column, rows, filters, active, onFiltersChange }: Props<T>) => {
+  const { t } = useI18n();
+  const [open, setOpen] = useState(false);
+
+  const stop = (event: MouseEvent) => event.stopPropagation();
+
+  const setText = (value: string) => {
+    onFiltersChange({ ...filters, text: { ...filters.text, [column.id]: value } });
+  };
+
+  const toggleOption = (option: string) => {
+    const selected = filters.enum[column.id] ?? [];
+    const next = selected.includes(option) ? selected.filter(o => o !== option) : [...selected, option];
+
+    onFiltersChange({ ...filters, enum: { ...filters.enum, [column.id]: next } });
+  };
+
+  const setBound = (bound: 'min' | 'max', raw: string) => {
+    const current = filters.range[column.id] ?? { min: null, max: null };
+
+    onFiltersChange({
+      ...filters,
+      range: { ...filters.range, [column.id]: { ...current, [bound]: parseBound(raw) } },
+    });
+  };
+
+  const clearColumn = () => {
+    onFiltersChange({
+      text: { ...filters.text, [column.id]: '' },
+      enum: { ...filters.enum, [column.id]: [] },
+      range: { ...filters.range, [column.id]: { min: null, max: null } },
+    });
+  };
+
+  const range = filters.range[column.id] ?? { min: null, max: null };
+  const selected = filters.enum[column.id] ?? [];
+
+  return (
+    <Popover open={open} align="end" side="bottom" onToggle={setOpen}>
+      <Popover.Trigger>
+        <button
+          type="button"
+          aria-label={t('dataTable.filterColumn')}
+          className={cnTw(
+            'flex h-4 w-4 items-center justify-center rounded text-xs transition-colors',
+            active ? 'text-icon-accent' : 'text-text-tertiary opacity-40 hover:opacity-100',
+          )}
+          onClick={stop}
+        >
+          {/* eslint-disable-next-line i18next/no-literal-string */}
+          <span>▾</span>
+        </button>
+      </Popover.Trigger>
+
+      <Popover.Content>
+        <div className="flex w-[220px] flex-col gap-y-2 p-3" onClick={stop}>
+          {column.filter === 'text' && (
+            <Input
+              value={filters.text[column.id] ?? ''}
+              placeholder={t('dataTable.containsPlaceholder')}
+              width="full"
+              onChange={setText}
+            />
+          )}
+
+          {column.filter === 'enum' && (
+            <div className="flex max-h-56 flex-col gap-y-1.5 overflow-y-auto">
+              {enumOptions(rows, column).map(option => (
+                <Checkbox key={option} checked={selected.includes(option)} onChange={() => toggleOption(option)}>
+                  {option}
+                </Checkbox>
+              ))}
+            </div>
+          )}
+
+          {column.filter === 'range' && (
+            <div className="flex items-center gap-x-2">
+              <Input
+                value={range.min === null ? '' : String(range.min)}
+                placeholder={t('dataTable.min')}
+                width="full"
+                onChange={value => setBound('min', value)}
+              />
+              <Input
+                value={range.max === null ? '' : String(range.max)}
+                placeholder={t('dataTable.max')}
+                width="full"
+                onChange={value => setBound('max', value)}
+              />
+            </div>
+          )}
+
+          {active && (
+            <button
+              type="button"
+              className="self-start rounded px-1 py-0.5 transition-colors hover:bg-action-background-hover"
+              onClick={clearColumn}
+            >
+              <FootnoteText className="text-text-tertiary">{t('dataTable.clearColumn')}</FootnoteText>
+            </button>
+          )}
+        </div>
+      </Popover.Content>
+    </Popover>
+  );
+};

--- a/src/renderer/shared/ui-kit/DataTable/DataTableFilterPopover.tsx
+++ b/src/renderer/shared/ui-kit/DataTable/DataTableFilterPopover.tsx
@@ -37,6 +37,7 @@ const parseBound = (raw: string): number | null => {
 export const DataTableFilterPopover = <T,>({ column, rows, filters, active, onFiltersChange }: Props<T>) => {
   const { t } = useI18n();
   const [open, setOpen] = useState(false);
+  const [rawBounds, setRawBounds] = useState<{ min: string; max: string }>({ min: '', max: '' });
 
   const stop = (event: MouseEvent) => event.stopPropagation();
 
@@ -54,13 +55,31 @@ export const DataTableFilterPopover = <T,>({ column, rows, filters, active, onFi
   const setBound = (bound: 'min' | 'max', raw: string) => {
     const current = filters.range[column.id] ?? { min: null, max: null };
 
+    setRawBounds(prev => ({ ...prev, [bound]: raw }));
     onFiltersChange({
       ...filters,
       range: { ...filters.range, [column.id]: { ...current, [bound]: parseBound(raw) } },
     });
   };
 
+  /**
+   * What the box shows while it is being typed in.
+   *
+   * Rendering `String(parsed)` swallowed a trailing separator — `0.` parses to
+   * `0`, so the dot was wiped on the next render and a decimal could never be
+   * entered at all. The raw text wins as long as it still means the value the
+   * filter holds, which also lets an external clear take the box back to
+   * empty.
+   */
+  const boundValue = (bound: 'min' | 'max', value: number | null): string => {
+    const raw = rawBounds[bound];
+    if (parseBound(raw) === value) return raw;
+
+    return value === null ? '' : String(value);
+  };
+
   const clearColumn = () => {
+    setRawBounds({ min: '', max: '' });
     onFiltersChange({
       text: { ...filters.text, [column.id]: '' },
       enum: { ...filters.enum, [column.id]: [] },
@@ -112,13 +131,13 @@ export const DataTableFilterPopover = <T,>({ column, rows, filters, active, onFi
           {column.filter === 'range' && (
             <div className="flex items-center gap-x-2">
               <Input
-                value={range.min === null ? '' : String(range.min)}
+                value={boundValue('min', range.min)}
                 placeholder={t('dataTable.min')}
                 width="full"
                 onChange={value => setBound('min', value)}
               />
               <Input
-                value={range.max === null ? '' : String(range.max)}
+                value={boundValue('max', range.max)}
                 placeholder={t('dataTable.max')}
                 width="full"
                 onChange={value => setBound('max', value)}

--- a/src/renderer/shared/ui-kit/DataTable/filtering.test.ts
+++ b/src/renderer/shared/ui-kit/DataTable/filtering.test.ts
@@ -122,6 +122,38 @@ describe('sortRows', () => {
     expect(sortRows(rows, columns, { column: 'actions', direction: 'asc' })).toBe(rows);
     expect(sortRows(rows, columns, null)).toBe(rows);
   });
+
+  /**
+   * A column that compares as big integers (planck amounts run past
+   * `Number.MAX_SAFE_INTEGER`) still has to sink its unknowns in both
+   * directions — multiplying the comparator's own null sentinel by the sort
+   * direction floated every `—` row to the top of a descending sort.
+   */
+  test('unknown values sort last in both directions on a compare column', () => {
+    const compareColumns: DataTableColumn<Row>[] = [
+      {
+        id: 'staked',
+        title: 'Staked',
+        sortable: true,
+        text: r => (r.staked === null ? '—' : String(r.staked)),
+        value: r => r.staked,
+        // The same shape as the real planck comparator: a direction-independent
+        // sentinel for the unknown side, which is exactly what breaks when the
+        // caller multiplies the result by the sort direction.
+        compare: (a, b) => {
+          if (a.staked === null && b.staked === null) return 0;
+          if (a.staked === null) return 1;
+          if (b.staked === null) return -1;
+
+          return a.staked - b.staked;
+        },
+        render: r => r.staked,
+      },
+    ];
+
+    expect(ids(sortRows(rows, compareColumns, { column: 'staked', direction: 'asc' }))).toEqual(['2', '1', '3']);
+    expect(ids(sortRows(rows, compareColumns, { column: 'staked', direction: 'desc' }))).toEqual(['1', '2', '3']);
+  });
 });
 
 describe('filter bookkeeping', () => {

--- a/src/renderer/shared/ui-kit/DataTable/filtering.test.ts
+++ b/src/renderer/shared/ui-kit/DataTable/filtering.test.ts
@@ -1,0 +1,145 @@
+import { describe, expect, test } from 'vitest';
+
+import {
+  countActiveFilters,
+  emptyFilterState,
+  enumOptions,
+  filterRows,
+  isColumnFiltered,
+  searchRows,
+  sortRows,
+} from './filtering';
+import { type DataTableColumn } from './types';
+
+type Row = {
+  id: string;
+  name: string;
+  chain: string;
+  staked: number | null;
+};
+
+const rows: Row[] = [
+  { id: '1', name: 'Treasury', chain: 'Polkadot Asset Hub', staked: 300 },
+  { id: '2', name: 'Ops wallet', chain: 'Kusama Asset Hub', staked: 100 },
+  { id: '3', name: 'Cold storage', chain: 'Polkadot Asset Hub', staked: null },
+];
+
+const columns: DataTableColumn<Row>[] = [
+  { id: 'name', title: 'Account', filter: 'text', sortable: true, text: r => r.name, render: r => r.name },
+  { id: 'chain', title: 'Chain', filter: 'enum', sortable: true, text: r => r.chain, render: r => r.chain },
+  {
+    id: 'staked',
+    title: 'Staked',
+    filter: 'range',
+    sortable: true,
+    text: r => (r.staked === null ? '—' : String(r.staked)),
+    value: r => r.staked,
+    render: r => r.staked,
+  },
+  { id: 'actions', title: '', decorative: true, render: () => null },
+];
+
+const ids = (list: Row[]) => list.map(r => r.id);
+
+describe('enumOptions', () => {
+  test('lists the distinct rendered values alphabetically', () => {
+    expect(enumOptions(rows, columns[1]!)).toEqual(['Kusama Asset Hub', 'Polkadot Asset Hub']);
+  });
+});
+
+describe('searchRows', () => {
+  test('keeps the source order instead of re-ranking by match weight', () => {
+    expect(ids(searchRows(rows, columns, 'o'))).toEqual(['1', '2', '3']);
+  });
+
+  test('matches any column the user can read', () => {
+    expect(ids(searchRows(rows, columns, 'kusama'))).toEqual(['2']);
+    expect(ids(searchRows(rows, columns, 'cold'))).toEqual(['3']);
+  });
+
+  test('an empty query filters nothing', () => {
+    expect(searchRows(rows, columns, '   ')).toBe(rows);
+  });
+});
+
+describe('filterRows', () => {
+  test('no active filter returns the same array', () => {
+    expect(filterRows(rows, columns, emptyFilterState())).toBe(rows);
+  });
+
+  test('text filter is a case-insensitive substring of the rendered string', () => {
+    const state = { ...emptyFilterState(), text: { name: 'trea' } };
+
+    expect(ids(filterRows(rows, columns, state))).toEqual(['1']);
+  });
+
+  test('enum filter keeps only the ticked values', () => {
+    const state = { ...emptyFilterState(), enum: { chain: ['Kusama Asset Hub'] } };
+
+    expect(ids(filterRows(rows, columns, state))).toEqual(['2']);
+  });
+
+  test('range filter honours each bound independently', () => {
+    expect(
+      ids(filterRows(rows, columns, { ...emptyFilterState(), range: { staked: { min: 200, max: null } } })),
+    ).toEqual(['1']);
+    expect(
+      ids(filterRows(rows, columns, { ...emptyFilterState(), range: { staked: { min: null, max: 200 } } })),
+    ).toEqual(['2']);
+  });
+
+  test('a row whose value is unknown never satisfies a bound', () => {
+    const state = { ...emptyFilterState(), range: { staked: { min: null, max: 1000 } } };
+
+    expect(ids(filterRows(rows, columns, state))).not.toContain('3');
+  });
+
+  test('filters compose', () => {
+    const state = {
+      ...emptyFilterState(),
+      enum: { chain: ['Polkadot Asset Hub'] },
+      range: { staked: { min: 200, max: null } },
+    };
+
+    expect(ids(filterRows(rows, columns, state))).toEqual(['1']);
+  });
+});
+
+describe('sortRows', () => {
+  test('sorts numerically when the column carries a value', () => {
+    expect(ids(sortRows(rows, columns, { column: 'staked', direction: 'asc' }))).toEqual(['2', '1', '3']);
+  });
+
+  test('unknown values sort last in both directions', () => {
+    expect(ids(sortRows(rows, columns, { column: 'staked', direction: 'desc' }))).toEqual(['1', '2', '3']);
+  });
+
+  test('falls back to the rendered string when there is no numeric value', () => {
+    expect(ids(sortRows(rows, columns, { column: 'name', direction: 'asc' }))).toEqual(['3', '2', '1']);
+  });
+
+  test('a non-sortable or unknown column leaves the order alone', () => {
+    expect(sortRows(rows, columns, { column: 'actions', direction: 'asc' })).toBe(rows);
+    expect(sortRows(rows, columns, null)).toBe(rows);
+  });
+});
+
+describe('filter bookkeeping', () => {
+  test('counts each narrowed column once', () => {
+    const state = {
+      text: { name: 'a', chain: '  ' },
+      enum: { chain: [] as string[] },
+      range: { staked: { min: 1, max: null } },
+    };
+
+    expect(countActiveFilters(state)).toBe(2);
+  });
+
+  test('reports which column is narrowed', () => {
+    const state = { ...emptyFilterState(), enum: { chain: ['Kusama Asset Hub'] } };
+
+    expect(isColumnFiltered(state, columns[1]!)).toBe(true);
+    expect(isColumnFiltered(state, columns[0]!)).toBe(false);
+    expect(isColumnFiltered(state, columns[3]!)).toBe(false);
+  });
+});

--- a/src/renderer/shared/ui-kit/DataTable/filtering.ts
+++ b/src/renderer/shared/ui-kit/DataTable/filtering.ts
@@ -93,19 +93,25 @@ export const sortRows = <T>(rows: T[], columns: DataTableColumn<T>[], sort: Tabl
   const sign = sort.direction === 'asc' ? 1 : -1;
 
   return [...rows].sort((a, b) => {
-    if (column.compare) {
-      return column.compare(a, b) * sign;
-    }
-
+    // Unknowns are settled before the direction is applied, so they sink in
+    // both directions. Leaving it to `compare` and multiplying its result by
+    // `sign` floated every `—` row to the top of a descending sort — which is
+    // most rows on a column like Self stake.
     if (column.value) {
       const left = column.value(a);
       const right = column.value(b);
 
-      if (left === null && right === null) return 0;
-      if (left === null) return 1;
-      if (right === null) return -1;
+      if (left === null || right === null) {
+        if (left === null && right === null) return 0;
 
-      return (left - right) * sign;
+        return left === null ? 1 : -1;
+      }
+
+      if (!column.compare) return (left - right) * sign;
+    }
+
+    if (column.compare) {
+      return column.compare(a, b) * sign;
     }
 
     return columnText(column, a).localeCompare(columnText(column, b)) * sign;

--- a/src/renderer/shared/ui-kit/DataTable/filtering.ts
+++ b/src/renderer/shared/ui-kit/DataTable/filtering.ts
@@ -1,0 +1,135 @@
+import { type TableSort } from '../Table';
+
+import { type DataTableColumn, type DataTableFilterState, EMPTY_FILTER_STATE } from './types';
+
+const columnText = <T>(column: DataTableColumn<T>, row: T): string => column.text?.(row) ?? '';
+
+/**
+ * The distinct display strings an `enum` column carries, in alphabetical order.
+ *
+ * Built from the rows themselves rather than from a hard-coded list, so a
+ * filter never offers an option that cannot match anything, and never hides one
+ * the data does contain.
+ */
+export const enumOptions = <T>(rows: T[], column: DataTableColumn<T>): string[] => {
+  const seen = new Set<string>();
+  for (const row of rows) {
+    const text = columnText(column, row);
+    if (text) seen.add(text);
+  }
+
+  return [...seen].sort((a, b) => a.localeCompare(b));
+};
+
+/**
+ * Rows the query matches, **in their original order**.
+ *
+ * Deliberately a predicate rather than `performSearch`: these tables are
+ * ordered by something that means something (stake, fiat value), and re-ranking
+ * them by match weight would destroy the ordering the user is reading. Matching
+ * runs over the columns' display strings, which is what the user typed from.
+ */
+export const searchRows = <T>(rows: T[], columns: DataTableColumn<T>[], query: string): T[] => {
+  const trimmed = query.trim().toLowerCase();
+  if (!trimmed) return rows;
+
+  const searchable = columns.filter(column => !column.decorative && column.text);
+
+  return rows.filter(row => searchable.some(column => columnText(column, row).toLowerCase().includes(trimmed)));
+};
+
+export const filterRows = <T>(rows: T[], columns: DataTableColumn<T>[], state: DataTableFilterState): T[] => {
+  const byId = new Map(columns.map(column => [column.id, column]));
+
+  const textEntries = Object.entries(state.text).filter(([, query]) => query.trim() !== '');
+  const enumEntries = Object.entries(state.enum).filter(([, selected]) => selected.length > 0);
+  const rangeEntries = Object.entries(state.range).filter(([, range]) => range.min !== null || range.max !== null);
+
+  if (textEntries.length === 0 && enumEntries.length === 0 && rangeEntries.length === 0) {
+    return rows;
+  }
+
+  return rows.filter(row => {
+    for (const [id, query] of textEntries) {
+      const column = byId.get(id);
+      if (!column) continue;
+      if (!columnText(column, row).toLowerCase().includes(query.trim().toLowerCase())) return false;
+    }
+
+    for (const [id, selected] of enumEntries) {
+      const column = byId.get(id);
+      if (!column) continue;
+      if (!selected.includes(columnText(column, row))) return false;
+    }
+
+    for (const [id, range] of rangeEntries) {
+      const column = byId.get(id);
+      if (!column) continue;
+
+      const value = column.value?.(row) ?? null;
+      // A row whose value is unknown is not evidence of anything, so a bound
+      // never claims it — it drops out rather than passing as a zero.
+      if (value === null) return false;
+      if (range.min !== null && value < range.min) return false;
+      if (range.max !== null && value > range.max) return false;
+    }
+
+    return true;
+  });
+};
+
+/**
+ * Sorts by the column's numeric `value` when it has one, by its display string
+ * otherwise. Rows with an unknown value sort last in **both** directions: they
+ * say "not read yet", and parking them at the top of a descending sort would
+ * read as "these are the biggest".
+ */
+export const sortRows = <T>(rows: T[], columns: DataTableColumn<T>[], sort: TableSort | null): T[] => {
+  if (!sort) return rows;
+
+  const column = columns.find(c => c.id === sort.column);
+  if (!column?.sortable) return rows;
+
+  const sign = sort.direction === 'asc' ? 1 : -1;
+
+  return [...rows].sort((a, b) => {
+    if (column.value) {
+      const left = column.value(a);
+      const right = column.value(b);
+
+      if (left === null && right === null) return 0;
+      if (left === null) return 1;
+      if (right === null) return -1;
+
+      return (left - right) * sign;
+    }
+
+    return columnText(column, a).localeCompare(columnText(column, b)) * sign;
+  });
+};
+
+export const countActiveFilters = (state: DataTableFilterState): number => {
+  const text = Object.values(state.text).filter(query => query.trim() !== '').length;
+  const enums = Object.values(state.enum).filter(selected => selected.length > 0).length;
+  const ranges = Object.values(state.range).filter(range => range.min !== null || range.max !== null).length;
+
+  return text + enums + ranges;
+};
+
+export const isColumnFiltered = <T>(state: DataTableFilterState, column: DataTableColumn<T>): boolean => {
+  switch (column.filter) {
+    case 'text':
+      return (state.text[column.id] ?? '').trim() !== '';
+    case 'enum':
+      return (state.enum[column.id] ?? []).length > 0;
+    case 'range': {
+      const range = state.range[column.id];
+
+      return Boolean(range && (range.min !== null || range.max !== null));
+    }
+    default:
+      return false;
+  }
+};
+
+export const emptyFilterState = (): DataTableFilterState => structuredClone(EMPTY_FILTER_STATE);

--- a/src/renderer/shared/ui-kit/DataTable/filtering.ts
+++ b/src/renderer/shared/ui-kit/DataTable/filtering.ts
@@ -93,6 +93,10 @@ export const sortRows = <T>(rows: T[], columns: DataTableColumn<T>[], sort: Tabl
   const sign = sort.direction === 'asc' ? 1 : -1;
 
   return [...rows].sort((a, b) => {
+    if (column.compare) {
+      return column.compare(a, b) * sign;
+    }
+
     if (column.value) {
       const left = column.value(a);
       const right = column.value(b);

--- a/src/renderer/shared/ui-kit/DataTable/index.ts
+++ b/src/renderer/shared/ui-kit/DataTable/index.ts
@@ -1,0 +1,4 @@
+export type { DataTableColumn, DataTableFilterKind, DataTableFilterState, DataTableRange } from './types';
+export { EMPTY_FILTER_STATE } from './types';
+export { countActiveFilters, emptyFilterState, enumOptions, filterRows, searchRows, sortRows } from './filtering';
+export { DataTable } from './DataTable';

--- a/src/renderer/shared/ui-kit/DataTable/types.ts
+++ b/src/renderer/shared/ui-kit/DataTable/types.ts
@@ -1,0 +1,61 @@
+import { type ReactNode } from 'react';
+
+/**
+ * How a column may be narrowed from its header.
+ *
+ * - `text` — substring over the string the cell renders;
+ * - `enum` — tick-list of the distinct values present in the data;
+ * - `range` — numeric min/max over {@link DataTableColumn.value}.
+ */
+export type DataTableFilterKind = 'text' | 'enum' | 'range';
+
+export type DataTableColumn<T> = {
+  /** Stable id. Also the key the sort and the filter state are stored under. */
+  id: string;
+  title: ReactNode;
+  width?: string;
+  sortable?: boolean;
+  /** Omit for a column that cannot be filtered (actions, icons). */
+  filter?: DataTableFilterKind;
+  /**
+   * The string the user actually reads in this cell.
+   *
+   * Search, the `text`/`enum` filters and the CSV export all run over this, so
+   * a resolved account name or a prefixed address must be supplied here rather
+   * than the raw record field — a query typed from what is on screen has to
+   * match what is on screen.
+   */
+  text?: (row: T) => string;
+  /**
+   * The number behind the cell. Drives sorting and the `range` filter; `null`
+   * for a row whose value is unknown, which always sorts last.
+   */
+  value?: (row: T) => number | null;
+  /**
+   * Full-precision value for the CSV. Falls back to {@link text} — the screen
+   * abbreviates, a spreadsheet is where people do arithmetic.
+   */
+  exportValue?: (row: T) => string;
+  render: (row: T) => ReactNode;
+  /**
+   * Presentational column (chevrons, access-mode glyphs). Excluded from search
+   * and from the export.
+   */
+  decorative?: boolean;
+};
+
+export type DataTableRange = {
+  min: number | null;
+  max: number | null;
+};
+
+export type DataTableFilterState = {
+  /** ColumnId → substring */
+  text: Record<string, string>;
+  /** ColumnId → the display strings that stay visible */
+  enum: Record<string, string[]>;
+  /** ColumnId → numeric bounds */
+  range: Record<string, DataTableRange>;
+};
+
+export const EMPTY_FILTER_STATE: DataTableFilterState = { text: {}, enum: {}, range: {} };

--- a/src/renderer/shared/ui-kit/DataTable/types.ts
+++ b/src/renderer/shared/ui-kit/DataTable/types.ts
@@ -32,6 +32,13 @@ export type DataTableColumn<T> = {
    */
   value?: (row: T) => number | null;
   /**
+   * Exact ordering, when a `number` cannot express it — planck amounts run past
+   * `Number.MAX_SAFE_INTEGER`, so a column that must not mis-order two large
+   * bonds compares them as big integers here. Takes precedence over
+   * {@link value} for sorting only; filtering still uses `value`.
+   */
+  compare?: (a: T, b: T) => number;
+  /**
    * Full-precision value for the CSV. Falls back to {@link text} — the screen
    * abbreviates, a spreadsheet is where people do arithmetic.
    */

--- a/src/renderer/shared/ui-kit/index.ts
+++ b/src/renderer/shared/ui-kit/index.ts
@@ -49,6 +49,14 @@ export {
   type TableVirtualization,
   Table,
 } from './Table';
+export {
+  type DataTableColumn,
+  type DataTableFilterKind,
+  type DataTableFilterState,
+  type DataTableRange,
+  DataTable,
+  emptyFilterState,
+} from './DataTable';
 export { Indicator } from './Indicator/Indicator';
 export { NotificationProvider, useNotification } from './NotificationContext';
 export { Speedometer } from './Speedometer/Speedomenter';


### PR DESCRIPTION
## Changes Made

**Shared**

- `ui-kit/DataTable` — sortable columns, per-column filters (tick-list / substring / numeric range), one search box, CSV
  export, sticky header, horizontal scroll. Everything runs over the **strings the columns render**, never the
  underlying record, so a query typed from what is on screen matches what is on screen.

**Overview tab**

- New **Balances by Account** card: one row per (account × chain) over the chain's native asset, split into
  Transferable / Staked / Governance / Other. `splitBalanceByPurpose` answers "what are these funds doing", which does
  not line up with the existing reserved/frozen split — staking on Asset Hub is a hold, conviction voting is a freeze,
  and one account can carry both. Staked comes from the bonded ledger, never from the deprecated `STAKING` lock.
- Preset delete now asks for confirmation (the i18n keys had been sitting there unused).
- Presets gained a **Network** filter, and the selector gained an ad-hoc **quick filter** popover (network / source /
  entity / contact type) applied on top of the active preset and deliberately not persisted.

**Staking tab**

- Positions table gained Network, Chain, Address, **Type** (validator/nominator) and the **Total balance / Nominating
  stake / Self stake** trio, plus per-column filters and CSV export.
- New **Rewards by Account** card and a **Custom** date range on the reward period tabs, with a realised annualised
  yield beside the network's own rate.
- New **Minimum Active-Set Stake** card — the smallest total backing any elected validator, over the last 7 closed
  eras.
- The claim modal now names the **dates** of the oldest unclaimed era (`earned 2 Jul, expires 24 Sep`) instead of only
  counting eras.

**Layout**

- Widgets can be **hidden and restored** (a tray appears in edit mode holding what was put away).
- Widgets can be **resized and pinned to a start column**. This is what unblocks "move the staking overview under the
  price tracker": CSS auto-placement fills row by row, so no ordering of a flat list can put a narrow card under a wide
  one — pinning its start column can. An absent placement means "wherever the flow puts it", which is what every saved
  layout already means, so **nothing had to be migrated**.

### Behaviour change worth flagging

Deriving the position role exposed that a stash **validating in the active era was reported as `Bonded`** — the opposite
of the truth. It now reports `Active`. Covered by new domain tests.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
