### PR TITLE
feat(staking): network average reward rate beside est. apy

### DIFF
--- a/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
@@ -9,7 +9,7 @@ import { apyService } from '../service';
 vi.mock('@/shared/pallet/staking', () => ({
   stakingPallet: {
     consts: { sessionsPerEra: vi.fn(), historyDepth: vi.fn() },
-    storage: { erasTotalStake: vi.fn(), erasValidatorReward: vi.fn() },
+    storage: { erasTotalStake: vi.fn(), erasTotalStakeMulti: vi.fn(), erasValidatorReward: vi.fn() },
   },
 }));
 
@@ -21,7 +21,7 @@ const storage = vi.mocked(stakingPallet.storage);
 const TO_STAKERS = '1301621489239150';
 const TOTAL_STAKED = '8739307348715573817';
 
-const mockApi = () => ({ query: {} }) as unknown as ApiPromise;
+const mockApi = () => ({}) as unknown as ApiPromise;
 
 // Relay chain: 24h era = 6 sessions × 2400 blocks × 6000ms.
 const relayApi = (epochDuration = 2400, blockTime = 6000): ApiPromise =>
@@ -45,13 +45,20 @@ const constantRewards = () => {
   );
 };
 
+/** Every requested era answers with the same constant total stake. */
+const constantStakes = () => {
+  storage.erasTotalStakeMulti.mockImplementation((_, eras) =>
+    Promise.resolve(eras.map(era => ({ era, totalStake: new BN(TOTAL_STAKED) }))),
+  );
+};
+
 describe('getNetworkAvgRewardRate', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     consts.sessionsPerEra.mockReturnValue(6);
     consts.historyDepth.mockReturnValue(84);
-    storage.erasTotalStake.mockResolvedValue(new BN(TOTAL_STAKED));
     constantRewards();
+    constantStakes();
   });
 
   test('averages the realized rate over a 30 era window on a 24h era chain', async () => {
@@ -109,7 +116,7 @@ describe('getNetworkAvgRewardRate', () => {
     expect(rate).toEqual({ ratePercent: '10.88', fromEra: 0, toEra: 1, days: 2 });
   });
 
-  test('skips eras with no recorded reward and averages the rest', async () => {
+  test('skips eras with no recorded reward and reports the window of eras that actually contributed', async () => {
     storage.erasValidatorReward.mockImplementation((_, eras) =>
       Promise.resolve(eras.map(era => ({ era, reward: era < 85 ? null : new BN(TO_STAKERS) }))),
     );
@@ -122,7 +129,28 @@ describe('getNetworkAvgRewardRate', () => {
       validators: validators(0),
     });
 
-    expect(rate?.ratePercent).toEqual('5.44');
+    // Window is [70..99], but only [85..99] (15 eras) produced a rate.
+    expect(rate).toEqual({ ratePercent: '5.44', fromEra: 85, toEra: 99, days: 15 });
+  });
+
+  test('aligns reward and stake reads by era instead of assuming matching order', async () => {
+    storage.erasTotalStakeMulti.mockImplementation((_, eras) =>
+      Promise.resolve(
+        eras.map(era => ({ era, totalStake: era === 0 ? new BN(TOTAL_STAKED) : new BN(TOTAL_STAKED).muln(2) })),
+      ),
+    );
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 2,
+      validators: validators(0),
+    });
+
+    // Era 0 rate is the 5.44% baseline; era 1's stake is doubled, halving its
+    // rate to 2.72% — the mean of the two is 4.08%.
+    expect(rate).toEqual({ ratePercent: '4.08', fromEra: 0, toEra: 1, days: 2 });
   });
 
   test('reduces the gross average by the median validator commission', async () => {
@@ -168,8 +196,24 @@ describe('getNetworkAvgRewardRate', () => {
     expect(rate).toBeNull();
   });
 
+  test('returns null when the stake history query fails instead of narrowing the average', async () => {
+    storage.erasTotalStakeMulti.mockRejectedValue(new Error('disconnected'));
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+  });
+
   test('returns null when every era reports zero total stake', async () => {
-    storage.erasTotalStake.mockResolvedValue(new BN(0));
+    storage.erasTotalStakeMulti.mockImplementation((_, eras) =>
+      Promise.resolve(eras.map(era => ({ era, totalStake: new BN(0) }))),
+    );
 
     const rate = await apyService.getNetworkAvgRewardRate({
       api: mockApi(),
@@ -196,5 +240,18 @@ describe('getNetworkAvgRewardRate', () => {
     });
 
     expect(rate).toBeNull();
+  });
+
+  test('returns null for era 0 without querying reward history', async () => {
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 0,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+    expect(storage.erasValidatorReward).not.toHaveBeenCalled();
   });
 });

--- a/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
@@ -36,7 +36,9 @@ const relayApi = (epochDuration = 2400, blockTime = 6000): ApiPromise =>
 
 const polkadotAh = { chainId: AssetHubChains.POLKADOT_AH } as Chain;
 
-const validators = (...commissions: number[]) => commissions.map(commission => ({ commission }));
+const loadValidators = (...commissions: number[]) => {
+  return async () => commissions.map(commission => ({ commission }));
+};
 
 /** Every requested era answers with the same constant reward. */
 const constantRewards = () => {
@@ -67,7 +69,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0, 0, 0),
+      loadValidators: loadValidators(0, 0, 0),
     });
 
     // 30d / 24h era = 30 completed eras: [70..99].
@@ -85,7 +87,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(600),
       chain: { chainId: AssetHubChains.KUSAMA_AH } as Chain,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     // 30d / 6h era = 120 eras wanted, capped at depth 84 → [16..99] ≈ 21 days.
@@ -109,7 +111,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 2,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     // 2× the single-era 5.44% baseline.
@@ -126,7 +128,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     // Window is [70..99], but only [85..99] (15 eras) produced a rate.
@@ -145,7 +147,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 2,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     // Era 0 rate is the 5.44% baseline; era 1's stake is doubled, halving its
@@ -159,7 +161,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(10, 10, 10),
+      loadValidators: loadValidators(10, 10, 10),
     });
 
     // 5.44 × (1 − 0.10)
@@ -176,7 +178,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     expect(rate).toBeNull();
@@ -184,13 +186,28 @@ describe('getNetworkAvgRewardRate', () => {
 
   test('returns null when the reward history query fails instead of guessing', async () => {
     storage.erasValidatorReward.mockRejectedValue(new Error('disconnected'));
+    const load = vi.fn(loadValidators(0));
 
     const rate = await apyService.getNetworkAvgRewardRate({
       api: mockApi(),
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: load,
+    });
+
+    expect(rate).toBeNull();
+    // The expensive prefs read must not run for a chain that produced no average.
+    expect(load).not.toHaveBeenCalled();
+  });
+
+  test('returns null when the validator prefs query fails instead of showing a gross rate', async () => {
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      loadValidators: vi.fn().mockRejectedValue(new Error('disconnected')),
     });
 
     expect(rate).toBeNull();
@@ -204,7 +221,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     expect(rate).toBeNull();
@@ -220,7 +237,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     expect(rate).toBeNull();
@@ -236,7 +253,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 100,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     expect(rate).toBeNull();
@@ -248,7 +265,7 @@ describe('getNetworkAvgRewardRate', () => {
       timelineApi: relayApi(),
       chain: polkadotAh,
       era: 0,
-      validators: validators(0),
+      loadValidators: loadValidators(0),
     });
 
     expect(rate).toBeNull();

--- a/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
@@ -133,7 +133,7 @@ describe('getNetworkAvgRewardRate', () => {
     expect(rate).toEqual({ ratePercent: '5.44', fromEra: 85, toEra: 99, days: 15 });
   });
 
-  test('aligns reward and stake reads by era instead of assuming matching order', async () => {
+  test('honours per-era stake when averaging across the window', async () => {
     storage.erasTotalStakeMulti.mockImplementation((_, eras) =>
       Promise.resolve(
         eras.map(era => ({ era, totalStake: era === 0 ? new BN(TOTAL_STAKED) : new BN(TOTAL_STAKED).muln(2) })),

--- a/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
+++ b/src/renderer/domains/staking/apy/__tests__/networkAvgRate.test.ts
@@ -1,0 +1,200 @@
+import { type ApiPromise } from '@polkadot/api';
+import { BN } from '@polkadot/util';
+
+import { type Chain } from '@/shared/core';
+import { stakingPallet } from '@/shared/pallet/staking';
+import { AssetHubChains } from '../../constants';
+import { apyService } from '../service';
+
+vi.mock('@/shared/pallet/staking', () => ({
+  stakingPallet: {
+    consts: { sessionsPerEra: vi.fn(), historyDepth: vi.fn() },
+    storage: { erasTotalStake: vi.fn(), erasValidatorReward: vi.fn() },
+  },
+}));
+
+const consts = vi.mocked(stakingPallet.consts);
+const storage = vi.mocked(stakingPallet.storage);
+
+// Polkadot Asset Hub-like figures: a per-era staker reward of 130 162 DOT over
+// a 24h era, against ~873.9M DOT staked → ~5.44% APR per era.
+const TO_STAKERS = '1301621489239150';
+const TOTAL_STAKED = '8739307348715573817';
+
+const mockApi = () => ({ query: {} }) as unknown as ApiPromise;
+
+// Relay chain: 24h era = 6 sessions × 2400 blocks × 6000ms.
+const relayApi = (epochDuration = 2400, blockTime = 6000): ApiPromise =>
+  ({
+    consts: {
+      babe: {
+        epochDuration: { toString: () => String(epochDuration) },
+        expectedBlockTime: { toString: () => String(blockTime) },
+      },
+    },
+  }) as unknown as ApiPromise;
+
+const polkadotAh = { chainId: AssetHubChains.POLKADOT_AH } as Chain;
+
+const validators = (...commissions: number[]) => commissions.map(commission => ({ commission }));
+
+/** Every requested era answers with the same constant reward. */
+const constantRewards = () => {
+  storage.erasValidatorReward.mockImplementation((_, eras) =>
+    Promise.resolve(eras.map(era => ({ era, reward: new BN(TO_STAKERS) }))),
+  );
+};
+
+describe('getNetworkAvgRewardRate', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    consts.sessionsPerEra.mockReturnValue(6);
+    consts.historyDepth.mockReturnValue(84);
+    storage.erasTotalStake.mockResolvedValue(new BN(TOTAL_STAKED));
+    constantRewards();
+  });
+
+  test('averages the realized rate over a 30 era window on a 24h era chain', async () => {
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0, 0, 0),
+    });
+
+    // 30d / 24h era = 30 completed eras: [70..99].
+    expect(storage.erasValidatorReward).toHaveBeenCalledWith(
+      expect.anything(),
+      Array.from({ length: 30 }, (_, index) => 70 + index),
+    );
+    expect(rate).toEqual({ ratePercent: '5.44', fromEra: 70, toEra: 99, days: 30 });
+  });
+
+  test('caps the window at HistoryDepth on a 6h era chain and reports the real day count', async () => {
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      // 6h era: 6 sessions × 600 blocks × 6000ms.
+      timelineApi: relayApi(600),
+      chain: { chainId: AssetHubChains.KUSAMA_AH } as Chain,
+      era: 100,
+      validators: validators(0),
+    });
+
+    // 30d / 6h era = 120 eras wanted, capped at depth 84 → [16..99] ≈ 21 days.
+    // Per-era rate is 4× the 24h-era baseline (4× the eras per year).
+    expect(rate).toEqual({ ratePercent: '21.76', fromEra: 16, toEra: 99, days: 21 });
+  });
+
+  test('shrinks the window on a chain younger than 30 days and truly averages the eras', async () => {
+    storage.erasValidatorReward.mockImplementation((_, eras) =>
+      Promise.resolve(
+        eras.map(era => ({
+          era,
+          // Era 0 pays the baseline, era 1 pays 3× — the mean is 2× the baseline.
+          reward: era === 0 ? new BN(TO_STAKERS) : new BN(TO_STAKERS).muln(3),
+        })),
+      ),
+    );
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 2,
+      validators: validators(0),
+    });
+
+    // 2× the single-era 5.44% baseline.
+    expect(rate).toEqual({ ratePercent: '10.88', fromEra: 0, toEra: 1, days: 2 });
+  });
+
+  test('skips eras with no recorded reward and averages the rest', async () => {
+    storage.erasValidatorReward.mockImplementation((_, eras) =>
+      Promise.resolve(eras.map(era => ({ era, reward: era < 85 ? null : new BN(TO_STAKERS) }))),
+    );
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate?.ratePercent).toEqual('5.44');
+  });
+
+  test('reduces the gross average by the median validator commission', async () => {
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(10, 10, 10),
+    });
+
+    // 5.44 × (1 − 0.10)
+    expect(rate?.ratePercent).toEqual('4.90');
+  });
+
+  test('returns null when no era in the window has a recorded reward — never the NPoS curve', async () => {
+    storage.erasValidatorReward.mockImplementation((_, eras) =>
+      Promise.resolve(eras.map(era => ({ era, reward: null }))),
+    );
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+  });
+
+  test('returns null when the reward history query fails instead of guessing', async () => {
+    storage.erasValidatorReward.mockRejectedValue(new Error('disconnected'));
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+  });
+
+  test('returns null when every era reports zero total stake', async () => {
+    storage.erasTotalStake.mockResolvedValue(new BN(0));
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+  });
+
+  test('returns null when the runtime exposes no HistoryDepth', async () => {
+    consts.historyDepth.mockImplementation(() => {
+      throw new Error('no staking pallet');
+    });
+
+    const rate = await apyService.getNetworkAvgRewardRate({
+      api: mockApi(),
+      timelineApi: relayApi(),
+      chain: polkadotAh,
+      era: 100,
+      validators: validators(0),
+    });
+
+    expect(rate).toBeNull();
+  });
+});

--- a/src/renderer/domains/staking/apy/hooks.ts
+++ b/src/renderer/domains/staking/apy/hooks.ts
@@ -2,26 +2,12 @@ import { type NullableMap } from '@/shared/core';
 import { nonNullableMap } from '@/shared/lib/utils';
 import { useResource } from '@/shared/query';
 
-import { type ApyResourceParams, type NetworkAvgRateParams, apyResource, networkAvgRateResource } from './resource';
-import { type NetworkAvgRate } from './service';
+import { type ApyResourceParams, apyResource } from './resource';
 
 export const useNetworkApy = (params: NullableMap<ApyResourceParams>) => {
   return useResource(apyResource, {
     params: nonNullableMap(params) ? params : null,
     defaultValue: undefined as string | undefined,
-    map: (cache, { chainId }) => cache[chainId] ?? undefined,
-  });
-};
-
-/**
- * `data` is `undefined` while loading AND when the rate is measured as unknown
- * — distinguish via `pending`: `data === undefined && !pending` means the chain
- * could not report a rate.
- */
-export const useNetworkAvgRate = (params: NullableMap<NetworkAvgRateParams>) => {
-  return useResource(networkAvgRateResource, {
-    params: nonNullableMap(params) ? params : null,
-    defaultValue: undefined as NetworkAvgRate | undefined,
     map: (cache, { chainId }) => cache[chainId] ?? undefined,
   });
 };

--- a/src/renderer/domains/staking/apy/hooks.ts
+++ b/src/renderer/domains/staking/apy/hooks.ts
@@ -13,6 +13,11 @@ export const useNetworkApy = (params: NullableMap<ApyResourceParams>) => {
   });
 };
 
+/**
+ * `data` is `undefined` while loading AND when the rate is measured as unknown
+ * — distinguish via `pending`: `data === undefined && !pending` means the chain
+ * could not report a rate.
+ */
 export const useNetworkAvgRate = (params: NullableMap<NetworkAvgRateParams>) => {
   return useResource(networkAvgRateResource, {
     params: nonNullableMap(params) ? params : null,

--- a/src/renderer/domains/staking/apy/hooks.ts
+++ b/src/renderer/domains/staking/apy/hooks.ts
@@ -2,12 +2,21 @@ import { type NullableMap } from '@/shared/core';
 import { nonNullableMap } from '@/shared/lib/utils';
 import { useResource } from '@/shared/query';
 
-import { type ApyResourceParams, apyResource } from './resource';
+import { type ApyResourceParams, type NetworkAvgRateParams, apyResource, networkAvgRateResource } from './resource';
+import { type NetworkAvgRate } from './service';
 
 export const useNetworkApy = (params: NullableMap<ApyResourceParams>) => {
   return useResource(apyResource, {
     params: nonNullableMap(params) ? params : null,
     defaultValue: undefined as string | undefined,
+    map: (cache, { chainId }) => cache[chainId] ?? undefined,
+  });
+};
+
+export const useNetworkAvgRate = (params: NullableMap<NetworkAvgRateParams>) => {
+  return useResource(networkAvgRateResource, {
+    params: nonNullableMap(params) ? params : null,
+    defaultValue: undefined as NetworkAvgRate | undefined,
     map: (cache, { chainId }) => cache[chainId] ?? undefined,
   });
 };

--- a/src/renderer/domains/staking/apy/resource.ts
+++ b/src/renderer/domains/staking/apy/resource.ts
@@ -45,19 +45,23 @@ const $networkAvgRateCache = createStore<Record<ChainId, NetworkAvgRate | null>>
  * `apyResource`: a rollover changes the key and triggers exactly one refetch; a
  * window of closed eras never changes, so a non-null result never goes stale; a
  * `null` (unknown) result is not cached and is re-requested on the next mount -
- * deliberate, it doubles as retry after a transient failure. The
- * `erasValidatorPrefs` read duplicates the one in `apyResource` — accepted,
- * both requests run once per era per chain.
+ * deliberate, it doubles as retry after a transient failure. To keep that retry
+ * cheap, the validator prefs (the heaviest read, duplicated with `apyResource`
+ * — accepted, once per era per chain) load lazily: an unmeasurable chain never
+ * pays for them.
  */
 export const networkAvgRateResource = createQueryResource<NetworkAvgRateParams>({
   key: ({ chainId, era }) => [chainId, String(era)],
 })
   .name('networkAvgRewardRate')
   .request<NetworkAvgRate | null>(async ({ api, timelineApi, chain, era }) => {
-    const prefs = await stakingPallet.storage.erasValidatorPrefs(api, era);
-    const validators = prefs.map(({ prefs }) => ({ commission: perbillToPercent(prefs.commission) }));
+    const loadValidators = async () => {
+      const prefs = await stakingPallet.storage.erasValidatorPrefs(api, era);
 
-    return apyService.getNetworkAvgRewardRate({ api, timelineApi, chain, era, validators });
+      return prefs.map(({ prefs }) => ({ commission: perbillToPercent(prefs.commission) }));
+    };
+
+    return apyService.getNetworkAvgRewardRate({ api, timelineApi, chain, era, loadValidators });
   })
   .cache({
     store: $networkAvgRateCache,

--- a/src/renderer/domains/staking/apy/resource.ts
+++ b/src/renderer/domains/staking/apy/resource.ts
@@ -6,7 +6,7 @@ import { stakingPallet } from '@/shared/pallet/staking';
 import { createQueryResource } from '@/shared/query';
 
 import { perbillToPercent } from './calculator';
-import { apyService } from './service';
+import { type NetworkAvgRate, apyService } from './service';
 
 export type ApyResourceParams = {
   api: ApiPromise;
@@ -32,6 +32,34 @@ export const apyResource = createQueryResource<ApyResourceParams>({
   .cache({
     store: $apyCache,
     map: (state, apy, { chainId }) => ({ ...state, [chainId]: apy }),
+    staleAfter: Number.POSITIVE_INFINITY,
+  })
+  .build();
+
+export type NetworkAvgRateParams = ApyResourceParams;
+
+const $networkAvgRateCache = createStore<Record<ChainId, NetworkAvgRate | null>>({});
+
+/**
+ * Trailing ~30d network average reward rate per chain. Era-keyed like
+ * `apyResource`: a rollover changes the key and triggers exactly one refetch; a
+ * window of closed eras never changes, so the cache never goes stale. The
+ * `erasValidatorPrefs` read duplicates the one in `apyResource` — accepted,
+ * both requests run once per era per chain.
+ */
+export const networkAvgRateResource = createQueryResource<NetworkAvgRateParams>({
+  key: ({ chainId, era }) => [chainId, String(era)],
+})
+  .name('networkAvgRewardRate')
+  .request<NetworkAvgRate | null>(async ({ api, timelineApi, chain, era }) => {
+    const prefs = await stakingPallet.storage.erasValidatorPrefs(api, era);
+    const validators = prefs.map(({ prefs }) => ({ commission: perbillToPercent(prefs.commission) }));
+
+    return apyService.getNetworkAvgRewardRate({ api, timelineApi, chain, era, validators });
+  })
+  .cache({
+    store: $networkAvgRateCache,
+    map: (state, rate, { chainId }) => ({ ...state, [chainId]: rate }),
     staleAfter: Number.POSITIVE_INFINITY,
   })
   .build();

--- a/src/renderer/domains/staking/apy/resource.ts
+++ b/src/renderer/domains/staking/apy/resource.ts
@@ -43,7 +43,9 @@ const $networkAvgRateCache = createStore<Record<ChainId, NetworkAvgRate | null>>
 /**
  * Trailing ~30d network average reward rate per chain. Era-keyed like
  * `apyResource`: a rollover changes the key and triggers exactly one refetch; a
- * window of closed eras never changes, so the cache never goes stale. The
+ * window of closed eras never changes, so a non-null result never goes stale; a
+ * `null` (unknown) result is not cached and is re-requested on the next mount -
+ * deliberate, it doubles as retry after a transient failure. The
  * `erasValidatorPrefs` read duplicates the one in `apyResource` — accepted,
  * both requests run once per era per chain.
  */

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -179,7 +179,12 @@ type NetworkAvgRateParams = {
   timelineApi?: ApiPromise | null;
   chain: ChainRef;
   era: EraIndex;
-  validators: Pick<ApyValidator, 'commission'>[];
+  /**
+   * Lazily loaded validator commissions — the full validator-set prefs read is
+   * the most expensive query involved, and a `null` result is never cached by
+   * the query layer, so it must only run once an average actually exists.
+   */
+  loadValidators: () => Promise<Pick<ApyValidator, 'commission'>[]>;
 };
 
 /**
@@ -194,7 +199,7 @@ type NetworkAvgRateParams = {
  * left unknown, never guessed.
  */
 async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<NetworkAvgRate | null> {
-  const { api, timelineApi, chain, era, validators } = params;
+  const { api, timelineApi, chain, era, loadValidators } = params;
 
   const eraDurationMs = getEraDurationMs(api, timelineApi, chain);
   const erasPerYear = MILLISECONDS_PER_YEAR / eraDurationMs;
@@ -255,6 +260,15 @@ async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<Ne
   }
 
   if (contributions.length === 0) return null;
+
+  let validators: Pick<ApyValidator, 'commission'>[];
+  try {
+    validators = await loadValidators();
+  } catch (error) {
+    console.warn('validator prefs query failed, leaving the network average unknown', error);
+
+    return null;
+  }
 
   const grossAverage = contributions.reduce((acc, { rate }) => acc + rate, 0) / contributions.length;
   const medianCommission = getMedianCommission(validators.map(validator => validator.commission));

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -4,7 +4,7 @@ import { default as BigNumber } from 'bignumber.js';
 import { type Chain, type EraIndex } from '@/shared/core';
 import { stakingPallet } from '@/shared/pallet/staking';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { getEraDurationMs } from '../era/duration';
+import { getEraDurationMs, getErasInDays } from '../era/duration';
 import { type ApyValidator } from '../types';
 
 import {
@@ -17,7 +17,7 @@ import {
 
 const MILLISECONDS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
 const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
-const NETWORK_AVG_WINDOW_MS = 30 * MILLISECONDS_PER_DAY;
+const NETWORK_AVG_WINDOW_DAYS = 30;
 
 type ChainRef = Pick<Chain, 'chainId'>;
 
@@ -213,7 +213,7 @@ async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<Ne
     return null;
   }
 
-  const targetEras = Math.max(1, Math.round(NETWORK_AVG_WINDOW_MS / eraDurationMs));
+  const targetEras = getErasInDays(NETWORK_AVG_WINDOW_DAYS, eraDurationMs);
   const windowSize = Math.min(targetEras, historyDepth, era);
   if (windowSize <= 0) return null;
 

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -158,12 +158,19 @@ export type NetworkAvgRate = {
    * dp.
    */
   ratePercent: string;
-  fromEra: EraIndex;
-  toEra: EraIndex;
   /**
-   * Real window length in days — 30 on a 24h era chain, 21 where HistoryDepth
-   * caps it.
+   * Inclusive lower bound of the eras that actually produced a rate. The range
+   * `[fromEra, toEra]` may contain gaps — eras with no recorded reward or zero
+   * stake are skipped rather than counted.
    */
+  fromEra: EraIndex;
+  /**
+   * Inclusive upper bound of the eras that actually produced a rate. The range
+   * `[fromEra, toEra]` may contain gaps — eras with no recorded reward or zero
+   * stake are skipped rather than counted.
+   */
+  toEra: EraIndex;
+  /** The eras that actually produced a rate, expressed in days. */
   days: number;
 };
 
@@ -207,41 +214,48 @@ async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<Ne
 
   const windowEras = Array.from({ length: windowSize }, (_, index) => era - windowSize + index);
 
-  let eraRewards;
+  let eraRewards: Awaited<ReturnType<typeof stakingPallet.storage.erasValidatorReward>>;
+  let eraStakes: Awaited<ReturnType<typeof stakingPallet.storage.erasTotalStakeMulti>>;
   try {
     eraRewards = await stakingPallet.storage.erasValidatorReward(api, windowEras);
+    eraStakes = await stakingPallet.storage.erasTotalStakeMulti(api, windowEras);
   } catch (error) {
-    console.warn('era reward history query failed, leaving the network average unknown', error);
+    console.warn('era reward/stake history query failed, leaving the network average unknown', error);
 
     return null;
   }
 
-  const rates = (
-    await Promise.all(
-      eraRewards.map(async ({ era: rewardEra, reward }) => {
-        if (!reward) return null;
+  const contributions: { era: EraIndex; rate: number }[] = [];
+  for (let index = 0; index < windowEras.length; index += 1) {
+    const rewardEntry = eraRewards[index];
+    const stakeEntry = eraStakes[index];
+    if (!rewardEntry || !stakeEntry || rewardEntry.era !== stakeEntry.era) continue;
 
-        const rewardValue = new BigNumber(reward.toString());
-        if (!rewardValue.isGreaterThan(0)) return null;
+    const { reward } = rewardEntry;
+    if (!reward) continue;
 
-        const totalStaked = await getTotalStaked(api, rewardEra);
-        if (!totalStaked) return null;
+    const rewardValue = new BigNumber(reward.toString());
+    if (!rewardValue.isGreaterThan(0)) continue;
 
-        return rewardValue.multipliedBy(erasPerYear).div(totalStaked).toNumber();
-      }),
-    )
-  ).filter((rate): rate is number => rate !== null);
+    const totalStaked = new BigNumber(stakeEntry.totalStake.toString());
+    if (!totalStaked.isGreaterThan(0)) continue;
 
-  if (rates.length === 0) return null;
+    contributions.push({
+      era: rewardEntry.era,
+      rate: rewardValue.multipliedBy(erasPerYear).div(totalStaked).toNumber(),
+    });
+  }
 
-  const grossAverage = rates.reduce((acc, rate) => acc + rate, 0) / rates.length;
+  if (contributions.length === 0) return null;
+
+  const grossAverage = contributions.reduce((acc, { rate }) => acc + rate, 0) / contributions.length;
   const medianCommission = getMedianCommission(validators.map(validator => validator.commission));
 
   return {
     ratePercent: calculateExpectedApy(grossAverage, medianCommission).toFixed(2),
-    fromEra: windowEras[0] ?? era,
-    toEra: windowEras[windowEras.length - 1] ?? era,
-    days: Math.max(1, Math.round((windowSize * eraDurationMs) / MILLISECONDS_PER_DAY)),
+    fromEra: contributions[0]!.era,
+    toEra: contributions[contributions.length - 1]!.era,
+    days: Math.max(1, Math.round((contributions.length * eraDurationMs) / MILLISECONDS_PER_DAY)),
   };
 }
 

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -217,8 +217,10 @@ async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<Ne
   let eraRewards: Awaited<ReturnType<typeof stakingPallet.storage.erasValidatorReward>>;
   let eraStakes: Awaited<ReturnType<typeof stakingPallet.storage.erasTotalStakeMulti>>;
   try {
-    eraRewards = await stakingPallet.storage.erasValidatorReward(api, windowEras);
-    eraStakes = await stakingPallet.storage.erasTotalStakeMulti(api, windowEras);
+    [eraRewards, eraStakes] = await Promise.all([
+      stakingPallet.storage.erasValidatorReward(api, windowEras),
+      stakingPallet.storage.erasTotalStakeMulti(api, windowEras),
+    ]);
   } catch (error) {
     console.warn('era reward/stake history query failed, leaving the network average unknown', error);
 
@@ -229,7 +231,13 @@ async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<Ne
   for (let index = 0; index < windowEras.length; index += 1) {
     const rewardEntry = eraRewards[index];
     const stakeEntry = eraStakes[index];
-    if (!rewardEntry || !stakeEntry || rewardEntry.era !== stakeEntry.era) continue;
+    if (!rewardEntry || !stakeEntry?.totalStake) continue;
+
+    if (rewardEntry.era !== stakeEntry.era) {
+      console.warn(`era mismatch between reward (${rewardEntry.era}) and stake (${stakeEntry.era}) entries, skipping`);
+
+      continue;
+    }
 
     const { reward } = rewardEntry;
     if (!reward) continue;

--- a/src/renderer/domains/staking/apy/service.ts
+++ b/src/renderer/domains/staking/apy/service.ts
@@ -16,6 +16,8 @@ import {
 } from './calculator';
 
 const MILLISECONDS_PER_YEAR = 365.25 * 24 * 60 * 60 * 1000;
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+const NETWORK_AVG_WINDOW_MS = 30 * MILLISECONDS_PER_DAY;
 
 type ChainRef = Pick<Chain, 'chainId'>;
 
@@ -23,6 +25,7 @@ export const apyService = {
   getStakersEraReward,
   getAvgRewardPercent,
   getNetworkApy,
+  getNetworkAvgRewardRate,
   getValidatorsApy,
 };
 
@@ -147,6 +150,99 @@ async function getNetworkApy(params: NetworkApyParams): Promise<string | null> {
   const medianCommission = getMedianCommission(validators.map(validator => validator.commission));
 
   return calculateExpectedApy(avgRewardPercent, medianCommission).toFixed(2);
+}
+
+export type NetworkAvgRate = {
+  /**
+   * Net-of-median-commission average reward rate over the window, percent, 2
+   * dp.
+   */
+  ratePercent: string;
+  fromEra: EraIndex;
+  toEra: EraIndex;
+  /**
+   * Real window length in days — 30 on a 24h era chain, 21 where HistoryDepth
+   * caps it.
+   */
+  days: number;
+};
+
+type NetworkAvgRateParams = {
+  api: ApiPromise;
+  timelineApi?: ApiPromise | null;
+  chain: ChainRef;
+  era: EraIndex;
+  validators: Pick<ApyValidator, 'commission'>[];
+};
+
+/**
+ * Network average reward rate over a trailing ~30 day window, in percent.
+ *
+ * The benchmark shown beside the dashboard's Est. APY: the mean of per-era
+ * realized rates (`erasValidatorReward × erasPerYear / erasTotalStake`) over
+ * the last ~30 days of completed eras, capped by the runtime `HistoryDepth` (84
+ * eras ≈ 21 days on Kusama Asset Hub). Made net of the current median
+ * commission so it is directly comparable with `getNetworkApy`. Realized-only
+ * on purpose — no NPoS-curve fallback: a benchmark that cannot be measured is
+ * left unknown, never guessed.
+ */
+async function getNetworkAvgRewardRate(params: NetworkAvgRateParams): Promise<NetworkAvgRate | null> {
+  const { api, timelineApi, chain, era, validators } = params;
+
+  const eraDurationMs = getEraDurationMs(api, timelineApi, chain);
+  const erasPerYear = MILLISECONDS_PER_YEAR / eraDurationMs;
+
+  let historyDepth: number;
+  try {
+    historyDepth = stakingPallet.consts.historyDepth(api);
+  } catch (error) {
+    console.warn('history depth unavailable, leaving the network average unknown', error);
+
+    return null;
+  }
+
+  const targetEras = Math.max(1, Math.round(NETWORK_AVG_WINDOW_MS / eraDurationMs));
+  const windowSize = Math.min(targetEras, historyDepth, era);
+  if (windowSize <= 0) return null;
+
+  const windowEras = Array.from({ length: windowSize }, (_, index) => era - windowSize + index);
+
+  let eraRewards;
+  try {
+    eraRewards = await stakingPallet.storage.erasValidatorReward(api, windowEras);
+  } catch (error) {
+    console.warn('era reward history query failed, leaving the network average unknown', error);
+
+    return null;
+  }
+
+  const rates = (
+    await Promise.all(
+      eraRewards.map(async ({ era: rewardEra, reward }) => {
+        if (!reward) return null;
+
+        const rewardValue = new BigNumber(reward.toString());
+        if (!rewardValue.isGreaterThan(0)) return null;
+
+        const totalStaked = await getTotalStaked(api, rewardEra);
+        if (!totalStaked) return null;
+
+        return rewardValue.multipliedBy(erasPerYear).div(totalStaked).toNumber();
+      }),
+    )
+  ).filter((rate): rate is number => rate !== null);
+
+  if (rates.length === 0) return null;
+
+  const grossAverage = rates.reduce((acc, rate) => acc + rate, 0) / rates.length;
+  const medianCommission = getMedianCommission(validators.map(validator => validator.commission));
+
+  return {
+    ratePercent: calculateExpectedApy(grossAverage, medianCommission).toFixed(2),
+    fromEra: windowEras[0] ?? era,
+    toEra: windowEras[windowEras.length - 1] ?? era,
+    days: Math.max(1, Math.round((windowSize * eraDurationMs) / MILLISECONDS_PER_DAY)),
+  };
 }
 
 type ValidatorsApyParams = {

--- a/src/renderer/domains/staking/apy/store.ts
+++ b/src/renderer/domains/staking/apy/store.ts
@@ -1,3 +1,3 @@
-import { apyResource } from './resource';
+import { apyResource, networkAvgRateResource } from './resource';
 
-export const apy = { apyResource };
+export const apy = { apyResource, networkAvgRateResource };

--- a/src/renderer/domains/staking/era/duration.ts
+++ b/src/renderer/domains/staking/era/duration.ts
@@ -11,6 +11,18 @@ import { DEFAULT_ERA_DURATION_MS, FALLBACK_ERA_DURATION_MS } from '../constants'
  */
 export type EraDurationChain = Pick<Chain, 'chainId'> | Chain;
 
+const MILLISECONDS_PER_DAY = 24 * 60 * 60 * 1000;
+
+/**
+ * Whole eras a window of `days` spans on a chain — `ceil`: a window must cover
+ * its days, never undershoot them. The single conversion rule for every
+ * days-framed era window (network average benchmark, rewards drill-down
+ * periods), so two surfaces never disagree on how long "30 days" is in eras.
+ */
+export function getErasInDays(days: number, eraDurationMs: number): number {
+  return Math.max(1, Math.ceil((days * MILLISECONDS_PER_DAY) / eraDurationMs));
+}
+
 /** Chain values arrive as codecs; `String()` covers both BN and primitives. */
 export function toChainNumber(value: unknown): number {
   const parsed = Number(String(value));

--- a/src/renderer/domains/staking/index.ts
+++ b/src/renderer/domains/staking/index.ts
@@ -6,6 +6,7 @@ export type { EraAnchor } from './era/service';
 export type { EraProgress } from './era/resource';
 export { era } from './era/store';
 export { eraService } from './era/service';
+export { getErasInDays } from './era/duration';
 export { useActiveEra, useEraProgress } from './era/hooks';
 
 export { staking } from './staking/store';

--- a/src/renderer/domains/staking/index.ts
+++ b/src/renderer/domains/staking/index.ts
@@ -24,10 +24,11 @@ export { exposurePagesCacheKey } from './exposures/resource';
 export { exposureService } from './exposures/service';
 export { useExposurePages, useExposures } from './exposures/hooks';
 
-export type { ApyResourceParams } from './apy/resource';
+export type { ApyResourceParams, NetworkAvgRateParams } from './apy/resource';
+export type { NetworkAvgRate } from './apy/service';
 export { apy } from './apy/store';
 export { apyService } from './apy/service';
-export { useNetworkApy } from './apy/hooks';
+export { useNetworkApy, useNetworkAvgRate } from './apy/hooks';
 
 export type { EraValidator, EraValidatorMap } from './validators/types';
 export type { ValidatorsResourceParams } from './validators/resource';

--- a/src/renderer/domains/staking/index.ts
+++ b/src/renderer/domains/staking/index.ts
@@ -29,7 +29,7 @@ export type { ApyResourceParams, NetworkAvgRateParams } from './apy/resource';
 export type { NetworkAvgRate } from './apy/service';
 export { apy } from './apy/store';
 export { apyService } from './apy/service';
-export { useNetworkApy, useNetworkAvgRate } from './apy/hooks';
+export { useNetworkApy } from './apy/hooks';
 
 export type { EraValidator, EraValidatorMap } from './validators/types';
 export type { ValidatorsResourceParams } from './validators/resource';

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -1,6 +1,6 @@
 # Staking KPI Cards
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-11
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-12
 
 ## Overview
 
@@ -70,6 +70,16 @@ to the bottom, so a footer appearing — or a shimmer resolving — never moves 
   answers "what is the stake that _is_ earning earning", so an idle ledger must not halve it. A chain whose APY is
   unknown is skipped rather than counted as zero, for the same reason. With nothing weighable the card shows a grey em
   dash instead of a confident `0.0%`.
+
+  A footer line — `network avg 14.2% · 30d` — gives the number something to be judged against. Unlike the headline,
+  which falls back to the NPoS inflation curve when a chain reports no era reward, the benchmark is **realized-only**:
+  the mean of what the chain's last ~30 days of completed eras actually paid, net of the current median commission, and
+  unmeasurable is left `null` rather than guessed at from the curve — a benchmark nobody can verify against a real
+  payout is worse than no benchmark. It is blended the same way as the headline, by the same fiat weights, and shown
+  only once it is complete: not loading, a headline to sit beside, a benchmark that resolved, and full coverage of the
+  earning stake. A benchmark that could not measure a chain holding part of the stake would describe a different
+  portfolio than the headline next to it, so it stays hidden rather than being presented as "the" network average.
+
 - **Nominated validators** — how many distinct validators the selection nominates, counted **per chain**: the same key
   elected on Polkadot and on Kusama is two validators, because it is two nomination sets and two rewards. The subline
   carries how many of them the era actually backs, which is what the card used to lead with. The headline moved because
@@ -173,7 +183,10 @@ chain's own era duration.
 
 - **Est. APY** opens the donut breakdown: one segment per position, hover-linked in both directions — the donut centre
   swaps to the hovered row, and hovering a row dims the other segments. A single position renders as a full ring rather
-  than disappearing.
+  than disappearing. Each row carries its own network average, under the row's APY, with **its exact window** —
+  `network avg 15.2% · 21d` on a Kusama row next to `· 30d` on a Polkadot one, because the two chains' history depths
+  genuinely differ. The row deliberately ignores the card footer's coverage gate: a single chain's average is complete
+  by definition, so a benchmark that could not cover every chain still degrades into detail here, never into nothing.
 - **Nominated validators** opens the nomination spread — where the selection's stake actually went, as opposed to where
   it was pointed. The table lists **every nomination of every account**, grouped by account (largest position first) and
   labelled with what the era did with it:
@@ -284,9 +297,12 @@ there everything is local: click a card or a footer link to open its drill-down,
 CSV. The only outbound step is a claim/redeem/unbond request handed to a staking flow, which takes over from the modal.
 
 Nothing here starts a chain subscription on mount — ledgers, nominations, eras and exposures are driven by the positions
-aggregate. The cards do drive three of their own reads (network APY, the 30-day reward window, and the unclaimed payout
-scan per stash), each through the shared ref-counted pools so a second card asking for the same data joins the request
-in flight instead of duplicating it.
+aggregate. The cards do drive four of their own reads (network APY, the network average benchmark, the 30-day reward
+window, and the unclaimed payout scan per stash), each through the shared ref-counted pools so a second card asking for
+the same data joins the request in flight instead of duplicating it. The benchmark is one more era-keyed read per chain
+(`networkAvgRateResource`: `erasValidatorPrefs` for the current median commission, plus `erasValidatorReward` and
+`erasTotalStakeMulti` batched over the trailing window) — cached like the network APY read it sits beside, so a rollover
+is the only thing that ever triggers a refetch.
 
 ## Related
 

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -76,9 +76,12 @@ to the bottom, so a footer appearing — or a shimmer resolving — never moves 
   the mean of what the chain's last ~30 days of completed eras actually paid, net of the current median commission, and
   unmeasurable is left `null` rather than guessed at from the curve — a benchmark nobody can verify against a real
   payout is worse than no benchmark. It is blended the same way as the headline, by the same fiat weights, and shown
-  only once it is complete: not loading, a headline to sit beside, a benchmark that resolved, and full coverage of the
-  earning stake. A benchmark that could not measure a chain holding part of the stake would describe a different
-  portfolio than the headline next to it, so it stays hidden rather than being presented as "the" network average.
+  only once it is complete: not loading, a headline to sit beside, a benchmark that resolved, full coverage of the
+  earning stake, and a contributing chain set exactly equal to the headline's — the two readings fail independently (the
+  headline still has a curve fallback, the benchmark does not), and a benchmark covering more or fewer chains than the
+  figure beside it is a false comparison in either direction. A benchmark that could not measure a chain holding part of
+  the stake would describe a different portfolio than the headline next to it, so it stays hidden rather than being
+  presented as "the" network average.
 
 - **Nominated validators** — how many distinct validators the selection nominates, counted **per chain**: the same key
   elected on Polkadot and on Kusama is two validators, because it is two nomination sets and two rewards. The subline

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useApyKpi.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useApyKpi.ts
@@ -1,0 +1,58 @@
+import { useMemo } from 'react';
+
+import { type ChainId } from '@/shared/core';
+import { keys } from '@/shared/lib/utils';
+import { type NetworkAvgRate, type StakingPosition } from '@/domains/staking';
+import {
+  type NetworkAvgBlend,
+  blendNetworkAvgRate,
+  computeWeightedApy,
+  earningStakeByChain,
+  sameContributingChains,
+} from '../lib/apy';
+
+import { useNetworkApys } from './useNetworkApys';
+import { useNetworkAvgRates } from './useNetworkAvgRates';
+
+type ApyKpi = {
+  /** The user's stake-weighted APY, `null` when nothing can be weighted. */
+  weightedApy: number | null;
+  /** The network benchmark blended with the same weights; `null` while unknown. */
+  networkAvg: NetworkAvgBlend | null;
+  apyByChain: Record<ChainId, number | null>;
+  avgRateByChain: Record<ChainId, NetworkAvgRate | null>;
+};
+
+/**
+ * The Est. APY card's two figures, blended from the same fiat weights (active
+ * stake of the earning positions). The benchmark is dropped to `null` unless
+ * its contributing chains are exactly the headline's — the two readings fail
+ * independently, and the figures must describe the same portfolio to sit next
+ * to each other.
+ */
+export function useApyKpi(
+  positions: StakingPosition[],
+  chainIds: ChainId[],
+  toFiat: (chainId: ChainId, planck: string) => string,
+): ApyKpi {
+  const apyByChain = useNetworkApys(chainIds);
+  const avgRateByChain = useNetworkAvgRates(chainIds);
+
+  const { weightedApy, networkAvg } = useMemo(() => {
+    const earningStake = earningStakeByChain(positions);
+    const chainWeights = keys(earningStake).map((chainId) => ({
+      chainId,
+      weight: toFiat(chainId, earningStake[chainId] ?? '0'),
+    }));
+
+    const apyEntries = chainWeights.map((entry) => ({ ...entry, apy: apyByChain[entry.chainId] ?? null }));
+    const rateEntries = chainWeights.map((entry) => ({ ...entry, rate: avgRateByChain[entry.chainId] ?? null }));
+
+    return {
+      weightedApy: computeWeightedApy(apyEntries),
+      networkAvg: sameContributingChains(apyEntries, rateEntries) ? blendNetworkAvgRate(rateEntries) : null,
+    };
+  }, [positions, apyByChain, avgRateByChain, toFiat]);
+
+  return { weightedApy, networkAvg, apyByChain, avgRateByChain };
+}

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useNetworkAvgRates.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useNetworkAvgRates.ts
@@ -1,0 +1,52 @@
+import { useUnit } from 'effector-react';
+import { useMemo } from 'react';
+
+import { type ChainId } from '@/shared/core';
+import { type NetworkAvgRate, type NetworkAvgRateParams, apy } from '@/domains/staking';
+import { networkModel } from '@/entities/network';
+
+import { useChainEras } from './useChainEras';
+import { useResourcePool } from './useResourcePool';
+
+const { networkAvgRateResource } = apy;
+
+/**
+ * Trailing ~30d network average reward rate per staking chain — the benchmark
+ * shown beside the user's Est. APY. Same relay-derived era duration as
+ * `useNetworkApys` (Asset Hub has no Babe pallet).
+ */
+export const useNetworkAvgRates = (chainIds: ChainId[]): Record<ChainId, NetworkAvgRate | null> => {
+  const chains = useUnit(networkModel.$chains);
+  const apis = useUnit(networkModel.$apis);
+  const eras = useChainEras();
+
+  const requests = useMemo(() => {
+    const result: NetworkAvgRateParams[] = [];
+
+    for (const chainId of chainIds) {
+      const chain = chains[chainId];
+      const api = apis[chainId];
+      const era = eras[chainId];
+      if (!chain || !api || era === undefined) continue;
+
+      const timelineApi = (chain.parentId ? apis[chain.parentId] : null) ?? api;
+      result.push({ chainId, api, timelineApi, chain, era });
+    }
+
+    return result;
+  }, [chainIds, chains, apis, eras]);
+
+  useResourcePool(networkAvgRateResource, requests);
+
+  const cache = useUnit(networkAvgRateResource.$cache);
+
+  return useMemo(() => {
+    const result: Record<ChainId, NetworkAvgRate | null> = {};
+
+    for (const chainId of chainIds) {
+      result[chainId] = cache[chainId] ?? null;
+    }
+
+    return result;
+  }, [chainIds, cache]);
+};

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
@@ -13,7 +13,7 @@ import { type StakingSummary, summarizePositions, useStakingPositions } from '@/
 import { getAccessMode } from '@/features/dashboard-staking-positions';
 import { type AccessMode } from '../lib/access';
 import { type AssetAmount, sumFiat, sumPlanck } from '../lib/amounts';
-import { computeWeightedApy, earningStakeByChain } from '../lib/apy';
+import { type NetworkAvgBlend, blendNetworkAvgRate, computeWeightedApy, earningStakeByChain } from '../lib/apy';
 import { daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
 import { type UnbondingFooter, type UnclaimedFooter, getUnbondingFooter, getUnclaimedFooter } from '../lib/footer';
 import { type NominationRow, buildNominationRows } from '../lib/nominations';
@@ -22,6 +22,7 @@ import { type BreakdownRow, type ClaimRow, type PositionRow } from '../lib/types
 
 import { useChainEras, useChainHistoryDepths, useEraDurations } from './useChainEras';
 import { useNetworkApys } from './useNetworkApys';
+import { useNetworkAvgRates } from './useNetworkAvgRates';
 import { REWARDS_WINDOW_DAYS, useRewardsWindow, useRewardsWindowStart } from './useRewardsWindow';
 import { useStakingChainAssets } from './useStakingChainAssets';
 import { unclaimedKey, useUnclaimedPayoutsByPosition } from './useUnclaimedPayouts';
@@ -48,6 +49,11 @@ export type StakingKpiData = {
   /** Estimated APY. */
   weightedApy: number | null;
   earningPositionCount: number;
+  /**
+   * Blended trailing-window network benchmark; `null` while unknown. The UI
+   * must check `coverage` before presenting it as "the network average".
+   */
+  networkAvg: NetworkAvgBlend | null;
 
   /** Nominated validators. */
   activeValidatorCount: number;
@@ -96,6 +102,7 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
   );
 
   const apyByChain = useNetworkApys(chainIds);
+  const avgRateByChain = useNetworkAvgRates(chainIds);
   const rewardsSince = useRewardsWindowStart();
   const { byChain: rewardsByChain } = useRewardsWindow(chainIds, stakingAccountIds, rewardsSince);
   const unclaimed = useUnclaimedPayoutsByPosition(positions);
@@ -172,6 +179,18 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
       })),
     );
   }, [positions, apyByChain, toFiat]);
+
+  const networkAvg = useMemo(() => {
+    const earningStake = earningStakeByChain(positions);
+
+    return blendNetworkAvgRate(
+      keys(earningStake).map((chainId) => ({
+        chainId,
+        rate: avgRateByChain[chainId] ?? null,
+        weight: toFiat(chainId, earningStake[chainId] ?? '0'),
+      })),
+    );
+  }, [positions, avgRateByChain, toFiat]);
 
   // --- Rewards ------------------------------------------------------------
 
@@ -317,13 +336,14 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
         fiat,
         color: getColorByPriceId(asset?.priceId ?? '', index),
         apy: apyByChain[position.chainId] ?? null,
+        networkAvgRate: avgRateByChain[position.chainId] ?? null,
         validatorCount: position.activeValidators.length,
         earning: position.status === 'active',
       } satisfies BreakdownRow;
     });
 
     return rows.sort((a, b) => b.value - a.value);
-  }, [positions, assets, toFiat, apyByChain]);
+  }, [positions, assets, toFiat, apyByChain, avgRateByChain]);
 
   return {
     positions,
@@ -338,6 +358,7 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
 
     weightedApy,
     earningPositionCount: summary.earningPositionCount,
+    networkAvg,
 
     activeValidatorCount: summary.activeValidatorCount,
     positionCount: summary.positionCount,

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
@@ -3,7 +3,6 @@ import { useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
 import { type Wallet } from '@/shared/core';
-import { keys } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { getColorByPriceId } from '@/shared/ui/chart-constants';
 import { type CurrencyItem } from '@/domains/price';
@@ -13,16 +12,15 @@ import { type StakingSummary, summarizePositions, useStakingPositions } from '@/
 import { getAccessMode } from '@/features/dashboard-staking-positions';
 import { type AccessMode } from '../lib/access';
 import { type AssetAmount, sumFiat, sumPlanck } from '../lib/amounts';
-import { type NetworkAvgBlend, blendNetworkAvgRate, computeWeightedApy, earningStakeByChain } from '../lib/apy';
+import { type NetworkAvgBlend } from '../lib/apy';
 import { daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
 import { type UnbondingFooter, type UnclaimedFooter, getUnbondingFooter, getUnclaimedFooter } from '../lib/footer';
 import { type NominationRow, buildNominationRows } from '../lib/nominations';
 import { filterPositionsByAccounts, withdrawablePositions } from '../lib/summary';
 import { type BreakdownRow, type ClaimRow, type PositionRow } from '../lib/types';
 
+import { useApyKpi } from './useApyKpi';
 import { useChainEras, useChainHistoryDepths, useEraDurations } from './useChainEras';
-import { useNetworkApys } from './useNetworkApys';
-import { useNetworkAvgRates } from './useNetworkAvgRates';
 import { REWARDS_WINDOW_DAYS, useRewardsWindow, useRewardsWindowStart } from './useRewardsWindow';
 import { useStakingChainAssets } from './useStakingChainAssets';
 import { unclaimedKey, useUnclaimedPayoutsByPosition } from './useUnclaimedPayouts';
@@ -101,8 +99,7 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
     [positions],
   );
 
-  const apyByChain = useNetworkApys(chainIds);
-  const avgRateByChain = useNetworkAvgRates(chainIds);
+  const { weightedApy, networkAvg, apyByChain, avgRateByChain } = useApyKpi(positions, chainIds, toFiat);
   const rewardsSince = useRewardsWindowStart();
   const { byChain: rewardsByChain } = useRewardsWindow(chainIds, stakingAccountIds, rewardsSince);
   const unclaimed = useUnclaimedPayoutsByPosition(positions);
@@ -165,32 +162,6 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
       }),
     };
   }, [summary, assets, toFiat, positions]);
-
-  // --- Estimated APY ------------------------------------------------------
-
-  const weightedApy = useMemo(() => {
-    const earningStake = earningStakeByChain(positions);
-
-    return computeWeightedApy(
-      keys(earningStake).map((chainId) => ({
-        chainId,
-        apy: apyByChain[chainId] ?? null,
-        weight: toFiat(chainId, earningStake[chainId] ?? '0'),
-      })),
-    );
-  }, [positions, apyByChain, toFiat]);
-
-  const networkAvg = useMemo(() => {
-    const earningStake = earningStakeByChain(positions);
-
-    return blendNetworkAvgRate(
-      keys(earningStake).map((chainId) => ({
-        chainId,
-        rate: avgRateByChain[chainId] ?? null,
-        weight: toFiat(chainId, earningStake[chainId] ?? '0'),
-      })),
-    );
-  }, [positions, avgRateByChain, toFiat]);
 
   // --- Rewards ------------------------------------------------------------
 

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
@@ -1,0 +1,43 @@
+import { type ChainId } from '@/shared/core';
+import { blendNetworkAvgRate } from '../apy';
+
+const PAH = '0x01' as ChainId;
+const KAH = '0x02' as ChainId;
+
+const rate = (ratePercent: string, days: number) => ({ ratePercent, fromEra: 0, toEra: 1, days });
+
+describe('blendNetworkAvgRate', () => {
+  test('weights the per-chain rates by fiat weight and reports the longest window', () => {
+    const blended = blendNetworkAvgRate([
+      { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
+      { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+    ]);
+
+    // (3 × 300 + 15 × 100) / 400 = 6; the PAH window (30d) is the longest.
+    expect(blended).toEqual({ rate: 6, days: 30 });
+  });
+
+  test('skips chains with an unknown rate instead of counting them as zero', () => {
+    const blended = blendNetworkAvgRate([
+      { chainId: PAH, rate: null, weight: '300' },
+      { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+    ]);
+
+    expect(blended).toEqual({ rate: 15, days: 21 });
+  });
+
+  test('skips chains with no weight — their window must not leak into the label', () => {
+    const blended = blendNetworkAvgRate([
+      { chainId: PAH, rate: rate('3.00', 30), weight: '0' },
+      { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+    ]);
+
+    expect(blended).toEqual({ rate: 15, days: 21 });
+  });
+
+  test('returns null when nothing can be weighted', () => {
+    expect(blendNetworkAvgRate([])).toBeNull();
+    expect(blendNetworkAvgRate([{ chainId: PAH, rate: null, weight: '300' }])).toBeNull();
+    expect(blendNetworkAvgRate([{ chainId: PAH, rate: rate('3.00', 30), weight: '0' }])).toBeNull();
+  });
+});

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
@@ -1,5 +1,5 @@
 import { type ChainId } from '@/shared/core';
-import { blendNetworkAvgRate, computeWeightedApy } from '../apy';
+import { blendNetworkAvgRate, computeWeightedApy, sameContributingChains } from '../apy';
 
 const PAH = '0x01' as ChainId;
 const KAH = '0x02' as ChainId;
@@ -71,5 +71,67 @@ describe('blendNetworkAvgRate', () => {
     expect(apyResult).not.toBeNull();
     expect(blendResult).not.toBeNull();
     expect(blendResult?.rate).toBe(apyResult);
+  });
+});
+
+describe('sameContributingChains', () => {
+  test('matches when both readings answer for the same chains, whatever the values are', () => {
+    const result = sameContributingChains(
+      [
+        { chainId: PAH, apy: 5, weight: '300' },
+        { chainId: KAH, apy: 14, weight: '100' },
+      ],
+      [
+        { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
+        { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+      ],
+    );
+
+    expect(result).toBe(true);
+  });
+
+  test('rejects a benchmark missing a chain the headline covers', () => {
+    const result = sameContributingChains(
+      [
+        { chainId: PAH, apy: 5, weight: '300' },
+        { chainId: KAH, apy: 14, weight: '100' },
+      ],
+      [
+        { chainId: PAH, rate: null, weight: '300' },
+        { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+      ],
+    );
+
+    expect(result).toBe(false);
+  });
+
+  test('rejects a benchmark covering a chain the headline does not', () => {
+    const result = sameContributingChains(
+      [
+        { chainId: PAH, apy: null, weight: '300' },
+        { chainId: KAH, apy: 14, weight: '100' },
+      ],
+      [
+        { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
+        { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+      ],
+    );
+
+    expect(result).toBe(false);
+  });
+
+  test('ignores weightless chains on both sides', () => {
+    const result = sameContributingChains(
+      [
+        { chainId: PAH, apy: 5, weight: '300' },
+        { chainId: KAH, apy: 14, weight: '0' },
+      ],
+      [
+        { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
+        { chainId: KAH, rate: null, weight: '0' },
+      ],
+    );
+
+    expect(result).toBe(true);
   });
 });

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/networkAvgBlend.test.ts
@@ -1,5 +1,5 @@
 import { type ChainId } from '@/shared/core';
-import { blendNetworkAvgRate } from '../apy';
+import { blendNetworkAvgRate, computeWeightedApy } from '../apy';
 
 const PAH = '0x01' as ChainId;
 const KAH = '0x02' as ChainId;
@@ -9,12 +9,12 @@ const rate = (ratePercent: string, days: number) => ({ ratePercent, fromEra: 0, 
 describe('blendNetworkAvgRate', () => {
   test('weights the per-chain rates by fiat weight and reports the longest window', () => {
     const blended = blendNetworkAvgRate([
-      { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
       { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+      { chainId: PAH, rate: rate('3.00', 30), weight: '300' },
     ]);
 
-    // (3 × 300 + 15 × 100) / 400 = 6; the PAH window (30d) is the longest.
-    expect(blended).toEqual({ rate: 6, days: 30 });
+    // (3 × 300 + 15 × 100) / 400 = 6; the PAH window (30d) is the longest even though it's listed second.
+    expect(blended).toEqual({ rate: 6, days: 30, coverage: 1 });
   });
 
   test('skips chains with an unknown rate instead of counting them as zero', () => {
@@ -23,7 +23,8 @@ describe('blendNetworkAvgRate', () => {
       { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
     ]);
 
-    expect(blended).toEqual({ rate: 15, days: 21 });
+    // PAH's weight still counts toward the positive pool, so coverage is 100 / (300 + 100) = 0.25.
+    expect(blended).toEqual({ rate: 15, days: 21, coverage: 0.25 });
   });
 
   test('skips chains with no weight — their window must not leak into the label', () => {
@@ -32,12 +33,43 @@ describe('blendNetworkAvgRate', () => {
       { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
     ]);
 
-    expect(blended).toEqual({ rate: 15, days: 21 });
+    // A zero weight is not "positive weight", so it never enters the coverage denominator either.
+    expect(blended).toEqual({ rate: 15, days: 21, coverage: 1 });
+  });
+
+  test('treats a non-numeric rate the same as an unknown rate', () => {
+    const blended = blendNetworkAvgRate([
+      { chainId: PAH, rate: rate('not-a-number', 30), weight: '300' },
+      { chainId: KAH, rate: rate('15.00', 21), weight: '100' },
+    ]);
+
+    expect(blended).toEqual({ rate: 15, days: 21, coverage: 0.25 });
   });
 
   test('returns null when nothing can be weighted', () => {
     expect(blendNetworkAvgRate([])).toBeNull();
     expect(blendNetworkAvgRate([{ chainId: PAH, rate: null, weight: '300' }])).toBeNull();
     expect(blendNetworkAvgRate([{ chainId: PAH, rate: rate('3.00', 30), weight: '0' }])).toBeNull();
+  });
+
+  test('agrees with computeWeightedApy on which chains contribute', () => {
+    // One chain with an unknown rate (but real weight), one with weight but no stake, two contributors.
+    const apyResult = computeWeightedApy([
+      { chainId: PAH, apy: null, weight: '500' },
+      { chainId: KAH, apy: 10, weight: '0' },
+      { chainId: '0x03' as ChainId, apy: 3, weight: '300' },
+      { chainId: '0x04' as ChainId, apy: 15, weight: '100' },
+    ]);
+
+    const blendResult = blendNetworkAvgRate([
+      { chainId: PAH, rate: null, weight: '500' },
+      { chainId: KAH, rate: rate('10.00', 21), weight: '0' },
+      { chainId: '0x03' as ChainId, rate: rate('3.00', 30), weight: '300' },
+      { chainId: '0x04' as ChainId, rate: rate('15.00', 21), weight: '100' },
+    ]);
+
+    expect(apyResult).not.toBeNull();
+    expect(blendResult).not.toBeNull();
+    expect(blendResult?.rate).toBe(apyResult);
   });
 });

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -110,6 +110,32 @@ export type NetworkAvgBlend = {
 export const NETWORK_AVG_MIN_COVERAGE = 1;
 
 /**
+ * The benchmark and the headline must describe the same chain set to be
+ * comparable — the two readings fail independently (the headline still has the
+ * NPoS-curve fallback, the benchmark deliberately does not), and a benchmark
+ * covering more or fewer chains than the figure beside it is a false comparison
+ * in either direction.
+ */
+export function sameContributingChains(apyEntries: ApyWeight[], rateEntries: NetworkAvgWeight[]): boolean {
+  const hasWeight = (weight: string) => new BigNumber(weight || '0').gt(0);
+
+  const apyChains = new Set(
+    apyEntries
+      .filter((entry) => entry.apy !== null && Number.isFinite(entry.apy) && hasWeight(entry.weight))
+      .map((entry) => entry.chainId),
+  );
+  const rateChains = new Set(
+    rateEntries
+      .filter(
+        (entry) => entry.rate !== null && parseRatePercent(entry.rate.ratePercent) !== null && hasWeight(entry.weight),
+      )
+      .map((entry) => entry.chainId),
+  );
+
+  return apyChains.size === rateChains.size && [...apyChains].every((chainId) => rateChains.has(chainId));
+}
+
+/**
  * Stake-weighted blend of the per-chain network average rates — the same
  * skip-not-zero weighting as `computeWeightedApy`, carrying the window length
  * along: the label shows the longest window among the contributing chains — the

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -101,11 +101,10 @@ export const NETWORK_AVG_MIN_COVERAGE = 1;
 /**
  * Stake-weighted blend of the per-chain network average rates — the same
  * skip-not-zero weighting as `computeWeightedApy`, carrying the window length
- * along: the label shows the longest window of the contributing chains — it
- * must not claim more history than the dominant component has, and the
- * per-chain breakdown shows each chain's exact window; "shortest" would
- * understate the majority component instead. A real tradeoff, revisit if it
- * confuses.
+ * along: the label shows the longest window among the contributing chains — the
+ * blend legitimately includes that much history for at least one component, and
+ * the per-chain breakdown shows each chain's exact window; "shortest" would
+ * understate every other component. A real tradeoff, revisit if it confuses.
  */
 export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): NetworkAvgBlend | null {
   let weighted = new BigNumber(0);

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -68,6 +68,17 @@ export function computeWeightedApy(entries: ApyWeight[]): number | null {
   return weighted.div(totalWeight).toNumber();
 }
 
+/**
+ * `NetworkAvgRate.ratePercent` travels as a string; the single parse rule for
+ * every consumer — a malformed value must read as unknown, never render
+ * "NaN%".
+ */
+export function parseRatePercent(ratePercent: string): number | null {
+  const rate = Number(ratePercent);
+
+  return Number.isFinite(rate) ? rate : null;
+}
+
 /** One chain's contribution to the blended network benchmark. */
 export type NetworkAvgWeight = {
   chainId: ChainId;
@@ -118,8 +129,8 @@ export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): NetworkAvgBlen
 
     if (entry.rate === null) continue;
 
-    const rate = Number(entry.rate.ratePercent);
-    if (!Number.isFinite(rate)) continue;
+    const rate = parseRatePercent(entry.rate.ratePercent);
+    if (rate === null) continue;
 
     if (!weight.gt(0)) continue;
 

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -78,23 +78,42 @@ export type NetworkAvgWeight = {
 };
 
 /**
+ * Blended benchmark. `coverage` is the share (0..1) of the positive weight that
+ * the contributing chains actually cover — the consumer must not present the
+ * blend as "the network average" when a chain holding most of the stake could
+ * not be measured (e.g. a transient RPC failure on Polkadot AH would otherwise
+ * leave a Kusama-only "network avg 15%" beside a mostly-Polkadot headline).
+ */
+export type NetworkAvgBlend = {
+  rate: number;
+  days: number;
+  coverage: number;
+};
+
+/**
  * Stake-weighted blend of the per-chain network average rates — the same
  * skip-not-zero weighting as `computeWeightedApy`, carrying the window length
- * along: the label shows the longest window among the contributing chains
- * ("30d" for Polkadot AH even when Kusama AH could only answer for 21).
+ * along: the label shows the longest window of the contributing chains — it
+ * must not claim more history than the dominant component has, and the
+ * per-chain breakdown shows each chain's exact window; "shortest" would
+ * understate the majority component instead. A real tradeoff, revisit if it
+ * confuses.
  */
-export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): { rate: number; days: number } | null {
+export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): NetworkAvgBlend | null {
   let weighted = new BigNumber(0);
   let totalWeight = new BigNumber(0);
+  let totalPositiveWeight = new BigNumber(0);
   let days = 0;
 
   for (const entry of entries) {
+    const weight = new BigNumber(entry.weight || '0');
+    if (weight.gt(0)) totalPositiveWeight = totalPositiveWeight.plus(weight);
+
     if (entry.rate === null) continue;
 
     const rate = Number(entry.rate.ratePercent);
     if (!Number.isFinite(rate)) continue;
 
-    const weight = new BigNumber(entry.weight || '0');
     if (!weight.gt(0)) continue;
 
     weighted = weighted.plus(weight.times(rate));
@@ -104,5 +123,9 @@ export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): { rate: number
 
   if (!totalWeight.gt(0)) return null;
 
-  return { rate: weighted.div(totalWeight).toNumber(), days };
+  return {
+    rate: weighted.div(totalWeight).toNumber(),
+    days,
+    coverage: totalWeight.div(totalPositiveWeight).toNumber(),
+  };
 }

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -91,6 +91,14 @@ export type NetworkAvgBlend = {
 };
 
 /**
+ * Minimum share of the earning stake's weight the benchmark must cover to be
+ * presented as "the network average". Full coverage: with only 2-3 staking
+ * chains, a benchmark that could not measure one of them describes a different
+ * portfolio than the headline next to it.
+ */
+export const NETWORK_AVG_MIN_COVERAGE = 1;
+
+/**
  * Stake-weighted blend of the per-chain network average rates — the same
  * skip-not-zero weighting as `computeWeightedApy`, carrying the window length
  * along: the label shows the longest window of the contributing chains — it

--- a/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/apy.ts
@@ -1,7 +1,7 @@
 import { default as BigNumber } from 'bignumber.js';
 
 import { type ChainId } from '@/shared/core';
-import { type StakingPosition } from '@/domains/staking';
+import { type NetworkAvgRate, type StakingPosition } from '@/domains/staking';
 
 /**
  * One chain's contribution to the blended APY: the network APY it pays and the
@@ -66,4 +66,43 @@ export function computeWeightedApy(entries: ApyWeight[]): number | null {
   if (!totalWeight.gt(0)) return null;
 
   return weighted.div(totalWeight).toNumber();
+}
+
+/** One chain's contribution to the blended network benchmark. */
+export type NetworkAvgWeight = {
+  chainId: ChainId;
+  /** The chain's trailing-window rate, `null` when it has not reported one. */
+  rate: Pick<NetworkAvgRate, 'ratePercent' | 'days'> | null;
+  /** Fiat value of the earning stake on that chain. */
+  weight: string;
+};
+
+/**
+ * Stake-weighted blend of the per-chain network average rates — the same
+ * skip-not-zero weighting as `computeWeightedApy`, carrying the window length
+ * along: the label shows the longest window among the contributing chains
+ * ("30d" for Polkadot AH even when Kusama AH could only answer for 21).
+ */
+export function blendNetworkAvgRate(entries: NetworkAvgWeight[]): { rate: number; days: number } | null {
+  let weighted = new BigNumber(0);
+  let totalWeight = new BigNumber(0);
+  let days = 0;
+
+  for (const entry of entries) {
+    if (entry.rate === null) continue;
+
+    const rate = Number(entry.rate.ratePercent);
+    if (!Number.isFinite(rate)) continue;
+
+    const weight = new BigNumber(entry.weight || '0');
+    if (!weight.gt(0)) continue;
+
+    weighted = weighted.plus(weight.times(rate));
+    totalWeight = totalWeight.plus(weight);
+    days = Math.max(days, entry.rate.days);
+  }
+
+  if (!totalWeight.gt(0)) return null;
+
+  return { rate: weighted.div(totalWeight).toNumber(), days };
 }

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -1,3 +1,5 @@
+import { getErasInDays } from '@/domains/staking';
+
 /** Windows the rewards drill-down can be looked at through. */
 export const REWARD_PERIODS = ['7d', '30d', 'all'] as const;
 
@@ -42,5 +44,5 @@ export function erasInPeriod(period: RewardPeriod, eraDurationMs: number | null,
   const days = periodDays(period);
   if (days === null || !eraDurationMs || eraDurationMs <= 0) return historyDepth;
 
-  return Math.min(historyDepth, Math.max(1, Math.ceil((days * DAY_MS) / eraDurationMs)));
+  return Math.min(historyDepth, getErasInDays(days, eraDurationMs));
 }

--- a/src/renderer/features/dashboard-staking-kpi/lib/types.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/types.ts
@@ -1,6 +1,6 @@
 import { type ChainId } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { type UnbondingChunk, type UnclaimedPayout } from '@/domains/staking';
+import { type NetworkAvgRate, type UnbondingChunk, type UnclaimedPayout } from '@/domains/staking';
 
 import { type AccessMode } from './access';
 
@@ -63,6 +63,8 @@ export type BreakdownRow = {
   color: string;
   /** APY of the chain, percent — `null` when unknown. */
   apy: number | null;
+  /** Trailing-window network average of the chain — `null` when unknown. */
+  networkAvgRate: NetworkAvgRate | null;
   validatorCount: number;
   earning: boolean;
 };

--- a/src/renderer/features/dashboard-staking-kpi/ui/ApyWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ApyWidget.tsx
@@ -1,7 +1,9 @@
 import { useCallback, useState } from 'react';
 
 import { useI18n } from '@/shared/i18n';
+import { HelpText } from '@/shared/ui';
 import { useStakingKpi } from '../hooks/useStakingKpi';
+import { NETWORK_AVG_MIN_COVERAGE } from '../lib/apy';
 
 import { BreakdownModal } from './BreakdownModal';
 import { KpiCard } from './KpiCard';
@@ -29,6 +31,19 @@ export const ApyWidget = ({ accountIds }: Props) => {
   const headline =
     kpi.weightedApy === null ? EM_DASH : t('dashboard.staking.kpi.apy.value', { apy: kpi.weightedApy.toFixed(1) });
 
+  // The benchmark renders only when it describes the same portfolio as the
+  // headline: full weight coverage, and a headline that exists at all.
+  const networkAvg =
+    !kpi.pending &&
+    kpi.weightedApy !== null &&
+    kpi.networkAvg !== null &&
+    kpi.networkAvg.coverage >= NETWORK_AVG_MIN_COVERAGE
+      ? t('dashboard.staking.kpi.apy.networkAvg', {
+          rate: kpi.networkAvg.rate.toFixed(1),
+          days: kpi.networkAvg.days,
+        })
+      : null;
+
   return (
     <KpiWidgetFrame>
       <KpiCard
@@ -38,6 +53,7 @@ export const ApyWidget = ({ accountIds }: Props) => {
         valueClass={kpi.weightedApy === null ? 'text-text-tertiary' : 'text-text-positive'}
         value={headline}
         subline={t('dashboard.staking.kpi.apy.subline', { count: kpi.earningPositionCount })}
+        footer={networkAvg ? <HelpText className="text-text-tertiary">{networkAvg}</HelpText> : undefined}
         onClick={handleOpen}
       />
 

--- a/src/renderer/features/dashboard-staking-kpi/ui/ApyWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ApyWidget.tsx
@@ -44,11 +44,13 @@ export const ApyWidget = ({ accountIds }: Props) => {
         })
       : null;
 
+  const ariaLabel = [title, headline, networkAvg].filter(Boolean).join(', ');
+
   return (
     <KpiWidgetFrame>
       <KpiCard
         title={title}
-        ariaLabel={title}
+        ariaLabel={ariaLabel}
         loading={kpi.pending}
         valueClass={kpi.weightedApy === null ? 'text-text-tertiary' : 'text-text-positive'}
         value={headline}

--- a/src/renderer/features/dashboard-staking-kpi/ui/BreakdownModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/BreakdownModal.tsx
@@ -129,6 +129,14 @@ export const BreakdownModal = memo(
                               ? t('dashboard.staking.kpi.apy.unknown')
                               : t('dashboard.staking.kpi.apy.value', { apy: row.apy.toFixed(1) })}
                           </FootnoteText>
+                          {row.networkAvgRate !== null && (
+                            <HelpText className="text-text-tertiary tabular-nums">
+                              {t('dashboard.staking.kpi.apy.networkAvg', {
+                                rate: Number(row.networkAvgRate.ratePercent).toFixed(1),
+                                days: row.networkAvgRate.days,
+                              })}
+                            </HelpText>
+                          )}
                           <HelpText className="text-text-tertiary tabular-nums">
                             <Price amount={row.fiat} currency={currency} />
                           </HelpText>

--- a/src/renderer/features/dashboard-staking-kpi/ui/BreakdownModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/BreakdownModal.tsx
@@ -10,6 +10,7 @@ import { type CurrencyItem } from '@/domains/price';
 import { networkModel } from '@/entities/network';
 import { NamedAccount } from '@/widgets/NameResolver';
 import { formatAssetAmount } from '../lib/amounts';
+import { parseRatePercent } from '../lib/apy';
 import { type BreakdownRow } from '../lib/types';
 
 import { DonutBreakdown } from './DonutBreakdown';
@@ -89,60 +90,68 @@ export const BreakdownModal = memo(
               <div className="max-h-80 min-w-0 flex-1">
                 <ScrollArea>
                   <div className="flex flex-col gap-1 pe-2">
-                    {rows.map((row) => (
-                      <div
-                        key={row.key}
-                        className={cnTw(
-                          'flex items-center gap-3 rounded-md px-2 py-1.5 transition-colors',
-                          hoveredId === row.key ? 'bg-hover' : 'bg-transparent',
-                        )}
-                        onMouseEnter={() => setHoveredId(row.key)}
-                        onMouseLeave={() => setHoveredId(null)}
-                      >
-                        <span
-                          className="h-6 w-1 shrink-0 rounded-full"
-                          style={{ backgroundColor: row.color }}
-                          aria-hidden
-                        />
-                        <div className="min-w-0 flex-1">
-                          <NamedAccount
-                            accountId={row.accountId}
-                            chain={chains[row.chainId]}
-                            wallet={walletByAccount[row.accountId]}
-                            titleClass="truncate font-semibold"
-                            variant="short"
-                            iconSize={20}
-                            hideExplorers
-                          />
-                          <HelpText className="text-text-tertiary">
-                            {row.chainName}
-                            {}
-                            {' · '}
-                            {formatAssetAmount({ symbol: row.symbol, precision: row.precision, amount: row.stake })}
-                          </HelpText>
-                        </div>
-                        <div className="shrink-0 text-right">
-                          <FootnoteText
-                            className={cnTw('tabular-nums', row.earning ? 'text-text-positive' : 'text-text-tertiary')}
-                          >
-                            {row.apy === null
-                              ? t('dashboard.staking.kpi.apy.unknown')
-                              : t('dashboard.staking.kpi.apy.value', { apy: row.apy.toFixed(1) })}
-                          </FootnoteText>
-                          {row.networkAvgRate !== null && (
-                            <HelpText className="text-text-tertiary tabular-nums">
-                              {t('dashboard.staking.kpi.apy.networkAvg', {
-                                rate: Number(row.networkAvgRate.ratePercent).toFixed(1),
-                                days: row.networkAvgRate.days,
-                              })}
-                            </HelpText>
+                    {rows.map((row) => {
+                      const networkAvgRate =
+                        row.networkAvgRate === null ? null : parseRatePercent(row.networkAvgRate.ratePercent);
+
+                      return (
+                        <div
+                          key={row.key}
+                          className={cnTw(
+                            'flex items-center gap-3 rounded-md px-2 py-1.5 transition-colors',
+                            hoveredId === row.key ? 'bg-hover' : 'bg-transparent',
                           )}
-                          <HelpText className="text-text-tertiary tabular-nums">
-                            <Price amount={row.fiat} currency={currency} />
-                          </HelpText>
+                          onMouseEnter={() => setHoveredId(row.key)}
+                          onMouseLeave={() => setHoveredId(null)}
+                        >
+                          <span
+                            className="h-6 w-1 shrink-0 rounded-full"
+                            style={{ backgroundColor: row.color }}
+                            aria-hidden
+                          />
+                          <div className="min-w-0 flex-1">
+                            <NamedAccount
+                              accountId={row.accountId}
+                              chain={chains[row.chainId]}
+                              wallet={walletByAccount[row.accountId]}
+                              titleClass="truncate font-semibold"
+                              variant="short"
+                              iconSize={20}
+                              hideExplorers
+                            />
+                            <HelpText className="text-text-tertiary">
+                              {row.chainName}
+                              {}
+                              {' · '}
+                              {formatAssetAmount({ symbol: row.symbol, precision: row.precision, amount: row.stake })}
+                            </HelpText>
+                          </div>
+                          <div className="shrink-0 text-right">
+                            <FootnoteText
+                              className={cnTw(
+                                'tabular-nums',
+                                row.earning ? 'text-text-positive' : 'text-text-tertiary',
+                              )}
+                            >
+                              {row.apy === null
+                                ? t('dashboard.staking.kpi.apy.unknown')
+                                : t('dashboard.staking.kpi.apy.value', { apy: row.apy.toFixed(1) })}
+                            </FootnoteText>
+                            {row.networkAvgRate !== null && networkAvgRate !== null && (
+                              <HelpText className="text-text-tertiary tabular-nums">
+                                {t('dashboard.staking.kpi.apy.networkAvg', {
+                                  rate: networkAvgRate.toFixed(1),
+                                  days: row.networkAvgRate.days,
+                                })}
+                              </HelpText>
+                            )}
+                            <HelpText className="text-text-tertiary tabular-nums">
+                              <Price amount={row.fiat} currency={currency} />
+                            </HelpText>
+                          </div>
                         </div>
-                      </div>
-                    ))}
+                      );
+                    })}
                   </div>
                 </ScrollArea>
               </div>

--- a/src/renderer/features/dashboard-staking-kpi/ui/NominationsWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/NominationsWidget.tsx
@@ -28,14 +28,20 @@ export const NominationsWidget = ({ accountIds }: Props) => {
   const title = t('dashboard.staking.kpi.nominations.title');
   if (accountIds.length === 0) return <NoSelectionCard title={title} />;
 
+  const subline = t('dashboard.staking.kpi.nominations.subline', { count: kpi.activeValidatorCount });
+  // An explicit aria-label replaces the card's inner text for screen readers,
+  // so it must carry what the card shows. The system tests anchor on the title
+  // prefix of this label.
+  const ariaLabel = [title, String(kpi.nominationRows.length), subline].join(', ');
+
   return (
     <KpiWidgetFrame>
       <KpiCard
         title={title}
-        ariaLabel={title}
+        ariaLabel={ariaLabel}
         loading={kpi.pending}
         value={kpi.nominationRows.length}
-        subline={t('dashboard.staking.kpi.nominations.subline', { count: kpi.activeValidatorCount })}
+        subline={subline}
         onClick={handleOpen}
       />
 

--- a/src/renderer/features/dashboard-staking-kpi/ui/RewardsWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/RewardsWidget.tsx
@@ -47,7 +47,9 @@ export const RewardsWidget = ({ accountIds }: Props) => {
   const unclaimedLabel = kpi.unclaimedFooter
     ? `${t('dashboard.staking.kpi.rewards.unclaimed')} ${formatAssetAmounts(kpi.unclaimedFooter.amounts)}`
     : null;
-  const ariaLabel = [title, subline, unclaimedLabel].filter(Boolean).join(', ');
+  // The token amounts always ride along: with fiat off the subline drops them,
+  // and a label without any value announces nothing.
+  const ariaLabel = [title, rewardTokens, subline, unclaimedLabel].filter(Boolean).join(', ');
 
   return (
     <KpiWidgetFrame>

--- a/src/renderer/features/dashboard-staking-kpi/ui/RewardsWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/RewardsWidget.tsx
@@ -35,22 +35,29 @@ export const RewardsWidget = ({ accountIds }: Props) => {
   const rewardTokens = formatAssetAmounts(kpi.rewardAmounts, { sign: '+', fallback: EM_DASH });
   const showFiat = kpi.fiatFlag !== false;
 
+  const subline = showFiat
+    ? t('dashboard.staking.kpi.rewards.subline', {
+        amounts: rewardTokens,
+        days: kpi.rewardsWindowDays,
+      })
+    : t('dashboard.staking.kpi.rewards.sublineNoFiat', { days: kpi.rewardsWindowDays });
+  // An explicit aria-label replaces the card's inner text for screen readers,
+  // so it must carry what the card shows. The system tests anchor on the title
+  // prefix of this label.
+  const unclaimedLabel = kpi.unclaimedFooter
+    ? `${t('dashboard.staking.kpi.rewards.unclaimed')} ${formatAssetAmounts(kpi.unclaimedFooter.amounts)}`
+    : null;
+  const ariaLabel = [title, subline, unclaimedLabel].filter(Boolean).join(', ');
+
   return (
     <KpiWidgetFrame>
       <KpiCard
         title={title}
-        ariaLabel={title}
+        ariaLabel={ariaLabel}
         loading={kpi.pending}
         valueClass="text-text-positive"
         value={showFiat ? <Price amount={kpi.rewardsFiat} currency={kpi.currency} /> : rewardTokens}
-        subline={
-          showFiat
-            ? t('dashboard.staking.kpi.rewards.subline', {
-                amounts: rewardTokens,
-                days: kpi.rewardsWindowDays,
-              })
-            : t('dashboard.staking.kpi.rewards.sublineNoFiat', { days: kpi.rewardsWindowDays })
-        }
+        subline={subline}
         footer={
           kpi.unclaimedFooter ? (
             <div className="flex items-center gap-2">

--- a/src/renderer/features/dashboard-staking-kpi/ui/TotalStakedWidget.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/TotalStakedWidget.tsx
@@ -34,11 +34,19 @@ export const TotalStakedWidget = ({ accountIds }: Props) => {
   // subline would only repeat the headline.
   const showFiat = kpi.fiatFlag !== false;
 
+  // An explicit aria-label replaces the card's inner text for screen readers,
+  // so it must carry what the card shows. The system tests anchor on the title
+  // prefix of this label.
+  const unbondingLabel = kpi.unbondingFooter
+    ? `${t('dashboard.staking.kpi.totalStaked.unbonding')} ${formatAssetAmounts(kpi.unbondingFooter.amounts)}`
+    : null;
+  const ariaLabel = [title, stakedTokens, unbondingLabel].filter(Boolean).join(', ');
+
   return (
     <KpiWidgetFrame>
       <KpiCard
         title={title}
-        ariaLabel={title}
+        ariaLabel={ariaLabel}
         loading={kpi.pending}
         value={showFiat ? <Price amount={kpi.totalStakedFiat} currency={kpi.currency} /> : stakedTokens}
         subline={showFiat ? stakedTokens : null}

--- a/src/renderer/features/dashboard-staking-positions/README.md
+++ b/src/renderer/features/dashboard-staking-positions/README.md
@@ -1,6 +1,6 @@
 # Dashboard Staking Positions
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-11
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-19
 
 ## Overview
 
@@ -83,8 +83,10 @@ descending by default, and clearing the sort returns to that default rather than
 - **Unclaimed** — the amount plus how long it has left. An unclaimed payout is not merely uncollected: it is destroyed
   once its era leaves the runtime history. The chip is red under 14 days, amber to 30, green beyond.
 
-Beyond 20 rows the table body becomes the scroll container — about eight rows visible, header pinned, and a footer
-saying how many there are in total. The card must not push the rest of the dashboard off the screen.
+The header row is always sticky — below the row threshold the widget shell is what scrolls, and the column names must
+survive that scrolling too. Beyond 20 rows the table body additionally becomes its own scroll container — about eight
+rows visible, header pinned to it, and a footer saying how many there are in total. The card must not push the rest of
+the dashboard off the screen.
 
 Loading renders the same table with the cells blanked: same header, same widths, same row height, so nothing moves when
 the data lands.

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionDetailDrawer.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionDetailDrawer.tsx
@@ -207,9 +207,8 @@ export const PositionDetailDrawer = ({ row, onClose }: Props) => {
                 {row.apy === null ? (
                   <FootnoteText className="text-text-tertiary">{t('dashboard.staking.positions.noValue')}</FootnoteText>
                 ) : (
-                  <FootnoteText className="text-text-positive">
-                    {t('dashboard.stakingOverview.apy', { apy: row.apy.toFixed(1) })}
-                  </FootnoteText>
+                  // The stat label already says APY — a bare percent, same as the table cell.
+                  <FootnoteText className="text-text-positive">{`${row.apy.toFixed(1)}%`}</FootnoteText>
                 )}
               </StatCell>
 

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
@@ -62,9 +62,9 @@ export const PositionsTable = ({ rows, sort, onSortChange, onRowClick }: Props) 
         row.apy === null ? (
           <FootnoteText className="text-text-tertiary">{t('dashboard.staking.positions.noValue')}</FootnoteText>
         ) : (
-          <FootnoteText className="text-text-positive">
-            {t('dashboard.stakingOverview.apy', { apy: row.apy.toFixed(1) })}
-          </FootnoteText>
+          // The column header already says APY — a bare percent keeps the cell
+          // on one line (same format as the nominations table).
+          <FootnoteText className="text-text-positive">{`${row.apy.toFixed(1)}%`}</FootnoteText>
         ),
 
       activeValidatorCount: (row) => (

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTable.tsx
@@ -109,11 +109,14 @@ export const PositionsTable = ({ rows, sort, onSortChange, onRowClick }: Props) 
       className={scrolls ? 'overflow-y-auto' : undefined}
       style={scrolls ? { maxHeight: SCROLL_MAX_HEIGHT } : undefined}
     >
+      {/* Always sticky: below the row threshold the nearest scrollport is the
+          widget shell, and the header must survive scrolling there too — not
+          only inside the table's own scroller. */}
       <Table
         columns={columns}
         data={rows}
         sort={sort}
-        stickyHeader={scrolls}
+        stickyHeader
         getRowKey={(row) => row.id}
         onSortChange={onSortChange}
         onRowClick={onRowClick}

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionsTableSkeleton.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionsTableSkeleton.tsx
@@ -58,5 +58,7 @@ export const PositionsTableSkeleton = () => {
     [t],
   );
 
-  return <Table columns={columns} data={rows} getRowKey={(row) => row.id} />;
+  // Same stickiness as the loaded table — the header must not gain a divider
+  // and start pinning only when the data lands.
+  return <Table columns={columns} data={rows} getRowKey={(row) => row.id} stickyHeader />;
 };

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -826,6 +826,7 @@
           "title": "Est. APY",
           "value": "{apy}%",
           "unknown": "—",
+          "networkAvg": "network avg {rate}% · {days}d",
           "subline_one": "stake-weighted · {count} earning position",
           "subline_other": "stake-weighted · {count} earning positions",
           "detailTitle": "Estimated APY breakdown"

--- a/src/renderer/shared/pallet/staking/stakingPallet.test.ts
+++ b/src/renderer/shared/pallet/staking/stakingPallet.test.ts
@@ -362,3 +362,28 @@ describe('stakingPallet storage.bondedEras', () => {
     ]);
   });
 });
+
+describe('stakingPallet storage.erasTotalStakeMulti', () => {
+  it('should zip eras with their total stakes in order', async () => {
+    const totalStakes = registry.createType('Vec<u128>', [1000, 2000]);
+
+    const query = Object.assign(vi.fn(), {
+      multi: vi.fn().mockResolvedValue(totalStakes),
+    });
+
+    const api = {
+      query: {
+        staking: { erasTotalStake: query },
+      },
+      runtimeChain: { toString: () => 'test-chain' },
+    } as unknown as ApiPromise;
+
+    const result = await storage.erasTotalStakeMulti(api, [10, 11]);
+
+    expect(query.multi).toHaveBeenCalledWith([10, 11]);
+    expect(result).toEqual([
+      { era: 10, totalStake: new BN(1000) },
+      { era: 11, totalStake: new BN(2000) },
+    ]);
+  });
+});

--- a/src/renderer/shared/pallet/staking/storage.ts
+++ b/src/renderer/shared/pallet/staking/storage.ts
@@ -70,6 +70,18 @@ export const storage = {
   },
 
   /**
+   * The total amount staked, for several eras at once.
+   */
+  erasTotalStakeMulti(api: ApiPromise, eras: number[]) {
+    const schema = pjsSchema.vec(pjsSchema.u128);
+
+    return substrateRpcPool
+      .call(() => getQuery(api, 'erasTotalStake').multi(eras))
+      .then(schema.parse)
+      .then(stakes => zipWith(eras, stakes, (era, totalStake) => ({ era, totalStake })));
+  },
+
+  /**
    * The total validator era payout for the last `HistoryDepth` eras.
    */
   erasValidatorReward(api: ApiPromise, eras: number[]) {

--- a/src/renderer/shared/ui-kit/Table/Table.css
+++ b/src/renderer/shared/ui-kit/Table/Table.css
@@ -37,6 +37,16 @@
   background-color: white;
 }
 
+/*
+ * The hover token is translucent (6% alpha). On a sticky header it must
+ * composite against the cell's own white — replacing `background-color`
+ * outright would let the rows scrolled beneath shine through the tint.
+ */
+.table-container--sticky-header .table-header-cell--sortable:hover {
+  background-image: linear-gradient(var(--action-background-hover), var(--action-background-hover));
+  background-color: white;
+}
+
 .table-header-cell {
   padding: 12px;
   color: var(--text-tertiary);

--- a/tests/system/cases/staking/staking-dashboard.system.test.ts
+++ b/tests/system/cases/staking/staking-dashboard.system.test.ts
@@ -42,42 +42,51 @@ test.describe('Staking dashboard — populated (watch-only nominator)', { tag: '
     await setupTestMetadata('Staking dashboard', 'Populated');
   });
 
-  test('S1: KPI cards and the positions table describe the live position', async ({ stakingDashboardPage }) => {
-    test.setTimeout(TEST_TIMEOUT);
+  // In the @regress rotation as the staking smoke: the KPI locators anchor on
+  // the aria-label title prefix, and this is the test that notices a break —
+  // the rest of the @staking suite only runs on manual dispatch.
+  test(
+    'S1: KPI cards and the positions table describe the live position',
+    { tag: '@regress' },
+    async ({ stakingDashboardPage }) => {
+      test.setTimeout(TEST_TIMEOUT);
 
-    // --- Total staked: a fiat headline over a per-asset subline
-    await expect(stakingDashboardPage.getKpiSubline('totalStaked')).toContainText(elements.amountPattern, {
-      timeout: LIVE_DATA_TIMEOUT,
-    });
-    await expect(stakingDashboardPage.getKpiValue('totalStaked')).toContainText(elements.nonZeroFiatPattern, {
-      timeout: LIVE_DATA_TIMEOUT,
-    });
+      // --- Total staked: a fiat headline over a per-asset subline
+      await expect(stakingDashboardPage.getKpiSubline('totalStaked')).toContainText(elements.amountPattern, {
+        timeout: LIVE_DATA_TIMEOUT,
+      });
+      await expect(stakingDashboardPage.getKpiValue('totalStaked')).toContainText(elements.nonZeroFiatPattern, {
+        timeout: LIVE_DATA_TIMEOUT,
+      });
 
-    // --- Est. APY: a percentage, not the em dash
-    await expect(stakingDashboardPage.getKpiValue('apy')).toContainText(elements.percentPattern, {
-      timeout: LIVE_DATA_TIMEOUT,
-    });
-    await expect(stakingDashboardPage.getKpiSubline('apy')).toContainText(/stake-weighted · [1-9]\d* earning position/);
+      // --- Est. APY: a percentage, not the em dash
+      await expect(stakingDashboardPage.getKpiValue('apy')).toContainText(elements.percentPattern, {
+        timeout: LIVE_DATA_TIMEOUT,
+      });
+      await expect(stakingDashboardPage.getKpiSubline('apy')).toContainText(
+        /stake-weighted · [1-9]\d* earning position/,
+      );
 
-    // --- Active nominations: a non-zero count over a non-zero position count
-    await expect(stakingDashboardPage.getKpiValue('nominations')).toHaveText(/^[1-9]\d*$/, {
-      timeout: LIVE_DATA_TIMEOUT,
-    });
-    await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(/validators · [1-9]\d* position/);
+      // --- Active nominations: a non-zero count over a non-zero position count
+      await expect(stakingDashboardPage.getKpiValue('nominations')).toHaveText(/^[1-9]\d*$/, {
+        timeout: LIVE_DATA_TIMEOUT,
+      });
+      await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(/validators · [1-9]\d* position/);
 
-    // --- Rewards card renders its window subline
-    await expect(stakingDashboardPage.getKpiSubline('rewards')).toContainText(/\d+d$/);
+      // --- Rewards card renders its window subline
+      await expect(stakingDashboardPage.getKpiSubline('rewards')).toContainText(/\d+d$/);
 
-    // --- Positions table
-    const row = stakingDashboardPage.getPositionRows().first();
-    await expect(row).toBeVisible({ timeout: LIVE_DATA_TIMEOUT });
-    await expect(row).toContainText(elements.amountPattern);
-    await expect(row).toContainText(elements.activeStatusLabel);
-    await expect(row).toContainText(elements.validatorsCellPattern);
-    await expect(row).toContainText(elements.percentPattern);
-    // A watch-only wallet marks its rows as view-only.
-    await expect(row).toContainText(elements.viewOnlyLabel);
-  });
+      // --- Positions table
+      const row = stakingDashboardPage.getPositionRows().first();
+      await expect(row).toBeVisible({ timeout: LIVE_DATA_TIMEOUT });
+      await expect(row).toContainText(elements.amountPattern);
+      await expect(row).toContainText(elements.activeStatusLabel);
+      await expect(row).toContainText(elements.validatorsCellPattern);
+      await expect(row).toContainText(elements.percentPattern);
+      // A watch-only wallet marks its rows as view-only.
+      await expect(row).toContainText(elements.viewOnlyLabel);
+    },
+  );
 
   test('S2: position row opens the detail drawer with no actions for watch-only', async ({ stakingDashboardPage }) => {
     test.setTimeout(TEST_TIMEOUT);

--- a/tests/system/cases/staking/staking-dashboard.system.test.ts
+++ b/tests/system/cases/staking/staking-dashboard.system.test.ts
@@ -42,51 +42,48 @@ test.describe('Staking dashboard — populated (watch-only nominator)', { tag: '
     await setupTestMetadata('Staking dashboard', 'Populated');
   });
 
-  // In the @regress rotation as the staking smoke: the KPI locators anchor on
-  // the aria-label title prefix, and this is the test that notices a break —
-  // the rest of the @staking suite only runs on manual dispatch.
-  test(
-    'S1: KPI cards and the positions table describe the live position',
-    { tag: '@regress' },
-    async ({ stakingDashboardPage }) => {
-      test.setTimeout(TEST_TIMEOUT);
+  // Deliberately NOT in the @regress rotation: this is a live-chain test
+  // (mainnet stashes, 120s data timeouts) and the rotation holds live-network
+  // suites out by convention — locator regressions surface on the suite's
+  // manual dispatch instead.
+  test('S1: KPI cards and the positions table describe the live position', async ({ stakingDashboardPage }) => {
+    test.setTimeout(TEST_TIMEOUT);
 
-      // --- Total staked: a fiat headline over a per-asset subline
-      await expect(stakingDashboardPage.getKpiSubline('totalStaked')).toContainText(elements.amountPattern, {
-        timeout: LIVE_DATA_TIMEOUT,
-      });
-      await expect(stakingDashboardPage.getKpiValue('totalStaked')).toContainText(elements.nonZeroFiatPattern, {
-        timeout: LIVE_DATA_TIMEOUT,
-      });
+    // --- Total staked: a fiat headline over a per-asset subline
+    await expect(stakingDashboardPage.getKpiSubline('totalStaked')).toContainText(elements.amountPattern, {
+      timeout: LIVE_DATA_TIMEOUT,
+    });
+    await expect(stakingDashboardPage.getKpiValue('totalStaked')).toContainText(elements.nonZeroFiatPattern, {
+      timeout: LIVE_DATA_TIMEOUT,
+    });
 
-      // --- Est. APY: a percentage, not the em dash
-      await expect(stakingDashboardPage.getKpiValue('apy')).toContainText(elements.percentPattern, {
-        timeout: LIVE_DATA_TIMEOUT,
-      });
-      await expect(stakingDashboardPage.getKpiSubline('apy')).toContainText(
-        /stake-weighted · [1-9]\d* earning position/,
-      );
+    // --- Est. APY: a percentage, not the em dash
+    await expect(stakingDashboardPage.getKpiValue('apy')).toContainText(elements.percentPattern, {
+      timeout: LIVE_DATA_TIMEOUT,
+    });
+    await expect(stakingDashboardPage.getKpiSubline('apy')).toContainText(/stake-weighted · [1-9]\d* earning position/);
 
-      // --- Active nominations: a non-zero count over a non-zero position count
-      await expect(stakingDashboardPage.getKpiValue('nominations')).toHaveText(/^[1-9]\d*$/, {
-        timeout: LIVE_DATA_TIMEOUT,
-      });
-      await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(/validators · [1-9]\d* position/);
+    // --- Active nominations: a non-zero count over a non-zero position count
+    await expect(stakingDashboardPage.getKpiValue('nominations')).toHaveText(/^[1-9]\d*$/, {
+      timeout: LIVE_DATA_TIMEOUT,
+    });
+    await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(
+      /validators · [1-9]\d* backed this era/,
+    );
 
-      // --- Rewards card renders its window subline
-      await expect(stakingDashboardPage.getKpiSubline('rewards')).toContainText(/\d+d$/);
+    // --- Rewards card renders its window subline
+    await expect(stakingDashboardPage.getKpiSubline('rewards')).toContainText(/\d+d$/);
 
-      // --- Positions table
-      const row = stakingDashboardPage.getPositionRows().first();
-      await expect(row).toBeVisible({ timeout: LIVE_DATA_TIMEOUT });
-      await expect(row).toContainText(elements.amountPattern);
-      await expect(row).toContainText(elements.activeStatusLabel);
-      await expect(row).toContainText(elements.validatorsCellPattern);
-      await expect(row).toContainText(elements.percentPattern);
-      // A watch-only wallet marks its rows as view-only.
-      await expect(row).toContainText(elements.viewOnlyLabel);
-    },
-  );
+    // --- Positions table
+    const row = stakingDashboardPage.getPositionRows().first();
+    await expect(row).toBeVisible({ timeout: LIVE_DATA_TIMEOUT });
+    await expect(row).toContainText(elements.amountPattern);
+    await expect(row).toContainText(elements.activeStatusLabel);
+    await expect(row).toContainText(elements.validatorsCellPattern);
+    await expect(row).toContainText(elements.percentPattern);
+    // A watch-only wallet marks its rows as view-only.
+    await expect(row).toContainText(elements.viewOnlyLabel);
+  });
 
   test('S2: position row opens the detail drawer with no actions for watch-only', async ({ stakingDashboardPage }) => {
     test.setTimeout(TEST_TIMEOUT);
@@ -229,7 +226,7 @@ test.describe('Staking dashboard — empty state (watch-only)', { tag: '@staking
     await expect(stakingDashboardPage.getKpiValue('apy')).toHaveText(elements.emDash, { timeout: LIVE_DATA_TIMEOUT });
     await expect(stakingDashboardPage.getKpiSubline('totalStaked')).toHaveText(elements.emDash);
     await expect(stakingDashboardPage.getKpiValue('totalStaked')).toContainText('0');
-    await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(/validators · 0 position/);
+    await expect(stakingDashboardPage.getKpiSubline('nominations')).toContainText(/validators · 0 backed this era/);
 
     for (const card of ['totalStaked', 'apy', 'nominations', 'rewards'] as const) {
       await expect(stakingDashboardPage.getKpiSkeletons(card)).toHaveCount(0);

--- a/tests/system/pages/_elements/StakingDashboardPageElements.ts
+++ b/tests/system/pages/_elements/StakingDashboardPageElements.ts
@@ -14,8 +14,9 @@ export class StakingDashboardPageElements implements BasePageElements {
   stakingTabLabel = 'Staking';
 
   // --- KPI row -------------------------------------------------------------
-  // Each KpiCard is a role="button" carrying its title as aria-label, which is
-  // the only exact hook the row exposes.
+  // Each KpiCard is a role="button" whose aria-label starts with its title and
+  // may append the current value and benchmark (e.g. "Est. APY, 5.4%, network
+  // avg 2.9% · 30d") — locators anchor on the title prefix, not an exact match.
   kpiTitles: Record<StakingKpiCard, string> = {
     totalStaked: 'Total staked',
     apy: 'Est. APY',

--- a/tests/system/pages/_elements/StakingDashboardPageElements.ts
+++ b/tests/system/pages/_elements/StakingDashboardPageElements.ts
@@ -20,7 +20,7 @@ export class StakingDashboardPageElements implements BasePageElements {
   kpiTitles: Record<StakingKpiCard, string> = {
     totalStaked: 'Total staked',
     apy: 'Est. APY',
-    nominations: 'Active nominations',
+    nominations: 'Nominated validators',
     rewards: 'Rewards',
   };
 
@@ -29,7 +29,7 @@ export class StakingDashboardPageElements implements BasePageElements {
   redeemLinkLabel = 'Redeem →';
 
   apyBreakdownTitle = 'Estimated APY breakdown';
-  nominationsBreakdownTitle = 'Active nominations breakdown';
+  nominationsBreakdownTitle = 'Nomination spread';
   positionsModalTitle = 'Staking positions';
   /** Green chip of a fully matured unbonding chunk: `{amount} ready`. */
   readyChipPattern = /ready/;

--- a/tests/system/pages/stakingDashboardPage/StakingDashboardPage.ts
+++ b/tests/system/pages/stakingDashboardPage/StakingDashboardPage.ts
@@ -47,7 +47,9 @@ export class StakingDashboardPage extends BasePage<StakingDashboardPageElements>
   // --- KPI row -------------------------------------------------------------
 
   public getKpiCard(card: StakingKpiCard): Locator {
-    return this.getPanel().getByLabel(this.pageElements.kpiTitles[card], { exact: true });
+    const title = this.pageElements.kpiTitles[card];
+
+    return this.getPanel().getByLabel(new RegExp(`^${title.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}(,|$)`));
   }
 
   /**


### PR DESCRIPTION
## Description

Customer request S4 ("Spektr Dashboards Requests" sheet): *"something next to the APY which shows the network average reward rate over that period, similar to staking.polkadot.cloud"*.

The Est. APY card shows the user's stake-weighted APY from a single-era snapshot, with nothing to compare it against. This PR adds the network benchmark: a trailing ~30-day average of **realized** era rewards (`erasValidatorReward / erasTotalStake`, annualized, net of the current median commission — same semantics as the headline, so the two figures are directly comparable). polkadot.cloud computes its "Average Reward Rate" from an indexer; we stay on-chain, so the window is capped by `HistoryDepth`: 30 eras / 30d on Polkadot AH, 84 eras / ~21d on Kusama AH — the label always reports the real window.

Honesty rules the implementation enforces:

- **Realized-only, no NPoS-curve fallback.** A chain that can't be measured returns `null` and the benchmark is hidden, never guessed (the curve overstates Polkadot ~2.7×).
- **Window metadata describes contributing eras only.** Eras with no recorded reward are skipped; a 15-era average says "15d", not "30d".
- **Coverage gate.** The card blends per-chain rates with the same fiat weights as the headline and refuses to render unless the benchmark covers 100% of the earning weight — a Kusama-only "network avg 15%" must not sit beside a mostly-Polkadot headline. The breakdown modal rows are deliberately ungated: a single chain's value is complete by definition, so partial coverage degrades into detail, not into nothing.

## Related Issues

Customer dashboard requests gap analysis — item S4 (`tasks/customer-dashboard-requests.md` on the base branch).

## Changes Made

- `domains/staking/apy`: `getNetworkAvgRewardRate` service + era-keyed `networkAvgRateResource` (`staleAfter: Infinity` for non-null results; a `null` re-requests on next mount, doubling as retry) + `useNetworkAvgRate`.
- `shared/pallet/staking`: `erasTotalStakeMulti` — one batched read instead of up to 84 per-era RPCs.
- `features/dashboard-staking-kpi`: pooled `useNetworkAvgRates` (mirror of `useNetworkApys`), coverage-aware `blendNetworkAvgRate` (+ `NETWORK_AVG_MIN_COVERAGE`), `networkAvg` on the KPI hook, per-chain `networkAvgRate` on breakdown rows.
- UI: «network avg {rate}% · {days}d» footer on the Est. APY card; per-chain line with the exact window in the breakdown modal; the card's aria-label now announces title + headline + benchmark.
- System tests: KPI card locator anchored on the title prefix of the aria-label (exact-match broke with the composed label; note `@staking` runs on manual dispatch only).
- Docs: `dashboard-staking-kpi/README.md` spec updated.

## Screenshots/Recordings

_Not attached: live browser verification was interrupted mid-run; see test plan below._

## Test plan

- `pnpm test:unit` — 3068 passed (16 new tests: service window math incl. the KAH HistoryDepth cap and per-era reward↔stake alignment, blend coverage/window semantics, `erasTotalStakeMulti` storage wiring).
- Manual: staking dashboard with a PAH nominator → footer ≈ "network avg 2.9% · 30d" class of figure; KAH position → breakdown row shows "· 21d"; selection with no earning positions → headline «—», no footer.
- `@staking` system suite (manual dispatch) covers the relocated locator: S1/S4.

## Checklist

- [x] I have performed a self-review of my own code
- [ ] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
