### PR TITLE
fix(dashboard): stop the rewards widget shaking

### DIFF
--- a/src/renderer/features/dashboard-staking-rewards-chart/README.md
+++ b/src/renderer/features/dashboard-staking-rewards-chart/README.md
@@ -35,8 +35,9 @@ recent payout is visible as a day rather than being averaged into a month.
 | Bar hover | Pointer over a bar                            | A floating card: bucket title, per-account rows, a Total footer with fiat |
 | Fiat off  | Global "show fiat" toggle is off              | The same card without the "≈ …" part of the total line                    |
 
-The loading shimmer, the empty message and the plot all occupy the same fixed box, so data arriving — or the user
-switching range or asset — never moves anything below the card.
+The loading shimmer, the empty message and the plot all occupy the same box, so data arriving — or the user switching
+range or asset — never moves anything below the card. That box is whatever height the widget's cell leaves over: the
+card never scrolls, the plot stretches into the space instead, and resizing the widget resizes the plot.
 
 ### Ranges and bucketing
 

--- a/src/renderer/features/dashboard-staking-rewards-chart/lib/constants.ts
+++ b/src/renderer/features/dashboard-staking-rewards-chart/lib/constants.ts
@@ -1,10 +1,2 @@
-/**
- * Minimum height of the plot area, in px. The area stretches to absorb extra
- * widget height, but never shrinks below this box — the skeleton and the empty
- * state occupy the same box so switching range/asset — or the data arriving —
- * never moves anything below the card.
- */
-export const CHART_HEIGHT = 180;
-
 /** Fixed width of the hover card, so its clamping needs no measurement. */
 export const TOOLTIP_WIDTH = 264;

--- a/src/renderer/features/dashboard-staking-rewards-chart/ui/RewardsChartWidget.tsx
+++ b/src/renderer/features/dashboard-staking-rewards-chart/ui/RewardsChartWidget.tsx
@@ -14,7 +14,7 @@ import { useRewardsChart } from '../hooks/useRewardsChart';
 import { useRewardsEraAnchor } from '../hooks/useRewardsEraAnchor';
 import { useWalletByAccountId } from '../hooks/useWalletByAccountId';
 import { DEFAULT_RANGE, RANGE_KEYS } from '../lib/buckets';
-import { CHART_HEIGHT, TOOLTIP_WIDTH } from '../lib/constants';
+import { TOOLTIP_WIDTH } from '../lib/constants';
 import { resolveBucketEra } from '../lib/era';
 import { type RangeKey } from '../lib/types';
 
@@ -88,10 +88,10 @@ export const RewardsChartWidget = ({ accountIds }: Props) => {
   const tooltipLeft = hover ? clamp(hover.x - TOOLTIP_WIDTH / 2, 0, Math.max(hover.width - TOOLTIP_WIDTH, 0)) : 0;
 
   return (
-    <DashboardWidget>
-      {/* min-h-full lets the plot area absorb extra cell height while keeping
-          the outer scroll when the cell is shorter than the content */}
-      <div className="flex min-h-full flex-col">
+    <DashboardWidget scroll={false}>
+      {/* The card never scrolls: the plot is sized from the cell, so it absorbs
+          whatever height is left over and shrinks with the widget instead. */}
+      <div className="flex h-full flex-col">
         <div className="flex items-center justify-between gap-4">
           <div className="flex items-center gap-3">
             <FootnoteText className="text-text-tertiary">{t('dashboard.staking.rewardsChart.title')}</FootnoteText>
@@ -134,10 +134,10 @@ export const RewardsChartWidget = ({ accountIds }: Props) => {
           )}
         </div>
 
-        <div ref={containerRef} className="relative mt-3 min-h-0 flex-1" style={{ minHeight: CHART_HEIGHT }}>
+        <div ref={containerRef} className="relative mt-3 min-h-0 flex-1">
           {/* The plot is absolutely positioned: the container's height comes
-              from flex + min-height, which is not a definite height, so an
-              in-flow percentage-sized chart would resolve to 0. */}
+              from the flex line, which is not a definite height, so an in-flow
+              percentage-sized chart would resolve to 0. */}
           <div className="absolute inset-0">
             {pending ? (
               <Skeleton width="100%" height="100%" />

--- a/src/renderer/pages/Dashboard/README.md
+++ b/src/renderer/pages/Dashboard/README.md
@@ -29,7 +29,9 @@ A widget occupies a rectangle `{ x, y, w, h }` in grid units:
 
 - `x` / `w` — column (0–3) and column span (1–4); `x + w` never exceeds 4.
 - `y` / `h` — row and row span; each row is a fixed height. Content taller than the assigned height **scrolls inside**
-  the widget.
+  the widget — vertically only, never sideways. A widget whose content is sized from the cell rather than from the
+  content itself (a chart filling its box) opts out of scrolling entirely and stretches into whatever height it is
+  given.
 
 Layout is stored per tab, per widget. Drag and resize update the moved/resized widget, then **collisions are resolved**
 (overlapped widgets are pushed down) and the whole tab is **vertically compacted**.

--- a/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
+++ b/src/renderer/pages/Dashboard/ui/DashboardGrid.tsx
@@ -130,9 +130,11 @@ const DashboardGridInner = <P extends SlotProps>({ slot, tab, props, editMode }:
 
   return (
     <DragDropProvider onDragEnd={handleDragEnd}>
+      {/* x is clipped, never scrolled: the columns are fractions of this box, so
+          anything wider than it is a rounding artefact — see DashboardWidget */}
       <div
         ref={gridRef}
-        className="grid h-full w-full gap-4 overflow-y-auto p-3"
+        className="grid h-full w-full gap-4 overflow-x-hidden overflow-y-auto p-3"
         style={{
           gridTemplateColumns: `repeat(${GRID_COLUMNS}, minmax(0, 1fr))`,
           gridAutoRows: `${ROW_HEIGHT_PX}px`,

--- a/src/renderer/pages/Dashboard/ui/DashboardWidget.tsx
+++ b/src/renderer/pages/Dashboard/ui/DashboardWidget.tsx
@@ -10,11 +10,29 @@ type Props = {
   children: ReactNode;
   className?: string;
   card?: boolean;
+  /**
+   * Whether content taller than the cell scrolls inside the widget. Widgets
+   * whose content is sized from the cell rather than from the content itself —
+   * a chart filling the box — pass `false`: for them a scrollbar can never be
+   * the right answer, and offering one is actively harmful, see below.
+   */
+  scroll?: boolean;
 };
 
 const CARD_CLASS = 'rounded-lg border border-token-container-border bg-white p-4 shadow-card-shadow';
 
-export const DashboardWidget = memo(({ children, className, card = true }: Props) => {
+/**
+ * Vertical only, on purpose. `overflow-y: auto` alone leaves the x axis at
+ * `visible`, which CSS then computes to `auto` — so a child a fraction of a
+ * pixel too wide (Recharts rounds its width up) earns a horizontal scrollbar.
+ * That scrollbar takes height from the box, which pushes `min-h-full` content
+ * past the remaining height, which raises the vertical scrollbar, which takes
+ * width, which changes what the chart rounds to — and the pair blinks in and
+ * out for as long as the widget is on screen.
+ */
+const SCROLL_CLASS = 'overflow-x-hidden overflow-y-auto';
+
+export const DashboardWidget = memo(({ children, className, card = true, scroll = true }: Props) => {
   const { t } = useI18n();
   const ctx = useWidgetSortable();
   const rect = ctx?.rect;
@@ -57,7 +75,7 @@ export const DashboardWidget = memo(({ children, className, card = true }: Props
           </svg>
         </button>
       )}
-      <div className="min-h-0 flex-1 overflow-y-auto">{children}</div>
+      <div className={cnTw('min-h-0 flex-1', scroll ? SCROLL_CLASS : 'overflow-hidden')}>{children}</div>
       {ctx?.editMode && rect && <WidgetResizeHandle />}
     </div>
   );


### PR DESCRIPTION
## Description

The rewards chart widget on the staking dashboard shakes: its scrollbars appear and disappear several times a second for as long as the tab is open.

Recharts rounds the width it measures for the chart (`Math.round` in `ResponsiveContainer`), so on a fractional grid width it draws the chart a hair wider than its box. `DashboardWidget` puts its content in `overflow-y-auto`, which leaves the x axis computing to `auto` — so that sub-pixel excess earns a real horizontal scrollbar (the app forces space-taking 8px scrollbars in `app/index.css`). That scrollbar takes 10px of height, `min-h-full` content does not shrink with it, so the vertical scrollbar appears too; it takes 10px of width, recharts re-measures, the width now rounds the other way, both scrollbars vanish, the width comes back — and round it goes, one cycle per ResizeObserver/render round.

Measured in an isolated harness with the real chart, alternating forever at a container width of 1620.5px:

```
rc 1542.70  cw 1553 sw 1553  ch 502 sh 502   hbar 0  vbar 0
rc 1552.70  cw 1543 sw 1553  ch 492 sh 502   hbar 10 vbar 10
```

The widget has no business scrolling in the first place — its content is sized from the cell, not the other way round — so it now opts out of scrolling and the plot stretches into whatever height the cell leaves over. The horizontal axis is clipped for every other widget too, since a widget wider than its own column is always a rounding artefact.

## Related Issues

—

## Changes Made

- `DashboardWidget`: new `scroll` prop (default `true`); scrolling widgets are now `overflow-x-hidden overflow-y-auto`, so no widget can cross axes into the same loop.
- `RewardsChartWidget`: `scroll={false}`, `h-full` instead of `min-h-full`, and the 180px plot floor dropped — the plot fills the cell and shrinks with it.
- `DashboardGrid`: same x-axis clip on the grid scroller.
- `CHART_HEIGHT` removed (now unused); dashboard and rewards-chart spec READMEs updated to describe stretch-not-scroll.

## Screenshots/Recordings

—

## Test steps

1. Open the dashboard → **Staking** tab with a wallet that has reward history, and leave it open: no scrollbar blinking in the rewards card, at any window width (the old behaviour needed a specific width, so drag the window edge slowly across a few hundred px to be sure).
2. Enter edit mode and resize the rewards widget taller and shorter: the plot grows and shrinks with the cell, and the card never gains a scrollbar.
3. At the widget's minimum size (3 rows) the chart is still readable — header, total and bars all fit, nothing clipped.
4. Other widgets still scroll vertically when their content is taller than the cell (e.g. Positions, Operations queue), and none of them shows a horizontal scrollbar.

## Checklist

- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable) — the fault is layout geometry, reproduced in a throwaway Storybook harness rather than in a committed test
- [x] My code follows the project's coding standards and style guidelines
