### PR TITLE
feat(drafts): unknown recipient gate on draft confirm screens

### DIFF
--- a/src/renderer/aggregates/recipient-verification/README.md
+++ b/src/renderer/aggregates/recipient-verification/README.md
@@ -1,6 +1,6 @@
 # Recipient Verification
 
-> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-07-17
+> Part of the [Feature Map](../../features/README.md) — Last reviewed: 2026-08-20
 
 ## Overview
 
@@ -52,10 +52,12 @@ of warning about a since-added contact is lower than the cost of silencing every
 - **Multisig approve dialog** (`features/multisig-operations`) — a badge plus an acknowledgement gate on Sign. The
   informational badge also shows in the shared Reject dialog, but the acknowledgement gate is approve-only (rejecting is
   always the safe action).
+- **Draft create + submit confirms** (`features/drafts`) — an acknowledgement gate on both confirm steps (Create and
+  Sign), plus a Recipient row on the submit confirm. See
+  [Drafts' "Unknown recipient warnings"](../../features/drafts/README.md#unknown-recipient-warnings).
 
-Not yet wired up (deliberately out of scope for this iteration, but cheap to add given the shared resolver): drafts
-submission, multi-transfer, vested transfer, teleport, and the send-to-contact prefill flow (its recipient already came
-from the address book, so it is known by construction).
+Not yet wired up (cheap to add given the shared resolver): multi-transfer, vested transfer, teleport, and the
+send-to-contact prefill flow (its recipient already came from the address book, so it is known by construction).
 
 ## Related
 

--- a/src/renderer/domains/backend/drafts/service.ts
+++ b/src/renderer/domains/backend/drafts/service.ts
@@ -2,7 +2,7 @@ import { type HexString } from '@polkadot/util/types';
 import { z } from 'zod';
 
 import { authFetch, parseResponse } from '@/shared/api/backend-fetch';
-import { type ChainId } from '@/shared/core';
+import { type CallData, type ChainId } from '@/shared/core';
 import { isCorrectAccountId, isEthereumAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 
@@ -43,7 +43,10 @@ const backendDraftSchema = z.object({
   proxyAccountId: accountIdStringSchema.nullable().optional(),
   proxyContact: z.object({ name: z.string(), accountId: z.string() }).nullable().optional(),
   chainId: chainIdStringSchema,
-  callData: z.string().nullable(),
+  callData: z
+    .string()
+    .nullable()
+    .transform(v => v as CallData | null),
   decodedCallData: z.unknown().optional(),
   description: z.string().nullable(),
   createdBy: z.string(),

--- a/src/renderer/features/README.md
+++ b/src/renderer/features/README.md
@@ -166,7 +166,8 @@ notes.
 - `sign-wallet-connect` (no spec planned)
 
 > See also: [`dashboard-operations-queue`](#dashboard) — surfaces pending drafts and operations awaiting signature on
-> the dashboard.
+> the dashboard. [`recipient-verification`](#contacts--notifications) — unknown-recipient gate on the draft confirm
+> steps.
 
 ## Basket
 
@@ -202,8 +203,8 @@ notes.
 - [`recipient-verification`](../aggregates/recipient-verification/README.md) (aggregate)
 
 > See also: [`send-to-contact`](#transfers) — the transfer flow launched from the contacts page;
-> [`transfer`](#transfers) and [`multisig-operations`](#multisig) — consume `recipient-verification` for
-> unknown-recipient warnings.
+> [`transfer`](#transfers), [`multisig-operations`](#multisig) and [`drafts`](#operations--signing) — consume
+> `recipient-verification` for unknown-recipient warnings.
 
 ## App Shell & Platform
 

--- a/src/renderer/features/drafts/README.md
+++ b/src/renderer/features/drafts/README.md
@@ -164,8 +164,9 @@ to a transfer (or XCM transfer) have a recipient; every other draft is unaffecte
   and relies on this step instead.
 - **Submit → Confirm.** The same box (with the multisig-signing copy — submitting is the first approval) appears above
   the Sign button; **Sign** is disabled until ticked. The acknowledgement resets on every flow start and finish.
-- **Recipient row.** The submit confirm always shows the decoded recipient as a **Recipient** row in the details — the
-  warning never points at an address the user can't see.
+- **Recipient row.** Whenever the call data decodes to a transfer, the submit confirm shows its recipient as a
+  **Recipient** row in the details — the warning never points at an address the user can't see. Proxy-only drafts (a
+  proxied source with no multisig hop) are covered the same way as multisig ones.
 
 ## States / scenarios
 

--- a/src/renderer/features/drafts/README.md
+++ b/src/renderer/features/drafts/README.md
@@ -1,6 +1,6 @@
 # Operation Drafts
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-21
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-22
 
 ## Overview
 
@@ -136,10 +136,11 @@ operation every co-signer then sees in the operations table.
 - **Call data** (only if the draft was saved without it) — the submitter pastes call data, sees a decoded preview, and
   confirms; this patches the draft on the backend, then advances to confirm.
 - **Confirm** — shows the signing path as a breadcrumb (plus a review popover for paths of length ≥ 2), a signatory
-  selector when more than one valid signatory exists, wallet/account/signatory details, description, an external decode
-  link, expandable call args, the **fee**, the **multisig deposit** when the route contains a multisig, and **validation
-  errors** from a balance-aware validator that checks every account that must pay along the route. The Sign button stays
-  disabled until the wrapped extrinsic and fee are ready, validation passes, and the initiator is available.
+  selector when more than one valid signatory exists, wallet/account/signatory details, the **recipient** of a transfer
+  call (when one can be decoded), description, an external decode link, expandable call args, the **fee**, the
+  **multisig deposit** when the route contains a multisig, and **validation errors** from a balance-aware validator that
+  checks every account that must pay along the route. The Sign button stays disabled until the wrapped extrinsic and fee
+  are ready, validation passes, and the initiator is available.
 - **Sign / Submit** — hands off to the shared `OperationSign` and `OperationSubmit` flows. On success it shows a success
   toast and records a backend operation description linking the draft to the resulting on-chain operation, so the
   multisig operation inherits the draft's description. A **Submitted** badge shows until the backend confirms.
@@ -148,6 +149,23 @@ Submission is gated: the user must be signed in to the backend, the draft must c
 primary action is _Add call data_), and a local account matching the draft's source must exist (otherwise a wallet
 pairing prompt is shown). Whether the wallet also holds a usable signatory on the path is a separate, later check inside
 the submit flow (see [States / scenarios](#states--scenarios)).
+
+### Unknown recipient warnings
+
+Gated by [`recipient-verification`](../../aggregates/recipient-verification/README.md), which is itself gated on the
+external address book connection — a user who never connected it sees nothing here. Only drafts whose call data decodes
+to a transfer (or XCM transfer) have a recipient; every other draft is unaffected.
+
+- **Create → Confirm.** When the decoded recipient is not known (`unknown`) or cannot be checked (`unverifiable`), an
+  amber acknowledgement box appears below the transaction card, above the "This does not sign yet" note. **Create
+  draft** stays disabled until its checkbox is ticked. The tick is cleared by anything that can change the recipient —
+  new call data, another chain, closing the modal, or opening a new one — so it never carries over to a different
+  address. This is where the transfer form's _draft mode_ hands off: the form skips its own gate when saving as a draft
+  and relies on this step instead.
+- **Submit → Confirm.** The same box (with the multisig-signing copy — submitting is the first approval) appears above
+  the Sign button; **Sign** is disabled until ticked. The acknowledgement resets on every flow start and finish.
+- **Recipient row.** The submit confirm always shows the decoded recipient as a **Recipient** row in the details — the
+  warning never points at an address the user can't see.
 
 ## States / scenarios
 

--- a/src/renderer/features/drafts/README.md
+++ b/src/renderer/features/drafts/README.md
@@ -116,7 +116,8 @@ The creation modal walks three steps — **Call data → Signing path → Confir
 2. **Signing path** — pick how the operation will be executed: which multisig, through which proxy (if any), and which
    signatory initiates. Drafts restrict sources and multisig hops to **address-book (backend contact) entries only**.
 3. **Confirm** — review the decoded call and signing path, and write the **description** (required, up to 500
-   characters) explaining the operation's intent to co-signers.
+   characters) explaining the operation's intent to co-signers. A transfer to a recipient that is not in the address
+   book must be acknowledged here first (see [Unknown recipient warnings](#unknown-recipient-warnings)).
 
 The wizard can **jump ahead** from a seed: chain + valid call data + complete path opens straight to _Confirm_; chain +
 call data only opens to _Signing path_. Drafts can also be started **from an operation form**: transfer, staking,
@@ -150,11 +151,12 @@ primary action is _Add call data_), and a local account matching the draft's sou
 pairing prompt is shown). Whether the wallet also holds a usable signatory on the path is a separate, later check inside
 the submit flow (see [States / scenarios](#states--scenarios)).
 
-### Unknown recipient warnings
+## Unknown recipient warnings
 
 Gated by [`recipient-verification`](../../aggregates/recipient-verification/README.md), which is itself gated on the
 external address book connection — a user who never connected it sees nothing here. Only drafts whose call data decodes
-to a transfer (or XCM transfer) have a recipient; every other draft is unaffected.
+to a transfer (or XCM transfer) have a recipient; every other draft is unaffected. Proxy-only drafts (a proxied source
+with no multisig hop) are covered the same way as multisig ones.
 
 - **Create → Confirm.** When the decoded recipient is not known (`unknown`) or cannot be checked (`unverifiable`), an
   amber acknowledgement box appears below the transaction card, above the "This does not sign yet" note. **Create
@@ -162,11 +164,15 @@ to a transfer (or XCM transfer) have a recipient; every other draft is unaffecte
   new call data, another chain, closing the modal, or opening a new one — so it never carries over to a different
   address. This is where the transfer form's _draft mode_ hands off: the form skips its own gate when saving as a draft
   and relies on this step instead.
+- **"Can't check" is not "nothing to check".** While the chain's api is not connected the call data can't be decoded, so
+  the recipient is unknown-unknown: **Create draft** stays disabled with a "waiting for the network connection" note
+  until the api is up. (With the address book never connected there is nothing to check, and the api is not required.)
 - **Submit → Confirm.** The same box (with the multisig-signing copy — submitting is the first approval) appears above
-  the Sign button; **Sign** is disabled until ticked. The acknowledgement resets on every flow start and finish.
+  the Sign button; **Sign** is disabled until ticked, and the signing step refuses to start without the tick. The
+  acknowledgement resets on every flow start and finish, and when late-filled call data replaces the draft.
 - **Recipient row.** Whenever the call data decodes to a transfer, the submit confirm shows its recipient as a
-  **Recipient** row in the details — the warning never points at an address the user can't see. Proxy-only drafts (a
-  proxied source with no multisig hop) are covered the same way as multisig ones.
+  **Recipient** row in the details (own accounts resolve to their wallet name) — the warning never points at an address
+  the user can't see.
 
 ## States / scenarios
 
@@ -177,6 +183,7 @@ to a transfer (or XCM transfer) have a recipient; every other draft is unaffecte
 | No signatories                  | The wallet holds no account that can sign                                                                | An empty-account warning, with an add-account affordance for Polkadot Vault                |
 | Initiator unavailable           | The draft's stored initiator can no longer sign                                                          | A banner asking the user to pick a replacement signatory; signing disabled until they do   |
 | Undecodable / missing call data | Bad or absent call data at create or submit entry                                                        | Blocked with a clear hint                                                                  |
+| Unknown recipient               | The draft's transfer recipient is not a contact / own account, or the address book can't vouch           | An acknowledgement checkbox gates **Create** (create flow) and **Sign** (submit flow)      |
 | Post-submit sync failure        | Recording the operation description fails after a successful on-chain submit                             | A toast with a **Retry** action; the draft stays visible and retryable                     |
 
 ## Sync & reconnect

--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -14,6 +14,7 @@ import { contactModel } from '@/entities/contact';
 import { networkModel, useApi } from '@/entities/network';
 import { decodeCallData, findCoreTransaction, getTransactionAmount, useTransactionAsset } from '@/entities/transaction';
 import { backendConfigurationModel } from '@/aggregates/backend';
+import { recipientVerificationModel } from '@/aggregates/recipient-verification';
 import { operationIconTransformer, operationTitleTransformer } from '@/features/multisig-operations';
 import {
   type PathNextOption,
@@ -51,6 +52,8 @@ export const CreateDraftModal = () => {
   const isDirty = useUnit(createDraftModel.$isDirty);
   const canContinue = useUnit(createDraftModel.$canContinue);
   const canSkip = useUnit(createDraftModel.$canSkip);
+  const isRiskAcknowledged = useUnit(createDraftModel.$isRiskAcknowledged);
+  const resolveRecipientWarning = useUnit(recipientVerificationModel.$resolveWarning);
 
   const path = useUnit(pathModel.$path);
   const resolveName = useUnit(graphModel.$nameResolver);
@@ -124,6 +127,8 @@ export const CreateDraftModal = () => {
 
   const coreTx = findCoreTransaction(decodedTransaction);
   const destinationAccountId = useMemo(() => getDestinationAccountId(coreTx), [coreTx]);
+  const recipientWarning = resolveRecipientWarning(destinationAccountId);
+  const isRecipientRiskAccepted = recipientWarning === 'none' || isRiskAcknowledged;
   const txAsset = useTransactionAsset(coreTx, selectedChain?.chainId ?? ('0x00' as ChainId));
 
   const externalTitle = useTransformer(operationTitleTransformer, {
@@ -179,7 +184,7 @@ export const CreateDraftModal = () => {
   };
 
   const handleCreateDraft = async () => {
-    if (!backendUrl || !selectedChain) return;
+    if (!backendUrl || !selectedChain || !isRecipientRiskAccepted) return;
 
     const validation = isValidPath(path);
     if (!validation.ok) {
@@ -281,9 +286,12 @@ export const CreateDraftModal = () => {
                 titleData={titleData}
                 operationIcon={operationIcon ?? null}
                 destinationAccountId={destinationAccountId}
+                recipientWarning={recipientWarning}
+                riskAcknowledged={isRiskAcknowledged}
                 description={description}
                 multisigName={multisigName}
                 multisigAccountId={multisigHopAccountId as AccountId | undefined}
+                onRiskAcknowledgedChange={createDraftModel.riskAcknowledgedToggled}
                 onDescriptionChanged={createDraftModel.descriptionChanged}
               />
             )}
@@ -312,7 +320,7 @@ export const CreateDraftModal = () => {
               </Tooltip>
             )}
             <Button
-              disabled={!canAdvanceCallData}
+              disabled={!canAdvanceCallData || (activeStep === 'confirm' && !isRecipientRiskAccepted)}
               isLoading={isSubmitting}
               onClick={activeStep === 'confirm' ? handleCreateDraft : () => createDraftModel.stepAdvanced()}
             >

--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -93,19 +93,22 @@ export const CreateDraftModal = () => {
   const specVersion = api?.runtimeVersion.specVersion.toNumber() ?? null;
 
   const multisigHopAccountId = useMemo(() => deriveMultisigAccountId(path), [path]);
+  // Decode origin = the draft's source: the multisig hop, or the path root for
+  // proxy-only paths. It only labels the sender; the decoded call is the same.
+  const decodeOriginAccountId = multisigHopAccountId ?? path[0]?.accountId ?? null;
 
   const decodedTransaction = useMemo<DecodedTransaction | null>(() => {
-    if (!deferredCallData || !isHex(deferredCallData) || !api || !selectedChain || !multisigHopAccountId) {
+    if (!deferredCallData || !isHex(deferredCallData) || !api || !selectedChain || !decodeOriginAccountId) {
       return null;
     }
     try {
       const nativeAssetId = getNativeAssetId(selectedChain.assets);
 
-      return decodeCallData(api, multisigHopAccountId as never, deferredCallData as CallData, nativeAssetId);
+      return decodeCallData(api, decodeOriginAccountId as never, deferredCallData as CallData, nativeAssetId);
     } catch {
       return null;
     }
-  }, [deferredCallData, api, selectedChain, multisigHopAccountId]);
+  }, [deferredCallData, api, selectedChain, decodeOriginAccountId]);
 
   const decodedCallData = useMemo(
     () => tryDecodeCallData(deferredCallData, api, selectedChain),

--- a/src/renderer/features/drafts/components/CreateDraftModal.tsx
+++ b/src/renderer/features/drafts/components/CreateDraftModal.tsx
@@ -1,10 +1,10 @@
 import { useUnit } from 'effector-react';
 import { type ReactElement, useDeferredValue, useMemo, useState } from 'react';
 
-import { type CallData, type ChainId, type DecodedTransaction } from '@/shared/core';
+import { type ChainId } from '@/shared/core';
 import { useTransformer } from '@/shared/di';
 import { useI18n } from '@/shared/i18n';
-import { formatSectionAndMethod, getNativeAssetId, isHex, toAddress, toShortAddress } from '@/shared/lib/utils';
+import { formatSectionAndMethod, isHex, toAddress, toShortAddress } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { Button } from '@/shared/ui';
 import { Identicon } from '@/shared/ui-entities';
@@ -12,9 +12,8 @@ import { ConfirmModal, Modal, Tooltip, useNotification } from '@/shared/ui-kit';
 import { draftsResource, draftsService } from '@/domains/backend';
 import { contactModel } from '@/entities/contact';
 import { networkModel, useApi } from '@/entities/network';
-import { decodeCallData, findCoreTransaction, getTransactionAmount, useTransactionAsset } from '@/entities/transaction';
+import { findCoreTransaction, getTransactionAmount, useTransactionAsset } from '@/entities/transaction';
 import { backendConfigurationModel } from '@/aggregates/backend';
-import { recipientVerificationModel } from '@/aggregates/recipient-verification';
 import { operationIconTransformer, operationTitleTransformer } from '@/features/multisig-operations';
 import {
   type PathNextOption,
@@ -27,7 +26,6 @@ import {
   pathModel,
 } from '@/features/signing-path';
 import { tryDecodeCallData } from '../lib/decode-call-data';
-import { getDestinationAccountId } from '../lib/get-destination-account-id';
 import { createDraftModel } from '../model/create-draft-model';
 import { StepReview } from '../steps/StepReview';
 import { StepTransaction } from '../steps/StepTransaction';
@@ -53,7 +51,11 @@ export const CreateDraftModal = () => {
   const canContinue = useUnit(createDraftModel.$canContinue);
   const canSkip = useUnit(createDraftModel.$canSkip);
   const isRiskAcknowledged = useUnit(createDraftModel.$isRiskAcknowledged);
-  const resolveRecipientWarning = useUnit(recipientVerificationModel.$resolveWarning);
+  const decodedTransaction = useUnit(createDraftModel.$decodedTransaction);
+  const destinationAccountId = useUnit(createDraftModel.$destinationAccountId);
+  const recipientWarning = useUnit(createDraftModel.$recipientWarning);
+  const isRecipientCheckable = useUnit(createDraftModel.$isRecipientCheckable);
+  const isRecipientRiskAccepted = useUnit(createDraftModel.$recipientRiskAccepted);
 
   const path = useUnit(pathModel.$path);
   const resolveName = useUnit(graphModel.$nameResolver);
@@ -93,22 +95,6 @@ export const CreateDraftModal = () => {
   const specVersion = api?.runtimeVersion.specVersion.toNumber() ?? null;
 
   const multisigHopAccountId = useMemo(() => deriveMultisigAccountId(path), [path]);
-  // Decode origin = the draft's source: the multisig hop, or the path root for
-  // proxy-only paths. It only labels the sender; the decoded call is the same.
-  const decodeOriginAccountId = multisigHopAccountId ?? path[0]?.accountId ?? null;
-
-  const decodedTransaction = useMemo<DecodedTransaction | null>(() => {
-    if (!deferredCallData || !isHex(deferredCallData) || !api || !selectedChain || !decodeOriginAccountId) {
-      return null;
-    }
-    try {
-      const nativeAssetId = getNativeAssetId(selectedChain.assets);
-
-      return decodeCallData(api, decodeOriginAccountId as never, deferredCallData as CallData, nativeAssetId);
-    } catch {
-      return null;
-    }
-  }, [deferredCallData, api, selectedChain, decodeOriginAccountId]);
 
   const decodedCallData = useMemo(
     () => tryDecodeCallData(deferredCallData, api, selectedChain),
@@ -129,9 +115,6 @@ export const CreateDraftModal = () => {
   const canAdvanceCallData = activeStep === 'call-data' ? canContinue && !isCallDataUndecodable : canContinue;
 
   const coreTx = findCoreTransaction(decodedTransaction);
-  const destinationAccountId = useMemo(() => getDestinationAccountId(coreTx), [coreTx]);
-  const recipientWarning = resolveRecipientWarning(destinationAccountId);
-  const isRecipientRiskAccepted = recipientWarning === 'none' || isRiskAcknowledged;
   const txAsset = useTransactionAsset(coreTx, selectedChain?.chainId ?? ('0x00' as ChainId));
 
   const externalTitle = useTransformer(operationTitleTransformer, {
@@ -290,6 +273,7 @@ export const CreateDraftModal = () => {
                 operationIcon={operationIcon ?? null}
                 destinationAccountId={destinationAccountId}
                 recipientWarning={recipientWarning}
+                recipientCheckPending={!isRecipientCheckable}
                 riskAcknowledged={isRiskAcknowledged}
                 description={description}
                 multisigName={multisigName}

--- a/src/renderer/features/drafts/components/SubmitDraftModal.tsx
+++ b/src/renderer/features/drafts/components/SubmitDraftModal.tsx
@@ -18,7 +18,7 @@ import {
   Separator,
   SmallTitleText,
 } from '@/shared/ui';
-import { Address, TransactionValidationError, WalletIcon } from '@/shared/ui-entities';
+import { Address, TransactionValidationError, UnknownRecipientAckBox, WalletIcon } from '@/shared/ui-entities';
 import { Box, Field, Input, Modal, Select } from '@/shared/ui-kit';
 import { Json } from '@/shared/ui-kit/Json/Json';
 import { JsonArgs } from '@/shared/ui-kit/JsonArgs/JsonArgs';
@@ -143,6 +143,9 @@ const ConfirmStep = () => {
   const validationErrors = useUnit(submitDraftModel.$validationErrors);
   const validationValid = useUnit(submitDraftModel.$validationValid);
   const validationPending = useUnit(submitDraftModel.$validationPending);
+  const destinationAccountId = useUnit(submitDraftModel.$destinationAccountId);
+  const recipientWarning = useUnit(submitDraftModel.$recipientWarning);
+  const isRiskAcknowledged = useUnit(submitDraftModel.$isRiskAcknowledged);
 
   const [showWalletDetails, setShowWalletDetails] = useState(false);
 
@@ -284,6 +287,7 @@ const ConfirmStep = () => {
   };
 
   const signingPath = draft?.signingPath ?? [];
+  const isRecipientRiskAccepted = recipientWarning === 'none' || isRiskAcknowledged;
 
   return (
     <>
@@ -355,6 +359,11 @@ const ConfirmStep = () => {
               <NamedAccount variant="short" accountId={initiator.accountId} chain={chain} />
             )}
           </DetailRow>
+          {destinationAccountId && (
+            <DetailRow label={t('operation.details.recipient')}>
+              <NamedAccount variant="short" accountId={destinationAccountId} chain={chain} />
+            </DetailRow>
+          )}
           <Separator className="border-filter-border" />
           <DetailRow label={t('transaction.details.sinatoryWallet')}>
             <div className="flex items-center gap-x-2">
@@ -405,6 +414,15 @@ const ConfirmStep = () => {
         </dl>
       </Box>
 
+      <div className="mx-5 mb-3 empty:hidden">
+        <UnknownRecipientAckBox
+          warning={recipientWarning}
+          context="multisigSign"
+          checked={isRiskAcknowledged}
+          onToggle={submitDraftModel.riskAcknowledgedToggled}
+        />
+      </div>
+
       {validationErrors.length > 0 && (
         <div className="mx-5 mb-3">
           <TransactionValidationError errors={validationErrors} wallets={wallets} />
@@ -415,7 +433,12 @@ const ConfirmStep = () => {
         <div />
         <SignButton
           disabled={
-            initiatorUnavailable || nullable(wrappedExtrinsic) || nullable(fee) || validationPending || !validationValid
+            initiatorUnavailable ||
+            nullable(wrappedExtrinsic) ||
+            nullable(fee) ||
+            validationPending ||
+            !validationValid ||
+            !isRecipientRiskAccepted
           }
           isDefault={initiatorUnavailable}
           type={confirm.signatoryWallet.type}

--- a/src/renderer/features/drafts/components/SubmitDraftModal.tsx
+++ b/src/renderer/features/drafts/components/SubmitDraftModal.tsx
@@ -22,7 +22,7 @@ import { Address, TransactionValidationError, UnknownRecipientAckBox, WalletIcon
 import { Box, Field, Input, Modal, Select } from '@/shared/ui-kit';
 import { Json } from '@/shared/ui-kit/Json/Json';
 import { JsonArgs } from '@/shared/ui-kit/JsonArgs/JsonArgs';
-import { transactionService } from '@/domains/network';
+import { accounts, transactionService } from '@/domains/network';
 import { SignButton } from '@/entities/operations';
 import { transactionService as entityTransactionService } from '@/entities/transaction';
 import { accountUtils, walletModel, walletUtils } from '@/entities/wallet';
@@ -146,6 +146,8 @@ const ConfirmStep = () => {
   const destinationAccountId = useUnit(submitDraftModel.$destinationAccountId);
   const recipientWarning = useUnit(submitDraftModel.$recipientWarning);
   const isRiskAcknowledged = useUnit(submitDraftModel.$isRiskAcknowledged);
+  const isRecipientRiskAccepted = useUnit(submitDraftModel.$recipientRiskAccepted);
+  const allAccounts = useUnit(accounts.$list);
 
   const [showWalletDetails, setShowWalletDetails] = useState(false);
 
@@ -287,7 +289,9 @@ const ConfirmStep = () => {
   };
 
   const signingPath = draft?.signingPath ?? [];
-  const isRecipientRiskAccepted = recipientWarning === 'none' || isRiskAcknowledged;
+  // A recipient that is one of the user's own accounts resolves to its wallet name.
+  const destinationAccount = allAccounts.find((account) => account.accountId === destinationAccountId);
+  const destinationWallet = destinationAccount ? walletUtils.getWalletById(wallets, destinationAccount.walletId) : null;
 
   return (
     <>
@@ -361,7 +365,7 @@ const ConfirmStep = () => {
           </DetailRow>
           {destinationAccountId && (
             <DetailRow label={t('operation.details.recipient')}>
-              <NamedAccount variant="short" accountId={destinationAccountId} chain={chain} />
+              <NamedAccount variant="short" accountId={destinationAccountId} chain={chain} wallet={destinationWallet} />
             </DetailRow>
           )}
           <Separator className="border-filter-border" />

--- a/src/renderer/features/drafts/lib/decode-call-data.ts
+++ b/src/renderer/features/drafts/lib/decode-call-data.ts
@@ -5,26 +5,45 @@ import { type CallData, type Chain } from '@/shared/core';
 import { transactionService } from '@/entities/transaction';
 
 /**
- * Strict decode: if the round-tripped hex doesn't match the input, treat as
- * undecodable.
+ * Builds a `Call` from hex only when the bytes round-trip exactly.
  *
  * `api.createType('Call', …)` is lenient — e.g. `0x00` is accepted as a trivial
  * call (pallet=0, call=0) even though the input is truncated. The backend
  * rejects such inputs with 422, so we mirror that strictness here: the encoded
- * call must re-produce the exact input bytes.
+ * call must re-produce the exact input bytes. `null` when it doesn't, or when
+ * the api can't parse the input at all.
+ */
+type RoundTrippedCall = NonNullable<ReturnType<typeof transactionService.createCallFromCallData>>;
+
+export const createRoundTrippedCall = (
+  callData: string,
+  api: ApiPromise | null | undefined,
+): RoundTrippedCall | null => {
+  if (!callData || !isHex(callData) || !api) return null;
+
+  try {
+    const call = transactionService.createCallFromCallData(callData as CallData, api);
+    if (!call) return null;
+
+    return call.toHex().toLowerCase() === callData.toLowerCase() ? call : null;
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Strict decode into the human-readable call shape used by the JSON views.
+ * `null` when the call data doesn't round-trip (see `createRoundTrippedCall`).
  */
 export const tryDecodeCallData = (
   callData: string,
   api: ApiPromise | null | undefined,
   chain: Chain | null | undefined,
 ): object | null => {
-  if (!callData || !isHex(callData) || !api || !chain) return null;
+  const call = createRoundTrippedCall(callData, api);
+  if (!call || !chain) return null;
 
   try {
-    const call = transactionService.createCallFromCallData(callData as CallData, api);
-    if (!call) return null;
-    if (call.toHex().toLowerCase() !== callData.toLowerCase()) return null;
-
     return transactionService.formatCall(call, chain);
   } catch {
     return null;

--- a/src/renderer/features/drafts/lib/decode-draft-transaction.test.ts
+++ b/src/renderer/features/drafts/lib/decode-draft-transaction.test.ts
@@ -1,0 +1,146 @@
+import { ApiPromise } from '@polkadot/api';
+import { MockProvider } from '@polkadot/rpc-provider/mock';
+import { TypeRegistry } from '@polkadot/types';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+
+import { type CallData } from '@/shared/core';
+import { polkadotChain } from '@/shared/mocks';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type Draft, type PathNode } from '@/domains/backend';
+// eslint-disable-next-line boundaries/entry-point -- reusing a real metadata blob fixture in tests only
+import { metadata } from '@/entities/transaction/lib/__tests__/metadata';
+
+import { decodeDraftTransaction, getDraftOriginAccountId, getPathOriginAccountId } from './decode-draft-transaction';
+
+const multisigId = `0x${'11'.repeat(32)}` as AccountId;
+const proxiedId = `0x${'22'.repeat(32)}` as AccountId;
+const signerId = `0x${'33'.repeat(32)}` as AccountId;
+
+// balances.transferKeepAlive(Evo4vR5tHsTVvNqYZNo4GVQc2xHcB5J8i7gKv4cwXKRynK3, 1 DOT)
+const TRANSFER_CALL_DATA: CallData =
+  '0x04030068161e62bc8d7cf1bef225fd2ed12857889718d97c687256cb4b8794cef1a242070010a5d4e8';
+// Same bytes, truncated: the lenient `createType('Call')` still parses it.
+const TRUNCATED_CALL_DATA: CallData = '0x0403';
+
+const draft: Draft = {
+  id: 'draft-1',
+  operation: null,
+  multisigAccountId: multisigId,
+  proxyAccountId: null,
+  chainId: polkadotChain.chainId,
+  callData: TRANSFER_CALL_DATA,
+  description: null,
+  createdBy: 'tester',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  signingPath: [],
+  initiatorAccountId: null,
+};
+
+describe('decodeDraftTransaction', () => {
+  const registry = new TypeRegistry();
+  let provider: MockProvider;
+  let api: ApiPromise;
+
+  beforeAll(async () => {
+    provider = new MockProvider(registry);
+    const genesisHash = registry.createType('Hash', await provider.send('chain_getBlockHash', [])).toHex();
+
+    api = await ApiPromise.create({
+      metadata: { [`${genesisHash}-0`]: metadata },
+      provider,
+      registry,
+      throwOnConnect: true,
+    });
+  });
+
+  afterAll(() => provider.disconnect());
+
+  it('decodes a transfer with the origin as sender and the recipient intact', () => {
+    const decoded = decodeDraftTransaction({
+      callData: TRANSFER_CALL_DATA,
+      originAccountId: multisigId,
+      api,
+      chain: polkadotChain,
+    });
+
+    expect(decoded).toMatchObject({
+      accountId: multisigId,
+      section: 'balances',
+      method: 'transferKeepAlive',
+      args: { dest: 'Evo4vR5tHsTVvNqYZNo4GVQc2xHcB5J8i7gKv4cwXKRynK3', value: '1000000000000' },
+    });
+  });
+
+  it('reads the same recipient regardless of the origin account', () => {
+    const viaMultisig = decodeDraftTransaction({
+      callData: TRANSFER_CALL_DATA,
+      originAccountId: multisigId,
+      api,
+      chain: polkadotChain,
+    });
+    const viaProxied = decodeDraftTransaction({
+      callData: TRANSFER_CALL_DATA,
+      originAccountId: proxiedId,
+      api,
+      chain: polkadotChain,
+    });
+
+    expect(viaProxied?.args?.dest).toBe(viaMultisig?.args?.dest);
+    expect(viaProxied?.accountId).toBe(proxiedId);
+  });
+
+  it('rejects call data that does not round-trip even though the lenient decoder accepts it', () => {
+    expect(api.createType('Call', TRUNCATED_CALL_DATA)).toBeDefined();
+
+    expect(
+      decodeDraftTransaction({ callData: TRUNCATED_CALL_DATA, originAccountId: multisigId, api, chain: polkadotChain }),
+    ).toBeNull();
+  });
+
+  it('returns null when any input is missing', () => {
+    expect(
+      decodeDraftTransaction({ callData: null, originAccountId: multisigId, api, chain: polkadotChain }),
+    ).toBeNull();
+    expect(
+      decodeDraftTransaction({ callData: TRANSFER_CALL_DATA, originAccountId: null, api, chain: polkadotChain }),
+    ).toBeNull();
+    expect(
+      decodeDraftTransaction({
+        callData: TRANSFER_CALL_DATA,
+        originAccountId: multisigId,
+        api: null,
+        chain: polkadotChain,
+      }),
+    ).toBeNull();
+    expect(
+      decodeDraftTransaction({ callData: TRANSFER_CALL_DATA, originAccountId: multisigId, api, chain: null }),
+    ).toBeNull();
+  });
+});
+
+describe('getDraftOriginAccountId', () => {
+  it('prefers the multisig and falls back to the proxied account', () => {
+    expect(getDraftOriginAccountId(draft)).toBe(multisigId);
+    expect(getDraftOriginAccountId({ ...draft, multisigAccountId: null, proxyAccountId: proxiedId })).toBe(proxiedId);
+    expect(getDraftOriginAccountId({ ...draft, multisigAccountId: null, proxyAccountId: null })).toBeNull();
+  });
+});
+
+describe('getPathOriginAccountId', () => {
+  it('uses the innermost multisig hop, else the path root', () => {
+    const nested: PathNode[] = [
+      { kind: 'proxied', accountId: proxiedId },
+      { kind: 'multisig', accountId: multisigId },
+      { kind: 'signer', accountId: signerId },
+    ];
+    const proxyOnly: PathNode[] = [
+      { kind: 'proxied', accountId: proxiedId },
+      { kind: 'signer', accountId: signerId },
+    ];
+
+    expect(getPathOriginAccountId(nested)).toBe(multisigId);
+    expect(getPathOriginAccountId(proxyOnly)).toBe(proxiedId);
+    expect(getPathOriginAccountId([])).toBeNull();
+  });
+});

--- a/src/renderer/features/drafts/lib/decode-draft-transaction.ts
+++ b/src/renderer/features/drafts/lib/decode-draft-transaction.ts
@@ -1,0 +1,59 @@
+import { type ApiPromise } from '@polkadot/api';
+
+import { type Chain, type DecodedTransaction } from '@/shared/core';
+import { getNativeAssetId, isHex } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type Draft, type PathNode } from '@/domains/backend';
+import { decodeCallData } from '@/entities/transaction';
+
+import { createRoundTrippedCall } from './decode-call-data';
+
+type DecodeDraftTransactionParams = {
+  callData: string | null | undefined;
+  /**
+   * Account the call is executed from. It only labels the transaction's sender
+   * — the decoded call, and any recipient read from it, is the same whichever
+   * account is passed.
+   */
+  originAccountId: AccountId | null | undefined;
+  api: ApiPromise | null | undefined;
+  chain: Chain | null | undefined;
+};
+
+/**
+ * The single way a draft's call data becomes a `DecodedTransaction`: strict
+ * round-trip check first (truncated bytes that the lenient decoder would still
+ * accept are rejected), then the full decode. `null` whenever any input is
+ * missing or the bytes don't decode for this chain.
+ */
+export const decodeDraftTransaction = ({
+  callData,
+  originAccountId,
+  api,
+  chain,
+}: DecodeDraftTransactionParams): DecodedTransaction | null => {
+  if (!callData || !isHex(callData) || !originAccountId || !api || !chain) return null;
+  if (!createRoundTrippedCall(callData, api)) return null;
+
+  try {
+    return decodeCallData(api, originAccountId, callData, getNativeAssetId(chain.assets));
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Decode origin of a stored draft: its multisig, or the proxied account for
+ * proxy-only drafts.
+ */
+export const getDraftOriginAccountId = (draft: Draft): AccountId | null => {
+  return draft.multisigAccountId ?? draft.proxyAccountId ?? null;
+};
+
+/**
+ * Decode origin of a signing path being authored: the innermost multisig hop,
+ * or the path root.
+ */
+export const getPathOriginAccountId = (path: PathNode[]): AccountId | null => {
+  return path.findLast((node) => node.kind === 'multisig')?.accountId ?? path[0]?.accountId ?? null;
+};

--- a/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
@@ -1,5 +1,5 @@
 import { type ApiPromise } from '@polkadot/api';
-import { describe, expect, it, vi } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type Chain, type ChainId, type DecodedTransaction, TransactionType } from '@/shared/core';
 import { TEST_ACCOUNTS, TEST_ADDRESS } from '@/shared/lib/utils';
@@ -8,6 +8,7 @@ import { type Draft } from '@/domains/backend';
 import type * as TransactionEntity from '@/entities/transaction';
 import { decodeCallData } from '@/entities/transaction';
 
+import { tryDecodeCallData } from './decode-call-data';
 import { getDestinationAccountId, getDraftDestinationAccountId } from './get-destination-account-id';
 
 vi.mock('@/entities/transaction', async (importOriginal) => ({
@@ -15,7 +16,12 @@ vi.mock('@/entities/transaction', async (importOriginal) => ({
   decodeCallData: vi.fn(),
 }));
 
+vi.mock('./decode-call-data', () => ({
+  tryDecodeCallData: vi.fn(),
+}));
+
 const multisigId = `0x${'11'.repeat(32)}` as AccountId;
+const proxiedId = `0x${'22'.repeat(32)}` as AccountId;
 const chain = {
   chainId: `0x${'aa'.repeat(32)}` as ChainId,
   addressPrefix: 0,
@@ -61,14 +67,21 @@ describe('getDestinationAccountId', () => {
 });
 
 describe('getDraftDestinationAccountId', () => {
-  it('returns null without decoding when any input is missing', () => {
-    vi.mocked(decodeCallData).mockClear();
+  beforeEach(() => {
+    vi.mocked(decodeCallData).mockReset();
+    vi.mocked(tryDecodeCallData).mockReset();
+    // Strict round-trip passes by default; individual cases override it.
+    vi.mocked(tryDecodeCallData).mockReturnValue({});
+  });
 
+  it('returns null without decoding when any input is missing', () => {
     expect(getDraftDestinationAccountId(null, api, chain)).toBeNull();
     expect(getDraftDestinationAccountId(draft, null, chain)).toBeNull();
     expect(getDraftDestinationAccountId(draft, api, null)).toBeNull();
     expect(getDraftDestinationAccountId({ ...draft, callData: null }, api, chain)).toBeNull();
-    expect(getDraftDestinationAccountId({ ...draft, multisigAccountId: null }, api, chain)).toBeNull();
+    expect(
+      getDraftDestinationAccountId({ ...draft, multisigAccountId: null, proxyAccountId: null }, api, chain),
+    ).toBeNull();
     expect(decodeCallData).not.toHaveBeenCalled();
   });
 
@@ -77,6 +90,23 @@ describe('getDraftDestinationAccountId', () => {
 
     expect(getDraftDestinationAccountId(draft, api, chain)).toBe(TEST_ACCOUNTS[0]);
     expect(decodeCallData).toHaveBeenCalledWith(api, multisigId, draft.callData, '0');
+  });
+
+  it('uses the proxied account as decode origin for proxy-only drafts', () => {
+    vi.mocked(decodeCallData).mockReturnValue(transferTx);
+
+    const proxyOnly = { ...draft, multisigAccountId: null, proxyAccountId: proxiedId };
+
+    expect(getDraftDestinationAccountId(proxyOnly, api, chain)).toBe(TEST_ACCOUNTS[0]);
+    expect(decodeCallData).toHaveBeenCalledWith(api, proxiedId, draft.callData, '0');
+  });
+
+  it('returns null without decoding when the call data fails the strict round-trip check', () => {
+    vi.mocked(tryDecodeCallData).mockReturnValue(null);
+    vi.mocked(decodeCallData).mockReturnValue(transferTx);
+
+    expect(getDraftDestinationAccountId(draft, api, chain)).toBeNull();
+    expect(decodeCallData).not.toHaveBeenCalled();
   });
 
   it('returns null when decoding throws', () => {

--- a/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
@@ -1,0 +1,89 @@
+import { type ApiPromise } from '@polkadot/api';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type Chain, type ChainId, type DecodedTransaction, TransactionType } from '@/shared/core';
+import { TEST_ACCOUNTS, TEST_ADDRESS } from '@/shared/lib/utils';
+import { type AccountId } from '@/shared/polkadotjs-schemas';
+import { type Draft } from '@/domains/backend';
+import type * as TransactionEntity from '@/entities/transaction';
+import { decodeCallData } from '@/entities/transaction';
+
+import { getDestinationAccountId, getDraftDestinationAccountId } from './get-destination-account-id';
+
+vi.mock('@/entities/transaction', async (importOriginal) => ({
+  ...(await importOriginal<typeof TransactionEntity>()),
+  decodeCallData: vi.fn(),
+}));
+
+const multisigId = `0x${'11'.repeat(32)}` as AccountId;
+const chain = {
+  chainId: `0x${'aa'.repeat(32)}` as ChainId,
+  addressPrefix: 0,
+  assets: [{ assetId: 0, symbol: 'DOT', precision: 10 }],
+} as unknown as Chain;
+const api = {} as ApiPromise;
+
+const draft: Draft = {
+  id: 'draft-1',
+  operation: null,
+  multisigAccountId: multisigId,
+  proxyAccountId: null,
+  chainId: chain.chainId,
+  callData: '0x0403001122',
+  description: null,
+  createdBy: 'tester',
+  createdAt: '2026-01-01T00:00:00Z',
+  updatedAt: '2026-01-01T00:00:00Z',
+  signingPath: [],
+  initiatorAccountId: null,
+};
+
+const transferTx = {
+  type: TransactionType.TRANSFER,
+  section: 'balances',
+  method: 'transferKeepAlive',
+  chainId: chain.chainId,
+  address: TEST_ADDRESS,
+  args: { dest: TEST_ADDRESS, value: '1' },
+} as unknown as DecodedTransaction;
+
+describe('getDestinationAccountId', () => {
+  it('returns null for a missing or non-transfer transaction', () => {
+    expect(getDestinationAccountId(null)).toBeNull();
+    expect(
+      getDestinationAccountId({ ...transferTx, type: TransactionType.BOND, args: {} } as unknown as DecodedTransaction),
+    ).toBeNull();
+  });
+
+  it('extracts the transfer dest as an AccountId', () => {
+    expect(getDestinationAccountId(transferTx)).toBe(TEST_ACCOUNTS[0]);
+  });
+});
+
+describe('getDraftDestinationAccountId', () => {
+  it('returns null without decoding when any input is missing', () => {
+    vi.mocked(decodeCallData).mockClear();
+
+    expect(getDraftDestinationAccountId(null, api, chain)).toBeNull();
+    expect(getDraftDestinationAccountId(draft, null, chain)).toBeNull();
+    expect(getDraftDestinationAccountId(draft, api, null)).toBeNull();
+    expect(getDraftDestinationAccountId({ ...draft, callData: null }, api, chain)).toBeNull();
+    expect(getDraftDestinationAccountId({ ...draft, multisigAccountId: null }, api, chain)).toBeNull();
+    expect(decodeCallData).not.toHaveBeenCalled();
+  });
+
+  it('decodes the call data and returns the transfer destination', () => {
+    vi.mocked(decodeCallData).mockReturnValue(transferTx);
+
+    expect(getDraftDestinationAccountId(draft, api, chain)).toBe(TEST_ACCOUNTS[0]);
+    expect(decodeCallData).toHaveBeenCalledWith(api, multisigId, draft.callData, '0');
+  });
+
+  it('returns null when decoding throws', () => {
+    vi.mocked(decodeCallData).mockImplementation(() => {
+      throw new Error('bad call data');
+    });
+
+    expect(getDraftDestinationAccountId(draft, api, chain)).toBeNull();
+  });
+});

--- a/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.test.ts
@@ -5,28 +5,19 @@ import { type Chain, type ChainId, type DecodedTransaction, TransactionType } fr
 import { TEST_ACCOUNTS, TEST_ADDRESS } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type Draft } from '@/domains/backend';
-import type * as TransactionEntity from '@/entities/transaction';
-import { decodeCallData } from '@/entities/transaction';
 
-import { tryDecodeCallData } from './decode-call-data';
+import type * as DecodeDraft from './decode-draft-transaction';
+import { decodeDraftTransaction } from './decode-draft-transaction';
 import { getDestinationAccountId, getDraftDestinationAccountId } from './get-destination-account-id';
 
-vi.mock('@/entities/transaction', async (importOriginal) => ({
-  ...(await importOriginal<typeof TransactionEntity>()),
-  decodeCallData: vi.fn(),
-}));
-
-vi.mock('./decode-call-data', () => ({
-  tryDecodeCallData: vi.fn(),
+vi.mock('./decode-draft-transaction', async (importOriginal) => ({
+  ...(await importOriginal<typeof DecodeDraft>()),
+  decodeDraftTransaction: vi.fn(),
 }));
 
 const multisigId = `0x${'11'.repeat(32)}` as AccountId;
 const proxiedId = `0x${'22'.repeat(32)}` as AccountId;
-const chain = {
-  chainId: `0x${'aa'.repeat(32)}` as ChainId,
-  addressPrefix: 0,
-  assets: [{ assetId: 0, symbol: 'DOT', precision: 10 }],
-} as unknown as Chain;
+const chain = { chainId: `0x${'aa'.repeat(32)}` as ChainId, addressPrefix: 0, assets: [] } as unknown as Chain;
 const api = {} as ApiPromise;
 
 const draft: Draft = {
@@ -68,52 +59,44 @@ describe('getDestinationAccountId', () => {
 
 describe('getDraftDestinationAccountId', () => {
   beforeEach(() => {
-    vi.mocked(decodeCallData).mockReset();
-    vi.mocked(tryDecodeCallData).mockReset();
-    // Strict round-trip passes by default; individual cases override it.
-    vi.mocked(tryDecodeCallData).mockReturnValue({});
+    vi.mocked(decodeDraftTransaction).mockReset();
   });
 
-  it('returns null without decoding when any input is missing', () => {
+  it('returns null without decoding when there is no draft', () => {
     expect(getDraftDestinationAccountId(null, api, chain)).toBeNull();
-    expect(getDraftDestinationAccountId(draft, null, chain)).toBeNull();
-    expect(getDraftDestinationAccountId(draft, api, null)).toBeNull();
-    expect(getDraftDestinationAccountId({ ...draft, callData: null }, api, chain)).toBeNull();
-    expect(
-      getDraftDestinationAccountId({ ...draft, multisigAccountId: null, proxyAccountId: null }, api, chain),
-    ).toBeNull();
-    expect(decodeCallData).not.toHaveBeenCalled();
+    expect(decodeDraftTransaction).not.toHaveBeenCalled();
   });
 
-  it('decodes the call data and returns the transfer destination', () => {
-    vi.mocked(decodeCallData).mockReturnValue(transferTx);
+  it('decodes from the multisig origin and returns the transfer destination', () => {
+    vi.mocked(decodeDraftTransaction).mockReturnValue(transferTx);
 
     expect(getDraftDestinationAccountId(draft, api, chain)).toBe(TEST_ACCOUNTS[0]);
-    expect(decodeCallData).toHaveBeenCalledWith(api, multisigId, draft.callData, '0');
+    expect(decodeDraftTransaction).toHaveBeenCalledWith({
+      callData: draft.callData,
+      originAccountId: multisigId,
+      api,
+      chain,
+    });
   });
 
-  it('uses the proxied account as decode origin for proxy-only drafts', () => {
-    vi.mocked(decodeCallData).mockReturnValue(transferTx);
+  it('decodes from the proxied account for proxy-only drafts', () => {
+    vi.mocked(decodeDraftTransaction).mockReturnValue(transferTx);
 
     const proxyOnly = { ...draft, multisigAccountId: null, proxyAccountId: proxiedId };
 
     expect(getDraftDestinationAccountId(proxyOnly, api, chain)).toBe(TEST_ACCOUNTS[0]);
-    expect(decodeCallData).toHaveBeenCalledWith(api, proxiedId, draft.callData, '0');
+    expect(decodeDraftTransaction).toHaveBeenCalledWith(expect.objectContaining({ originAccountId: proxiedId }));
   });
 
-  it('returns null without decoding when the call data fails the strict round-trip check', () => {
-    vi.mocked(tryDecodeCallData).mockReturnValue(null);
-    vi.mocked(decodeCallData).mockReturnValue(transferTx);
-
+  it('returns null when the draft does not decode or is not a transfer', () => {
+    vi.mocked(decodeDraftTransaction).mockReturnValue(null);
     expect(getDraftDestinationAccountId(draft, api, chain)).toBeNull();
-    expect(decodeCallData).not.toHaveBeenCalled();
-  });
 
-  it('returns null when decoding throws', () => {
-    vi.mocked(decodeCallData).mockImplementation(() => {
-      throw new Error('bad call data');
-    });
-
+    vi.mocked(decodeDraftTransaction).mockReturnValue({
+      ...transferTx,
+      type: TransactionType.BOND,
+      args: {},
+    } as unknown as DecodedTransaction);
     expect(getDraftDestinationAccountId(draft, api, chain)).toBeNull();
   });
 });

--- a/src/renderer/features/drafts/lib/get-destination-account-id.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.ts
@@ -1,7 +1,16 @@
-import { type DecodedTransaction } from '@/shared/core';
-import { toAccountId } from '@/shared/lib/utils';
+import { type ApiPromise } from '@polkadot/api';
+
+import { type CallData, type Chain, type DecodedTransaction } from '@/shared/core';
+import { getNativeAssetId, toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { getXcmTransactionBeneficiary, isTransferTransaction, isXcmTransaction } from '@/entities/transaction';
+import { type Draft } from '@/domains/backend';
+import {
+  decodeCallData,
+  findCoreTransaction,
+  getXcmTransactionBeneficiary,
+  isTransferTransaction,
+  isXcmTransaction,
+} from '@/entities/transaction';
 
 export const getDestinationAccountId = (coreTx: DecodedTransaction | null): AccountId | null => {
   if (!coreTx) return null;
@@ -14,6 +23,32 @@ export const getDestinationAccountId = (coreTx: DecodedTransaction | null): Acco
 
   try {
     return toAccountId(coreTx.args.dest);
+  } catch {
+    return null;
+  }
+};
+
+/**
+ * Destination of a stored draft: decodes its call data against the chain api
+ * and reads the core transfer's recipient. `null` for non-transfer drafts,
+ * drafts without call data, and whenever decoding is not possible yet.
+ */
+export const getDraftDestinationAccountId = (
+  draft: Draft | null,
+  api: ApiPromise | null,
+  chain: Chain | null,
+): AccountId | null => {
+  if (!draft?.callData || !draft.multisigAccountId || !api || !chain) return null;
+
+  try {
+    const decoded = decodeCallData(
+      api,
+      draft.multisigAccountId,
+      draft.callData as CallData,
+      getNativeAssetId(chain.assets),
+    );
+
+    return getDestinationAccountId(findCoreTransaction(decoded));
   } catch {
     return null;
   }

--- a/src/renderer/features/drafts/lib/get-destination-account-id.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.ts
@@ -1,19 +1,22 @@
 import { type ApiPromise } from '@polkadot/api';
 
-import { type CallData, type Chain, type DecodedTransaction } from '@/shared/core';
-import { getNativeAssetId, toAccountId } from '@/shared/lib/utils';
+import { type Chain, type DecodedTransaction } from '@/shared/core';
+import { toAccountId } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type Draft } from '@/domains/backend';
 import {
-  decodeCallData,
   findCoreTransaction,
   getXcmTransactionBeneficiary,
   isTransferTransaction,
   isXcmTransaction,
 } from '@/entities/transaction';
 
-import { tryDecodeCallData } from './decode-call-data';
+import { decodeDraftTransaction, getDraftOriginAccountId } from './decode-draft-transaction';
 
+/**
+ * Recipient of a decoded core transaction: XCM beneficiary or transfer `dest`;
+ * `null` for anything else.
+ */
 export const getDestinationAccountId = (coreTx: DecodedTransaction | null): AccountId | null => {
   if (!coreTx) return null;
 
@@ -31,31 +34,23 @@ export const getDestinationAccountId = (coreTx: DecodedTransaction | null): Acco
 };
 
 /**
- * Destination of a stored draft: decodes its call data against the chain api
- * and reads the core transfer's recipient. `null` for non-transfer drafts,
- * drafts without call data, and whenever decoding is not possible yet.
- *
- * The decode origin is the draft's source — the multisig, or the proxied
- * account for proxy-only drafts. It only labels the transaction's sender and
- * never influences the recipient that is read back.
+ * Recipient of a stored draft. `null` for non-transfer drafts, drafts without
+ * call data, and whenever decoding is not possible yet (see
+ * `decodeDraftTransaction`).
  */
 export const getDraftDestinationAccountId = (
   draft: Draft | null,
   api: ApiPromise | null,
   chain: Chain | null,
 ): AccountId | null => {
-  const origin = draft?.multisigAccountId ?? draft?.proxyAccountId;
-  if (!draft?.callData || !origin || !api || !chain) return null;
+  if (!draft) return null;
 
-  // Same strictness as the call-data step: bytes that don't round-trip are not
-  // a transaction we should derive a recipient from.
-  if (!tryDecodeCallData(draft.callData, api, chain)) return null;
+  const decoded = decodeDraftTransaction({
+    callData: draft.callData,
+    originAccountId: getDraftOriginAccountId(draft),
+    api,
+    chain,
+  });
 
-  try {
-    const decoded = decodeCallData(api, origin, draft.callData as CallData, getNativeAssetId(chain.assets));
-
-    return getDestinationAccountId(findCoreTransaction(decoded));
-  } catch {
-    return null;
-  }
+  return getDestinationAccountId(findCoreTransaction(decoded));
 };

--- a/src/renderer/features/drafts/lib/get-destination-account-id.ts
+++ b/src/renderer/features/drafts/lib/get-destination-account-id.ts
@@ -12,6 +12,8 @@ import {
   isXcmTransaction,
 } from '@/entities/transaction';
 
+import { tryDecodeCallData } from './decode-call-data';
+
 export const getDestinationAccountId = (coreTx: DecodedTransaction | null): AccountId | null => {
   if (!coreTx) return null;
 
@@ -32,21 +34,25 @@ export const getDestinationAccountId = (coreTx: DecodedTransaction | null): Acco
  * Destination of a stored draft: decodes its call data against the chain api
  * and reads the core transfer's recipient. `null` for non-transfer drafts,
  * drafts without call data, and whenever decoding is not possible yet.
+ *
+ * The decode origin is the draft's source — the multisig, or the proxied
+ * account for proxy-only drafts. It only labels the transaction's sender and
+ * never influences the recipient that is read back.
  */
 export const getDraftDestinationAccountId = (
   draft: Draft | null,
   api: ApiPromise | null,
   chain: Chain | null,
 ): AccountId | null => {
-  if (!draft?.callData || !draft.multisigAccountId || !api || !chain) return null;
+  const origin = draft?.multisigAccountId ?? draft?.proxyAccountId;
+  if (!draft?.callData || !origin || !api || !chain) return null;
+
+  // Same strictness as the call-data step: bytes that don't round-trip are not
+  // a transaction we should derive a recipient from.
+  if (!tryDecodeCallData(draft.callData, api, chain)) return null;
 
   try {
-    const decoded = decodeCallData(
-      api,
-      draft.multisigAccountId,
-      draft.callData as CallData,
-      getNativeAssetId(chain.assets),
-    );
+    const decoded = decodeCallData(api, origin, draft.callData as CallData, getNativeAssetId(chain.assets));
 
     return getDestinationAccountId(findCoreTransaction(decoded));
   } catch {

--- a/src/renderer/features/drafts/lib/useDecodedDraftTransaction.ts
+++ b/src/renderer/features/drafts/lib/useDecodedDraftTransaction.ts
@@ -1,23 +1,18 @@
-import { isHex } from '@polkadot/util';
 import { useMemo } from 'react';
 
-import { type CallData, type DecodedTransaction } from '@/shared/core';
-import { getNativeAssetId } from '@/shared/lib/utils';
+import { type DecodedTransaction } from '@/shared/core';
 import { type Draft } from '@/domains/backend';
 import { useApi, useChain } from '@/entities/network';
-import { decodeCallData } from '@/entities/transaction';
+
+import { decodeDraftTransaction, getDraftOriginAccountId } from './decode-draft-transaction';
 
 export const useDecodedDraftTransaction = (draft: Draft): DecodedTransaction | null => {
   const chain = useChain(draft.chainId);
   const api = useApi(draft.chainId);
 
-  return useMemo(() => {
-    if (!draft.callData || !isHex(draft.callData) || !api || !chain || !draft.multisigAccountId) return null;
-
-    try {
-      return decodeCallData(api, draft.multisigAccountId, draft.callData as CallData, getNativeAssetId(chain.assets));
-    } catch {
-      return null;
-    }
-  }, [draft.callData, draft.multisigAccountId, api, chain]);
+  return useMemo(
+    () =>
+      decodeDraftTransaction({ callData: draft.callData, originAccountId: getDraftOriginAccountId(draft), api, chain }),
+    [draft, api, chain],
+  );
 };

--- a/src/renderer/features/drafts/model/create-draft-model.test.ts
+++ b/src/renderer/features/drafts/model/create-draft-model.test.ts
@@ -292,3 +292,49 @@ describe('createDraftModel · seed jump-ahead', () => {
     expect(scope.getState(createDraftModel.$activeStep)).toBe('call-data');
   });
 });
+
+describe('createDraftModel · unknown recipient acknowledgement', () => {
+  it('starts unacknowledged and follows the toggle', async () => {
+    const scope = forkWithChains([chainA]);
+    await open(scope);
+
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(true);
+
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: false });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+  });
+
+  it('resets when the call data changes (the recipient may have changed)', async () => {
+    const scope = forkWithChains([chainA]);
+    await open(scope);
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+
+    await allSettled(createDraftModel.callDataChanged, { scope, params: VALID_CALL_DATA });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+  });
+
+  it('resets when the chain changes', async () => {
+    const scope = forkWithChains([chainA, chainB]);
+    await open(scope);
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+
+    await allSettled(createDraftModel.chainSelected, { scope, params: chainB });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+  });
+
+  it('resets when the modal closes and when a new flow opens', async () => {
+    const scope = forkWithChains([chainA]);
+    await open(scope);
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+
+    await allSettled(createDraftModel.modalClosed, { scope });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+    await open(scope, { chainId: CHAIN_A, callData: VALID_CALL_DATA, path: COMPLETE_PATH });
+    expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+  });
+});

--- a/src/renderer/features/drafts/model/create-draft-model.test.ts
+++ b/src/renderer/features/drafts/model/create-draft-model.test.ts
@@ -1,14 +1,24 @@
+import { type ApiPromise } from '@polkadot/api';
 import { type Scope, allSettled, fork } from 'effector';
-import { describe, expect, it } from 'vitest';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
 
 import { type Chain, type ChainId } from '@/shared/core';
+import { type DecodedTransaction, TransactionType } from '@/shared/core';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type PathNode } from '@/domains/backend';
 import { AssetHubChains } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
+import { authModel, connectionHistoryModel } from '@/aggregates/backend';
 import { pathModel } from '@/features/signing-path';
+import type * as DecodeDraft from '../lib/decode-draft-transaction';
+import { decodeDraftTransaction } from '../lib/decode-draft-transaction';
 
 import { type DraftSeed, DESCRIPTION_MAX_LENGTH, STEPS_ORDER, createDraftModel } from './create-draft-model';
+
+vi.mock('../lib/decode-draft-transaction', async (importOriginal) => ({
+  ...(await importOriginal<typeof DecodeDraft>()),
+  decodeDraftTransaction: vi.fn(() => null),
+}));
 
 const acc = (n: number): AccountId => `0x${n.toString(16).padStart(64, '0')}` as AccountId;
 const signer = (accountId: AccountId): PathNode => ({ kind: 'signer', accountId });
@@ -336,5 +346,76 @@ describe('createDraftModel · unknown recipient acknowledgement', () => {
     await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
     await open(scope, { chainId: CHAIN_A, callData: VALID_CALL_DATA, path: COMPLETE_PATH });
     expect(scope.getState(createDraftModel.$isRiskAcknowledged)).toBe(false);
+  });
+});
+
+describe('createDraftModel · unknown recipient gate', () => {
+  const STRANGER = acc(9);
+  const transferToStranger = {
+    type: TransactionType.TRANSFER,
+    section: 'balances',
+    method: 'transferKeepAlive',
+    chainId: CHAIN_A,
+    address: '',
+    args: { dest: STRANGER, value: '1' },
+  } as unknown as DecodedTransaction;
+  const healthyBook = { accountId: acc(8), accountName: 'Backend user', permissions: [] };
+  const seed: DraftSeed = { chainId: CHAIN_A, callData: VALID_CALL_DATA, path: COMPLETE_PATH };
+
+  const forkConnected = (withApi: boolean) =>
+    fork({
+      values: new Map()
+        .set(networkModel.$chains, { [CHAIN_A]: chainA })
+        .set(networkModel.$apis, withApi ? { [CHAIN_A]: {} as ApiPromise } : {})
+        .set(connectionHistoryModel.$hasEverConnected, true)
+        .set(authModel.$authState, healthyBook),
+    });
+
+  beforeEach(() => {
+    vi.mocked(decodeDraftTransaction).mockReset();
+    vi.mocked(decodeDraftTransaction).mockReturnValue(null);
+  });
+
+  it('blocks Create for an unknown recipient until acknowledged', async () => {
+    vi.mocked(decodeDraftTransaction).mockReturnValue(transferToStranger);
+    const scope = forkConnected(true);
+    await open(scope, seed);
+
+    expect(scope.getState(createDraftModel.$destinationAccountId)).toBe(STRANGER);
+    expect(scope.getState(createDraftModel.$recipientWarning)).toBe('unknown');
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(false);
+
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(true);
+  });
+
+  it('accepts a draft with no recipient to check', async () => {
+    const scope = forkConnected(true);
+    await open(scope, seed);
+
+    expect(scope.getState(createDraftModel.$destinationAccountId)).toBeNull();
+    expect(scope.getState(createDraftModel.$recipientWarning)).toBe('none');
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(true);
+  });
+
+  it('never treats "cannot check yet" as safe: no chain api + call data blocks Create even when ticked', async () => {
+    const scope = forkConnected(false);
+    await open(scope, seed);
+
+    expect(scope.getState(createDraftModel.$isRecipientCheckable)).toBe(false);
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(false);
+
+    await allSettled(createDraftModel.riskAcknowledgedToggled, { scope, params: true });
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(false);
+  });
+
+  it('does not require the chain api while recipient verification is off', async () => {
+    const scope = fork({
+      values: new Map().set(networkModel.$chains, { [CHAIN_A]: chainA }).set(networkModel.$apis, {}),
+    });
+    await open(scope, seed);
+
+    expect(scope.getState(createDraftModel.$isRecipientCheckable)).toBe(true);
+    expect(scope.getState(createDraftModel.$recipientRiskAccepted)).toBe(true);
   });
 });

--- a/src/renderer/features/drafts/model/create-draft-model.ts
+++ b/src/renderer/features/drafts/model/create-draft-model.ts
@@ -5,7 +5,11 @@ import { isHex } from '@/shared/lib/utils';
 import { type PathNode } from '@/domains/backend';
 import { AssetHubChains } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
+import { findCoreTransaction } from '@/entities/transaction';
+import { recipientVerificationModel } from '@/aggregates/recipient-verification';
 import { graphModel, pathModel } from '@/features/signing-path';
+import { decodeDraftTransaction, getPathOriginAccountId } from '../lib/decode-draft-transaction';
+import { getDestinationAccountId } from '../lib/get-destination-account-id';
 
 export type Step = 'call-data' | 'select-path' | 'confirm';
 
@@ -91,6 +95,40 @@ const $description = createStore<string>('')
 const $isRiskAcknowledged = createStore(false)
   .on(riskAcknowledgedToggled, (_, checked) => checked)
   .reset([createDraftRequested, modalClosed, callDataChanged, chainSelected]);
+
+// --- Unknown recipient gate ---
+
+const $api = combine($selectedChain, networkModel.$apis, (chain, apis) =>
+  chain ? (apis[chain.chainId] ?? null) : null,
+);
+
+const $decodedTransaction = combine(
+  { callData: $callData, path: pathModel.$path, api: $api, chain: $selectedChain },
+  ({ callData, path, api, chain }) =>
+    decodeDraftTransaction({ callData, originAccountId: getPathOriginAccountId(path), api, chain }),
+);
+
+const $destinationAccountId = $decodedTransaction.map((transaction) =>
+  getDestinationAccountId(findCoreTransaction(transaction)),
+);
+
+const $recipientWarning = combine(
+  recipientVerificationModel.$resolveWarning,
+  $destinationAccountId,
+  (resolveWarning, destinationAccountId) => resolveWarning(destinationAccountId),
+);
+
+// "Can't check" is not "nothing to check": with call data on hand but no chain
+// api, the recipient is simply unknown — never silently treated as safe.
+const $isRecipientCheckable = combine(
+  { mode: recipientVerificationModel.$mode, callData: $callData, api: $api },
+  ({ mode, callData, api }) => mode === 'off' || callData.length === 0 || api !== null,
+);
+
+const $recipientRiskAccepted = combine(
+  { warning: $recipientWarning, acknowledged: $isRiskAcknowledged, checkable: $isRecipientCheckable },
+  ({ warning, acknowledged, checkable }) => checkable && (warning === 'none' || acknowledged),
+);
 
 sample({
   clock: createDraftRequested,
@@ -199,6 +237,11 @@ export const createDraftModel = {
   $selectedChain,
   $description,
   $isRiskAcknowledged,
+  $decodedTransaction,
+  $destinationAccountId,
+  $recipientWarning,
+  $isRecipientCheckable,
+  $recipientRiskAccepted,
   $callDataErrorKey,
   $isDescriptionTooLong,
   $isDirty,

--- a/src/renderer/features/drafts/model/create-draft-model.ts
+++ b/src/renderer/features/drafts/model/create-draft-model.ts
@@ -51,6 +51,7 @@ const callDataChanged = createEvent<string>();
 const inputModeChanged = createEvent<'paste' | 'build'>();
 const chainSelected = createEvent<Chain | null>();
 const descriptionChanged = createEvent<string>();
+const riskAcknowledgedToggled = createEvent<boolean>();
 
 const advance = (s: Step) => STEPS_ORDER[Math.min(STEPS_ORDER.indexOf(s) + 1, STEPS_ORDER.length - 1)] ?? s;
 const revert = (s: Step) => STEPS_ORDER[Math.max(STEPS_ORDER.indexOf(s) - 1, 0)] ?? s;
@@ -83,6 +84,13 @@ const $selectedChain = createStore<Chain | null>(null)
 const $description = createStore<string>('')
   .on(descriptionChanged, (_, d) => d)
   .reset(modalClosed);
+
+// Unknown-recipient acknowledgement for the confirm step. Anything that can
+// change the recipient — new call data, another chain, a new flow — clears it
+// so a tick never silently carries over to a different address.
+const $isRiskAcknowledged = createStore(false)
+  .on(riskAcknowledgedToggled, (_, checked) => checked)
+  .reset([createDraftRequested, modalClosed, callDataChanged, chainSelected]);
 
 sample({
   clock: createDraftRequested,
@@ -183,12 +191,14 @@ export const createDraftModel = {
   inputModeChanged,
   chainSelected,
   descriptionChanged,
+  riskAcknowledgedToggled,
   $isOpen,
   $activeStep,
   $callData,
   $inputMode,
   $selectedChain,
   $description,
+  $isRiskAcknowledged,
   $callDataErrorKey,
   $isDescriptionTooLong,
   $isDirty,

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -125,6 +125,12 @@ const $isRiskAcknowledged = createStore(false)
   .on(riskAcknowledgedToggled, (_, checked) => checked)
   .reset([flowStarted, flowFinished]);
 
+const $recipientRiskAccepted = combine(
+  $recipientWarning,
+  $isRiskAcknowledged,
+  (warning, acknowledged) => warning === 'none' || acknowledged,
+);
+
 // --- Late call-data entry (drafts created with the call-data step skipped) ---
 
 const callDataChanged = createEvent<string>();
@@ -568,8 +574,11 @@ sample({
 
 // --- Step transitions ---
 
+// Both `startSigning` consumers are gated on the recipient acknowledgement,
+// so the Sign button's `disabled` is not the only thing standing in the way.
 sample({
   clock: confirmModel.startSigning,
+  filter: $recipientRiskAccepted,
   fn: () => Step.SIGN,
   target: stepChanged,
 });
@@ -644,6 +653,7 @@ const sign = sample({
     chain: $chain,
     signatory: $signatoryStore,
   },
+  filter: $recipientRiskAccepted,
   fn({ wrappedTx, api, chain, signatory }) {
     if (nullable(api) || nullable(wrappedTx) || nullable(chain) || nullable(signatory)) return null;
 
@@ -860,6 +870,7 @@ export const submitDraftModel = {
   $destinationAccountId,
   $recipientWarning,
   $isRiskAcknowledged,
+  $recipientRiskAccepted,
   $savingCallData: submitCallDataFx.pending,
 
   flowStarted,

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -39,11 +39,13 @@ import { networkModel } from '@/entities/network';
 import { accountUtils, walletModel } from '@/entities/wallet';
 import { backendConfigurationModel } from '@/aggregates/backend';
 import { multisigOperationDescription } from '@/aggregates/multisig-operation-description';
+import { recipientVerificationModel } from '@/aggregates/recipient-verification';
 import { balanceSubModel } from '@/features/assets-balances';
 import { type TransactionSigningPayload, signModel } from '@/features/operations/OperationSign';
 import { type SuccessResult, ExtrinsicResult, submitModel } from '@/features/operations/OperationSubmit';
 import { createPathRouteStore } from '@/features/signing-path';
 import { tryDecodeCallData } from '../lib/decode-call-data';
+import { getDraftDestinationAccountId } from '../lib/get-destination-account-id';
 
 import './drafts-model'; // side-effect: orchestration wiring
 
@@ -103,6 +105,25 @@ const $transaction = $draft.map((draft): EncodedTransaction | null => {
     callData: draft.callData as CallData,
   };
 });
+
+// --- Unknown recipient gate ---
+
+const $destinationAccountId = combine({ draft: $draft, api: $api, chain: $chain }, ({ draft, api, chain }) =>
+  getDraftDestinationAccountId(draft, api, chain),
+);
+
+const $recipientWarning = combine(
+  recipientVerificationModel.$resolveWarning,
+  $destinationAccountId,
+  (resolveWarning, destinationAccountId) => resolveWarning(destinationAccountId),
+);
+
+const riskAcknowledgedToggled = createEvent<boolean>();
+
+// A fresh flow never inherits a previous acknowledgement.
+const $isRiskAcknowledged = createStore(false)
+  .on(riskAcknowledgedToggled, (_, checked) => checked)
+  .reset([flowStarted, flowFinished]);
 
 // --- Late call-data entry (drafts created with the call-data step skipped) ---
 
@@ -833,6 +854,9 @@ export const submitDraftModel = {
   $pendingCallDataDecoded,
   $pendingCallDataError,
   $canConfirmCallData,
+  $destinationAccountId,
+  $recipientWarning,
+  $isRiskAcknowledged,
   $savingCallData: submitCallDataFx.pending,
 
   flowStarted,
@@ -840,6 +864,7 @@ export const submitDraftModel = {
   signatoryChanged: $signatory,
   callDataChanged,
   callDataConfirmRequested,
+  riskAcknowledgedToggled,
 
   confirmModel,
 

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -151,6 +151,9 @@ const submitCallDataFx = createEffect(({ id, callData, baseUrl }: { id: string; 
   draftsService.updateDraft(baseUrl, id, { callData }),
 );
 
+// Late-filled call data replaces the draft, and with it the recipient.
+$isRiskAcknowledged.reset(submitCallDataFx.doneData);
+
 sample({
   clock: callDataConfirmRequested,
   source: {

--- a/src/renderer/features/drafts/steps/StepReview.tsx
+++ b/src/renderer/features/drafts/steps/StepReview.tsx
@@ -29,6 +29,11 @@ type Props = {
   operationIcon: IconNames | null;
   destinationAccountId: AccountId | null;
   recipientWarning: RecipientWarning;
+  /**
+   * Call data is on hand but the chain api isn't — the recipient can't be
+   * checked yet.
+   */
+  recipientCheckPending: boolean;
   riskAcknowledged: boolean;
   onRiskAcknowledgedChange: (checked: boolean) => void;
   description: string;
@@ -49,6 +54,7 @@ export const StepReview = ({
   operationIcon,
   destinationAccountId,
   recipientWarning,
+  recipientCheckPending,
   riskAcknowledged,
   onRiskAcknowledgedChange,
   description,
@@ -127,6 +133,12 @@ export const StepReview = ({
         checked={riskAcknowledged}
         onToggle={onRiskAcknowledgedChange}
       />
+
+      {recipientCheckPending && (
+        <FootnoteText className="text-center text-text-tertiary">
+          {t('operations.drafts.recipientCheckPending')}
+        </FootnoteText>
+      )}
 
       {!callData && (
         <FootnoteText className="text-center text-text-tertiary">

--- a/src/renderer/features/drafts/steps/StepReview.tsx
+++ b/src/renderer/features/drafts/steps/StepReview.tsx
@@ -1,5 +1,6 @@
 import { type Chain, type WalletType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
+import { type RecipientWarning } from '@/shared/lib/recipient-verification';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import {
   type IconNames,
@@ -11,6 +12,7 @@ import {
   Separator,
   SmallTitleText,
 } from '@/shared/ui';
+import { UnknownRecipientAckBox } from '@/shared/ui-entities';
 import { Field, TextArea } from '@/shared/ui-kit';
 import { type PathNode } from '@/domains/backend';
 import { type OperationTitle } from '@/features/multisig-operations';
@@ -26,6 +28,9 @@ type Props = {
   titleData: OperationTitle | null;
   operationIcon: IconNames | null;
   destinationAccountId: AccountId | null;
+  recipientWarning: RecipientWarning;
+  riskAcknowledged: boolean;
+  onRiskAcknowledgedChange: (checked: boolean) => void;
   description: string;
   onDescriptionChanged: (v: string) => void;
   // Legacy-shape props for DraftSummary — required while DraftSummary hasn't been updated yet:
@@ -43,6 +48,9 @@ export const StepReview = ({
   titleData,
   operationIcon,
   destinationAccountId,
+  recipientWarning,
+  riskAcknowledged,
+  onRiskAcknowledgedChange,
   description,
   onDescriptionChanged,
   multisigName,
@@ -112,6 +120,13 @@ export const StepReview = ({
           />
         </div>
       </div>
+
+      <UnknownRecipientAckBox
+        warning={recipientWarning}
+        context="draftCreate"
+        checked={riskAcknowledged}
+        onToggle={onRiskAcknowledgedChange}
+      />
 
       {!callData && (
         <FootnoteText className="text-center text-text-tertiary">

--- a/src/renderer/features/transfer/README.md
+++ b/src/renderer/features/transfer/README.md
@@ -1,6 +1,6 @@
 # Transfer
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-07-17
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-20
 
 ## Overview
 
@@ -91,7 +91,8 @@ external address book connection — nothing here shows for a user who has never
   acknowledgement never silently carries over to a different address; it survives the warning's own copy changing (e.g.
   a mid-flow reconnect turning `unverifiable` into `unknown`).
 - **Draft mode exemption.** The acknowledgement gate does not apply, and the box is not shown, while saving as a draft —
-  nothing is signed yet, so the warning fires later when the draft is actually signed.
+  nothing is signed yet. The gate runs instead on the draft's own confirm steps (Create and Submit), see
+  [Drafts](../drafts/README.md#unknown-recipient-warnings).
 - **Confirmation step.** A one-line amber note appears under the Recipient row restating that the address is not in the
   address book. It is informational only — the gate already ran on the form, so there is nothing to acknowledge again
   here.

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -3076,6 +3076,7 @@
       "signingPathUnresolved": "The signing path saved with this draft can no longer be resolved against your accounts. The draft cannot be submitted along the original route.",
       "submitSuccess": "Draft submitted",
       "initiatorUnavailable": "The initiator is no longer a signatory of this multisig. Please pick another.",
+      "recipientCheckPending": "Waiting for the network connection to check the recipient before the draft can be created.",
       "submittedBadge": "Submitted",
       "stepMultisig": "Account",
       "stepCallData": "Call data",

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -3420,6 +3420,11 @@
       "body": "Your signature moves this transfer closer to execution. Confirm you have verified the recipient before approving.",
       "ackLabel": "I have verified the recipient address and approve this transfer"
     },
+    "draftCreate": {
+      "title": "Recipient is not in your address book",
+      "body": "Co-signers will rely on this draft. Confirm you have verified the recipient address before saving it.",
+      "ackLabel": "I have verified the recipient address and want to save this draft"
+    },
     "unverifiable": {
       "title": "Recipient can't be verified",
       "body": "The address book is disconnected, so recipients can't be checked. Reconnect to verify, or confirm the address manually.",

--- a/src/renderer/shared/ui-entities/UnknownRecipient/UnknownRecipientAckBox.tsx
+++ b/src/renderer/shared/ui-entities/UnknownRecipient/UnknownRecipientAckBox.tsx
@@ -6,10 +6,11 @@ import { Checkbox } from '@/shared/ui-kit';
 type Props = {
   warning: RecipientWarning;
   /**
-   * Picks the copy set: transfer form vs multisig signing. Ignored while the
-   * warning is `unverifiable` — both contexts share the reconnect copy then.
+   * Picks the copy set: transfer form, multisig signing, or draft creation.
+   * Ignored while the warning is `unverifiable` — every context shares the
+   * reconnect copy then.
    */
-  context: 'transfer' | 'multisigSign';
+  context: 'transfer' | 'multisigSign' | 'draftCreate';
   checked: boolean;
   onToggle: (checked: boolean) => void;
 };

--- a/tests/integrations/cases/drafts/submit-draft.integration.test.ts
+++ b/tests/integrations/cases/drafts/submit-draft.integration.test.ts
@@ -21,7 +21,7 @@ import { type AnyAccount, type Extrinsic, accounts, transactionService } from '@
 import { contactModel } from '@/entities/contact';
 import { proxyModel } from '@/entities/proxy';
 import { accountUtils, walletModel } from '@/entities/wallet';
-import { authModel, backendConfigurationModel } from '@/aggregates/backend';
+import { authModel, backendConfigurationModel, connectionHistoryModel } from '@/aggregates/backend';
 import { multisigOperationDescription } from '@/aggregates/multisig-operation-description';
 import { findRouteMultisigAccountId } from '@/aggregates/multisig-operation-description/lib/findRouteMultisigAccountId';
 import { getDraftSubmitGate } from '@/features/drafts/lib/submit-draft-availability';
@@ -653,6 +653,64 @@ describe('Submit Draft — submit & edit flows', () => {
       await allSettled(submitDraftModel.callDataConfirmRequested, { scope: env.scope });
       expect(updateSpy).not.toHaveBeenCalled();
       expect(env.getState(submitDraftModel.$step)).toBe(submitDraftModel.Step.CALL_DATA);
+    });
+  });
+
+  describe('unknown recipient acknowledgement', () => {
+    beforeEach(async () => {
+      await allureMetadata({
+        epic: 'Drafts',
+        feature: 'Submit Draft',
+        story: 'Unknown recipient gate',
+      });
+    });
+
+    const directPath: PathNode[] = [
+      { kind: 'multisig', accountId: MULTISIG_TOP_ID },
+      { kind: 'signer', accountId: SIGNER_ID },
+    ];
+
+    const startFlow = (draft: Draft) =>
+      allSettled(submitDraftModel.flowStarted, {
+        scope: env.scope,
+        params: { draft, initiator: multisigDirect, chain: polkadotChain },
+      });
+
+    it('follows the toggle and resets on flow start and flow finish', async () => {
+      seamSpies();
+      env = await buildEnv([multisigDirect, signerAccount], (b) => b.withApi(polkadotChainId, fakeApi));
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(false);
+
+      await allSettled(submitDraftModel.riskAcknowledgedToggled, { scope: env.scope, params: true });
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(true);
+
+      await allSettled(submitDraftModel.flowFinished, { scope: env.scope });
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(false);
+
+      await allSettled(submitDraftModel.riskAcknowledgedToggled, { scope: env.scope, params: true });
+      await startFlow(draft);
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(false);
+    });
+
+    it('carries no warning while the call data yields no destination', async () => {
+      seamSpies();
+      // The api double has no `tx`, so decoding throws → destination null → nothing
+      // to warn about, even with the address book connected and healthy.
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b
+          .withApi(polkadotChainId, fakeApi)
+          .withStoreValue(authModel.$authState, authState)
+          .withStoreValue(connectionHistoryModel.$hasEverConnected, true),
+      );
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+
+      expect(env.getState(submitDraftModel.$destinationAccountId)).toBeNull();
+      expect(env.getState(submitDraftModel.$recipientWarning)).toBe('none');
     });
   });
 });

--- a/tests/integrations/cases/drafts/submit-draft.integration.test.ts
+++ b/tests/integrations/cases/drafts/submit-draft.integration.test.ts
@@ -24,6 +24,8 @@ import { accountUtils, walletModel } from '@/entities/wallet';
 import { authModel, backendConfigurationModel, connectionHistoryModel } from '@/aggregates/backend';
 import { multisigOperationDescription } from '@/aggregates/multisig-operation-description';
 import { findRouteMultisigAccountId } from '@/aggregates/multisig-operation-description/lib/findRouteMultisigAccountId';
+import type * as DestinationHelper from '@/features/drafts/lib/get-destination-account-id';
+import { getDraftDestinationAccountId } from '@/features/drafts/lib/get-destination-account-id';
 import { getDraftSubmitGate } from '@/features/drafts/lib/submit-draft-availability';
 import { submitDraftModel } from '@/features/drafts/model/submit-draft-model';
 import { signModel } from '@/features/operations/OperationSign';
@@ -36,6 +38,13 @@ import {
   allureMetadata,
   seedAccountHandlers,
 } from '../../utils/index';
+
+// The api double can't decode real call data, so the recipient resolution is
+// stubbed: `null` by default (no recipient), overridden per test.
+vi.mock('@/features/drafts/lib/get-destination-account-id', async (importOriginal) => ({
+  ...(await importOriginal<typeof DestinationHelper>()),
+  getDraftDestinationAccountId: vi.fn(() => null),
+}));
 
 const BASE_URL = 'https://backend.test';
 // Lowercase hex — `tryDecodeCallData` requires the decoded call to round-trip
@@ -53,6 +62,7 @@ const CONTACT_MULTISIG_ID: AccountId = createAccountId('contact-multisig');
 const CONTACT_PROXY_ID: AccountId = createAccountId('contact-pure-proxy');
 const CONTACT_PLAIN_ID: AccountId = createAccountId('contact-plain');
 const EXTERNAL_SIGNER_ID: AccountId = createAccountId('external-signer');
+const STRANGER_ID: AccountId = createAccountId('stranger-recipient');
 
 const signerAccount: AnyAccount = {
   id: 'signer-1',
@@ -711,6 +721,81 @@ describe('Submit Draft — submit & edit flows', () => {
 
       expect(env.getState(submitDraftModel.$destinationAccountId)).toBeNull();
       expect(env.getState(submitDraftModel.$recipientWarning)).toBe('none');
+    });
+
+    it('warns about a recipient that is neither a contact nor an own account while the book is healthy', async () => {
+      seamSpies();
+      vi.mocked(getDraftDestinationAccountId).mockReturnValue(STRANGER_ID);
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b
+          .withApi(polkadotChainId, fakeApi)
+          .withStoreValue(authModel.$authState, authState)
+          .withStoreValue(connectionHistoryModel.$hasEverConnected, true),
+      );
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+
+      expect(env.getState(submitDraftModel.$destinationAccountId)).toBe(STRANGER_ID);
+      expect(env.getState(submitDraftModel.$recipientWarning)).toBe('unknown');
+    });
+
+    it('stays quiet for a recipient that is an address-book contact', async () => {
+      seamSpies();
+      vi.mocked(getDraftDestinationAccountId).mockReturnValue(STRANGER_ID);
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b
+          .withApi(polkadotChainId, fakeApi)
+          .withStoreValue(authModel.$authState, authState)
+          .withStoreValue(connectionHistoryModel.$hasEverConnected, true)
+          .withStoreValue(contactModel.$backendContacts, [makeBackendContact(STRANGER_ID, 'known-recipient')]),
+      );
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+
+      expect(env.getState(submitDraftModel.$recipientWarning)).toBe('none');
+    });
+
+    it('warns about every recipient while the book was connected before but is unhealthy now', async () => {
+      seamSpies();
+      vi.mocked(getDraftDestinationAccountId).mockReturnValue(STRANGER_ID);
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b
+          .withApi(polkadotChainId, fakeApi)
+          .withStoreValue(authModel.$authState, null)
+          .withStoreValue(connectionHistoryModel.$hasEverConnected, true)
+          .withStoreValue(contactModel.$backendContacts, [makeBackendContact(STRANGER_ID, 'known-recipient')]),
+      );
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+
+      expect(env.getState(submitDraftModel.$recipientWarning)).toBe('unverifiable');
+    });
+
+    it('drops the acknowledgement when late-filled call data replaces the draft', async () => {
+      seamSpies();
+      const draft = makeDraft(directPath, {
+        multisigAccountId: MULTISIG_TOP_ID,
+        initiatorAccountId: SIGNER_ID,
+        callData: null,
+      });
+      const serverDraft: Draft = { ...draft, callData: CALL_DATA, updatedAt: '2026-01-02T00:00:00Z' };
+      vi.spyOn(draftsService, 'updateDraft').mockResolvedValue(serverDraft);
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b.withApi(polkadotChainId, fakeApi).withStoreValue(backendConfigurationModel.$backendUrl, BASE_URL),
+      );
+
+      await startFlow(draft);
+      await allSettled(submitDraftModel.riskAcknowledgedToggled, { scope: env.scope, params: true });
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(true);
+
+      await allSettled(submitDraftModel.callDataChanged, { scope: env.scope, params: CALL_DATA });
+      await allSettled(submitDraftModel.callDataConfirmRequested, { scope: env.scope });
+
+      expect(env.getState(submitDraftModel.$draft)).toEqual(serverDraft);
+      expect(env.getState(submitDraftModel.$isRiskAcknowledged)).toBe(false);
     });
   });
 });

--- a/tests/integrations/cases/drafts/submit-draft.integration.test.ts
+++ b/tests/integrations/cases/drafts/submit-draft.integration.test.ts
@@ -673,6 +673,8 @@ describe('Submit Draft — submit & edit flows', () => {
         feature: 'Submit Draft',
         story: 'Unknown recipient gate',
       });
+      // Factory mocks survive `vi.restoreAllMocks`; pin the default so tests don't depend on order.
+      vi.mocked(getDraftDestinationAccountId).mockReturnValue(null);
     });
 
     const directPath: PathNode[] = [
@@ -772,6 +774,31 @@ describe('Submit Draft — submit & edit flows', () => {
       await startFlow(draft);
 
       expect(env.getState(submitDraftModel.$recipientWarning)).toBe('unverifiable');
+    });
+
+    it('refuses to start signing until an unknown recipient is acknowledged', async () => {
+      seamSpies();
+      vi.mocked(getDraftDestinationAccountId).mockReturnValue(STRANGER_ID);
+      env = await buildEnv([multisigDirect, signerAccount], (b) =>
+        b
+          .withApi(polkadotChainId, fakeApi)
+          .withStoreValue(authModel.$authState, authState)
+          .withStoreValue(connectionHistoryModel.$hasEverConnected, true),
+      );
+      const draft = makeDraft(directPath, { multisigAccountId: MULTISIG_TOP_ID, initiatorAccountId: SIGNER_ID });
+
+      await startFlow(draft);
+      expect(env.getState(submitDraftModel.$step)).toBe(submitDraftModel.Step.CONFIRM);
+      expect(env.getState(submitDraftModel.$recipientRiskAccepted)).toBe(false);
+
+      await allSettled(submitDraftModel.confirmModel.startSigning, { scope: env.scope });
+      expect(env.getState(submitDraftModel.$step)).toBe(submitDraftModel.Step.CONFIRM);
+
+      await allSettled(submitDraftModel.riskAcknowledgedToggled, { scope: env.scope, params: true });
+      expect(env.getState(submitDraftModel.$recipientRiskAccepted)).toBe(true);
+
+      await allSettled(submitDraftModel.confirmModel.startSigning, { scope: env.scope });
+      expect(env.getState(submitDraftModel.$step)).toBe(submitDraftModel.Step.SIGN);
     });
 
     it('drops the acknowledgement when late-filled call data replaces the draft', async () => {


### PR DESCRIPTION
## Description

`recipient-verification` warns about transfer recipients that are not in the address book on the transfer form, the transfer confirmation and the multisig approve dialog — but drafts were left out. The transfer form even skips its own gate in draft mode with the promise that the warning "fires later when the draft is actually signed", and nothing fired: a draft transfer to an unknown address could be created and submitted (first multisig approval signed) with no warning at all.

This PR closes that gap by wiring the same acknowledgement gate (`UnknownRecipientAckBox`) into both draft confirm screens, following the existing `approve-model` pattern: the warning and the acknowledgement live in each draft Effector model, the UI only renders the shared box and ANDs `!accepted` into the primary button's `disabled`.

- **Create draft → Confirm** — amber box with a checkbox below the transaction card; **Create draft** stays disabled until ticked. The tick is cleared by anything that can change the recipient (new call data, another chain, closing the modal, a new flow).
- **Submit draft → Confirm** — the same box (multisig-signing copy, since submitting is the first approval) above **Sign**, which stays disabled until ticked; the tick resets on every flow start/finish and when late-filled call data replaces the draft. The confirm also gains a **Recipient** row, so the warning never points at an address the user can't see.
- Inherits the aggregate's modes: invisible while the address book was never connected (`off`), "reconnect" copy for every recipient while it is unhealthy (`unverifiable`).
- Proxy-only drafts (`[proxied, signer]`, no multisig hop) are covered too — the decode origin falls back to the proxied account.

Non-transfer drafts, and drafts whose call data can't be decoded, are unaffected. The transfer form's draft-mode exemption is unchanged — the gate now genuinely runs on the draft's confirm steps the form hands off to.

## Related Issues

Follow-up to the recipient-verification rollout (transfer + multisig operations); drafts were listed there as "not yet wired up".

## Changes Made

- `shared/ui-entities/UnknownRecipientAckBox`: new `draftCreate` copy context (+ `recipientVerification.draftCreate.*` strings).
- `features/drafts/lib/get-destination-account-id`: `getDraftDestinationAccountId(draft, api, chain)` — strict round-trip check, then decode → core tx → recipient; origin is the multisig or, for proxy-only drafts, the proxied account.
- `create-draft-model`: `$isRiskAcknowledged` / `riskAcknowledgedToggled`, reset on `createDraftRequested`, `modalClosed`, `callDataChanged`, `chainSelected`. `CreateDraftModal` + `StepReview` render the box and gate Create; the decode origin now also falls back to the path root so proxy-only drafts get a decoded title/recipient.
- `submit-draft-model`: `$destinationAccountId`, `$recipientWarning`, `$isRiskAcknowledged` / `riskAcknowledgedToggled` (reset on `flowStarted`, `flowFinished`, `submitCallDataFx.doneData`). `SubmitDraftModal` renders the Recipient row, the box, and gates Sign.
- Tests: unit (`get-destination-account-id`, `create-draft-model` reset semantics) and integration (`submit-draft`: toggle/reset, `'none'` / `'unknown'` / `'unverifiable'` derivation, late-fill reset).
- Specs: `features/drafts` (new "Unknown recipient warnings" section), `aggregates/recipient-verification` (drafts added to consuming surfaces), `features/transfer` (draft-mode exemption reworded), Feature Map cross-references.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
