### PR TITLE
feat: highlight the hovered column in the operations table

### DIFF
--- a/src/renderer/aggregates/operations-table-layout/README.md
+++ b/src/renderer/aggregates/operations-table-layout/README.md
@@ -23,6 +23,10 @@ cell scaffolding (row height, cell classes, the left Operation+Value block) live
   coalesced during a drag so a pointer move does not hit storage on every pixel.
 - The drag flag is on for the duration of a header-handle drag so the list can suspend text selection while the pointer
   moves.
+- Hovering a cell highlights its whole column — every operation and draft row plus the header caption — so a value can
+  be read down the table without losing the column. Operation and Value count as one column with the left block; the
+  highlight clears over row gaps, headings and when the pointer leaves the list. It is a browser-only repaint: no row
+  re-renders, no state.
 
 ## Used by
 

--- a/src/renderer/aggregates/operations-table-layout/__tests__/column-hover.test.tsx
+++ b/src/renderer/aggregates/operations-table-layout/__tests__/column-hover.test.tsx
@@ -1,0 +1,60 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+
+import { handleColumnPointerLeave, handleColumnPointerOver } from '../column-hover';
+import { COLUMN_DEFAULT_WIDTHS, HOVERED_COLUMN_ATTRIBUTE, getCellProps, getHoverableProps } from '../layout';
+
+const renderTable = () =>
+  render(
+    <div data-testid="scroller" onPointerOver={handleColumnPointerOver} onPointerLeave={handleColumnPointerLeave}>
+      <div {...getCellProps('submitter', COLUMN_DEFAULT_WIDTHS)}>
+        <span data-testid="submitter-content">Alice</span>
+      </div>
+      <div {...getHoverableProps('description')} data-testid="description" />
+      <div data-testid="gap" />
+    </div>,
+  );
+
+describe('aggregates/operations-table-layout/column-hover', () => {
+  it('should mirror the hovered cell column onto the scroller', () => {
+    renderTable();
+
+    fireEvent.pointerOver(screen.getByTestId('submitter-content'));
+
+    expect(screen.getByTestId('scroller')).toHaveAttribute(HOVERED_COLUMN_ATTRIBUTE, 'submitter');
+  });
+
+  it('should switch the column when the pointer moves to another cell', () => {
+    renderTable();
+
+    fireEvent.pointerOver(screen.getByTestId('submitter-content'));
+    fireEvent.pointerOver(screen.getByTestId('description'));
+
+    expect(screen.getByTestId('scroller')).toHaveAttribute(HOVERED_COLUMN_ATTRIBUTE, 'description');
+  });
+
+  it('should clear the column over something that is not a cell', () => {
+    renderTable();
+
+    fireEvent.pointerOver(screen.getByTestId('submitter-content'));
+    fireEvent.pointerOver(screen.getByTestId('gap'));
+
+    expect(screen.getByTestId('scroller')).not.toHaveAttribute(HOVERED_COLUMN_ATTRIBUTE);
+  });
+
+  it('should clear the column when the pointer leaves the scroller', () => {
+    renderTable();
+
+    fireEvent.pointerOver(screen.getByTestId('submitter-content'));
+    fireEvent.pointerLeave(screen.getByTestId('scroller'));
+
+    expect(screen.getByTestId('scroller')).not.toHaveAttribute(HOVERED_COLUMN_ATTRIBUTE);
+  });
+
+  it('should tag cells with their column and the hover class that keys off the scroller', () => {
+    const props = getCellProps('status', COLUMN_DEFAULT_WIDTHS);
+
+    expect(props['data-column']).toBe('status');
+    expect(props.className).toContain('group-data-[hovered-column=status]/table:bg-hover');
+  });
+});

--- a/src/renderer/aggregates/operations-table-layout/column-hover.ts
+++ b/src/renderer/aggregates/operations-table-layout/column-hover.ts
@@ -1,0 +1,36 @@
+import { type PointerEvent } from 'react';
+
+import { CELL_COLUMN_ATTRIBUTE, HOVERED_COLUMN_ATTRIBUTE } from './layout';
+
+const setHoveredColumn = (scroller: HTMLElement, column: string | null) => {
+  // `pointerover` fires for every element the pointer enters; skip the write
+  // when the column did not change so moving inside one cell costs nothing.
+  if (scroller.getAttribute(HOVERED_COLUMN_ATTRIBUTE) === column) return;
+
+  if (column) {
+    scroller.setAttribute(HOVERED_COLUMN_ATTRIBUTE, column);
+  } else {
+    scroller.removeAttribute(HOVERED_COLUMN_ATTRIBUTE);
+  }
+};
+
+/**
+ * Delegated `onPointerOver` for the table scroller: finds the cell under the
+ * pointer by its `data-column` and mirrors it into `data-hovered-column` on the
+ * scroller, which the cells' hover classes key off. A pointer over something
+ * that is not a cell (row gap, section heading) clears it.
+ */
+export const handleColumnPointerOver = (event: PointerEvent<HTMLElement>) => {
+  const cell = event.target instanceof Element ? event.target.closest(`[${CELL_COLUMN_ATTRIBUTE}]`) : null;
+  const column = cell && event.currentTarget.contains(cell) ? cell.getAttribute(CELL_COLUMN_ATTRIBUTE) : null;
+
+  setHoveredColumn(event.currentTarget, column);
+};
+
+/**
+ * Delegated `onPointerLeave` for the table scroller: no pointer, no highlighted
+ * column.
+ */
+export const handleColumnPointerLeave = (event: PointerEvent<HTMLElement>) => {
+  setHoveredColumn(event.currentTarget, null);
+};

--- a/src/renderer/aggregates/operations-table-layout/index.ts
+++ b/src/renderer/aggregates/operations-table-layout/index.ts
@@ -1,8 +1,10 @@
 export {
   type ColumnVisibility,
   type ColumnWidths,
+  type HoverColumn,
   type ResizableColumn,
   type ToggleableColumn,
+  CELL_COLUMN_ATTRIBUTE,
   COLUMN_DEFAULT_WIDTHS,
   COLUMN_FIT_WIDTHS,
   COLUMN_MAX_WIDTHS,
@@ -10,21 +12,26 @@ export {
   EMPTY_SECTION_BOX_HEIGHT,
   EMPTY_SECTION_HEIGHT,
   HEADER_SEPARATOR_CLASS,
+  HOVERED_COLUMN_ATTRIBUTE,
   INITIATOR_COLUMN_MEDIA_QUERY,
   RESIZABLE_COLUMNS,
   ROW_GAP,
   ROW_HEIGHT,
   SECTION_HEADER_HEIGHT,
+  TABLE_GROUP_CLASS,
   TOGGLEABLE_COLUMNS,
   clampColumnWidth,
   getCellProps,
   getColumnStyle,
+  getDescriptionCellProps,
   getHeaderCellProps,
+  getHoverableProps,
   getLeftBlockProps,
   getLeftBlockWidth,
   getOperationsMinWidth,
   getRowProps,
   operationColumns,
 } from './layout';
+export { handleColumnPointerLeave, handleColumnPointerOver } from './column-hover';
 export { operationsTableLayoutModel } from './model';
 export { useIsResizingColumns, useOperationColumnVisibility, useOperationColumnWidths } from './hooks';

--- a/src/renderer/aggregates/operations-table-layout/layout.ts
+++ b/src/renderer/aggregates/operations-table-layout/layout.ts
@@ -168,12 +168,53 @@ export const SECTION_HEADER_HEIGHT = 42;
 export const EMPTY_SECTION_BOX_HEIGHT = 60;
 export const EMPTY_SECTION_HEIGHT = EMPTY_SECTION_BOX_HEIGHT + ROW_GAP;
 
-type CellProps = { className: string; style: CSSProperties };
 /**
  * Fixed-width columns rendered as plain cells — Operation is the left block
  * (`getLeftBlockProps`), not a cell of its own.
  */
 type CellColumn = Exclude<ResizableColumn, 'operation'>;
+/**
+ * Every column a pointer can rest on; the left Operation+Value block counts as
+ * Operation.
+ */
+export type HoverColumn = ResizableColumn | 'description';
+
+/**
+ * Column hover is one DOM attribute on the scroller, not React state: cells are
+ * flex children of their own rows, so no `:hover` can span a column, and a
+ * store would re-render every visible row on each pointer move. The scroller
+ * carries `TABLE_GROUP_CLASS` and gets `data-hovered-column="<column>"` from
+ * `column-hover.ts`; each cell carries `data-column` and the matching
+ * `group-data-[hovered-column=…]/table:` class, so the browser repaints only
+ * the cells of that column.
+ */
+export const HOVERED_COLUMN_ATTRIBUTE = 'data-hovered-column';
+export const CELL_COLUMN_ATTRIBUTE = 'data-column';
+export const TABLE_GROUP_CLASS = 'group/table';
+// Full literal strings — Tailwind only generates the classes it can see in the source.
+const COLUMN_HOVER_CLASS: Record<HoverColumn, string> = {
+  operation: 'group-data-[hovered-column=operation]/table:bg-hover',
+  value: 'group-data-[hovered-column=value]/table:bg-hover',
+  submitter: 'group-data-[hovered-column=submitter]/table:bg-hover',
+  initiator: 'group-data-[hovered-column=initiator]/table:bg-hover',
+  description: 'group-data-[hovered-column=description]/table:bg-hover',
+  status: 'group-data-[hovered-column=status]/table:bg-hover',
+  actions: 'group-data-[hovered-column=actions]/table:bg-hover',
+};
+
+type HoverableProps = { className: string; [CELL_COLUMN_ATTRIBUTE]: HoverColumn };
+type RowProps = { className: string; style: CSSProperties };
+type CellProps = HoverableProps & { style: CSSProperties };
+
+/**
+ * Marks an element as a cell of `column` for the column-hover highlight: the
+ * `data-column` the scroller's pointer handler reads, plus the class that
+ * paints the cell while that column is hovered.
+ */
+export const getHoverableProps = (column: HoverColumn, className?: string): HoverableProps => ({
+  className: cnTw(COLUMN_HOVER_CLASS[column], className),
+  [CELL_COLUMN_ATTRIBUTE]: column,
+});
 
 /** A row cell fills the row height and centres its content vertically. */
 const ROW_CELL_CLASS = 'flex h-full items-center';
@@ -182,7 +223,7 @@ const ROW_CELL_CLASS = 'flex h-full items-center';
  * The strip of cells inside an operation or draft row; its height is the one
  * the virtualizer measures with.
  */
-export const getRowProps = (className?: string): CellProps => ({
+export const getRowProps = (className?: string): RowProps => ({
   className: cnTw('flex w-full items-center gap-x-2 overflow-hidden', className),
   style: { height: ROW_HEIGHT },
 });
@@ -193,21 +234,28 @@ export const getLeftBlockProps = (
   visibility: ColumnVisibility,
   className?: string,
 ): CellProps => ({
-  className: cnTw(operationColumns.leftBlock, ROW_CELL_CLASS, className),
+  ...getHoverableProps('operation', cnTw(operationColumns.leftBlock, ROW_CELL_CLASS, className)),
   style: getColumnStyle(getLeftBlockWidth(widths, visibility)),
 });
 
 /** A fixed-width row cell; `className` adds the per-column alignment. */
 export const getCellProps = (column: CellColumn, widths: ColumnWidths, className?: string): CellProps => ({
-  className: cnTw(operationColumns[column], ROW_CELL_CLASS, className),
+  ...getHoverableProps(column, cnTw(operationColumns[column], ROW_CELL_CLASS, className)),
   style: getColumnStyle(widths[column]),
 });
+
+/**
+ * The flexible Description cell (row or header); `className` adds the context's
+ * own classes.
+ */
+export const getDescriptionCellProps = (className?: string): HoverableProps =>
+  getHoverableProps('description', cnTw(operationColumns.description, className));
 
 /**
  * The header caption over a fixed-width column: the left hairline, no
  * row-height stretch.
  */
 export const getHeaderCellProps = (column: CellColumn, widths: ColumnWidths, className?: string): CellProps => ({
-  className: cnTw(operationColumns[column], HEADER_SEPARATOR_CLASS, 'flex', className),
+  ...getHoverableProps(column, cnTw(operationColumns[column], HEADER_SEPARATOR_CLASS, 'flex', className)),
   style: getColumnStyle(widths[column]),
 });

--- a/src/renderer/features/drafts/components/DraftRow.tsx
+++ b/src/renderer/features/drafts/components/DraftRow.tsx
@@ -15,6 +15,7 @@ import { accountUtils, walletModel } from '@/entities/wallet';
 import { authModel } from '@/aggregates/backend';
 import {
   getCellProps,
+  getDescriptionCellProps,
   getLeftBlockProps,
   getRowProps,
   operationColumns,
@@ -234,7 +235,7 @@ export const DraftRow = ({
             {/* A hidden Description leaves the same flexible spacer behind so the trailing
                 columns keep their place at the row's right edge. */}
             {visibility.description ? (
-              <div className={cnTw(operationColumns.description, 'flex h-full items-center')}>
+              <div {...getDescriptionCellProps('flex h-full items-center')}>
                 <DraftDescription description={draft.description} />
               </div>
             ) : (

--- a/src/renderer/features/multisig-operations/components/Operation.tsx
+++ b/src/renderer/features/multisig-operations/components/Operation.tsx
@@ -30,6 +30,7 @@ import {
 import { accountUtils } from '@/entities/wallet';
 import {
   getCellProps,
+  getDescriptionCellProps,
   getLeftBlockProps,
   getRowProps,
   operationColumns,
@@ -219,7 +220,7 @@ export const Operation = memo(({ operation, multisigAccount, isDefaultOpen = fal
             {/* A hidden Description leaves the same flexible spacer behind so the trailing
                 columns keep their place at the row's right edge. */}
             {visibility.description ? (
-              <div className={cnTw(operationColumns.description, 'flex h-full items-center gap-x-2')}>
+              <div {...getDescriptionCellProps('flex h-full items-center gap-x-2')}>
                 {isDraftLinked && (
                   <Tooltip open={description ? undefined : false}>
                     <Tooltip.Trigger>

--- a/src/renderer/features/multisig-operations/components/Operations.tsx
+++ b/src/renderer/features/multisig-operations/components/Operations.tsx
@@ -16,7 +16,10 @@ import {
   ROW_GAP,
   ROW_HEIGHT,
   SECTION_HEADER_HEIGHT,
+  TABLE_GROUP_CLASS,
   getOperationsMinWidth,
+  handleColumnPointerLeave,
+  handleColumnPointerOver,
   useIsResizingColumns,
   useOperationColumnVisibility,
   useOperationColumnWidths,
@@ -176,7 +179,12 @@ export const Operations = () => {
       )}
 
       {hasMultisigAccounts && (
-        <div className="h-full overflow-x-auto overflow-y-hidden" data-operations-scroller>
+        <div
+          className={cnTw('h-full overflow-x-auto overflow-y-hidden', TABLE_GROUP_CLASS)}
+          data-operations-scroller
+          onPointerOver={handleColumnPointerOver}
+          onPointerLeave={handleColumnPointerLeave}
+        >
           <div
             className={cnTw('h-full', isResizing && 'select-none')}
             style={showTable ? { minWidth: getOperationsMinWidth(widths, visibility) } : undefined}

--- a/src/renderer/features/multisig-operations/components/OperationsTableHeader.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationsTableHeader.tsx
@@ -12,7 +12,9 @@ import {
   HEADER_SEPARATOR_CLASS,
   TOGGLEABLE_COLUMNS,
   getColumnStyle,
+  getDescriptionCellProps,
   getHeaderCellProps,
+  getHoverableProps,
   getLeftBlockWidth,
   operationColumns,
   operationsTableLayoutModel,
@@ -131,7 +133,7 @@ export const OperationsTableHeader = () => {
   return (
     <div className="sticky top-0 z-10 flex items-center gap-x-2 border-b border-divider bg-background-default px-4 py-2">
       <div
-        className={cnTw(operationColumns.leftBlock, 'flex items-center gap-x-2')}
+        {...getHoverableProps('operation', cnTw(operationColumns.leftBlock, 'flex items-center gap-x-2'))}
         style={getColumnStyle(getLeftBlockWidth(widths, visibility))}
       >
         <HeaderCell
@@ -173,7 +175,7 @@ export const OperationsTableHeader = () => {
           until it has been connected, mirroring the drafts section gate. A hidden Description keeps
           the same flexible spacer so the fixed columns don't slide left. */}
       {visibility.description ? (
-        <div className={cnTw(operationColumns.description, HEADER_SEPARATOR_CLASS, LABEL_CLASS, 'text-text-tertiary')}>
+        <div {...getDescriptionCellProps(cnTw(HEADER_SEPARATOR_CLASS, LABEL_CLASS, 'text-text-tertiary'))}>
           {hasEverConnected && t('operations.table.description')}
         </div>
       ) : (


### PR DESCRIPTION
## Description

Hovering a cell now highlights its whole column — every operation and draft row plus the header caption — so a value can be read down the table without losing which column it belongs to. Requested as a follow-up on #5991 ("hover Submitter and the whole column is hovered").

The table is virtualized flex rows, not a `<table>`, so no `:hover` can span a column, and a `$hoveredColumn` store would re-render every visible row on each pointer move. Instead the highlight is one DOM attribute: the scroller carries `group/table` and a delegated `onPointerOver` mirrors the cell's `data-column` into `data-hovered-column` on it; each cell carries `data-column` and a `group-data-[hovered-column=…]/table:bg-hover` class. No React state, no row re-renders — the browser repaints only the cells of that column. Writes are skipped when the column didn't change, and the attribute clears over row gaps, headings and on pointer leave.

Builds on #5991: the `getCellProps` / `getLeftBlockProps` / `getHeaderCellProps` helpers introduced there are the single place the `data-column` + hover class are attached, so operation rows, draft rows and the header pick it up together.

## Related Issues

Follow-up to #5991.

## Changes Made

- `aggregates/operations-table-layout/layout.ts`: `HoverColumn`, `HOVERED_COLUMN_ATTRIBUTE` / `CELL_COLUMN_ATTRIBUTE` / `TABLE_GROUP_CLASS`, `getHoverableProps`, `getDescriptionCellProps`; the existing cell helpers now emit `data-column` + the hover class (static literal strings, so Tailwind sees them).
- `aggregates/operations-table-layout/column-hover.ts` (new): `handleColumnPointerOver` / `handleColumnPointerLeave` — the delegated scroller handlers.
- `Operations.tsx`: scroller gets `group/table` and the two handlers. `Operation.tsx`, `DraftRow.tsx`, `OperationsTableHeader.tsx`: the hand-built Description cells and the header's Operation block go through the helpers so they take part too. Operation and Value count as one column with the left block.
- README of the aggregate: behaviour bullet.

Decisions worth a look:
- Colour is the ui-kit `bg-hover` token; row hover stays a shadow, so the two don't stack. Design has not signed this off — the hairlines were just removed at their request, so treat the visual as a proposal.
- Header captions highlight together with the rows (they carry the same `data-column`).

## Screenshots/Recordings

Not attached. Verified against the dev server that Tailwind generates the rules — e.g. `.group-data-\[hovered-column\=submitter\]\/table\:bg-hover { &:is(:where(.group\/table)[data-hovered-column="submitter"] *) … }` — 7 rules, one per column.

## Testing

- `pnpm vitest run src/renderer/aggregates/operations-table-layout src/renderer/features/multisig-operations/components src/renderer/features/drafts/components` — green (13 files / 105 tests; 5 new in `column-hover.test.tsx`: mirror, switch, clear over a non-cell, clear on leave, cell props carry `data-column` + hover class).
- `pnpm types:go`, `pnpm check:feature-map`, eslint on the diff — clean (3 pre-existing warnings in untouched lines).
- Manual: open Operations → move the pointer across Submitter cells: the Submitter column tints in every row and in the header; move into the row gap / a section heading → tint clears; leave the list → clears; hover the Operation title or the Value cell → the whole left block tints; same on draft rows.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
