### PR TITLE
fix(operations): always show the source row in operation details

### DIFF
--- a/src/renderer/features/multisig-operations/README.md
+++ b/src/renderer/features/multisig-operations/README.md
@@ -1,6 +1,6 @@
 # Multisig Operations
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-21
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-22
 
 ## Overview
 
@@ -172,9 +172,10 @@ three panels:
   individual signatory account that reserved the multisig deposit, resolved like any account (custom name → contact →
   identity → the owning wallet's name → stored account name → short address) — the wallet name only ever fills in for a
   key the address book doesn't know, it never overrides a contact name; **Multisig** — the multisig account itself (for
-  a flexible multisig, the backing multisig); **Source** — only for proxied operations, the proxied account the call
-  executes from (for a flexible multisig, its pure proxy); then the recognised transaction's specifics (Recipient,
-  networks, validators…); **Operation type** — the raw `Pallet · Call` of the core call in a monospace chip
+  a flexible multisig, the backing multisig); **Source** — the account the call executes from: for a proxied operation
+  the proxied account (for a flexible multisig, its pure proxy), otherwise the multisig itself — always shown, so the
+  origin of funds is stated even when it repeats the Multisig row; then the recognised transaction's specifics
+  (Recipient, networks, validators…); **Operation type** — the raw `Pallet · Call` of the core call in a monospace chip
   (verification data, not a title; omitted when the call is unknown); **Amount** when the row's Value cell shows one;
   and the shared **operation description** as full wrapped text under a hairline (descriptions past 620 characters
   collapse behind _Show more_), with an Edit action when editing is allowed. Special shapes render their bespoke details

--- a/src/renderer/features/multisig-operations/components/OperationDetails.test.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationDetails.test.tsx
@@ -117,7 +117,7 @@ describe('OperationDetails', () => {
     }
   });
 
-  it('renders Date & Time first, then Depositor, Multisig, slot content, Operation type', () => {
+  it('renders Date & Time first, then Depositor, Multisig, Source, slot content, Operation type', () => {
     render(
       <OperationDetails operation={baseOperation}>
         <div data-testid="row-slot">recipient</div>
@@ -129,6 +129,7 @@ describe('OperationDetails', () => {
       'row-operation.details.dateTime',
       'row-operation.details.depositor',
       'row-operation.details.multisig',
+      'row-operation.details.source',
       'row-slot',
       'row-operation.details.operationType',
     ]);
@@ -136,9 +137,13 @@ describe('OperationDetails', () => {
     expect(screen.getByTestId('row-operation.details.operationType')).toHaveTextContent('Balances · TransferKeepAlive');
   });
 
-  it('omits the Source row for a non-proxied operation', () => {
+  it('shows the Source row with the multisig account for a non-proxied operation', () => {
     render(<OperationDetails operation={baseOperation} />);
-    expect(screen.queryByTestId('row-operation.details.source')).toBeNull();
+
+    const row = screen.getByTestId('row-operation.details.source');
+    expect(row).toHaveTextContent(multisigId);
+    expect(row.querySelector('[data-title]')).toBeNull();
+    expect(row.querySelector('[data-wallet-as="fallback"]')).not.toBeNull();
   });
 
   it('shows the Multisig row from multisigAccountId and the Source row from proxiedAccountId', () => {

--- a/src/renderer/features/multisig-operations/components/OperationDetails.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationDetails.tsx
@@ -51,9 +51,11 @@ export const OperationDetails = ({ operation, amount, children }: Props) => {
   const initEvent = approvals.find(e => e.accountId === operation.depositor);
   const date = new Date(operation.timestamp || initEvent?.timestamp || Date.now());
 
-  // Both ids are recorded on the operation at ingest; a Source exists only when the call really is proxied.
+  // Source is the account the call executes from — the proxied account when the call is
+  // proxied, otherwise the multisig itself (shown even though it repeats the Multisig row,
+  // so that the origin of funds is always stated, never inferred).
   const multisigAccountId = operation.multisigAccountId;
-  const sourceAccountId = operation.proxiedAccountId;
+  const sourceAccountId = operation.proxiedAccountId ?? multisigAccountId;
 
   // Proxy wrappers are unwrapped so the chip names the call a signer is actually
   // authorising; the raw section/method fallback covers undecoded operations.
@@ -73,9 +75,7 @@ export const OperationDetails = ({ operation, amount, children }: Props) => {
 
         <AccountRow label={t('operation.details.multisig')} accountId={multisigAccountId} chain={chain} />
 
-        {sourceAccountId && (
-          <AccountRow label={t('operation.details.source')} accountId={sourceAccountId} chain={chain} />
-        )}
+        <AccountRow label={t('operation.details.source')} accountId={sourceAccountId} chain={chain} />
 
         {children}
 


### PR DESCRIPTION
**Was:** the Details panel showed a Source row only for proxied operations; a plain multisig transfer had none.

**Now:** Source is always shown — the proxied account when the call is proxied, otherwise the multisig itself.

**Testing:** `OperationDetails.test.tsx` — row order now expects Source after Multisig; the non-proxied case asserts the Source row shows the multisig account; the proxied case is unchanged. `pnpm types:go`, lint and `pnpm check:feature-map -- --changed origin/dev` pass.