### PR TITLE
feat(operations): needs my signature filter

### DIFF
--- a/src/renderer/domains/network/multisig-operation/service.test.ts
+++ b/src/renderer/domains/network/multisig-operation/service.test.ts
@@ -5,6 +5,7 @@ import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { accountService } from '../account/service';
 import { type AnyAccount } from '../account/types';
 
+import { CONTACT_MULTISIG_WALLET_ID } from './contact-multisigs';
 import { multisigOperationService } from './service';
 import { type MultisigEvent, type MultisigOperation, MultisigEventStatus } from './types';
 
@@ -605,6 +606,64 @@ describe('multisig operation service', () => {
             null,
           ),
         ).toBe(false);
+      });
+    });
+
+    describe('needsUserSignature', () => {
+      const makeOperation = (overrides: Partial<MultisigOperation> = {}) =>
+        ({ status: 'pending', events: [], ...overrides }) as MultisigOperation;
+
+      // The user holds only sigA; sigB belongs to someone else.
+      const multisig = makeMultisigAccount([{ accountId: sigA }, { accountId: sigB }]);
+      const accountA = makeWalletAccount(sigA, 1);
+
+      it('is true while an own signatory still has to act', () => {
+        expect(multisigOperationService.needsUserSignature(makeOperation(), multisig, [accountA], polkadotChain)).toBe(
+          true,
+        );
+      });
+
+      it('is false once every own signatory has approved', () => {
+        const op = makeOperation({ events: [makeApproveEvent(sigA)] });
+
+        expect(multisigOperationService.needsUserSignature(op, multisig, [accountA], polkadotChain)).toBe(false);
+      });
+
+      it('stays true while another own signatory has not approved', () => {
+        const accountB = makeWalletAccount(sigB, 2);
+        const op = makeOperation({ events: [makeApproveEvent(sigA)] });
+
+        expect(multisigOperationService.needsUserSignature(op, multisig, [accountA, accountB], polkadotChain)).toBe(
+          true,
+        );
+      });
+
+      it('is false for an operation awaiting its on-chain outcome', () => {
+        const op = makeOperation({ awaitingOutcome: true });
+
+        expect(multisigOperationService.needsUserSignature(op, multisig, [accountA], polkadotChain)).toBe(false);
+      });
+
+      it('is false for a contact multisig (no local signatory keys)', () => {
+        const contactMultisig = { ...multisig, walletId: CONTACT_MULTISIG_WALLET_ID };
+
+        expect(
+          multisigOperationService.needsUserSignature(makeOperation(), contactMultisig, [accountA], polkadotChain),
+        ).toBe(false);
+      });
+
+      it('is false for a resolved operation', () => {
+        for (const status of ['executed', 'cancelled'] as const) {
+          expect(
+            multisigOperationService.needsUserSignature(makeOperation({ status }), multisig, [accountA], polkadotChain),
+          ).toBe(false);
+        }
+      });
+
+      it('is false when the chain is unknown', () => {
+        expect(multisigOperationService.needsUserSignature(makeOperation(), multisig, [accountA], undefined)).toBe(
+          false,
+        );
       });
     });
   });

--- a/src/renderer/domains/network/multisig-operation/service.ts
+++ b/src/renderer/domains/network/multisig-operation/service.ts
@@ -26,7 +26,8 @@ import { type AnyAccount } from '../account/types';
 import { transactionService } from '../transaction/service';
 
 import { DEFAULT_BLOCK_HASH, MULTISIG_EXTRINSIC_CALL_INDEX, WRAP_EXTRINSIC_CALL_INDEX } from './constants';
-import { type MultisigEvent, type MultisigOperation, MultisigEventStatus } from './types';
+import { isContactMultisigAccount } from './contact-multisigs';
+import { type MultisigEvent, type MultisigOperation, MultisigEventStatus, MultisigOperationStatus } from './types';
 
 /**
  * Public keys of signers' wallets are compared byte-for-byte and sorted
@@ -331,6 +332,28 @@ function hasSignedWithAllOwnSignatories(
   return ownSignatories.every(signatory => approvedBy.has(signatory.accountId));
 }
 
+/**
+ * Whether the operation still needs the user: it is collecting approvals and at
+ * least one own signatory (see `findActionableSignatories`) has not acted yet —
+ * the user can approve it, or add the call data it waits on. Shared by the
+ * row's Approve button, the dashboard queue and the "Needs my signature" filter
+ * so they can never disagree.
+ */
+function needsUserSignature(
+  op: Pick<MultisigOperation, 'events' | 'status' | 'awaitingOutcome'>,
+  multisigAccount: MultisigAccount | FlexibleMultisigAccount,
+  walletAccounts: AnyAccount[],
+  chain: Chain | null | undefined,
+): boolean {
+  // An awaiting-outcome operation has already left on-chain storage — it only
+  // looks pending until the indexer reports; signing it would fail.
+  if (op.status !== MultisigOperationStatus.Pending || op.awaitingOutcome) return false;
+  // The user holds no signatory keys for a contact-backed multisig.
+  if (isContactMultisigAccount(multisigAccount)) return false;
+
+  return findActionableSignatories(op, multisigAccount, walletAccounts, chain).length > 0;
+}
+
 export const multisigOperationService = {
   getOperationId,
   getEventId,
@@ -355,6 +378,7 @@ export const multisigOperationService = {
   getOperationTimestamp,
   findOwnSignatories,
   findActionableSignatories,
+  needsUserSignature,
   hasSignedWithAllOwnSignatories,
   accountMatchesSignatory,
 };

--- a/src/renderer/features/dashboard-operations-queue/README.md
+++ b/src/renderer/features/dashboard-operations-queue/README.md
@@ -1,6 +1,6 @@
 # Operations Queue
 
-> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-22
+> Part of the [Feature Map](../README.md) — Last reviewed: 2026-08-25
 
 ## Overview
 
@@ -71,7 +71,9 @@ resolved on-chain — only the outcome is unknown, so there is nothing left to s
 current selection, and the user controls at least one signatory that can still act on it. That last check is the
 load-bearing one — it excludes operations the user has _already_ approved, operations where they hold no signatory at
 all, and signatories on chains the account cannot use. Watch-only signatories never count: they cannot sign, so
-surfacing the operation as actionable would be a lie.
+surfacing the operation as actionable would be a lie. The rule is `multisigOperationService.needsUserSignature` in
+`domains/network` — the same predicate behind the Operations view's Approve button and its **Needs my signature**
+filter, so the three surfaces cannot disagree.
 
 Rows show the operation's method, chain, multisig name, description, transfer amount where one can be extracted, and the
 approval status, plus the same approve/reject actions as the Operations page.

--- a/src/renderer/features/dashboard-operations-queue/model/queue-model.ts
+++ b/src/renderer/features/dashboard-operations-queue/model/queue-model.ts
@@ -1,11 +1,6 @@
 import { type Chain, type ChainId } from '@/shared/core';
 import { type Draft } from '@/domains/backend';
-import {
-  type AnyAccount,
-  type MultisigOperation,
-  MultisigOperationStatus,
-  multisigOperationService,
-} from '@/domains/network';
+import { type AnyAccount, type MultisigOperation, multisigOperationService } from '@/domains/network';
 import { accountUtils } from '@/entities/wallet';
 
 export function filterScopedDrafts(drafts: Draft[], selectedAccountIds: Set<string>): Draft[] {
@@ -38,18 +33,9 @@ export function filterAwaitingSignature(
   if (multisigByAccountId.size === 0) return [];
 
   return operations.filter((op) => {
-    // awaitingOutcome: already resolved on-chain, only the final status is unknown — nothing to sign
-    if (op.status !== MultisigOperationStatus.Pending || op.awaitingOutcome) return false;
     const multisig = multisigByAccountId.get(op.multisigAccountId);
     if (!multisig || !accountUtils.isAnyMultisigAccount(multisig)) return false;
 
-    const actionable = multisigOperationService.findActionableSignatories(
-      op,
-      multisig,
-      walletAccounts,
-      chains[op.chainId],
-    );
-
-    return actionable.length > 0;
+    return multisigOperationService.needsUserSignature(op, multisig, walletAccounts, chains[op.chainId]);
   });
 }

--- a/src/renderer/features/drafts/README.md
+++ b/src/renderer/features/drafts/README.md
@@ -12,14 +12,15 @@ right permissions) can review, edit, share, submit, or delete a draft.
 Drafts surface as a **Drafts group** inside the operations table on the
 [Operations view's](../multisig-operations/README.md) Pending tab — the first group, styled and column-aligned like
 operation rows, gated by the view's Status filter and narrowed by the filters a draft can evaluate (network, date range,
-search, and **Needs my signature**, which keeps only drafts assigned to a local initiator who can sign — a draft nobody
-local can initiate is not "mine"; an active transaction-type or proxy-type filter hides all drafts — see the Operations
-view spec). Because it is the first visible group, its **heading (label and count) is drawn and its collapse state is
-owned by the Operations view**, not by this feature: `useDraftsSectionState` (in `lib/useDraftsSectionState.ts`) is the
-one source of truth for whether the group renders, its rows and the count the heading shows (`0` for an empty group,
-like the In-progress group; no chip while the address book is unhealthy), and `DraftsSection`
-(`components/DraftsSection.tsx`) reads the same hook to render only the rows and the New-draft control, taking
-`isCollapsed` as a prop instead of drawing its own header. Search matches a draft's description and the names and
+search, and **Needs my signature**, which keeps only drafts the user can submit — `findSubmittableInitiator` in
+`lib/draft-initiator.ts`, the same rule that enables Submit, so a draft nobody local can initiate or a legacy draft
+without a signing path is not "mine"; an active transaction-type or proxy-type filter hides all drafts — see the
+Operations view spec). Because it is the first visible group, its **heading (label and count) is drawn and its collapse
+state is owned by the Operations view**, not by this feature: `useDraftsSectionState` (in
+`lib/useDraftsSectionState.ts`) is the one source of truth for whether the group renders, its rows and the count the
+heading shows (`0` for an empty group, like the In-progress group; no chip while the address book is unhealthy), and
+`DraftsSection` (`components/DraftsSection.tsx`) reads the same hook to render only the rows and the New-draft control,
+taking `isCollapsed` as a prop instead of drawing its own header. Search matches a draft's description and the names and
 addresses of every account it shows — the proxy, the multisig and the assigned **initiator** — so "which drafts is Adam
 expected to submit?" is answerable by typing a name, without opening each draft's Submit dialog (see
 [`operations-search`](../../aggregates/operations-search/README.md)). A compact subsection with the same submit gating

--- a/src/renderer/features/drafts/README.md
+++ b/src/renderer/features/drafts/README.md
@@ -12,16 +12,18 @@ right permissions) can review, edit, share, submit, or delete a draft.
 Drafts surface as a **Drafts group** inside the operations table on the
 [Operations view's](../multisig-operations/README.md) Pending tab — the first group, styled and column-aligned like
 operation rows, gated by the view's Status filter and narrowed by the filters a draft can evaluate (network, date range,
-search; an active transaction-type or proxy-type filter hides all drafts — see the Operations view spec). Because it is
-the first visible group, its **heading (label and count) is drawn and its collapse state is owned by the Operations
-view**, not by this feature: `useDraftsSectionState` (in `lib/useDraftsSectionState.ts`) is the one source of truth for
-whether the group renders, its rows and the count the heading shows (`0` for an empty group, like the In-progress group;
-no chip while the address book is unhealthy), and `DraftsSection` (`components/DraftsSection.tsx`) reads the same hook
-to render only the rows and the New-draft control, taking `isCollapsed` as a prop instead of drawing its own header.
-Search matches a draft's description and the names and addresses of every account it shows — the proxy, the multisig and
-the assigned **initiator** — so "which drafts is Adam expected to submit?" is answerable by typing a name, without
-opening each draft's Submit dialog (see [`operations-search`](../../aggregates/operations-search/README.md)). A compact
-subsection with the same submit gating also appears in the dashboard's operations queue.
+search, and **Needs my signature**, which keeps only drafts assigned to a local initiator who can sign — a draft nobody
+local can initiate is not "mine"; an active transaction-type or proxy-type filter hides all drafts — see the Operations
+view spec). Because it is the first visible group, its **heading (label and count) is drawn and its collapse state is
+owned by the Operations view**, not by this feature: `useDraftsSectionState` (in `lib/useDraftsSectionState.ts`) is the
+one source of truth for whether the group renders, its rows and the count the heading shows (`0` for an empty group,
+like the In-progress group; no chip while the address book is unhealthy), and `DraftsSection`
+(`components/DraftsSection.tsx`) reads the same hook to render only the rows and the New-draft control, taking
+`isCollapsed` as a prop instead of drawing its own header. Search matches a draft's description and the names and
+addresses of every account it shows — the proxy, the multisig and the assigned **initiator** — so "which drafts is Adam
+expected to submit?" is answerable by typing a name, without opening each draft's Submit dialog (see
+[`operations-search`](../../aggregates/operations-search/README.md)). A compact subsection with the same submit gating
+also appears in the dashboard's operations queue.
 
 Because drafts live on the backend they are inherently multi-user: shareable via a deep link
 (`Paths.OPERATIONS?draftId=…`), auto-fetched on sign-in, and re-polled every 30s — so every client picks up others' add

--- a/src/renderer/features/drafts/lib/draft-initiator.ts
+++ b/src/renderer/features/drafts/lib/draft-initiator.ts
@@ -1,0 +1,35 @@
+import { type Draft } from '@/domains/backend';
+import { type AnyAccount, accountService } from '@/domains/network';
+
+import { hasSigningPath } from './submit-draft-availability';
+
+/**
+ * The local account the draft's assigned initiator resolves to — a wallet
+ * account allowed to sign — or `null` when the user holds no such key.
+ */
+export const findLocalInitiator = (
+  draft: Pick<Draft, 'initiatorAccountId'>,
+  accounts: AnyAccount[],
+): AnyAccount | null => {
+  if (!draft.initiatorAccountId) return null;
+
+  return (
+    accounts.find(
+      (account) => account.accountId === draft.initiatorAccountId && accountService.hasPermissionToMakeActions(account),
+    ) ?? null
+  );
+};
+
+/**
+ * The account the user can submit this draft with: `findLocalInitiator` on a
+ * draft that also carries a usable signing path. A legacy draft without a path
+ * has to be recreated, so it is nobody's to sign. One rule for the Submit
+ * dialog (`submit-draft-model`) and the "Needs my signature" filter, so the two
+ * never disagree.
+ */
+export const findSubmittableInitiator = (
+  draft: Pick<Draft, 'initiatorAccountId' | 'signingPath'>,
+  accounts: AnyAccount[],
+): AnyAccount | null => {
+  return hasSigningPath(draft) ? findLocalInitiator(draft, accounts) : null;
+};

--- a/src/renderer/features/drafts/lib/draft-scope.test.ts
+++ b/src/renderer/features/drafts/lib/draft-scope.test.ts
@@ -70,14 +70,14 @@ const resolvers: SearchResolvers = {
 };
 
 /** Mirrors what useVisibleDrafts does: resolve names, then filter. */
-const filterWithSearch = (drafts: Draft[], scope: DraftListScope) => {
+const filterWithSearch = (drafts: Draft[], scope: DraftListScope, localSignerIds = new Set<string>()) => {
   const searchMatchedIds = searchOperationRows(
     drafts.map((draft) => buildDraftSearchRow(draft, chains, resolvers.resolveWalletName)),
     scope.searchQuery,
     resolvers,
   );
 
-  return filterDraftsByScope(drafts, scope, searchMatchedIds);
+  return filterDraftsByScope(drafts, scope, searchMatchedIds, localSignerIds);
 };
 
 describe('filterDraftsByScope', () => {
@@ -295,6 +295,35 @@ describe('filterDraftsByScope', () => {
       expect(filterWithSearch([nestedDraft], { ...emptyScope, searchQuery: 'Adam' }).map((d) => d.id)).toEqual([
         'draft-nested',
       ]);
+    });
+  });
+
+  describe('needs my signature', () => {
+    // Bob is a local account that can sign; Charlie is not local.
+    const localSignerIds = new Set<string>([BOB_ACCOUNT_ID]);
+    const mineDraft = createMockDraft({ id: 'draft-mine', initiatorAccountId: BOB_ACCOUNT_ID });
+    const foreignDraft = createMockDraft({ id: 'draft-foreign', initiatorAccountId: CHARLIE_ACCOUNT_ID });
+    const unassignedDraft = createMockDraft({ id: 'draft-unassigned', initiatorAccountId: null });
+
+    test('off: keeps every draft whoever the initiator is', () => {
+      const result = filterWithSearch([mineDraft, foreignDraft, unassignedDraft], emptyScope, localSignerIds);
+      expect(result.map((d) => d.id)).toEqual(['draft-mine', 'draft-foreign', 'draft-unassigned']);
+    });
+
+    test('on: keeps only drafts assigned to a local signer', () => {
+      const scope = { ...emptyScope, needsMySignature: true };
+      const result = filterWithSearch([mineDraft, foreignDraft, unassignedDraft], scope, localSignerIds);
+      expect(result.map((d) => d.id)).toEqual(['draft-mine']);
+    });
+
+    test('on: a draft nobody local can initiate is not mine', () => {
+      const scope = { ...emptyScope, needsMySignature: true };
+      expect(filterWithSearch([foreignDraft, unassignedDraft], scope, localSignerIds)).toEqual([]);
+    });
+
+    test('on: combines with the other scope filters', () => {
+      const scope = { ...emptyScope, needsMySignature: true, network: [KUSAMA_CHAIN_ID] };
+      expect(filterWithSearch([mineDraft], scope, localSignerIds)).toEqual([]);
     });
   });
 });

--- a/src/renderer/features/drafts/lib/draft-scope.test.ts
+++ b/src/renderer/features/drafts/lib/draft-scope.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
-import { type Chain, type ChainId } from '@/shared/core';
+import { type Chain, type ChainId, AccountType, CryptoType, SigningType } from '@/shared/core';
 import { toAddress } from '@/shared/lib/utils';
 import { type Draft } from '@/domains/backend';
+import { type AnyAccount, accountService } from '@/domains/network';
 import { type SearchResolvers, searchOperationRows } from '@/aggregates/operations-search';
 
 import { type DraftListScope, buildDraftSearchRow, filterDraftsByScope } from './draft-scope';
@@ -70,14 +71,14 @@ const resolvers: SearchResolvers = {
 };
 
 /** Mirrors what useVisibleDrafts does: resolve names, then filter. */
-const filterWithSearch = (drafts: Draft[], scope: DraftListScope, localSignerIds = new Set<string>()) => {
+const filterWithSearch = (drafts: Draft[], scope: DraftListScope, walletAccounts: AnyAccount[] = []) => {
   const searchMatchedIds = searchOperationRows(
     drafts.map((draft) => buildDraftSearchRow(draft, chains, resolvers.resolveWalletName)),
     scope.searchQuery,
     resolvers,
   );
 
-  return filterDraftsByScope(drafts, scope, searchMatchedIds, localSignerIds);
+  return filterDraftsByScope(drafts, scope, searchMatchedIds, walletAccounts);
 };
 
 describe('filterDraftsByScope', () => {
@@ -299,31 +300,82 @@ describe('filterDraftsByScope', () => {
   });
 
   describe('needs my signature', () => {
+    const makeAccount = (accountId: string, signingType = SigningType.POLKADOT_VAULT): AnyAccount =>
+      ({
+        id: `account-${accountId}`,
+        walletId: 1,
+        accountId,
+        name: 'Bob',
+        type: 'universal',
+        accountType: AccountType.BASE,
+        cryptoType: CryptoType.SR25519,
+        signingType,
+        createdAt: 0,
+      }) as never;
+
     // Bob is a local account that can sign; Charlie is not local.
-    const localSignerIds = new Set<string>([BOB_ACCOUNT_ID]);
-    const mineDraft = createMockDraft({ id: 'draft-mine', initiatorAccountId: BOB_ACCOUNT_ID });
-    const foreignDraft = createMockDraft({ id: 'draft-foreign', initiatorAccountId: CHARLIE_ACCOUNT_ID });
-    const unassignedDraft = createMockDraft({ id: 'draft-unassigned', initiatorAccountId: null });
+    const walletAccounts = [makeAccount(BOB_ACCOUNT_ID)];
+    // A usable path needs the multisig hop and the signing leaf.
+    const path = [
+      { kind: 'multisig', accountId: MOCK_ACCOUNT_ID },
+      { kind: 'signatory', accountId: BOB_ACCOUNT_ID },
+    ] as never;
+    const mineDraft = createMockDraft({ id: 'draft-mine', initiatorAccountId: BOB_ACCOUNT_ID, signingPath: path });
+    const foreignDraft = createMockDraft({
+      id: 'draft-foreign',
+      initiatorAccountId: CHARLIE_ACCOUNT_ID,
+      signingPath: path,
+    });
+    const unassignedDraft = createMockDraft({ id: 'draft-unassigned', initiatorAccountId: null, signingPath: path });
+    const legacyDraft = createMockDraft({ id: 'draft-legacy', initiatorAccountId: BOB_ACCOUNT_ID, signingPath: [] });
+
+    // `hasPermissionToMakeActions` resolves through a DI anyOf with no handlers
+    // in unit tests — seed the same watch-only rule the account domain uses.
+    beforeEach(() => {
+      accountService.accountActionPermissionAnyOf.registerHandler({
+        body: ({ account }) => account.signingType !== SigningType.WATCH_ONLY,
+        available: () => true,
+      });
+    });
+
+    afterEach(() => {
+      accountService.accountActionPermissionAnyOf.resetHandlers();
+    });
 
     test('off: keeps every draft whoever the initiator is', () => {
-      const result = filterWithSearch([mineDraft, foreignDraft, unassignedDraft], emptyScope, localSignerIds);
-      expect(result.map((d) => d.id)).toEqual(['draft-mine', 'draft-foreign', 'draft-unassigned']);
+      const result = filterWithSearch(
+        [mineDraft, foreignDraft, unassignedDraft, legacyDraft],
+        emptyScope,
+        walletAccounts,
+      );
+      expect(result.map((d) => d.id)).toEqual(['draft-mine', 'draft-foreign', 'draft-unassigned', 'draft-legacy']);
     });
 
     test('on: keeps only drafts assigned to a local signer', () => {
       const scope = { ...emptyScope, needsMySignature: true };
-      const result = filterWithSearch([mineDraft, foreignDraft, unassignedDraft], scope, localSignerIds);
+      const result = filterWithSearch([mineDraft, foreignDraft, unassignedDraft], scope, walletAccounts);
       expect(result.map((d) => d.id)).toEqual(['draft-mine']);
     });
 
     test('on: a draft nobody local can initiate is not mine', () => {
       const scope = { ...emptyScope, needsMySignature: true };
-      expect(filterWithSearch([foreignDraft, unassignedDraft], scope, localSignerIds)).toEqual([]);
+      expect(filterWithSearch([foreignDraft, unassignedDraft], scope, walletAccounts)).toEqual([]);
+    });
+
+    test('on: a legacy draft without a signing path is not mine even if the initiator is local', () => {
+      const scope = { ...emptyScope, needsMySignature: true };
+      expect(filterWithSearch([legacyDraft], scope, walletAccounts)).toEqual([]);
+    });
+
+    test('on: a watch-only initiator cannot sign, so the draft is not mine', () => {
+      const scope = { ...emptyScope, needsMySignature: true };
+      const watchOnly = [makeAccount(BOB_ACCOUNT_ID, SigningType.WATCH_ONLY)];
+      expect(filterWithSearch([mineDraft], scope, watchOnly)).toEqual([]);
     });
 
     test('on: combines with the other scope filters', () => {
       const scope = { ...emptyScope, needsMySignature: true, network: [KUSAMA_CHAIN_ID] };
-      expect(filterWithSearch([mineDraft], scope, localSignerIds)).toEqual([]);
+      expect(filterWithSearch([mineDraft], scope, walletAccounts)).toEqual([]);
     });
   });
 });

--- a/src/renderer/features/drafts/lib/draft-scope.ts
+++ b/src/renderer/features/drafts/lib/draft-scope.ts
@@ -1,6 +1,7 @@
 import { endOfDay, isAfter, isWithinInterval, startOfDay } from 'date-fns';
 
 import { type Chain, type ChainId } from '@/shared/core';
+import { nonNullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type DateRange } from '@/shared/ui-kit';
 import { type Draft } from '@/domains/backend';
@@ -18,6 +19,11 @@ export type DraftListScope = {
   proxyType: string[];
   dateRange?: DateRange;
   searchQuery: string;
+  /**
+   * "Needs my signature": keep only drafts whose assigned initiator is a local
+   * account that can sign (see `filterDraftsByScope`'s `localSignerIds`).
+   */
+  needsMySignature?: boolean;
 };
 
 const matchesNetwork = (draft: Draft, networkIds: string[]): boolean => {
@@ -37,6 +43,12 @@ const matchesDateRange = (draft: Draft, dateRange: DateRange | undefined): boole
     return isAfter(createdDate, startOfDay(from)) || createdDate.getTime() === startOfDay(from).getTime();
   }
   return true;
+};
+
+// A draft is "mine" when the account assigned to submit it is one the user can
+// sign with — the same rule submit-draft-model uses to enable Submit.
+const hasLocalInitiator = (draft: Draft, localSignerIds: Set<string>): boolean => {
+  return nonNullable(draft.initiatorAccountId) && localSignerIds.has(draft.initiatorAccountId);
 };
 
 /**
@@ -110,12 +122,15 @@ export const buildDraftSearchRow = (
  * (drafts match only the dedicated `drafts` status).
  *
  * `searchMatchedIds` comes from the caller because it needs resolved display
- * names; `null` means no query.
+ * names; `null` means no query. `localSignerIds` — account ids of the local
+ * accounts allowed to sign — is consulted only when `scope.needsMySignature` is
+ * set.
  */
 export const filterDraftsByScope = (
   drafts: Draft[],
   scope: DraftListScope,
   searchMatchedIds: Set<string> | null,
+  localSignerIds: Set<string>,
 ): Draft[] => {
   if (scope.type.length > 0 || scope.proxyType.length > 0) return [];
 
@@ -123,6 +138,7 @@ export const filterDraftsByScope = (
     (draft) =>
       matchesNetwork(draft, scope.network) &&
       matchesDateRange(draft, scope.dateRange) &&
-      (searchMatchedIds === null || searchMatchedIds.has(draft.id)),
+      (searchMatchedIds === null || searchMatchedIds.has(draft.id)) &&
+      (!scope.needsMySignature || hasLocalInitiator(draft, localSignerIds)),
   );
 };

--- a/src/renderer/features/drafts/lib/draft-scope.ts
+++ b/src/renderer/features/drafts/lib/draft-scope.ts
@@ -5,7 +5,10 @@ import { nonNullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type DateRange } from '@/shared/ui-kit';
 import { type Draft } from '@/domains/backend';
+import { type AnyAccount } from '@/domains/network';
 import { type OperationSearchRow, type SearchAccountRef } from '@/aggregates/operations-search';
+
+import { findSubmittableInitiator } from './draft-initiator';
 
 /**
  * The subset of the Operations view's filters a draft can honor. A draft's
@@ -20,8 +23,8 @@ export type DraftListScope = {
   dateRange?: DateRange;
   searchQuery: string;
   /**
-   * "Needs my signature": keep only drafts whose assigned initiator is a local
-   * account that can sign (see `filterDraftsByScope`'s `localSignerIds`).
+   * "Needs my signature": keep only drafts the user can submit — see
+   * `findSubmittableInitiator`.
    */
   needsMySignature?: boolean;
 };
@@ -43,12 +46,6 @@ const matchesDateRange = (draft: Draft, dateRange: DateRange | undefined): boole
     return isAfter(createdDate, startOfDay(from)) || createdDate.getTime() === startOfDay(from).getTime();
   }
   return true;
-};
-
-// A draft is "mine" when the account assigned to submit it is one the user can
-// sign with — the same rule submit-draft-model uses to enable Submit.
-const hasLocalInitiator = (draft: Draft, localSignerIds: Set<string>): boolean => {
-  return nonNullable(draft.initiatorAccountId) && localSignerIds.has(draft.initiatorAccountId);
 };
 
 /**
@@ -122,15 +119,14 @@ export const buildDraftSearchRow = (
  * (drafts match only the dedicated `drafts` status).
  *
  * `searchMatchedIds` comes from the caller because it needs resolved display
- * names; `null` means no query. `localSignerIds` — account ids of the local
- * accounts allowed to sign — is consulted only when `scope.needsMySignature` is
- * set.
+ * names; `null` means no query. `walletAccounts` is consulted only when
+ * `scope.needsMySignature` is set.
  */
 export const filterDraftsByScope = (
   drafts: Draft[],
   scope: DraftListScope,
   searchMatchedIds: Set<string> | null,
-  localSignerIds: Set<string>,
+  walletAccounts: AnyAccount[],
 ): Draft[] => {
   if (scope.type.length > 0 || scope.proxyType.length > 0) return [];
 
@@ -139,6 +135,6 @@ export const filterDraftsByScope = (
       matchesNetwork(draft, scope.network) &&
       matchesDateRange(draft, scope.dateRange) &&
       (searchMatchedIds === null || searchMatchedIds.has(draft.id)) &&
-      (!scope.needsMySignature || hasLocalInitiator(draft, localSignerIds)),
+      (!scope.needsMySignature || nonNullable(findSubmittableInitiator(draft, walletAccounts))),
   );
 };

--- a/src/renderer/features/drafts/lib/useVisibleDrafts.ts
+++ b/src/renderer/features/drafts/lib/useVisibleDrafts.ts
@@ -2,7 +2,7 @@ import { useStoreMap, useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
 import { type Draft } from '@/domains/backend';
-import { accountService, accounts } from '@/domains/network';
+import { type AnyAccount, accounts } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { $searchResolvers, searchOperationRows } from '@/aggregates/operations-search';
 
@@ -10,7 +10,7 @@ import { type DraftListScope, buildDraftSearchRow, filterDraftsByScope } from '.
 import { useReadableDrafts } from './useReadableDrafts';
 import { filterVisibleDrafts } from './visible-drafts';
 
-const NO_SIGNER_IDS = new Set<string>();
+const NO_ACCOUNTS: AnyAccount[] = [];
 
 /**
  * Readable drafts minus the ones already linked to a live operation — exactly
@@ -36,13 +36,10 @@ export function useVisibleDrafts(scope?: DraftListScope): { drafts: Draft[]; ava
 
   const needsMySignature = Boolean(scope?.needsMySignature);
   // Same idea: the account list is only consulted while the toggle is on.
-  const localSignerIds = useStoreMap({
+  const walletAccounts = useStoreMap({
     store: accounts.$list,
     keys: [needsMySignature],
-    fn: (allAccounts) =>
-      needsMySignature
-        ? new Set<string>(allAccounts.filter(accountService.hasPermissionToMakeActions).map((a) => a.accountId))
-        : NO_SIGNER_IDS,
+    fn: (allAccounts) => (needsMySignature ? allAccounts : NO_ACCOUNTS),
   });
 
   const visibleDrafts = useMemo(() => {
@@ -59,8 +56,8 @@ export function useVisibleDrafts(scope?: DraftListScope): { drafts: Draft[]; ava
         )
       : null;
 
-    return filterDraftsByScope(visible, scope, searchMatchedIds, localSignerIds);
-  }, [drafts, scope, chains, resolvers, localSignerIds]);
+    return filterDraftsByScope(visible, scope, searchMatchedIds, walletAccounts);
+  }, [drafts, scope, chains, resolvers, walletAccounts]);
 
   return { drafts: visibleDrafts, available };
 }

--- a/src/renderer/features/drafts/lib/useVisibleDrafts.ts
+++ b/src/renderer/features/drafts/lib/useVisibleDrafts.ts
@@ -2,12 +2,15 @@ import { useStoreMap, useUnit } from 'effector-react';
 import { useMemo } from 'react';
 
 import { type Draft } from '@/domains/backend';
+import { accountService, accounts } from '@/domains/network';
 import { networkModel } from '@/entities/network';
 import { $searchResolvers, searchOperationRows } from '@/aggregates/operations-search';
 
 import { type DraftListScope, buildDraftSearchRow, filterDraftsByScope } from './draft-scope';
 import { useReadableDrafts } from './useReadableDrafts';
 import { filterVisibleDrafts } from './visible-drafts';
+
+const NO_SIGNER_IDS = new Set<string>();
 
 /**
  * Readable drafts minus the ones already linked to a live operation — exactly
@@ -31,6 +34,17 @@ export function useVisibleDrafts(scope?: DraftListScope): { drafts: Draft[]; ava
     fn: (resolvers) => (hasQuery ? resolvers : null),
   });
 
+  const needsMySignature = Boolean(scope?.needsMySignature);
+  // Same idea: the account list is only consulted while the toggle is on.
+  const localSignerIds = useStoreMap({
+    store: accounts.$list,
+    keys: [needsMySignature],
+    fn: (allAccounts) =>
+      needsMySignature
+        ? new Set<string>(allAccounts.filter(accountService.hasPermissionToMakeActions).map((a) => a.accountId))
+        : NO_SIGNER_IDS,
+  });
+
   const visibleDrafts = useMemo(() => {
     const visible = filterVisibleDrafts(drafts);
     if (!scope) return visible;
@@ -45,8 +59,8 @@ export function useVisibleDrafts(scope?: DraftListScope): { drafts: Draft[]; ava
         )
       : null;
 
-    return filterDraftsByScope(visible, scope, searchMatchedIds);
-  }, [drafts, scope, chains, resolvers]);
+    return filterDraftsByScope(visible, scope, searchMatchedIds, localSignerIds);
+  }, [drafts, scope, chains, resolvers, localSignerIds]);
 
   return { drafts: visibleDrafts, available };
 }

--- a/src/renderer/features/drafts/model/submit-draft-model.ts
+++ b/src/renderer/features/drafts/model/submit-draft-model.ts
@@ -45,6 +45,7 @@ import { type TransactionSigningPayload, signModel } from '@/features/operations
 import { type SuccessResult, ExtrinsicResult, submitModel } from '@/features/operations/OperationSubmit';
 import { MIN_PATH_LENGTH, createPathResolutionStore, isUsablePath } from '@/features/signing-path';
 import { tryDecodeCallData } from '../lib/decode-call-data';
+import { findLocalInitiator, findSubmittableInitiator } from '../lib/draft-initiator';
 import { getDraftDestinationAccountId } from '../lib/get-destination-account-id';
 import { preserveSigningPath } from '../lib/preserve-signing-path';
 import { type SubmitDraftErrorKind } from '../lib/submit-draft-screen';
@@ -348,15 +349,7 @@ const $graphSignatories = createSignatoriesStore({
 // topology.
 const $savedPathSignatory = combine(
   { draft: $draft, accounts: walletModel.$availableAccounts },
-  ({ draft, accounts }): AnyAccount | null => {
-    if (!draft?.initiatorAccountId) return null;
-    if (!Array.isArray(draft.signingPath) || draft.signingPath.length === 0) return null;
-
-    return (
-      accounts.find((a) => a.accountId === draft.initiatorAccountId && accountService.hasPermissionToMakeActions(a)) ??
-      null
-    );
-  },
+  ({ draft, accounts }): AnyAccount | null => (draft ? findSubmittableInitiator(draft, accounts) : null),
 );
 
 const $signatories = combine($graphSignatories, $savedPathSignatory, (graphSignatories, savedPathSignatory) => {
@@ -467,9 +460,7 @@ const $initiatorUnavailable = combine(
     // the banner has nothing left to ask for.
     if (signatory !== null) return false;
 
-    return !availableAccounts.some(
-      (a) => a.accountId === draft.initiatorAccountId && accountService.hasPermissionToMakeActions(a),
-    );
+    return nullable(findLocalInitiator(draft, availableAccounts));
   },
 );
 
@@ -497,15 +488,8 @@ sample({
 sample({
   clock: [walletModel.$availableAccounts, $draft],
   source: { draft: $draft, accounts: walletModel.$availableAccounts },
-  filter: ({ draft, accounts }) =>
-    nonNullable(draft) &&
-    Array.isArray(draft.signingPath) &&
-    draft.signingPath.length > 0 &&
-    nonNullable(draft.initiatorAccountId) &&
-    accounts.some((a) => a.accountId === draft!.initiatorAccountId && accountService.hasPermissionToMakeActions(a)),
-  fn: ({ draft, accounts }) =>
-    accounts.find((a) => a.accountId === draft!.initiatorAccountId && accountService.hasPermissionToMakeActions(a)) ??
-    null,
+  filter: ({ draft, accounts }) => nonNullable(draft) && nonNullable(findSubmittableInitiator(draft, accounts)),
+  fn: ({ draft, accounts }) => findSubmittableInitiator(draft!, accounts),
   target: $signatory,
 });
 

--- a/src/renderer/features/multisig-operations/README.md
+++ b/src/renderer/features/multisig-operations/README.md
@@ -454,8 +454,10 @@ The list can be narrowed by **search** and six **filters**:
   the filters a draft can evaluate — network (the draft's chain), date range (creation date), and search (submitter,
   initiator, description or address) — while an active transaction-type or proxy-type filter puts every draft out of
   scope (a draft's call may be absent or undecoded), so the drafts section and the merged "All operations" count stay
-  consistent with the filtered list. With **Needs my signature** on, the drafts section keeps only drafts whose assigned
-  initiator is a local account that can sign — a draft nobody local can initiate is not "mine".
+  consistent with the filtered list. With **Needs my signature** on, the drafts section keeps only drafts the user can
+  actually submit — the assigned initiator is a local account that can sign and the draft carries a signing path (the
+  same rule that enables **Submit**); a draft nobody local can initiate, or a legacy draft that has to be recreated, is
+  not "mine".
 - **Proxy type** — for flexible multisigs, filters by the proxy's access type.
 - **Network** — matches the operation's chain or, for XCM, its destination chain.
 - **Transaction type** — Transfer, Cross-chain, the staking / governance / proxy types, or Unknown.

--- a/src/renderer/features/multisig-operations/README.md
+++ b/src/renderer/features/multisig-operations/README.md
@@ -397,14 +397,15 @@ The list is split into three tabs, and an operation belongs to exactly one:
 The view opens on **Pending**; a deep link switches to the tab holding the focused operation; unhiding the last hidden
 operation switches back to Pending.
 
-**Merged scope.** When any **non-search filter** is active (status, network, type, proxy type, or date range), the tabs
-collapse into a single **"All operations"** pill showing the total matching count (drafts rows included when the drafts
-section is in scope), and the filter applies across all statuses at once — pending and resolved results appear together,
-each under its status section. Activating such a filter also normalizes the underlying tab to Pending, regardless of
-which tab was active beforehand — so the merged scope always includes the drafts section (subject to the Status filter,
-below). Hidden operations join the merged scope only when the Status filter selects **Hidden** — they then appear under
-a trailing **Hidden** section; otherwise they remain reachable only through the Hidden tab. Search alone does not merge
-the scope — it narrows the current tab. Clearing the filters restores the tabs, reopening on Pending.
+**Merged scope.** When any **non-search filter** is active (Needs my signature, status, network, type, proxy type, or
+date range), the tabs collapse into a single **"All operations"** pill showing the total matching count (drafts rows
+included when the drafts section is in scope), and the filter applies across all statuses at once — pending and resolved
+results appear together, each under its status section. Activating such a filter also normalizes the underlying tab to
+Pending, regardless of which tab was active beforehand — so the merged scope always includes the drafts section (subject
+to the Status filter, below). Hidden operations join the merged scope only when the Status filter selects **Hidden** —
+they then appear under a trailing **Hidden** section; otherwise they remain reachable only through the Hidden tab.
+Search alone does not merge the scope — it narrows the current tab. Clearing the filters restores the tabs, reopening on
+Pending.
 
 ### Sections, sorting, and navigation
 
@@ -431,8 +432,14 @@ never toggles a sort.
   accounts, the contact name for contact-backed multisigs, with a short-address fallback.
 
 With sorting off, operations are ordered **newest first** by their creation time (block and extrinsic index break ties).
-The list can be narrowed by **search** and five **filters**:
+The list can be narrowed by **search** and six **filters**:
 
+- **Needs my signature** — a checkbox, first in the filter bar. Keeps only operations still collecting approvals that a
+  local signatory can still act on — approve, or add the call data the final signing is waiting for. An operation every
+  local signatory has already signed (the row shows **Signed**), one awaiting its on-chain outcome, a contact-backed
+  multisig (no local keys), and any resolved operation never match. It is the same rule that shows the row's **Approve**
+  button, so the filter and the row can never disagree. Like every other non-search filter it merges the tabs into **All
+  operations**, is cleared by **Clear filters**, and is not remembered across app restarts.
 - **Search** — matches the names and addresses the row displays: the submitter (as shown in the Submitter column,
   resolved through custom name → contact → identity, not the raw stored name), the **initiator** — who submitted an
   operation, or who is assigned to submit a draft — and the call hash. Addresses are matched with the prefix the row
@@ -447,7 +454,8 @@ The list can be narrowed by **search** and five **filters**:
   the filters a draft can evaluate — network (the draft's chain), date range (creation date), and search (submitter,
   initiator, description or address) — while an active transaction-type or proxy-type filter puts every draft out of
   scope (a draft's call may be absent or undecoded), so the drafts section and the merged "All operations" count stay
-  consistent with the filtered list.
+  consistent with the filtered list. With **Needs my signature** on, the drafts section keeps only drafts whose assigned
+  initiator is a local account that can sign — a draft nobody local can initiate is not "mine".
 - **Proxy type** — for flexible multisigs, filters by the proxy's access type.
 - **Network** — matches the operation's chain or, for XCM, its destination chain.
 - **Transaction type** — Transfer, Cross-chain, the staking / governance / proxy types, or Unknown.

--- a/src/renderer/features/multisig-operations/components/OperationActions.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationActions.tsx
@@ -78,16 +78,17 @@ export const OperationActions = memo(({ operation, account, className }: Props) 
       return isDepositor && isOnChain && !accountUtils.isWatchOnlyAccount(a);
     });
 
-  const hasApproveAccount =
-    !isContact && multisigOperationService.findActionableSignatories(operation, account, allAccounts, chain).length > 0;
+  // Same predicate as the "Needs my signature" filter and the dashboard queue;
+  // it already covers the contact and awaiting-outcome cases.
+  const hasApproveAccount = multisigOperationService.needsUserSignature(operation, account, allAccounts, chain);
 
   const isRejectAvailable = isActionable && hasRejectAccount;
 
   const isFinalSigning = operation.events.length === account.threshold - 1;
   const hasValidCallData = operation.callData && validateCallData(operation.callData, operation.callHash);
-  const isApproveAvailable = isActionable && hasApproveAccount && (!isFinalSigning || hasValidCallData);
+  const isApproveAvailable = hasApproveAccount && (!isFinalSigning || hasValidCallData);
 
-  const needsCallData = isActionable && hasApproveAccount && isFinalSigning && !hasValidCallData;
+  const needsCallData = hasApproveAccount && isFinalSigning && !hasValidCallData;
 
   // Nothing left to approve because the user already did — say so instead of leaving a blank cell.
   // "Own" is decided by the same service predicate that gates Approve, so the two can never disagree.

--- a/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
+++ b/src/renderer/features/multisig-operations/components/OperationsFilter.tsx
@@ -6,7 +6,7 @@ import { ProxyTypeOrder, TransactionType } from '@/shared/core';
 import { useI18n } from '@/shared/i18n';
 import { performSearch } from '@/shared/lib/utils';
 import { Button, Icon, MultiSelect } from '@/shared/ui';
-import { DateRangePicker } from '@/shared/ui-kit';
+import { Checkbox, DateRangePicker } from '@/shared/ui-kit';
 import { networkModel } from '@/entities/network';
 import { STATUS_FILTER_LABEL_KEYS, STATUS_FILTER_ORDER, isStatusFilterValue } from '../lib/operations-sections';
 import { operationsContextModel } from '../model/context';
@@ -81,6 +81,14 @@ export const OperationsFilter = memo(() => {
           {t('operations.filters.clearFilters')}
         </Button>
       )}
+      <div className="shrink-0 whitespace-nowrap">
+        <Checkbox
+          checked={selectedOptions.needsMySignature}
+          onChange={checked => operationsContextModel.setFilter({ needsMySignature: checked })}
+        >
+          {t('operations.filters.needsMySignature')}
+        </Checkbox>
+      </div>
       <div className="w-[136px]">
         <DateRangePicker
           value={selectedOptions.dateRange}

--- a/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
@@ -1,28 +1,18 @@
-import { afterEach, beforeEach, describe, expect, test } from 'vitest';
+import { describe, expect, test } from 'vitest';
 
 import {
   type Chain,
   type Contact,
-  type MultisigAccount,
   type Wallet,
   AccountNameType,
-  AccountType,
   CryptoType,
   SigningType,
   TransactionType,
   WalletType,
 } from '@/shared/core';
 import { toAddress } from '@/shared/lib/utils';
-import { createAccountId, polkadotChain } from '@/shared/mocks';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import {
-  type AnyAccount,
-  type MultisigEvent,
-  type MultisigOperation,
-  CONTACT_MULTISIG_WALLET_ID,
-  MultisigEventStatus,
-  accountService,
-} from '@/domains/network';
+import { type AnyAccount, type MultisigOperation } from '@/domains/network';
 import { type OperationSearchRow, type SearchResolvers, searchOperationRows } from '@/aggregates/operations-search';
 
 import {
@@ -39,7 +29,6 @@ import {
   matchesStatus,
   matchesTab,
   matchesTxType,
-  operationNeedsMySignature,
   shouldAlwaysShowInProgress,
 } from './operations-filter';
 
@@ -650,122 +639,6 @@ describe('operations-filter', () => {
       const op = createMockOperation({ id: 'op-1', status: 'pending' });
 
       expect(filterOperation(op, mockMultisigAccount, { ...emptyContext, needsMySignatureIds: null })).toBe(true);
-    });
-  });
-
-  describe('operationNeedsMySignature', () => {
-    const SIGNER_ID = createAccountId('signer-a');
-    const OTHER_SIGNER_ID = createAccountId('signer-b');
-
-    const multisigAccount = {
-      id: 'multisig-1',
-      walletId: 1,
-      name: 'Team multisig',
-      type: 'universal',
-      accountType: AccountType.MULTISIG,
-      accountId: MOCK_ACCOUNT_ID,
-      cryptoType: CryptoType.SR25519,
-      signingType: SigningType.MULTISIG,
-      signatories: [{ accountId: SIGNER_ID }, { accountId: OTHER_SIGNER_ID }],
-      threshold: 2,
-      createdAt: 0,
-    } as unknown as MultisigAccount;
-
-    // The user holds only signer-a; signer-b belongs to someone else.
-    const signerAccount = {
-      id: 'signer-a',
-      walletId: 1,
-      name: 'Signer A',
-      type: 'universal',
-      accountType: AccountType.BASE,
-      accountId: SIGNER_ID,
-      cryptoType: CryptoType.SR25519,
-      signingType: SigningType.POLKADOT_VAULT,
-      createdAt: 0,
-    } as unknown as AnyAccount;
-
-    const approveEvent = (accountId: AccountId): MultisigEvent =>
-      ({
-        id: `approve-${accountId}`,
-        accountId,
-        status: MultisigEventStatus.Approve,
-        blockCreated: 100,
-        indexCreated: 0,
-        timestamp: 0,
-      }) as unknown as MultisigEvent;
-
-    // `findActionableSignatories` checks chain availability through a DI anyOf
-    // that has no handlers in unit tests — seed the same chain-matching handler
-    // the service tests use.
-    beforeEach(() => {
-      accountService.accountAvailabilityOnChainAnyOf.registerHandler({
-        body: ({ account, chain }) =>
-          accountService.isChainAccount(account) ? account.chainId === chain.chainId : true,
-        available: () => true,
-      });
-    });
-
-    afterEach(() => {
-      accountService.accountAvailabilityOnChainAnyOf.resetHandlers();
-    });
-
-    test('pending operation with an own signatory still to act needs my signature', () => {
-      const op = createMockOperation({ status: 'pending', events: [] });
-
-      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(true);
-    });
-
-    test('does not match once every own signatory has approved', () => {
-      const op = createMockOperation({ status: 'pending', events: [approveEvent(SIGNER_ID)] });
-
-      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(false);
-    });
-
-    test('still matches while another own signatory has not approved', () => {
-      const otherSignerAccount = { ...signerAccount, id: 'signer-b', accountId: OTHER_SIGNER_ID } as AnyAccount;
-      const op = createMockOperation({ status: 'pending', events: [approveEvent(SIGNER_ID)] });
-
-      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount, otherSignerAccount], polkadotChain)).toBe(
-        true,
-      );
-    });
-
-    test('does not match an operation awaiting its on-chain outcome', () => {
-      const op = createMockOperation({ status: 'pending', awaitingOutcome: true, events: [] });
-
-      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(false);
-    });
-
-    test('does not match a contact multisig (no local signatory keys)', () => {
-      const contactMultisig = { ...multisigAccount, walletId: CONTACT_MULTISIG_WALLET_ID } as MultisigAccount;
-      const op = createMockOperation({ status: 'pending', events: [] });
-
-      expect(operationNeedsMySignature(op, contactMultisig, [signerAccount], polkadotChain)).toBe(false);
-    });
-
-    test('does not match a resolved operation', () => {
-      expect(
-        operationNeedsMySignature(
-          createMockOperation({ status: 'executed' }),
-          multisigAccount,
-          [signerAccount],
-          polkadotChain,
-        ),
-      ).toBe(false);
-      expect(
-        operationNeedsMySignature(
-          createMockOperation({ status: 'cancelled' }),
-          multisigAccount,
-          [signerAccount],
-          polkadotChain,
-        ),
-      ).toBe(false);
-    });
-
-    test('does not match when the chain is unknown', () => {
-      const op = createMockOperation({ status: 'pending', events: [] });
-
-      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], undefined)).toBe(false);
     });
   });
 

--- a/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
@@ -1,18 +1,28 @@
-import { describe, expect, test } from 'vitest';
+import { afterEach, beforeEach, describe, expect, test } from 'vitest';
 
 import {
   type Chain,
   type Contact,
+  type MultisigAccount,
   type Wallet,
   AccountNameType,
+  AccountType,
   CryptoType,
   SigningType,
   TransactionType,
   WalletType,
 } from '@/shared/core';
 import { toAddress } from '@/shared/lib/utils';
+import { createAccountId, polkadotChain } from '@/shared/mocks';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { type AnyAccount, type MultisigOperation } from '@/domains/network';
+import {
+  type AnyAccount,
+  type MultisigEvent,
+  type MultisigOperation,
+  CONTACT_MULTISIG_WALLET_ID,
+  MultisigEventStatus,
+  accountService,
+} from '@/domains/network';
 import { type OperationSearchRow, type SearchResolvers, searchOperationRows } from '@/aggregates/operations-search';
 
 import {
@@ -29,6 +39,7 @@ import {
   matchesStatus,
   matchesTab,
   matchesTxType,
+  operationNeedsMySignature,
   shouldAlwaysShowInProgress,
 } from './operations-filter';
 
@@ -617,6 +628,122 @@ describe('operations-filter', () => {
       };
       expect(filterOperation(hiddenOp, mockMultisigAccount, ctx)).toBe(true);
       expect(filterOperation(visibleOp, mockMultisigAccount, ctx)).toBe(false);
+    });
+  });
+
+  describe('operationNeedsMySignature', () => {
+    const SIGNER_ID = createAccountId('signer-a');
+    const OTHER_SIGNER_ID = createAccountId('signer-b');
+
+    const multisigAccount = {
+      id: 'multisig-1',
+      walletId: 1,
+      name: 'Team multisig',
+      type: 'universal',
+      accountType: AccountType.MULTISIG,
+      accountId: MOCK_ACCOUNT_ID,
+      cryptoType: CryptoType.SR25519,
+      signingType: SigningType.MULTISIG,
+      signatories: [{ accountId: SIGNER_ID }, { accountId: OTHER_SIGNER_ID }],
+      threshold: 2,
+      createdAt: 0,
+    } as unknown as MultisigAccount;
+
+    // The user holds only signer-a; signer-b belongs to someone else.
+    const signerAccount = {
+      id: 'signer-a',
+      walletId: 1,
+      name: 'Signer A',
+      type: 'universal',
+      accountType: AccountType.BASE,
+      accountId: SIGNER_ID,
+      cryptoType: CryptoType.SR25519,
+      signingType: SigningType.POLKADOT_VAULT,
+      createdAt: 0,
+    } as unknown as AnyAccount;
+
+    const approveEvent = (accountId: AccountId): MultisigEvent =>
+      ({
+        id: `approve-${accountId}`,
+        accountId,
+        status: MultisigEventStatus.Approve,
+        blockCreated: 100,
+        indexCreated: 0,
+        timestamp: 0,
+      }) as unknown as MultisigEvent;
+
+    // `findActionableSignatories` checks chain availability through a DI anyOf
+    // that has no handlers in unit tests — seed the same chain-matching handler
+    // the service tests use.
+    beforeEach(() => {
+      accountService.accountAvailabilityOnChainAnyOf.registerHandler({
+        body: ({ account, chain }) =>
+          accountService.isChainAccount(account) ? account.chainId === chain.chainId : true,
+        available: () => true,
+      });
+    });
+
+    afterEach(() => {
+      accountService.accountAvailabilityOnChainAnyOf.resetHandlers();
+    });
+
+    test('pending operation with an own signatory still to act needs my signature', () => {
+      const op = createMockOperation({ status: 'pending', events: [] });
+
+      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(true);
+    });
+
+    test('does not match once every own signatory has approved', () => {
+      const op = createMockOperation({ status: 'pending', events: [approveEvent(SIGNER_ID)] });
+
+      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(false);
+    });
+
+    test('still matches while another own signatory has not approved', () => {
+      const otherSignerAccount = { ...signerAccount, id: 'signer-b', accountId: OTHER_SIGNER_ID } as AnyAccount;
+      const op = createMockOperation({ status: 'pending', events: [approveEvent(SIGNER_ID)] });
+
+      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount, otherSignerAccount], polkadotChain)).toBe(
+        true,
+      );
+    });
+
+    test('does not match an operation awaiting its on-chain outcome', () => {
+      const op = createMockOperation({ status: 'pending', awaitingOutcome: true, events: [] });
+
+      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], polkadotChain)).toBe(false);
+    });
+
+    test('does not match a contact multisig (no local signatory keys)', () => {
+      const contactMultisig = { ...multisigAccount, walletId: CONTACT_MULTISIG_WALLET_ID } as MultisigAccount;
+      const op = createMockOperation({ status: 'pending', events: [] });
+
+      expect(operationNeedsMySignature(op, contactMultisig, [signerAccount], polkadotChain)).toBe(false);
+    });
+
+    test('does not match a resolved operation', () => {
+      expect(
+        operationNeedsMySignature(
+          createMockOperation({ status: 'executed' }),
+          multisigAccount,
+          [signerAccount],
+          polkadotChain,
+        ),
+      ).toBe(false);
+      expect(
+        operationNeedsMySignature(
+          createMockOperation({ status: 'cancelled' }),
+          multisigAccount,
+          [signerAccount],
+          polkadotChain,
+        ),
+      ).toBe(false);
+    });
+
+    test('does not match when the chain is unknown', () => {
+      const op = createMockOperation({ status: 'pending', events: [] });
+
+      expect(operationNeedsMySignature(op, multisigAccount, [signerAccount], undefined)).toBe(false);
     });
   });
 

--- a/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.test.ts
@@ -74,10 +74,12 @@ const emptyContext: OperationsFilterContext = {
     proxyType: [],
     status: [],
     searchQuery: '',
+    needsMySignature: false,
   },
   tab: 'pending',
   hiddenIds: [],
   searchMatchedIds: null,
+  needsMySignatureIds: null,
   isScopeMerged: false,
 };
 
@@ -629,6 +631,26 @@ describe('operations-filter', () => {
       expect(filterOperation(hiddenOp, mockMultisigAccount, ctx)).toBe(true);
       expect(filterOperation(visibleOp, mockMultisigAccount, ctx)).toBe(false);
     });
+
+    test('needs-my-signature ids: keeps only listed operations', () => {
+      const mine = createMockOperation({ id: 'op-mine', status: 'pending' });
+      const signed = createMockOperation({ id: 'op-signed', status: 'pending' });
+      const ctx: OperationsFilterContext = {
+        ...emptyContext,
+        filters: { ...emptyContext.filters, needsMySignature: true },
+        isScopeMerged: true,
+        needsMySignatureIds: new Set(['op-mine']),
+      };
+
+      expect(filterOperation(mine, mockMultisigAccount, ctx)).toBe(true);
+      expect(filterOperation(signed, mockMultisigAccount, ctx)).toBe(false);
+    });
+
+    test('needs-my-signature ids: null applies no narrowing', () => {
+      const op = createMockOperation({ id: 'op-1', status: 'pending' });
+
+      expect(filterOperation(op, mockMultisigAccount, { ...emptyContext, needsMySignatureIds: null })).toBe(true);
+    });
   });
 
   describe('operationNeedsMySignature', () => {
@@ -815,10 +837,15 @@ describe('operations-filter', () => {
       status: [],
       dateRange: undefined,
       searchQuery: '',
+      needsMySignature: false,
     };
 
     test('empty filter narrows nothing', () => {
       expect(hasNarrowingFilter(emptyFilter)).toBe(false);
+    });
+
+    test('needs my signature narrows the list', () => {
+      expect(hasNarrowingFilter({ ...emptyFilter, needsMySignature: true })).toBe(true);
     });
 
     test('blank search query narrows nothing', () => {
@@ -854,6 +881,7 @@ describe('operations-filter', () => {
       status: [],
       dateRange: undefined,
       searchQuery: '',
+      needsMySignature: false,
     };
 
     test('kept on the pending tab with no filter', () => {

--- a/src/renderer/features/multisig-operations/lib/operations-filter.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.ts
@@ -13,7 +13,14 @@ import {
 import { nonNullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type DateRange } from '@/shared/ui-kit';
-import { type AnyAccount, type IdentityMap, type MultisigOperation, accountService } from '@/domains/network';
+import {
+  type AnyAccount,
+  type IdentityMap,
+  type MultisigOperation,
+  accountService,
+  isContactMultisigAccount,
+  multisigOperationService,
+} from '@/domains/network';
 import { TransferTypes, XcmTypes, findCoreBatchAll } from '@/entities/transaction';
 import { accountUtils } from '@/entities/wallet';
 import { type OperationSearchRow } from '@/aggregates/operations-search';
@@ -141,6 +148,28 @@ export const matchesDateRange = (operation: MultisigOperation, dateRange: Operat
     return isAfter(txDate, startOfDay(from)) || txDate.getTime() === startOfDay(from).getTime();
   }
   return true;
+};
+
+/**
+ * Whether the operation still needs the user: it is collecting approvals and at
+ * least one locally available signatory has not acted yet — the user can
+ * approve it, or add the call data it waits on. This is the rule behind the
+ * row's Approve button (`OperationActions`) and the dashboard queue, so the
+ * filter and the row can never disagree.
+ */
+export const operationNeedsMySignature = (
+  operation: MultisigOperation,
+  account: MultisigAccount | FlexibleMultisigAccount,
+  walletAccounts: AnyAccount[],
+  chain: Chain | null | undefined,
+): boolean => {
+  // An awaiting-outcome operation has already left on-chain storage — it only
+  // looks pending until the indexer reports; signing it would fail.
+  if (operation.status !== 'pending' || operation.awaitingOutcome) return false;
+  // The user holds no signatory keys for a contact-backed multisig.
+  if (isContactMultisigAccount(account)) return false;
+
+  return multisigOperationService.findActionableSignatories(operation, account, walletAccounts, chain).length > 0;
 };
 
 /**

--- a/src/renderer/features/multisig-operations/lib/operations-filter.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.ts
@@ -34,6 +34,7 @@ export interface OperationsFilterCriteria {
   status: StatusFilterValue[];
   dateRange?: DateRange;
   searchQuery: string;
+  needsMySignature: boolean;
 }
 
 export type OperationsFilterTab = 'pending' | 'history' | 'hidden';
@@ -46,6 +47,10 @@ export interface OperationsFilterContext {
   // once for the whole list (see `buildOperationSearchRow`) rather than per
   // operation, because resolving display names is shared work.
   searchMatchedIds: Set<string> | null;
+  // Ids of operations a local signatory can still act on, or `null` when the
+  // "Needs my signature" toggle is off. Computed once for the whole list (see
+  // `operationNeedsMySignature`) so `filterOperation` needs no wallets/chains.
+  needsMySignatureIds: Set<string> | null;
   // Any non-search filter active → tabs collapse to "All operations".
   isScopeMerged: boolean;
 }
@@ -173,14 +178,15 @@ export const operationNeedsMySignature = (
 };
 
 /**
- * Whether the filter narrows the list in any way: a search query, a
- * network/type/proxy-type selection, a date range, or a status selection other
- * than `in_progress`. Selecting only `in_progress` matches the default view, so
- * it narrows nothing.
+ * Whether the filter narrows the list in any way: a search query, the
+ * needs-my-signature toggle, a network/type/proxy-type selection, a date range,
+ * or a status selection other than `in_progress`. Selecting only `in_progress`
+ * matches the default view, so it narrows nothing.
  */
 export const hasNarrowingFilter = (filters: OperationsFilterCriteria): boolean => {
   return (
     filters.searchQuery.trim().length > 0 ||
+    filters.needsMySignature ||
     filters.network.length > 0 ||
     filters.type.length > 0 ||
     filters.proxyType.length > 0 ||
@@ -275,7 +281,7 @@ export const filterOperation = (
   account: MultisigAccount | FlexibleMultisigAccount,
   context: OperationsFilterContext,
 ) => {
-  const { filters, tab, hiddenIds, searchMatchedIds } = context;
+  const { filters, tab, hiddenIds, searchMatchedIds, needsMySignatureIds } = context;
 
   if (context.isScopeMerged) {
     const isHidden = hiddenIds.includes(operation.id);
@@ -295,6 +301,7 @@ export const filterOperation = (
   if (!matchesProxyType(filters.proxyType, account)) return false;
   if (!matchesDateRange(operation, filters.dateRange)) return false;
   if (searchMatchedIds !== null && !searchMatchedIds.has(operation.id)) return false;
+  if (needsMySignatureIds !== null && !needsMySignatureIds.has(operation.id)) return false;
 
   return true;
 };

--- a/src/renderer/features/multisig-operations/lib/operations-filter.ts
+++ b/src/renderer/features/multisig-operations/lib/operations-filter.ts
@@ -13,14 +13,7 @@ import {
 import { nonNullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
 import { type DateRange } from '@/shared/ui-kit';
-import {
-  type AnyAccount,
-  type IdentityMap,
-  type MultisigOperation,
-  accountService,
-  isContactMultisigAccount,
-  multisigOperationService,
-} from '@/domains/network';
+import { type AnyAccount, type IdentityMap, type MultisigOperation, accountService } from '@/domains/network';
 import { TransferTypes, XcmTypes, findCoreBatchAll } from '@/entities/transaction';
 import { accountUtils } from '@/entities/wallet';
 import { type OperationSearchRow } from '@/aggregates/operations-search';
@@ -49,7 +42,8 @@ export interface OperationsFilterContext {
   searchMatchedIds: Set<string> | null;
   // Ids of operations a local signatory can still act on, or `null` when the
   // "Needs my signature" toggle is off. Computed once for the whole list (see
-  // `operationNeedsMySignature`) so `filterOperation` needs no wallets/chains.
+  // `multisigOperationService.needsUserSignature`) so `filterOperation` needs
+  // no wallets/chains.
   needsMySignatureIds: Set<string> | null;
   // Any non-search filter active → tabs collapse to "All operations".
   isScopeMerged: boolean;
@@ -153,28 +147,6 @@ export const matchesDateRange = (operation: MultisigOperation, dateRange: Operat
     return isAfter(txDate, startOfDay(from)) || txDate.getTime() === startOfDay(from).getTime();
   }
   return true;
-};
-
-/**
- * Whether the operation still needs the user: it is collecting approvals and at
- * least one locally available signatory has not acted yet — the user can
- * approve it, or add the call data it waits on. This is the rule behind the
- * row's Approve button (`OperationActions`) and the dashboard queue, so the
- * filter and the row can never disagree.
- */
-export const operationNeedsMySignature = (
-  operation: MultisigOperation,
-  account: MultisigAccount | FlexibleMultisigAccount,
-  walletAccounts: AnyAccount[],
-  chain: Chain | null | undefined,
-): boolean => {
-  // An awaiting-outcome operation has already left on-chain storage — it only
-  // looks pending until the indexer reports; signing it would fail.
-  if (operation.status !== 'pending' || operation.awaitingOutcome) return false;
-  // The user holds no signatory keys for a contact-backed multisig.
-  if (isContactMultisigAccount(account)) return false;
-
-  return multisigOperationService.findActionableSignatories(operation, account, walletAccounts, chain).length > 0;
 };
 
 /**

--- a/src/renderer/features/multisig-operations/model/context.test.ts
+++ b/src/renderer/features/multisig-operations/model/context.test.ts
@@ -661,6 +661,12 @@ describe('operations context model', () => {
 
       expect(scope.getState(operationsContextModel.$isFiltersSelected)).toBe(true);
     });
+
+    it('should start with the needs-my-signature toggle off', () => {
+      const scope = fork();
+
+      expect(scope.getState(operationsContextModel.$filter).needsMySignature).toBe(false);
+    });
   });
 
   describe('Sectioned operations', () => {

--- a/src/renderer/features/multisig-operations/model/context.test.ts
+++ b/src/renderer/features/multisig-operations/model/context.test.ts
@@ -9,12 +9,14 @@ vi.mock('../components/Operation', () => ({
 import { type MultisigAccount, AccountType, ProxyVariant, WalletType } from '@/shared/core';
 import { createAccountId, kusamaChainId, polkadotChainId } from '@/shared/mocks';
 import { accounts, multisigOperation } from '@/domains/network';
+import { networkModel } from '@/entities/network';
 import { walletModel } from '@/entities/wallet';
 import { draftDeepLinkModel } from '@/features/drafts';
 
 import { operationsContextModel } from './context';
 import { deepLinkModel } from './deep-link';
 import './draft-deep-link-expand';
+import { TEST_CHAIN_ID, aId, createMultisigAccount, seedDiHandlers, testChain, vaultAccount } from './test-helpers';
 
 describe('operations context model', () => {
   const mockAccountId = createAccountId(1);
@@ -666,6 +668,97 @@ describe('operations context model', () => {
       const scope = fork();
 
       expect(scope.getState(operationsContextModel.$filter).needsMySignature).toBe(false);
+    });
+  });
+
+  describe('Needs my signature', () => {
+    const signerId = aId(1);
+    const otherSignerId = aId(2);
+    const multisigId = aId(3);
+    // The user holds signer 1 only; signer 2 belongs to someone else.
+    const multisig = createMultisigAccount(multisigId, [signerId, otherSignerId]);
+    const signer = vaultAccount(signerId);
+
+    const approveEvent = (accountId: typeof signerId) => ({
+      id: `approve-${accountId}`,
+      accountId,
+      status: 'approve',
+      blockCreated: 100,
+      indexCreated: 0,
+      timestamp: 0,
+    });
+
+    const createTestOperation = (callHash: string, events: ReturnType<typeof approveEvent>[] = []) => ({
+      ...createMockOperation('pending', callHash),
+      chainId: TEST_CHAIN_ID,
+      multisigAccountId: multisigId,
+      events,
+    });
+
+    const createScope = async (operations: unknown[]) => {
+      const scope = fork({
+        values: new Map()
+          .set(multisigOperation.__test.$cachedOperations, operations)
+          .set(networkModel.$chains, { [TEST_CHAIN_ID]: testChain })
+          .set(operationsContextModel.$tab, 'pending')
+          .set(accounts.__test.$populated, true),
+      });
+      await seedDiHandlers(scope);
+      await populateAccounts(scope, [multisig, signer]);
+
+      return scope;
+    };
+
+    it('should compute no ids while the toggle is off', async () => {
+      const scope = await createScope([createTestOperation('0xmine')]);
+
+      expect(scope.getState(operationsContextModel.$needsMySignatureIds)).toBeNull();
+      expect(scope.getState(operationsContextModel.$filteredOperations)).toHaveLength(1);
+    });
+
+    it('should keep only operations a local signatory can still act on', async () => {
+      const needsMe = createTestOperation('0xmine');
+      const signedByMe = createTestOperation('0xsigned', [approveEvent(signerId)]);
+      const awaiting = { ...createTestOperation('0xawaiting'), awaitingOutcome: true };
+      const scope = await createScope([needsMe, signedByMe, awaiting]);
+
+      await allSettled(operationsContextModel.setFilter, { scope, params: { needsMySignature: true } });
+
+      expect(scope.getState(operationsContextModel.$needsMySignatureIds)).toEqual(new Set([needsMe.id]));
+      expect(scope.getState(operationsContextModel.$filteredOperations).map(o => o.operation.id)).toEqual([needsMe.id]);
+    });
+
+    it('should merge the scope and normalize the tab to pending', async () => {
+      const scope = await createScope([]);
+      await allSettled(operationsContextModel.setTab, { scope, params: 'history' });
+
+      await allSettled(operationsContextModel.setFilter, { scope, params: { needsMySignature: true } });
+
+      expect(scope.getState(operationsContextModel.$isScopeMerged)).toBe(true);
+      expect(scope.getState(operationsContextModel.$isFiltersSelected)).toBe(true);
+      expect(scope.getState(operationsContextModel.$tab)).toBe('pending');
+    });
+
+    it('should drop resolved operations from the merged scope', async () => {
+      const executed = { ...createTestOperation('0xdone'), status: 'executed' };
+      const scope = await createScope([createTestOperation('0xmine'), executed]);
+
+      await allSettled(operationsContextModel.setFilter, { scope, params: { needsMySignature: true } });
+
+      expect(scope.getState(operationsContextModel.$filteredOperations).map(o => o.operation.status)).toEqual([
+        'pending',
+      ]);
+    });
+
+    it('should clear the toggle on resetFilters', async () => {
+      const scope = await createScope([createTestOperation('0xmine')]);
+      await allSettled(operationsContextModel.setFilter, { scope, params: { needsMySignature: true } });
+
+      await allSettled(operationsContextModel.resetFilters, { scope });
+
+      expect(scope.getState(operationsContextModel.$filter).needsMySignature).toBe(false);
+      expect(scope.getState(operationsContextModel.$needsMySignatureIds)).toBeNull();
+      expect(scope.getState(operationsContextModel.$isScopeMerged)).toBe(false);
     });
   });
 

--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -12,7 +12,6 @@ import {
 } from '@/shared/core';
 import { nonNullable, nullable } from '@/shared/lib/utils';
 import { type AccountId } from '@/shared/polkadotjs-schemas';
-import { type DateRange } from '@/shared/ui-kit';
 import {
   type AnyAccount,
   type MultisigOperation,
@@ -21,6 +20,7 @@ import {
   contactMultisigsModel,
   identity,
   multisigOperation,
+  multisigOperationService,
 } from '@/domains/network';
 import { contactModel } from '@/entities/contact';
 import { networkModel, networkUtils } from '@/entities/network';
@@ -30,11 +30,11 @@ import { $searchResolvers, haveSameMatchedIds, searchOperationRows } from '@/agg
 import { walletSelect } from '@/aggregates/wallet-select';
 import { bucketOperations } from '../lib/bucket-operations';
 import {
+  type OperationsFilterCriteria,
   type WalletSearchEntry,
   buildOperationSearchRow,
   filterOperation,
   getWalletSearchEntries,
-  operationNeedsMySignature,
   shouldAlwaysShowInProgress,
 } from '../lib/operations-filter';
 import { type StatusFilterValue, getOperationSection } from '../lib/operations-sections';
@@ -46,15 +46,8 @@ import { multisigOperationsFeature } from './feature';
 
 export { type OperationWithAccount } from '../lib/types';
 
-interface SelectedFilters {
-  network: string[];
-  type: string[];
-  proxyType: string[];
-  status: StatusFilterValue[];
-  dateRange?: DateRange;
-  searchQuery: string;
-  needsMySignature: boolean;
-}
+// One shape for the store and the pure filter — a new criterion is added once.
+type SelectedFilters = OperationsFilterCriteria;
 export type TabFilter = 'pending' | 'history' | 'hidden';
 
 const $hiddenOperationIds = createStore<string[]>([]);
@@ -333,7 +326,7 @@ const $needsMySignatureIdsRaw = combine(
 
     const ids = new Set<string>();
     for (const { operation, account } of operationsWithAccounts) {
-      if (operationNeedsMySignature(operation, account, walletAccounts, chains[operation.chainId])) {
+      if (multisigOperationService.needsUserSignature(operation, account, walletAccounts, chains[operation.chainId])) {
         ids.add(operation.id);
       }
     }

--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -52,6 +52,7 @@ interface SelectedFilters {
   status: StatusFilterValue[];
   dateRange?: DateRange;
   searchQuery: string;
+  needsMySignature: boolean;
 }
 export type TabFilter = 'pending' | 'history' | 'hidden';
 
@@ -73,6 +74,7 @@ const initialFilter: SelectedFilters = {
   status: [],
   dateRange: undefined,
   searchQuery: '',
+  needsMySignature: false,
 };
 
 const setFilter = createEvent<Partial<SelectedFilters>>();
@@ -333,6 +335,7 @@ const $filteredOperations = combine(
         tab,
         hiddenIds,
         searchMatchedIds,
+        needsMySignatureIds: null,
         isScopeMerged,
       }),
     );

--- a/src/renderer/features/multisig-operations/model/context.ts
+++ b/src/renderer/features/multisig-operations/model/context.ts
@@ -34,6 +34,7 @@ import {
   buildOperationSearchRow,
   filterOperation,
   getWalletSearchEntries,
+  operationNeedsMySignature,
   shouldAlwaysShowInProgress,
 } from '../lib/operations-filter';
 import { type StatusFilterValue, getOperationSection } from '../lib/operations-sections';
@@ -92,7 +93,8 @@ const $filter = createStore(initialFilter)
 // Any non-search filter active → tabs collapse to "All operations" (search alone doesn't merge scope).
 const $isScopeMerged = $filter.map(filter =>
   Boolean(
-    filter.network.length ||
+    filter.needsMySignature ||
+      filter.network.length ||
       filter.type.length ||
       filter.proxyType.length ||
       filter.status.length ||
@@ -319,6 +321,31 @@ const $searchMatchedOperationIds = createGuardedStore<Set<string> | null>(
   haveSameMatchedIds,
 );
 
+const $needsMySignatureIdsRaw = combine(
+  {
+    operationsWithAccounts: $operationsWithAccounts,
+    enabled: $filter.map(filter => filter.needsMySignature),
+    walletAccounts: accounts.$list,
+    chains: networkModel.$chains,
+  },
+  ({ operationsWithAccounts, enabled, walletAccounts, chains }): Set<string> | null => {
+    if (!enabled) return null;
+
+    const ids = new Set<string>();
+    for (const { operation, account } of operationsWithAccounts) {
+      if (operationNeedsMySignature(operation, account, walletAccounts, chains[operation.chainId])) {
+        ids.add(operation.id);
+      }
+    }
+
+    return ids;
+  },
+);
+
+// `accounts.$list` churns on unrelated account edits; like the search ids, the
+// guard keeps an unchanged set from re-running the downstream filter chain.
+const $needsMySignatureIds = createGuardedStore<Set<string> | null>($needsMySignatureIdsRaw, null, haveSameMatchedIds);
+
 const $filteredOperations = combine(
   {
     operationsWithAccounts: $operationsWithAccounts,
@@ -326,16 +353,25 @@ const $filteredOperations = combine(
     tab: $tab,
     hiddenIds: $hiddenOperationIds,
     searchMatchedIds: $searchMatchedOperationIds,
+    needsMySignatureIds: $needsMySignatureIds,
     isScopeMerged: $isScopeMerged,
   },
-  ({ operationsWithAccounts, filter, tab, hiddenIds, searchMatchedIds, isScopeMerged }): OperationWithAccount[] => {
+  ({
+    operationsWithAccounts,
+    filter,
+    tab,
+    hiddenIds,
+    searchMatchedIds,
+    needsMySignatureIds,
+    isScopeMerged,
+  }): OperationWithAccount[] => {
     return operationsWithAccounts.filter(({ operation, account }) =>
       filterOperation(operation, account, {
         filters: filter,
         tab,
         hiddenIds,
         searchMatchedIds,
-        needsMySignatureIds: null,
+        needsMySignatureIds,
         isScopeMerged,
       }),
     );
@@ -556,6 +592,7 @@ export const operationsContextModel = {
   $filter,
   $isFiltersSelected,
   $isScopeMerged,
+  $needsMySignatureIds,
   $filteredOperations,
   $sectionedOperations,
   $multisigAccounts,

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -3154,6 +3154,7 @@
       "clearFilters": "Clear filters",
       "dateRangePlaceholder": "Date range",
       "multisigStatusPlaceholder": "Status",
+      "needsMySignature": "Needs my signature",
       "networkPlaceholder": "Networks",
       "networkSummary": "Networks",
       "operationTypePlaceholder": "Operation type",


### PR DESCRIPTION
**Was:** no way to narrow the operations list to what still needs the user's own approval; the "Signed" state existed
only per row.
**Now:** a **Needs my signature** filter keeps only in-progress operations a local signatory can still approve (or
add call data to) and drafts assigned to a local initiator; it behaves like the other filters (merges tabs, cleared by
Clear filters).