### PR TITLE
feat(dashboard): custom date range on the rewards drill-down

### DIFF
--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -168,8 +168,10 @@ donut and the Earned column), and the CSV export. They deliberately do **not** f
 and wonder which one won. Both ends of the range are inclusive of the whole day, so 1 Jul – 31 Jul is 31 days, and a
 half-picked or not-yet-picked range is a real state: nothing is fetched or reported until both ends land — the table
 gives way to a "Pick dates" hint and the export is disabled — because an open-ended window would quietly read as "all
-time" behind a tab that says "custom". A range that ends in the past still costs the eras since it **started** — eras
-are counted backwards from the active one, so a July window looked at in September replays September's eras too.
+time" behind a tab that says "custom". A range that ends in the past is attributed over the closed eras inside it
+**only** — eras are numbered from the active one, so a July window looked at in September still reaches back over the
+eras since July, but the ones that closed after 31 Jul are neither fetched nor counted; an era straddling either end is
+kept, since era boundaries are only known to the day.
 
 There is deliberately **no "received in period" figure** next to the tabs. Received (actual payouts, on the indexer's
 timestamps) and earned (the eras' arithmetic) are different facts on different clocks — old eras claimed inside the

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -168,10 +168,11 @@ donut and the Earned column), and the CSV export. They deliberately do **not** f
 and wonder which one won. Both ends of the range are inclusive of the whole day, so 1 Jul – 31 Jul is 31 days, and a
 half-picked or not-yet-picked range is a real state: nothing is fetched or reported until both ends land — the table
 gives way to a "Pick dates" hint and the export is disabled — because an open-ended window would quietly read as "all
-time" behind a tab that says "custom". A range that ends in the past is attributed over the closed eras inside it
-**only** — eras are numbered from the active one, so a July window looked at in September still reaches back over the
-eras since July, but the ones that closed after 31 Jul are neither fetched nor counted; an era straddling either end is
-kept, since era boundaries are only known to the day.
+time" behind a tab that says "custom". Switching to a preset hides the field but keeps the dates: **Custom** comes back
+to the range it was left at, and only the picker's own Reset clears it. A range that ends in the past is attributed over
+the closed eras inside it **only** — eras are numbered from the active one, so a July window looked at in September
+still reaches back over the eras since July, but the ones that closed after 31 Jul are neither fetched nor counted; an
+era straddling either end is kept, since era boundaries are only known to the day.
 
 There is deliberately **no "received in period" figure** next to the tabs. Received (actual payouts, on the indexer's
 timestamps) and earned (the eras' arithmetic) are different facts on different clocks — old eras claimed inside the

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -160,9 +160,16 @@ per combination. Only the **period** changes a request, because it changes which
 
 ### The period tabs
 
-`7d / 30d / All time` sit on the rewards drill-down and move **two** things: the earned attribution window (the donut
-and the Earned column), and the CSV export. They deliberately do **not** filter the claim: a payout expires by **era**,
-not by date, and hiding part of what is still claimable behind a date filter hides money.
+`7d / 30d / All time / Custom` sit on the rewards drill-down and move **two** things: the earned attribution window (the
+donut and the Earned column), and the CSV export. They deliberately do **not** filter the claim: a payout expires by
+**era**, not by date, and hiding part of what is still claimable behind a date filter hides money.
+
+**Custom** opens a date-range picker, and only then — a date field sitting next to "30d" invites the user to set both
+and wonder which one won. Both ends of the range are inclusive of the whole day, so 1 Jul – 31 Jul is 31 days, and a
+half-picked or not-yet-picked range is a real state: nothing is fetched or reported until both ends land — the table
+gives way to a "Pick dates" hint and the export is disabled — because an open-ended window would quietly read as "all
+time" behind a tab that says "custom". A range that ends in the past still costs the eras since it **started** — eras
+are counted backwards from the active one, so a July window looked at in September replays September's eras too.
 
 There is deliberately **no "received in period" figure** next to the tabs. Received (actual payouts, on the indexer's
 timestamps) and earned (the eras' arithmetic) are different facts on different clocks — old eras claimed inside the

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
@@ -45,7 +45,10 @@ export type ValidatorRewardsResult = {
  * The era range is what keeps that affordable, which is why the window is a
  * parameter of the fetch rather than a filter over a fetched year.
  */
-export const useValidatorRewards = (positions: StakingPosition[], window: RewardWindow): ValidatorRewardsResult => {
+export const useValidatorRewards = (
+  positions: StakingPosition[],
+  rewardWindow: RewardWindow,
+): ValidatorRewardsResult => {
   const chains = useUnit(networkModel.$chains);
   const apis = useUnit(networkModel.$apis);
   const eras = useChainEras();
@@ -77,12 +80,13 @@ export const useValidatorRewards = (positions: StakingPosition[], window: Reward
         continue;
       }
 
-      const eraRange = windowEraRange(window, {
+      const eraRange = windowEraRange(rewardWindow, {
         activeEra,
         eraDurationMs: eraDurations[chainId] ?? null,
         historyDepth,
       });
-      // Nothing closed inside the window — or nothing of it is still on chain.
+      // Nothing closed inside the window, nothing of it still on chain — or the
+      // window is a custom range still waiting for its dates.
       if (!eraRange) continue;
 
       byChain.set(chainId, {
@@ -96,7 +100,7 @@ export const useValidatorRewards = (positions: StakingPosition[], window: Reward
 
     // Sorted so the cache key of a selection does not depend on row order.
     return [...byChain.values()].map((request) => ({ ...request, stashes: [...request.stashes].sort() }));
-  }, [positions, chains, apis, eras, eraDurations, window]);
+  }, [positions, chains, apis, eras, eraDurations, rewardWindow]);
 
   useResourcePool(eraRewardsResource, requests);
 

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
@@ -12,7 +12,7 @@ import {
   rewardsService,
 } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
-import { type RewardWindow, erasInWindow } from '../lib/reward-period';
+import { type RewardWindow, windowEraRange } from '../lib/reward-period';
 
 import { useChainEras, useEraDurations } from './useChainEras';
 import { useResourcePool } from './useResourcePool';
@@ -77,17 +77,19 @@ export const useValidatorRewards = (positions: StakingPosition[], window: Reward
         continue;
       }
 
-      // The active era has not paid anything yet — its arithmetic is not final.
-      const eraTo = activeEra - 1;
-      const eraFrom = Math.max(0, eraTo - erasInWindow(window, eraDurations[chainId] ?? null, historyDepth) + 1);
-      if (eraTo < eraFrom) continue;
+      const eraRange = windowEraRange(window, {
+        activeEra,
+        eraDurationMs: eraDurations[chainId] ?? null,
+        historyDepth,
+      });
+      // Nothing closed inside the window — or nothing of it is still on chain.
+      if (!eraRange) continue;
 
       byChain.set(chainId, {
         chainId,
         api,
         stashes: [position.stake.stash],
-        eraFrom,
-        eraTo,
+        ...eraRange,
         rewardSources: rewardsService.collectChainRewardSources(chain, chains, 'staking-chain'),
       });
     }

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useValidatorRewards.ts
@@ -12,7 +12,7 @@ import {
   rewardsService,
 } from '@/domains/staking';
 import { networkModel } from '@/entities/network';
-import { type RewardPeriod, erasInPeriod } from '../lib/reward-period';
+import { type RewardWindow, erasInWindow } from '../lib/reward-period';
 
 import { useChainEras, useEraDurations } from './useChainEras';
 import { useResourcePool } from './useResourcePool';
@@ -45,7 +45,7 @@ export type ValidatorRewardsResult = {
  * The era range is what keeps that affordable, which is why the window is a
  * parameter of the fetch rather than a filter over a fetched year.
  */
-export const useValidatorRewards = (positions: StakingPosition[], period: RewardPeriod): ValidatorRewardsResult => {
+export const useValidatorRewards = (positions: StakingPosition[], window: RewardWindow): ValidatorRewardsResult => {
   const chains = useUnit(networkModel.$chains);
   const apis = useUnit(networkModel.$apis);
   const eras = useChainEras();
@@ -79,7 +79,7 @@ export const useValidatorRewards = (positions: StakingPosition[], period: Reward
 
       // The active era has not paid anything yet — its arithmetic is not final.
       const eraTo = activeEra - 1;
-      const eraFrom = Math.max(0, eraTo - erasInPeriod(period, eraDurations[chainId] ?? null, historyDepth) + 1);
+      const eraFrom = Math.max(0, eraTo - erasInWindow(window, eraDurations[chainId] ?? null, historyDepth) + 1);
       if (eraTo < eraFrom) continue;
 
       byChain.set(chainId, {
@@ -94,7 +94,7 @@ export const useValidatorRewards = (positions: StakingPosition[], period: Reward
 
     // Sorted so the cache key of a selection does not depend on row order.
     return [...byChain.values()].map((request) => ({ ...request, stashes: [...request.stashes].sort() }));
-  }, [positions, chains, apis, eras, eraDurations, period]);
+  }, [positions, chains, apis, eras, eraDurations, window]);
 
   useResourcePool(eraRewardsResource, requests);
 

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
@@ -5,6 +5,7 @@ import {
   DEFAULT_REWARD_WINDOW,
   erasInPeriod,
   erasInWindow,
+  isCustomWindowPending,
   isWindowReady,
   periodStart,
   windowBounds,
@@ -181,6 +182,20 @@ describe('isWindowReady', () => {
     expect(isWindowReady(emptyCustom)).toBe(false);
     expect(isWindowReady(halfPicked)).toBe(false);
     expect(isWindowReady(july)).toBe(true);
+  });
+});
+
+describe('isCustomWindowPending', () => {
+  it('is pending only for a custom window without both dates', () => {
+    expect(isCustomWindowPending(emptyCustom)).toBe(true);
+    expect(isCustomWindowPending(halfPicked)).toBe(true);
+    expect(isCustomWindowPending(july)).toBe(false);
+  });
+
+  it('never holds a preset back, the default included', () => {
+    expect(isCustomWindowPending(DEFAULT_REWARD_WINDOW)).toBe(false);
+    expect(isCustomWindowPending(preset('7d'))).toBe(false);
+    expect(isCustomWindowPending(preset('all'))).toBe(false);
   });
 });
 

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
@@ -1,9 +1,25 @@
 import { describe, expect, it } from 'vitest';
 
-import { erasInPeriod, periodStart } from '../reward-period';
+import { type RewardWindow, erasInPeriod, periodStart, windowEraRange } from '../reward-period';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const HISTORY_DEPTH = 84;
+
+// Local-time days, the way the picker hands them over.
+const JULY_1 = new Date(2026, 6, 1);
+const JULY_31 = new Date(2026, 6, 31);
+const AUGUST_20 = new Date(2026, 7, 20);
+const AUGUST_21 = new Date(2026, 7, 21);
+const AUGUST_22 = new Date(2026, 7, 22);
+
+/** Looked at on 22 Aug at noon, local time. */
+const NOW = new Date(2026, 7, 22, 12).getTime();
+
+const july: RewardWindow = { period: 'custom', range: { from: JULY_1, to: JULY_31 } };
+const preset = (period: RewardWindow['period']): RewardWindow => ({ period, range: null });
+
+const polkadot = { activeEra: 100, eraDurationMs: DAY_MS, historyDepth: HISTORY_DEPTH };
+const kusama = { activeEra: 1000, eraDurationMs: DAY_MS / 4, historyDepth: HISTORY_DEPTH };
 
 describe('periodStart', () => {
   it('anchors to UTC midnight so the key does not move with the clock', () => {
@@ -43,5 +59,58 @@ describe('erasInPeriod', () => {
 
   it('falls back to the full depth when the era duration is unknown', () => {
     expect(erasInPeriod('7d', null, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
+  });
+});
+
+describe('windowEraRange', () => {
+  it('ends a preset at the last closed era and reaches back the period', () => {
+    // The active era has not paid anything yet, so 99 is the newest era that counts.
+    expect(windowEraRange(preset('7d'), polkadot, NOW)).toEqual({ eraFrom: 93, eraTo: 99 });
+    expect(windowEraRange(preset('all'), polkadot, NOW)).toEqual({ eraFrom: 16, eraTo: 99 });
+  });
+
+  it('never reaches below era zero', () => {
+    expect(windowEraRange(preset('all'), { ...polkadot, activeEra: 10 }, NOW)).toEqual({ eraFrom: 0, eraTo: 9 });
+  });
+
+  it('stops a past custom window at the eras that closed inside it', () => {
+    // 1–31 Jul looked at on 22 Aug: the 21 full days of August that have
+    // elapsed since the window ended are not part of it. The era straddling
+    // each end is kept — era boundaries are only known to the day.
+    expect(windowEraRange(july, polkadot, NOW)).toEqual({ eraFrom: 47, eraTo: 78 });
+  });
+
+  it('runs a window that reaches today up to the last closed era', () => {
+    const thisWeek: RewardWindow = { period: 'custom', range: { from: AUGUST_20, to: AUGUST_22 } };
+
+    expect(windowEraRange(thisWeek, polkadot, NOW)).toEqual({ eraFrom: 97, eraTo: 99 });
+  });
+
+  it('drops the eras of today from a window that ended yesterday on a four-era day', () => {
+    const untilYesterday: RewardWindow = { period: 'custom', range: { from: AUGUST_20, to: AUGUST_21 } };
+
+    // Noon is two Kusama eras into the day; the second one is wholly today.
+    expect(windowEraRange(untilYesterday, kusama, NOW)).toEqual({ eraFrom: 990, eraTo: 998 });
+  });
+
+  it('keeps a half-picked range open-ended on the missing side', () => {
+    const fromJuly: RewardWindow = { period: 'custom', range: { from: JULY_1, to: undefined } };
+    const empty: RewardWindow = { period: 'custom', range: null };
+
+    expect(windowEraRange(fromJuly, polkadot, NOW)).toEqual({ eraFrom: 47, eraTo: 99 });
+    expect(windowEraRange(empty, polkadot, NOW)).toEqual({ eraFrom: 16, eraTo: 99 });
+  });
+
+  it('has no eras for a window older than the history the chain keeps', () => {
+    // 84 Kusama eras are 21 days; July is gone from the chain by 22 Aug.
+    expect(windowEraRange(july, kusama, NOW)).toBeNull();
+  });
+
+  it('has no eras before the first one closes', () => {
+    expect(windowEraRange(preset('7d'), { ...polkadot, activeEra: 0 }, NOW)).toBeNull();
+  });
+
+  it('falls back to the whole depth when the era duration is unknown', () => {
+    expect(windowEraRange(july, { ...polkadot, eraDurationMs: null }, NOW)).toEqual({ eraFrom: 16, eraTo: 99 });
   });
 });

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
@@ -3,13 +3,11 @@ import { describe, expect, it } from 'vitest';
 import {
   type RewardWindow,
   DEFAULT_REWARD_WINDOW,
-  erasInPeriod,
   erasInWindow,
   isCustomWindowPending,
   isWindowReady,
   periodStart,
   windowBounds,
-  windowDays,
   windowEraRange,
   windowSlug,
 } from '../reward-period';
@@ -54,25 +52,25 @@ describe('periodStart', () => {
   });
 });
 
-describe('erasInPeriod', () => {
+describe('erasInWindow (presets)', () => {
   it('counts a day per era on Polkadot', () => {
-    expect(erasInPeriod('7d', DAY_MS, HISTORY_DEPTH)).toBe(7);
-    expect(erasInPeriod('30d', DAY_MS, HISTORY_DEPTH)).toBe(30);
+    expect(erasInWindow(preset('7d'), DAY_MS, HISTORY_DEPTH)).toBe(7);
+    expect(erasInWindow(preset('30d'), DAY_MS, HISTORY_DEPTH)).toBe(30);
   });
 
   it('counts four eras a day on Kusama', () => {
-    expect(erasInPeriod('7d', DAY_MS / 4, HISTORY_DEPTH)).toBe(28);
+    expect(erasInWindow(preset('7d'), DAY_MS / 4, HISTORY_DEPTH)).toBe(28);
   });
 
   it('never asks for more history than the chain keeps', () => {
     // 30 Kusama days would be 120 eras; nothing older than the depth is on
     // chain to attribute a reward to.
-    expect(erasInPeriod('30d', DAY_MS / 4, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
-    expect(erasInPeriod('all', DAY_MS, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
+    expect(erasInWindow(preset('30d'), DAY_MS / 4, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
+    expect(erasInWindow(preset('all'), DAY_MS, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
   });
 
   it('falls back to the full depth when the era duration is unknown', () => {
-    expect(erasInPeriod('7d', null, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
+    expect(erasInWindow(preset('7d'), null, HISTORY_DEPTH)).toBe(HISTORY_DEPTH);
   });
 });
 
@@ -107,12 +105,10 @@ describe('windowEraRange', () => {
     expect(windowEraRange(untilYesterday, kusama, NOW)).toEqual({ eraFrom: 990, eraTo: 998 });
   });
 
-  it('keeps a half-picked range open-ended on the missing side', () => {
-    const fromJuly: RewardWindow = { period: 'custom', range: { from: JULY_1, to: undefined } };
-    const empty: RewardWindow = { period: 'custom', range: null };
-
-    expect(windowEraRange(fromJuly, polkadot, NOW)).toEqual({ eraFrom: 47, eraTo: 99 });
-    expect(windowEraRange(empty, polkadot, NOW)).toEqual({ eraFrom: 16, eraTo: 99 });
+  it('has no eras until both ends of a custom range are picked', () => {
+    // Nothing is fetched for a pending window; an open end would quietly read as "all time".
+    expect(windowEraRange(halfPicked, polkadot, NOW)).toBeNull();
+    expect(windowEraRange(emptyCustom, polkadot, NOW)).toBeNull();
   });
 
   it('has no eras for a window older than the history the chain keeps', () => {
@@ -134,7 +130,8 @@ describe('windowBounds', () => {
     const { from, to } = windowBounds(july);
 
     expect(from).toBe(Math.floor(JULY_1.getTime() / 1000));
-    expect(to).toBe(Math.floor((JULY_31.getTime() + DAY_MS - 1) / 1000));
+    // The last millisecond of the 31st — the next local midnight, minus one.
+    expect(to).toBe(Math.floor((new Date(2026, 7, 1).getTime() - 1) / 1000));
   });
 
   it('keeps a half-picked range open-ended on the missing side', () => {
@@ -147,27 +144,6 @@ describe('windowBounds', () => {
 
     expect(windowBounds(preset('7d'), now)).toEqual({ from: periodStart('7d', now), to: null });
     expect(windowBounds(preset('all'), now)).toEqual({ from: null, to: null });
-  });
-});
-
-describe('windowDays', () => {
-  it('counts both end days, so 1 Jul – 31 Jul is 31 days', () => {
-    expect(windowDays(july)).toBe(31);
-  });
-
-  it('counts a single-day range as one day', () => {
-    expect(windowDays({ period: 'custom', range: { from: JULY_1, to: JULY_1 } })).toBe(1);
-  });
-
-  it('has no length until both ends are picked', () => {
-    expect(windowDays(halfPicked)).toBeNull();
-    expect(windowDays(emptyCustom)).toBeNull();
-  });
-
-  it('keeps the preset lengths', () => {
-    expect(windowDays(preset('7d'))).toBe(7);
-    expect(windowDays(preset('30d'))).toBe(30);
-    expect(windowDays(preset('all'))).toBeNull();
   });
 });
 
@@ -206,7 +182,7 @@ describe('windowSlug', () => {
   });
 
   it('names a full custom range by its local days', () => {
-    expect(windowSlug(july)).toBe('2026-07-01_2026-07-31');
+    expect(windowSlug(july)).toBe('from-2026-07-01-to-2026-07-31');
   });
 
   it('falls back to "custom" while the range is incomplete', () => {
@@ -248,12 +224,5 @@ describe('erasInWindow', () => {
 
   it('falls back to the full depth when the era duration is unknown', () => {
     expect(erasInWindow(july, null, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
-  });
-
-  it('matches erasInPeriod for presets', () => {
-    expect(erasInWindow(preset('7d'), DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(
-      erasInPeriod('7d', DAY_MS, HISTORY_DEPTH),
-    );
-    expect(erasInWindow(preset('all'), DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
   });
 });

--- a/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/__tests__/reward-period.test.ts
@@ -1,6 +1,17 @@
 import { describe, expect, it } from 'vitest';
 
-import { type RewardWindow, erasInPeriod, periodStart, windowEraRange } from '../reward-period';
+import {
+  type RewardWindow,
+  DEFAULT_REWARD_WINDOW,
+  erasInPeriod,
+  erasInWindow,
+  isWindowReady,
+  periodStart,
+  windowBounds,
+  windowDays,
+  windowEraRange,
+  windowSlug,
+} from '../reward-period';
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 const HISTORY_DEPTH = 84;
@@ -16,6 +27,8 @@ const AUGUST_22 = new Date(2026, 7, 22);
 const NOW = new Date(2026, 7, 22, 12).getTime();
 
 const july: RewardWindow = { period: 'custom', range: { from: JULY_1, to: JULY_31 } };
+const halfPicked: RewardWindow = { period: 'custom', range: { from: JULY_1, to: undefined } };
+const emptyCustom: RewardWindow = { period: 'custom', range: null };
 const preset = (period: RewardWindow['period']): RewardWindow => ({ period, range: null });
 
 const polkadot = { activeEra: 100, eraDurationMs: DAY_MS, historyDepth: HISTORY_DEPTH };
@@ -112,5 +125,120 @@ describe('windowEraRange', () => {
 
   it('falls back to the whole depth when the era duration is unknown', () => {
     expect(windowEraRange(july, { ...polkadot, eraDurationMs: null }, NOW)).toEqual({ eraFrom: 16, eraTo: 99 });
+  });
+});
+
+describe('windowBounds', () => {
+  it('covers both picked days in full, in unix seconds', () => {
+    const { from, to } = windowBounds(july);
+
+    expect(from).toBe(Math.floor(JULY_1.getTime() / 1000));
+    expect(to).toBe(Math.floor((JULY_31.getTime() + DAY_MS - 1) / 1000));
+  });
+
+  it('keeps a half-picked range open-ended on the missing side', () => {
+    expect(windowBounds(halfPicked)).toEqual({ from: Math.floor(JULY_1.getTime() / 1000), to: null });
+    expect(windowBounds(emptyCustom)).toEqual({ from: null, to: null });
+  });
+
+  it('delegates presets to periodStart and never bounds them from above', () => {
+    const now = new Date('2026-07-31T12:00:00Z');
+
+    expect(windowBounds(preset('7d'), now)).toEqual({ from: periodStart('7d', now), to: null });
+    expect(windowBounds(preset('all'), now)).toEqual({ from: null, to: null });
+  });
+});
+
+describe('windowDays', () => {
+  it('counts both end days, so 1 Jul – 31 Jul is 31 days', () => {
+    expect(windowDays(july)).toBe(31);
+  });
+
+  it('counts a single-day range as one day', () => {
+    expect(windowDays({ period: 'custom', range: { from: JULY_1, to: JULY_1 } })).toBe(1);
+  });
+
+  it('has no length until both ends are picked', () => {
+    expect(windowDays(halfPicked)).toBeNull();
+    expect(windowDays(emptyCustom)).toBeNull();
+  });
+
+  it('keeps the preset lengths', () => {
+    expect(windowDays(preset('7d'))).toBe(7);
+    expect(windowDays(preset('30d'))).toBe(30);
+    expect(windowDays(preset('all'))).toBeNull();
+  });
+});
+
+describe('isWindowReady', () => {
+  it('is true for every preset, the default included', () => {
+    expect(isWindowReady(DEFAULT_REWARD_WINDOW)).toBe(true);
+    expect(isWindowReady(preset('7d'))).toBe(true);
+    expect(isWindowReady(preset('all'))).toBe(true);
+  });
+
+  it('is false for a custom window until both ends land', () => {
+    expect(isWindowReady(emptyCustom)).toBe(false);
+    expect(isWindowReady(halfPicked)).toBe(false);
+    expect(isWindowReady(july)).toBe(true);
+  });
+});
+
+describe('windowSlug', () => {
+  it('names presets by their period', () => {
+    expect(windowSlug(preset('30d'))).toBe('30d');
+    expect(windowSlug(preset('all'))).toBe('all');
+  });
+
+  it('names a full custom range by its local days', () => {
+    expect(windowSlug(july)).toBe('2026-07-01_2026-07-31');
+  });
+
+  it('falls back to "custom" while the range is incomplete', () => {
+    expect(windowSlug(halfPicked)).toBe('custom');
+    expect(windowSlug(emptyCustom)).toBe('custom');
+  });
+});
+
+describe('erasInWindow', () => {
+  // Local midnights ten days apart, no DST change in between.
+  const AUGUST_21_MIDNIGHT = new Date(2026, 7, 21).getTime();
+  const AUG_11 = new Date(2026, 7, 11);
+  const AUG_15 = new Date(2026, 7, 15);
+
+  it('replays the eras since a past window started, not only those inside it', () => {
+    const pastWindow: RewardWindow = { period: 'custom', range: { from: AUG_11, to: AUG_15 } };
+
+    expect(erasInWindow(pastWindow, DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(10);
+    expect(erasInWindow(pastWindow, DAY_MS / 4, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(40);
+  });
+
+  it('costs at least one era for a window that starts today', () => {
+    const today = new Date(2026, 7, 21);
+
+    expect(
+      erasInWindow({ period: 'custom', range: { from: today, to: today } }, DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT),
+    ).toBe(1);
+  });
+
+  it('asks for the full depth when the start is not picked yet', () => {
+    expect(erasInWindow(emptyCustom, DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
+  });
+
+  it('never asks for more history than the chain keeps', () => {
+    const longAgo: RewardWindow = { period: 'custom', range: { from: new Date(2025, 0, 1), to: AUG_15 } };
+
+    expect(erasInWindow(longAgo, DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
+  });
+
+  it('falls back to the full depth when the era duration is unknown', () => {
+    expect(erasInWindow(july, null, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
+  });
+
+  it('matches erasInPeriod for presets', () => {
+    expect(erasInWindow(preset('7d'), DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(
+      erasInPeriod('7d', DAY_MS, HISTORY_DEPTH),
+    );
+    expect(erasInWindow(preset('all'), DAY_MS, HISTORY_DEPTH, AUGUST_21_MIDNIGHT)).toBe(HISTORY_DEPTH);
   });
 });

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -1,19 +1,105 @@
+import { type DateRange } from '@/shared/ui-kit';
 import { getErasInDays } from '@/domains/staking';
 
 /** Windows the rewards drill-down can be looked at through. */
-export const REWARD_PERIODS = ['7d', '30d', 'all'] as const;
+export const REWARD_PERIODS = ['7d', '30d', 'all', 'custom'] as const;
 
 export type RewardPeriod = (typeof REWARD_PERIODS)[number];
 
 export const DEFAULT_REWARD_PERIOD: RewardPeriod = '30d';
 
-const DAYS_BY_PERIOD: Record<RewardPeriod, number | null> = { '7d': 7, '30d': 30, all: null };
+/**
+ * A period plus, for `custom`, the dates behind it.
+ *
+ * The two travel together because every consumer needs both: the tab decides
+ * how the window is described, the range decides where it starts and ends, and
+ * a `custom` period with no range yet is a real state — the picker is open and
+ * nothing has been chosen.
+ */
+export type RewardWindow = {
+  period: RewardPeriod;
+  /**
+   * Inclusive day bounds, local time. Only meaningful for `custom`, and
+   * half-filled while the user is still picking — `react-day-picker` reports
+   * the first click as `{ from }` alone.
+   */
+  range: DateRange | null;
+};
+
+export const DEFAULT_REWARD_WINDOW: RewardWindow = { period: DEFAULT_REWARD_PERIOD, range: null };
+
+const DAYS_BY_PERIOD: Record<RewardPeriod, number | null> = { '7d': 7, '30d': 30, all: null, custom: null };
 
 const DAY_MS = 24 * 60 * 60 * 1000;
 
 /** Days the period covers, `null` for "everything there is". */
 export function periodDays(period: RewardPeriod): number | null {
   return DAYS_BY_PERIOD[period];
+}
+
+/**
+ * Unix **seconds** the window covers — the unit the indexer stamps payouts with
+ * — both bounds inclusive of the whole day the user picked: someone asking for
+ * "1 Jul – 31 Jul" means the 31st, not the instant it began.
+ *
+ * `null` bounds mean "unbounded that way", which is what `all` is, and what a
+ * half-picked custom range is until its other end lands.
+ */
+export function windowBounds(window: RewardWindow, now = new Date()): { from: number | null; to: number | null } {
+  if (window.period === 'custom') {
+    const { from, to } = window.range ?? {};
+
+    return {
+      from: from ? Math.floor(startOfDayMs(from) / 1000) : null,
+      to: to ? Math.floor((startOfDayMs(to) + DAY_MS - 1) / 1000) : null,
+    };
+  }
+
+  const start = periodStart(window.period, now);
+
+  return { from: start ?? null, to: null };
+}
+
+function startOfDayMs(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate()).getTime();
+}
+
+/**
+ * Days the window spans, used to annualise what it earned. A custom range
+ * counts both end days, so 1 Jul – 31 Jul is 31 days rather than 30.
+ */
+export function windowDays(window: RewardWindow): number | null {
+  if (window.period !== 'custom') return periodDays(window.period);
+
+  const { from, to } = window.range ?? {};
+  if (!from || !to) return null;
+
+  return Math.max(1, Math.round((startOfDayMs(to) - startOfDayMs(from)) / DAY_MS) + 1);
+}
+
+/** Whether the window is fully specified — a half-picked range is not. */
+export function isWindowReady(window: RewardWindow): boolean {
+  return window.period !== 'custom' || Boolean(window.range?.from && window.range.to);
+}
+
+/** Short label for a file name: `30d`, `all`, or `2026-07-01_2026-07-31`. */
+export function windowSlug(window: RewardWindow): string {
+  if (window.period !== 'custom') return window.period;
+
+  const { from, to } = window.range ?? {};
+  if (!from || !to) return 'custom';
+
+  return `${toIsoDay(from)}_${toIsoDay(to)}`;
+}
+
+function toIsoDay(date: Date): string {
+  // Built from the local parts on purpose: `toISOString` would shift the day
+  // for anyone east or west of UTC, and the name has to match the days the
+  // picker showed.
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+
+  return `${date.getFullYear()}-${month}-${day}`;
 }
 
 /**
@@ -41,8 +127,35 @@ export function periodStart(period: RewardPeriod, now = new Date()): number | un
  * walk that can only come back empty.
  */
 export function erasInPeriod(period: RewardPeriod, eraDurationMs: number | null, historyDepth: number): number {
-  const days = periodDays(period);
-  if (days === null || !eraDurationMs || eraDurationMs <= 0) return historyDepth;
+  return erasInWindow({ period, range: null }, eraDurationMs, historyDepth);
+}
+
+/**
+ * Same, for a window that may be a custom range.
+ *
+ * A range that ends in the past still has to be replayed from **now** back to
+ * its start — eras are counted backwards from the active one, so a July window
+ * looked at in September costs the eras since July, not the eras inside it.
+ */
+export function erasInWindow(
+  window: RewardWindow,
+  eraDurationMs: number | null,
+  historyDepth: number,
+  now = Date.now(),
+): number {
+  if (!eraDurationMs || eraDurationMs <= 0) return historyDepth;
+
+  if (window.period === 'custom') {
+    const from = window.range?.from;
+    if (!from) return historyDepth;
+
+    const span = Math.max(DAY_MS, now - startOfDayMs(from));
+
+    return Math.min(historyDepth, Math.max(1, Math.ceil(span / eraDurationMs)));
+  }
+
+  const days = periodDays(window.period);
+  if (days === null) return historyDepth;
 
   return Math.min(historyDepth, getErasInDays(days, eraDurationMs));
 }

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -82,6 +82,14 @@ export function isWindowReady(window: RewardWindow): boolean {
   return window.period !== 'custom' || Boolean(window.range?.from && window.range.to);
 }
 
+/**
+ * A custom window still waiting for its dates. The drill-down reports nothing
+ * for it — falling back to "all time" would answer a question nobody asked.
+ */
+export function isCustomWindowPending(window: RewardWindow): boolean {
+  return window.period === 'custom' && !isWindowReady(window);
+}
+
 /** Short label for a file name: `30d`, `all`, or `2026-07-01_2026-07-31`. */
 export function windowSlug(window: RewardWindow): string {
   if (window.period !== 'custom') return window.period;

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -133,9 +133,9 @@ export function erasInPeriod(period: RewardPeriod, eraDurationMs: number | null,
 /**
  * Same, for a window that may be a custom range.
  *
- * A range that ends in the past still has to be replayed from **now** back to
- * its start — eras are counted backwards from the active one, so a July window
- * looked at in September costs the eras since July, not the eras inside it.
+ * Counted from **now** back to the range's start — eras are numbered from the
+ * active one, so a July window looked at in September reaches back over the
+ * eras since July. `windowEraRange` trims the ones after its end off again.
  */
 export function erasInWindow(
   window: RewardWindow,
@@ -158,4 +158,54 @@ export function erasInWindow(
   if (days === null) return historyDepth;
 
   return Math.min(historyDepth, getErasInDays(days, eraDurationMs));
+}
+
+/** The eras a window is attributed over — both bounds inclusive. */
+export type EraRange = { eraFrom: number; eraTo: number };
+
+type ChainEraFacts = {
+  activeEra: number;
+  eraDurationMs: number | null;
+  historyDepth: number;
+};
+
+/**
+ * The closed eras of a chain that fall inside the window, `null` when none
+ * does.
+ *
+ * The active era is never part of it: it has not paid anything yet, so its
+ * arithmetic is not final. A preset therefore ends at the last closed era and
+ * reaches back `erasInWindow`; a custom range is trimmed on **both** sides —
+ * 1–31 Jul looked at on 22 Aug must not carry August's eras into a figure
+ * captioned "over the period". Era boundaries are only known to the day, so an
+ * era straddling either end is kept rather than dropped.
+ */
+export function windowEraRange(window: RewardWindow, chain: ChainEraFacts, now = Date.now()): EraRange | null {
+  const { activeEra, eraDurationMs, historyDepth } = chain;
+  const lastClosed = activeEra - 1;
+
+  const eraFrom = Math.max(0, lastClosed - erasInWindow(window, eraDurationMs, historyDepth, now) + 1);
+  const eraTo = lastClosed - erasSinceWindowEnd(window, eraDurationMs, now);
+
+  return eraTo < eraFrom ? null : { eraFrom, eraTo };
+}
+
+/**
+ * How many closed eras lie wholly after the window — the ones that closed
+ * between its end and now. Zero for every window that reaches now, which is
+ * every preset and a custom range whose end is today or still unpicked.
+ */
+function erasSinceWindowEnd(window: RewardWindow, eraDurationMs: number | null, now: number): number {
+  if (window.period !== 'custom' || !eraDurationMs || eraDurationMs <= 0) return 0;
+
+  const to = window.range?.to;
+  if (!to) return 0;
+
+  // The day after the last picked one, at midnight — the instant the window closed.
+  const elapsed = now - (startOfDayMs(to) + DAY_MS);
+  if (elapsed <= 0) return 0;
+
+  // The era the end falls into may still hold the window's last hours; only
+  // the eras entirely past it are dropped.
+  return Math.max(0, Math.ceil(elapsed / eraDurationMs) - 1);
 }

--- a/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/reward-period.ts
@@ -1,4 +1,3 @@
-import { type DateRange } from '@/shared/ui-kit';
 import { getErasInDays } from '@/domains/staking';
 
 /** Windows the rewards drill-down can be looked at through. */
@@ -7,6 +6,13 @@ export const REWARD_PERIODS = ['7d', '30d', 'all', 'custom'] as const;
 export type RewardPeriod = (typeof REWARD_PERIODS)[number];
 
 export const DEFAULT_REWARD_PERIOD: RewardPeriod = '30d';
+
+/**
+ * Inclusive day bounds, local time. Structurally the shape `react-day-picker`
+ * reports (`from` present but possibly undefined, `to` optional), kept as a
+ * local type so the date math here does not depend on the picker.
+ */
+export type RewardDateRange = { from: Date | undefined; to?: Date };
 
 /**
  * A period plus, for `custom`, the dates behind it.
@@ -19,11 +25,10 @@ export const DEFAULT_REWARD_PERIOD: RewardPeriod = '30d';
 export type RewardWindow = {
   period: RewardPeriod;
   /**
-   * Inclusive day bounds, local time. Only meaningful for `custom`, and
-   * half-filled while the user is still picking — `react-day-picker` reports
-   * the first click as `{ from }` alone.
+   * Only meaningful for `custom`, and half-filled while the user is still
+   * picking — the picker reports the first click as `{ from }` alone.
    */
-  range: DateRange | null;
+  range: RewardDateRange | null;
 };
 
 export const DEFAULT_REWARD_WINDOW: RewardWindow = { period: DEFAULT_REWARD_PERIOD, range: null };
@@ -37,6 +42,15 @@ export function periodDays(period: RewardPeriod): number | null {
   return DAYS_BY_PERIOD[period];
 }
 
+function isCustom(rewardWindow: RewardWindow): boolean {
+  return rewardWindow.period === 'custom';
+}
+
+/** The range behind a custom window; empty for presets and before a pick. */
+function customRange(rewardWindow: RewardWindow): Partial<RewardDateRange> {
+  return isCustom(rewardWindow) ? (rewardWindow.range ?? {}) : {};
+}
+
 /**
  * Unix **seconds** the window covers — the unit the indexer stamps payouts with
  * — both bounds inclusive of the whole day the user picked: someone asking for
@@ -45,17 +59,17 @@ export function periodDays(period: RewardPeriod): number | null {
  * `null` bounds mean "unbounded that way", which is what `all` is, and what a
  * half-picked custom range is until its other end lands.
  */
-export function windowBounds(window: RewardWindow, now = new Date()): { from: number | null; to: number | null } {
-  if (window.period === 'custom') {
-    const { from, to } = window.range ?? {};
+export function windowBounds(rewardWindow: RewardWindow, now = new Date()): { from: number | null; to: number | null } {
+  if (isCustom(rewardWindow)) {
+    const { from, to } = customRange(rewardWindow);
 
     return {
       from: from ? Math.floor(startOfDayMs(from) / 1000) : null,
-      to: to ? Math.floor((startOfDayMs(to) + DAY_MS - 1) / 1000) : null,
+      to: to ? Math.floor(endOfDayMs(to) / 1000) : null,
     };
   }
 
-  const start = periodStart(window.period, now);
+  const start = periodStart(rewardWindow.period, now);
 
   return { from: start ?? null, to: null };
 }
@@ -65,39 +79,41 @@ function startOfDayMs(date: Date): number {
 }
 
 /**
- * Days the window spans, used to annualise what it earned. A custom range
- * counts both end days, so 1 Jul – 31 Jul is 31 days rather than 30.
+ * The last millisecond of the local day. Taken from the next midnight rather
+ * than `start + 24h`: a day that changes the clocks is 23 or 25 hours long.
  */
-export function windowDays(window: RewardWindow): number | null {
-  if (window.period !== 'custom') return periodDays(window.period);
-
-  const { from, to } = window.range ?? {};
-  if (!from || !to) return null;
-
-  return Math.max(1, Math.round((startOfDayMs(to) - startOfDayMs(from)) / DAY_MS) + 1);
+function endOfDayMs(date: Date): number {
+  return new Date(date.getFullYear(), date.getMonth(), date.getDate() + 1).getTime() - 1;
 }
 
 /** Whether the window is fully specified — a half-picked range is not. */
-export function isWindowReady(window: RewardWindow): boolean {
-  return window.period !== 'custom' || Boolean(window.range?.from && window.range.to);
+export function isWindowReady(rewardWindow: RewardWindow): boolean {
+  const { from, to } = customRange(rewardWindow);
+
+  return !isCustom(rewardWindow) || Boolean(from && to);
 }
 
 /**
  * A custom window still waiting for its dates. The drill-down reports nothing
  * for it — falling back to "all time" would answer a question nobody asked.
  */
-export function isCustomWindowPending(window: RewardWindow): boolean {
-  return window.period === 'custom' && !isWindowReady(window);
+export function isCustomWindowPending(rewardWindow: RewardWindow): boolean {
+  return isCustom(rewardWindow) && !isWindowReady(rewardWindow);
 }
 
-/** Short label for a file name: `30d`, `all`, or `2026-07-01_2026-07-31`. */
-export function windowSlug(window: RewardWindow): string {
-  if (window.period !== 'custom') return window.period;
+/**
+ * Short label for a file name: `30d`, `all`, or
+ * `from-2026-07-01-to-2026-07-31`. Spelled with words rather than a symbol
+ * between the days because the file name folds every non-alphanumeric into `-`
+ * and three dates in a row do not read.
+ */
+export function windowSlug(rewardWindow: RewardWindow): string {
+  if (!isCustom(rewardWindow)) return rewardWindow.period;
 
-  const { from, to } = window.range ?? {};
+  const { from, to } = customRange(rewardWindow);
   if (!from || !to) return 'custom';
 
-  return `${toIsoDay(from)}_${toIsoDay(to)}`;
+  return `from-${toIsoDay(from)}-to-${toIsoDay(to)}`;
 }
 
 function toIsoDay(date: Date): string {
@@ -133,28 +149,22 @@ export function periodStart(period: RewardPeriod, now = new Date()): number | un
  * from the chain's own era duration. Capped by `historyDepth`: nothing older is
  * on chain to attribute a reward to, and asking for it costs an indexer page
  * walk that can only come back empty.
- */
-export function erasInPeriod(period: RewardPeriod, eraDurationMs: number | null, historyDepth: number): number {
-  return erasInWindow({ period, range: null }, eraDurationMs, historyDepth);
-}
-
-/**
- * Same, for a window that may be a custom range.
  *
- * Counted from **now** back to the range's start — eras are numbered from the
- * active one, so a July window looked at in September reaches back over the
- * eras since July. `windowEraRange` trims the ones after its end off again.
+ * A custom range is counted from **now** back to its start — eras are numbered
+ * from the active one, so a July window looked at in September reaches back
+ * over the eras since July. `windowEraRange` trims the ones after its end off
+ * again.
  */
 export function erasInWindow(
-  window: RewardWindow,
+  rewardWindow: RewardWindow,
   eraDurationMs: number | null,
   historyDepth: number,
   now = Date.now(),
 ): number {
   if (!eraDurationMs || eraDurationMs <= 0) return historyDepth;
 
-  if (window.period === 'custom') {
-    const from = window.range?.from;
+  if (isCustom(rewardWindow)) {
+    const { from } = customRange(rewardWindow);
     if (!from) return historyDepth;
 
     const span = Math.max(DAY_MS, now - startOfDayMs(from));
@@ -162,7 +172,7 @@ export function erasInWindow(
     return Math.min(historyDepth, Math.max(1, Math.ceil(span / eraDurationMs)));
   }
 
-  const days = periodDays(window.period);
+  const days = periodDays(rewardWindow.period);
   if (days === null) return historyDepth;
 
   return Math.min(historyDepth, getErasInDays(days, eraDurationMs));
@@ -178,8 +188,9 @@ type ChainEraFacts = {
 };
 
 /**
- * The closed eras of a chain that fall inside the window, `null` when none
- * does.
+ * The closed eras of a chain that fall inside the window, `null` when none does
+ * — or when the window is a custom range still waiting for its dates, since
+ * nothing is fetched or reported until both ends land.
  *
  * The active era is never part of it: it has not paid anything yet, so its
  * arithmetic is not final. A preset therefore ends at the last closed era and
@@ -188,12 +199,14 @@ type ChainEraFacts = {
  * captioned "over the period". Era boundaries are only known to the day, so an
  * era straddling either end is kept rather than dropped.
  */
-export function windowEraRange(window: RewardWindow, chain: ChainEraFacts, now = Date.now()): EraRange | null {
+export function windowEraRange(rewardWindow: RewardWindow, chain: ChainEraFacts, now = Date.now()): EraRange | null {
+  if (!isWindowReady(rewardWindow)) return null;
+
   const { activeEra, eraDurationMs, historyDepth } = chain;
   const lastClosed = activeEra - 1;
 
-  const eraFrom = Math.max(0, lastClosed - erasInWindow(window, eraDurationMs, historyDepth, now) + 1);
-  const eraTo = lastClosed - erasSinceWindowEnd(window, eraDurationMs, now);
+  const eraFrom = Math.max(0, lastClosed - erasInWindow(rewardWindow, eraDurationMs, historyDepth, now) + 1);
+  const eraTo = lastClosed - erasSinceWindowEnd(rewardWindow, eraDurationMs, now);
 
   return eraTo < eraFrom ? null : { eraFrom, eraTo };
 }
@@ -203,14 +216,14 @@ export function windowEraRange(window: RewardWindow, chain: ChainEraFacts, now =
  * between its end and now. Zero for every window that reaches now, which is
  * every preset and a custom range whose end is today or still unpicked.
  */
-function erasSinceWindowEnd(window: RewardWindow, eraDurationMs: number | null, now: number): number {
-  if (window.period !== 'custom' || !eraDurationMs || eraDurationMs <= 0) return 0;
+function erasSinceWindowEnd(rewardWindow: RewardWindow, eraDurationMs: number | null, now: number): number {
+  if (!eraDurationMs || eraDurationMs <= 0) return 0;
 
-  const to = window.range?.to;
+  const { to } = customRange(rewardWindow);
   if (!to) return 0;
 
-  // The day after the last picked one, at midnight — the instant the window closed.
-  const elapsed = now - (startOfDayMs(to) + DAY_MS);
+  // The first instant after the last picked day — when the window closed.
+  const elapsed = now - (endOfDayMs(to) + 1);
   if (elapsed <= 0) return 0;
 
   // The era the end falls into may still hold the window's last hours; only

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -22,7 +22,13 @@ import { formatAssetAmountExact, sumFiat } from '../lib/amounts';
 import { csvFileName, rawPayoutCsvColumns } from '../lib/csv';
 import { DEFAULT_CLAIM_WINDOW_ERAS, daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
 import { formatFiat } from '../lib/format-fiat';
-import { type RewardWindow, DEFAULT_REWARD_WINDOW, windowBounds, windowSlug } from '../lib/reward-period';
+import {
+  type RewardWindow,
+  DEFAULT_REWARD_WINDOW,
+  isCustomWindowPending,
+  windowBounds,
+  windowSlug,
+} from '../lib/reward-period';
 import { DEFAULT_REWARD_SORT, isRewardSortColumn, sortRewardRows } from '../lib/reward-sorting';
 import { type ClaimRow } from '../lib/types';
 import {
@@ -56,6 +62,9 @@ type Props = {
 };
 
 type DisplayRow = ValidatorRewardRow & { color: string; accruedFiat: string; expiryDays: number | null };
+
+// Stable empty selection — a fresh [] per render would re-key the memos below.
+const NO_POSITIONS: StakingPosition[] = [];
 
 /** A segmented-control button, styled like `Tabs.Trigger` without its panels. */
 const FilterChip = ({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) => (
@@ -99,6 +108,12 @@ export const ClaimModal = memo(
     const blockedChains = useUnit(dashboardStakingKpiActions.$blockedClaimChains);
 
     const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
+    /**
+     * A Custom tab with no dates yet. Nothing is fetched or reported for it —
+     * an unbounded window would quietly read as "all time" behind a tab that
+     * says "custom".
+     */
+    const windowPending = isCustomWindowPending(rewardWindow);
     const [chainFilter, setChainFilter] = useState<ChainId | null>(null);
     const [nominatorFilter, setNominatorFilter] = useState<AccountId | null>(null);
     const [tableSort, setTableSort] = useState<TableSort>(DEFAULT_REWARD_SORT);
@@ -106,7 +121,7 @@ export const ClaimModal = memo(
     const hoveredId = hovered?.id ?? null;
     const listRef = useRef<HTMLDivElement>(null);
 
-    const { rewards, pendingChains } = useValidatorRewards(positions, rewardWindow);
+    const { rewards, pendingChains } = useValidatorRewards(windowPending ? NO_POSITIONS : positions, rewardWindow);
     const pendingChainSet = useMemo(() => new Set(pendingChains), [pendingChains]);
 
     /**
@@ -346,18 +361,18 @@ export const ClaimModal = memo(
     const rawPayouts = useRawRewardPayouts(payoutRequests);
 
     const bounds = windowBounds(rewardWindow);
-    const windowedPayouts = useMemo(
-      () =>
-        rawPayouts.filter(
-          (payout) =>
-            (bounds.from === null || payout.timestamp >= bounds.from) &&
-            (bounds.to === null || payout.timestamp <= bounds.to) &&
-            (chainFilter === null || payout.chainId === chainFilter) &&
-            // The indexer speaks addresses; the filter speaks account ids.
-            (nominatorFilter === null || toAccountId(payout.address) === nominatorFilter),
-        ),
-      [rawPayouts, bounds.from, bounds.to, chainFilter, nominatorFilter],
-    );
+    const windowedPayouts = useMemo(() => {
+      if (windowPending) return [];
+
+      return rawPayouts.filter(
+        (payout) =>
+          (bounds.from === null || payout.timestamp >= bounds.from) &&
+          (bounds.to === null || payout.timestamp <= bounds.to) &&
+          (chainFilter === null || payout.chainId === chainFilter) &&
+          // The indexer speaks addresses; the filter speaks account ids.
+          (nominatorFilter === null || toAccountId(payout.address) === nominatorFilter),
+      );
+    }, [rawPayouts, windowPending, bounds.from, bounds.to, chainFilter, nominatorFilter]);
 
     /**
      * Exports the indexer's own payout rows, scoped to the period on screen.
@@ -712,7 +727,7 @@ export const ClaimModal = memo(
                                 </CaptionText>
                               </div>
                             ) : null}
-                            {pendingChainSet.has(nominator.chainId) ? (
+                            {windowPending ? null : pendingChainSet.has(nominator.chainId) ? (
                               <Skeleton width="56px" height="12px" />
                             ) : (
                               <HelpText className="shrink-0 text-text-tertiary tabular-nums">
@@ -726,7 +741,11 @@ export const ClaimModal = memo(
                   </div>
 
                   <div ref={listRef} className="min-w-0 flex-1 overflow-y-auto">
-                    {displayRows.length === 0 ? (
+                    {windowPending ? (
+                      <FootnoteText className="px-3 py-6 text-text-tertiary">
+                        {t('dashboard.staking.kpi.rewards.period.pickDates')}
+                      </FootnoteText>
+                    ) : displayRows.length === 0 ? (
                       loading ? (
                         <RewardsTableSkeleton titles={columnTitles} />
                       ) : (
@@ -781,7 +800,7 @@ export const ClaimModal = memo(
                         .join(' · ')}
             </FootnoteText>
             <div className="flex items-center gap-2">
-              <Button variant="text" size="sm" onClick={handleExport}>
+              <Button variant="text" size="sm" disabled={windowPending} onClick={handleExport}>
                 {t('dashboard.staking.kpi.exportCsv')}
               </Button>
               <Tooltip open={claimEnabled ? false : undefined}>

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -22,7 +22,7 @@ import { formatAssetAmountExact, sumFiat } from '../lib/amounts';
 import { csvFileName, rawPayoutCsvColumns } from '../lib/csv';
 import { DEFAULT_CLAIM_WINDOW_ERAS, daysUntilExpiry, erasUntilExpiry, oldestPayoutEra } from '../lib/expiry';
 import { formatFiat } from '../lib/format-fiat';
-import { type RewardPeriod, DEFAULT_REWARD_PERIOD, periodStart } from '../lib/reward-period';
+import { type RewardWindow, DEFAULT_REWARD_WINDOW, windowBounds, windowSlug } from '../lib/reward-period';
 import { DEFAULT_REWARD_SORT, isRewardSortColumn, sortRewardRows } from '../lib/reward-sorting';
 import { type ClaimRow } from '../lib/types';
 import {
@@ -98,7 +98,7 @@ export const ClaimModal = memo(
     const signableChains = useSignableChains();
     const blockedChains = useUnit(dashboardStakingKpiActions.$blockedClaimChains);
 
-    const [period, setPeriod] = useState<RewardPeriod>(DEFAULT_REWARD_PERIOD);
+    const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
     const [chainFilter, setChainFilter] = useState<ChainId | null>(null);
     const [nominatorFilter, setNominatorFilter] = useState<AccountId | null>(null);
     const [tableSort, setTableSort] = useState<TableSort>(DEFAULT_REWARD_SORT);
@@ -106,7 +106,7 @@ export const ClaimModal = memo(
     const hoveredId = hovered?.id ?? null;
     const listRef = useRef<HTMLDivElement>(null);
 
-    const { rewards, pendingChains } = useValidatorRewards(positions, period);
+    const { rewards, pendingChains } = useValidatorRewards(positions, rewardWindow);
     const pendingChainSet = useMemo(() => new Set(pendingChains), [pendingChains]);
 
     /**
@@ -345,17 +345,18 @@ export const ClaimModal = memo(
 
     const rawPayouts = useRawRewardPayouts(payoutRequests);
 
-    const windowStart = periodStart(period);
+    const bounds = windowBounds(rewardWindow);
     const windowedPayouts = useMemo(
       () =>
         rawPayouts.filter(
           (payout) =>
-            (windowStart === undefined || payout.timestamp >= windowStart) &&
+            (bounds.from === null || payout.timestamp >= bounds.from) &&
+            (bounds.to === null || payout.timestamp <= bounds.to) &&
             (chainFilter === null || payout.chainId === chainFilter) &&
             // The indexer speaks addresses; the filter speaks account ids.
             (nominatorFilter === null || toAccountId(payout.address) === nominatorFilter),
         ),
-      [rawPayouts, windowStart, chainFilter, nominatorFilter],
+      [rawPayouts, bounds.from, bounds.to, chainFilter, nominatorFilter],
     );
 
     /**
@@ -389,8 +390,11 @@ export const ClaimModal = memo(
       const network =
         chainFilter === null ? 'all-networks' : (networks.find((n) => n.chainId === chainFilter)?.chainName ?? '');
 
-      downloadCsv(csvFileName('reward-payouts', { parts: [network, period] }), buildCsv(columns, windowedPayouts));
-    }, [windowedPayouts, scopedClaimRows, chainFilter, networks, period, t]);
+      downloadCsv(
+        csvFileName('reward-payouts', { parts: [network, windowSlug(rewardWindow)] }),
+        buildCsv(columns, windowedPayouts),
+      );
+    }, [windowedPayouts, scopedClaimRows, chainFilter, networks, rewardWindow, t]);
 
     const handleClaimRow = useCallback(
       (row: ValidatorRewardRow) => claimRequested({ requests: toClaimRequests([row], signableChains) }),
@@ -610,7 +614,7 @@ export const ClaimModal = memo(
                 slightly different number (actual payouts land on their own
                 clock) read as a discrepancy rather than a different fact. */}
               <div className="flex items-center justify-end gap-4">
-                <PeriodTabs value={period} onChange={setPeriod} />
+                <PeriodTabs value={rewardWindow} onChange={setRewardWindow} />
               </div>
 
               {/* One network is not a choice — the filter appears with the second. */}

--- a/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/ClaimModal.tsx
@@ -63,9 +63,6 @@ type Props = {
 
 type DisplayRow = ValidatorRewardRow & { color: string; accruedFiat: string; expiryDays: number | null };
 
-// Stable empty selection — a fresh [] per render would re-key the memos below.
-const NO_POSITIONS: StakingPosition[] = [];
-
 /** A segmented-control button, styled like `Tabs.Trigger` without its panels. */
 const FilterChip = ({ label, active, onClick }: { label: string; active: boolean; onClick: () => void }) => (
   <button
@@ -109,9 +106,10 @@ export const ClaimModal = memo(
 
     const [rewardWindow, setRewardWindow] = useState<RewardWindow>(DEFAULT_REWARD_WINDOW);
     /**
-     * A Custom tab with no dates yet. Nothing is fetched or reported for it —
-     * an unbounded window would quietly read as "all time" behind a tab that
-     * says "custom".
+     * A Custom tab with no dates yet. Nothing is reported for it — an unbounded
+     * window would quietly read as "all time" behind a tab that says "custom".
+     * The fetch side is handled by `windowEraRange`, which yields no era range
+     * for a pending window, so the hook below simply has nothing to request.
      */
     const windowPending = isCustomWindowPending(rewardWindow);
     const [chainFilter, setChainFilter] = useState<ChainId | null>(null);
@@ -121,7 +119,7 @@ export const ClaimModal = memo(
     const hoveredId = hovered?.id ?? null;
     const listRef = useRef<HTMLDivElement>(null);
 
-    const { rewards, pendingChains } = useValidatorRewards(windowPending ? NO_POSITIONS : positions, rewardWindow);
+    const { rewards, pendingChains } = useValidatorRewards(positions, rewardWindow);
     const pendingChainSet = useMemo(() => new Set(pendingChains), [pendingChains]);
 
     /**

--- a/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
@@ -5,7 +5,7 @@ import { type RewardWindow, REWARD_PERIODS } from '../lib/reward-period';
 
 type Props = {
   value: RewardWindow;
-  onChange: (window: RewardWindow) => void;
+  onChange: (rewardWindow: RewardWindow) => void;
 };
 
 /** The window everything time-bounded on the rewards screen is read through. */

--- a/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
@@ -1,10 +1,11 @@
 import { useI18n } from '@/shared/i18n';
 import { cnTw } from '@/shared/lib/utils';
-import { type RewardPeriod, REWARD_PERIODS } from '../lib/reward-period';
+import { DateRangePicker } from '@/shared/ui-kit';
+import { type RewardWindow, REWARD_PERIODS } from '../lib/reward-period';
 
 type Props = {
-  value: RewardPeriod;
-  onChange: (period: RewardPeriod) => void;
+  value: RewardWindow;
+  onChange: (window: RewardWindow) => void;
 };
 
 /** The window everything time-bounded on the rewards screen is read through. */
@@ -12,22 +13,38 @@ export const PeriodTabs = ({ value, onChange }: Props) => {
   const { t } = useI18n();
 
   return (
-    <div className="flex w-fit shrink-0 items-center gap-x-1 rounded-md bg-tab-background p-0.5">
-      {REWARD_PERIODS.map((period) => (
-        <button
-          key={period}
-          type="button"
-          className={cnTw(
-            'cursor-pointer rounded-sm px-3 py-1 text-button-small transition-all duration-100',
-            value === period
-              ? 'bg-white text-text-primary shadow-card-shadow'
-              : 'text-text-secondary hover:text-text-primary',
-          )}
-          onClick={() => onChange(period)}
-        >
-          {t(`dashboard.staking.kpi.rewards.period.${period}`)}
-        </button>
-      ))}
+    <div className="flex shrink-0 items-center gap-x-2">
+      <div className="flex w-fit items-center gap-x-1 rounded-md bg-tab-background p-0.5">
+        {REWARD_PERIODS.map((period) => (
+          <button
+            key={period}
+            type="button"
+            className={cnTw(
+              'cursor-pointer rounded-sm px-3 py-1 text-button-small transition-all duration-100',
+              value.period === period
+                ? 'bg-white text-text-primary shadow-card-shadow'
+                : 'text-text-secondary hover:text-text-primary',
+            )}
+            onClick={() => onChange({ period, range: period === 'custom' ? value.range : null })}
+          >
+            {t(`dashboard.staking.kpi.rewards.period.${period}`)}
+          </button>
+        ))}
+      </div>
+
+      {/*
+        The picker appears only under the Custom tab: a date field sitting next
+        to "30d" invites the user to set both and wonder which one won.
+      */}
+      {value.period === 'custom' && (
+        <div className="w-[160px]">
+          <DateRangePicker
+            value={value.range ?? undefined}
+            placeholder={t('dashboard.staking.kpi.rewards.period.pickDates')}
+            onChange={(range) => onChange({ period: 'custom', range: range ?? null })}
+          />
+        </div>
+      )}
     </div>
   );
 };

--- a/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/PeriodTabs.tsx
@@ -25,7 +25,10 @@ export const PeriodTabs = ({ value, onChange }: Props) => {
                 ? 'bg-white text-text-primary shadow-card-shadow'
                 : 'text-text-secondary hover:text-text-primary',
             )}
-            onClick={() => onChange({ period, range: period === 'custom' ? value.range : null })}
+            // The range rides along under the presets, which ignore it, so that
+            // Custom comes back to the dates it was left at rather than to
+            // "Pick dates"; only the picker's own Reset clears them.
+            onClick={() => onChange({ ...value, period })}
           >
             {t(`dashboard.staking.kpi.rewards.period.${period}`)}
           </button>

--- a/src/renderer/features/dashboard-staking-kpi/ui/__tests__/PeriodTabs.test.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/__tests__/PeriodTabs.test.tsx
@@ -1,0 +1,57 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+import { type RewardWindow } from '../../lib/reward-period';
+import { PeriodTabs } from '../PeriodTabs';
+
+vi.mock('@/shared/i18n', () => ({
+  useI18n: () => ({ t: (key: string) => key }),
+}));
+
+// Local-time days, the way the picker hands them over.
+const july = { from: new Date(2026, 6, 1), to: new Date(2026, 6, 31) };
+const customJuly: RewardWindow = { period: 'custom', range: july };
+
+const tab = (period: RewardWindow['period']) =>
+  screen.getByRole('button', { name: `dashboard.staking.kpi.rewards.period.${period}` });
+
+describe('PeriodTabs', () => {
+  it('shows the picked range under the Custom tab', () => {
+    render(<PeriodTabs value={customJuly} onChange={vi.fn()} />);
+
+    expect(screen.getByText('Jul 01 - Jul 31')).not.toBeNull();
+  });
+
+  it('hides the picker, not the range, when a preset takes over', () => {
+    const onChange = vi.fn();
+    render(<PeriodTabs value={customJuly} onChange={onChange} />);
+
+    fireEvent.click(tab('30d'));
+
+    expect(onChange).toHaveBeenCalledWith({ period: '30d', range: july });
+  });
+
+  it('keeps the field out of sight while a preset is on', () => {
+    render(<PeriodTabs value={{ period: '30d', range: july }} onChange={vi.fn()} />);
+
+    expect(screen.queryByText('Jul 01 - Jul 31')).toBeNull();
+  });
+
+  it('brings the remembered range back with the Custom tab', () => {
+    const onChange = vi.fn();
+    render(<PeriodTabs value={{ period: '30d', range: july }} onChange={onChange} />);
+
+    fireEvent.click(tab('custom'));
+
+    expect(onChange).toHaveBeenCalledWith({ period: 'custom', range: july });
+  });
+
+  it('opens Custom empty when nothing was ever picked', () => {
+    const onChange = vi.fn();
+    render(<PeriodTabs value={{ period: '30d', range: null }} onChange={onChange} />);
+
+    fireEvent.click(tab('custom'));
+
+    expect(onChange).toHaveBeenCalledWith({ period: 'custom', range: null });
+  });
+});

--- a/src/renderer/features/dashboard-staking-kpi/ui/__tests__/PeriodTabs.test.tsx
+++ b/src/renderer/features/dashboard-staking-kpi/ui/__tests__/PeriodTabs.test.tsx
@@ -1,12 +1,19 @@
 import { fireEvent, render, screen } from '@testing-library/react';
 import { describe, expect, it, vi } from 'vitest';
 
-import { type RewardWindow } from '../../lib/reward-period';
+import { type RewardWindow, REWARD_PERIODS } from '../../lib/reward-period';
 import { PeriodTabs } from '../PeriodTabs';
 
 vi.mock('@/shared/i18n', () => ({
   useI18n: () => ({ t: (key: string) => key }),
 }));
+
+/**
+ * The picker is the one button beyond the period tabs. Counted rather than
+ * matched by its formatted dates so the test does not lean on the picker's own
+ * date format.
+ */
+const pickerShown = () => screen.getAllByRole('button').length === REWARD_PERIODS.length + 1;
 
 // Local-time days, the way the picker hands them over.
 const july = { from: new Date(2026, 6, 1), to: new Date(2026, 6, 31) };
@@ -16,10 +23,10 @@ const tab = (period: RewardWindow['period']) =>
   screen.getByRole('button', { name: `dashboard.staking.kpi.rewards.period.${period}` });
 
 describe('PeriodTabs', () => {
-  it('shows the picked range under the Custom tab', () => {
+  it('shows the picker under the Custom tab', () => {
     render(<PeriodTabs value={customJuly} onChange={vi.fn()} />);
 
-    expect(screen.getByText('Jul 01 - Jul 31')).not.toBeNull();
+    expect(pickerShown()).toBe(true);
   });
 
   it('hides the picker, not the range, when a preset takes over', () => {
@@ -34,7 +41,7 @@ describe('PeriodTabs', () => {
   it('keeps the field out of sight while a preset is on', () => {
     render(<PeriodTabs value={{ period: '30d', range: july }} onChange={vi.fn()} />);
 
-    expect(screen.queryByText('Jul 01 - Jul 31')).toBeNull();
+    expect(pickerShown()).toBe(false);
   });
 
   it('brings the remembered range back with the Custom tab', () => {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -967,7 +967,9 @@
           "period": {
             "7d": "7d",
             "30d": "30d",
-            "all": "All time"
+            "all": "All time",
+            "custom": "Custom",
+            "pickDates": "Pick dates"
           }
         },
         "positions": {


### PR DESCRIPTION
**Was:** rewards drill-down and its CSV export covered fixed windows only — 7 days, 30 days, all time.
**Now:** a **Custom** tab opens a date-range picker; the earned attribution, the donut, the table and the CSV follow the chosen window (both days inclusive). The claim list is unaffected — payouts expire by era, not by date.

**Testing:** `pnpm types:go`, `pnpm vitest run src/renderer/features/dashboard-staking-kpi` (14 files / 153 tests; reward-period: 36, PeriodTabs: 5 — a picked range survives switching to a preset and comes back with Custom), `pnpm check:feature-map --changed origin/dev`, eslint/prettier on the diff — clean; manual: Custom tab + picker stay on one line in the rewards modal header at its minimum width, a Custom tab without dates shows the "Pick dates" hint with no donut / export and no fetch, a picked range drives the donut / Earned column / CSV name, claim list unchanged.