### PR TITLE
fix(ui-kit): virtualized table renders rows when data is present on first mount

### DIFF
--- a/src/renderer/shared/ui-kit/Table/Table.test.tsx
+++ b/src/renderer/shared/ui-kit/Table/Table.test.tsx
@@ -1,0 +1,67 @@
+import { act, render, screen } from '@testing-library/react';
+import { useRef } from 'react';
+
+import { ScrollArea } from '../ScrollArea/ScrollArea';
+
+import { type Column, Table } from './Table';
+
+type Row = { id: string; name: string };
+
+const columns: Column<Row>[] = [{ key: 'name', title: 'Name' }];
+
+const rows: Row[] = Array.from({ length: 100 }, (_, index) => ({ id: `row-${index}`, name: `Row ${index}` }));
+
+const ROW_HEIGHT = 40;
+const VIEWPORT_HEIGHT = 200;
+
+/**
+ * Mirrors how `ValidatorTable` wires the table: the scroll element is the
+ * `ScrollArea` viewport, an ancestor of the table, reached through a ref.
+ */
+const VirtualizedTable = ({ data }: { data: Row[] }) => {
+  const viewportRef = useRef<HTMLDivElement>(null);
+
+  return (
+    <ScrollArea viewportRef={viewportRef}>
+      <Table
+        columns={columns}
+        data={data}
+        getRowKey={row => row.id}
+        virtualization={{ getScrollElement: () => viewportRef.current, rowHeight: ROW_HEIGHT }}
+      />
+    </ScrollArea>
+  );
+};
+
+describe('Table virtualization', () => {
+  beforeEach(() => {
+    // happy-dom has no layout; give the viewport a size (the virtualizer reads
+    // `offsetHeight`) so there is something to fit rows into.
+    vi.spyOn(HTMLElement.prototype, 'offsetHeight', 'get').mockImplementation(function (this: HTMLElement) {
+      return this.classList.contains('scrollArea') ? VIEWPORT_HEIGHT : 0;
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  test('renders rows when the data is already there on first mount', async () => {
+    await act(async () => {
+      render(<VirtualizedTable data={rows} />);
+    });
+
+    expect(screen.getByText('Row 0')).toBeInTheDocument();
+    expect(screen.queryByText('Row 99')).not.toBeInTheDocument();
+  });
+
+  test('renders rows once the data arrives after mount', async () => {
+    const { rerender } = render(<VirtualizedTable data={[]} />);
+
+    await act(async () => {
+      rerender(<VirtualizedTable data={rows} />);
+    });
+
+    expect(screen.getByText('Row 0')).toBeInTheDocument();
+  });
+});

--- a/src/renderer/shared/ui-kit/Table/Table.tsx
+++ b/src/renderer/shared/ui-kit/Table/Table.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type ReactNode, isValidElement, memo, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import { type ReactNode, isValidElement, memo, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
 
 import { cnTw } from '@/shared/lib/utils';
 
@@ -281,12 +281,15 @@ const VirtualizedTableBody = <T,>({
   const [scrollMargin, setScrollMargin] = useState(0);
 
   // The scroll element is an *ancestor* of this table, and React attaches an
-  // ancestor's ref after a descendant's layout effect has already run — so on
-  // first mount `getScrollElement()` answers `null`. Resolving it into state on
-  // every render (a ref read, nothing measured) is what lets the measuring
-  // effect below start once it actually exists.
+  // ancestor's ref after a descendant's layout effect has already run — so in
+  // a layout effect on first mount `getScrollElement()` answers `null`, and if
+  // nothing re-renders the table afterwards (the data was already there when
+  // it mounted) it stays `null` and the virtualizer renders no rows at all.
+  // A passive effect runs once the whole commit is done, refs included, so
+  // resolving here (a ref read, nothing measured) is what lets the measuring
+  // effect below start as soon as the element exists.
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
-  useLayoutEffect(() => {
+  useEffect(() => {
     const next = virtualization.getScrollElement();
     setScrollElement(prev => (prev === next ? prev : next));
   });

--- a/src/renderer/shared/ui-kit/VirtualList/VirtualList.tsx
+++ b/src/renderer/shared/ui-kit/VirtualList/VirtualList.tsx
@@ -1,5 +1,5 @@
 import { useVirtualizer } from '@tanstack/react-virtual';
-import { type ReactNode, useLayoutEffect, useRef, useState } from 'react';
+import { type ReactNode, useEffect, useLayoutEffect, useRef, useState } from 'react';
 
 import { cnTw } from '@/shared/lib/utils';
 import { useScrollAreaViewport } from '../ScrollArea/context';
@@ -56,11 +56,15 @@ export const VirtualList = <T,>({
   const [scrollMargin, setScrollMargin] = useState(0);
 
   // The viewport is an *ancestor*, and React attaches an ancestor's ref only
-  // after a descendant's layout effect has run — so on first mount the ref is
-  // still empty. Resolving it into state on every render (a ref read, nothing
-  // measured) is what lets the measuring effect below start once it exists.
+  // after a descendant's layout effect has run — so in a layout effect on
+  // first mount the ref is still empty, and if nothing re-renders the list
+  // afterwards (the items were already there when it mounted) it stays empty
+  // and only the placeholder below ever shows. A passive effect runs once the
+  // whole commit is done, refs included, so resolving here (a ref read,
+  // nothing measured) is what lets the measuring effect below start as soon
+  // as the viewport exists.
   const [scrollElement, setScrollElement] = useState<HTMLElement | null>(null);
-  useLayoutEffect(() => {
+  useEffect(() => {
     const next = viewportRef?.current ?? null;
     setScrollElement(prev => (prev === next ? prev : next));
   });
@@ -124,9 +128,9 @@ export const VirtualList = <T,>({
 
     // Inside a `ScrollArea`, but this is the first render of the commit that
     // creates the viewport, so its ref is not attached yet. Render only the
-    // full-height placeholder: the layout effect above resolves the viewport
-    // and re-renders with real rows before the browser paints, so nothing
-    // blank is ever shown — while rendering the rows here would mount the
+    // full-height placeholder: the effect above resolves the viewport as soon
+    // as the commit is done and re-renders with real rows, so at most a blank
+    // frame is shown — while rendering the rows here would mount the
     // entire list once just to throw it away, which is the cost this component
     // exists to avoid.
     return (


### PR DESCRIPTION
## Description
Opening **Change validators** from the dashboard Positions drawer showed an empty table while the footer said "Showing 600 of 600 · 12 of 16 selected shown". The rows were in the data; the virtualized `Table` just never rendered them.

Root cause: `VirtualizedTableBody` (and `VirtualList`) resolve their scroll element — the `ScrollArea` viewport, an *ancestor* — inside a `useLayoutEffect`. React attaches an ancestor's ref only after the descendants' layout effects have run, so on first mount the read returns `null`. The code relied on "some later render" to pick it up, but when the data is already there in the first commit (the elected set is cached by the positions widget) nothing re-renders, the virtualizer keeps `scrollElement === null` and yields zero rows. Bond & nominate looked fine only because its data arrives after mount.

Fix: resolve the scroll element in a passive `useEffect`, which runs after the whole commit (refs included). Same change applied to `VirtualList`, which carried the identical pattern.

## Related Issues
—

## Changes Made
- `ui-kit/Table`: resolve the virtualization scroll element in `useEffect` instead of `useLayoutEffect`
- `ui-kit/VirtualList`: same fix; comment on the placeholder branch updated accordingly
- `Table.test.tsx`: virtualized table renders rows when data is present on first mount (failed before the fix) and when data arrives after mount

## Screenshots/Recordings
Before: Change validators modal opens with an empty table and "Showing 600 of 600" in the footer.

After — rows render immediately on open:

<img width="1323" height="738" alt="change-validators-after" src="https://github.com/user-attachments/assets/789f839b-14b7-49a7-9395-7f4f6cb880a6" />

## Test steps
1. Dashboard → Staking tab → open a position that has nominations → **Change validators**
2. The table shows validators right away (previously empty); current nominations are checked
3. Close and reopen the modal — rows still render
4. `pnpm vitest run src/renderer/shared/ui-kit/Table src/renderer/shared/ui-kit/VirtualList`

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [x] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
