### PR TITLE
fix(staking): dashboard staked figure is the active stake, not the ledger total

### DIFF
--- a/src/renderer/aggregates/staking-positions/README.md
+++ b/src/renderer/aggregates/staking-positions/README.md
@@ -124,9 +124,10 @@ Those rules live in one pure function, `summarizePositions(positions)`, which is
 exported alongside it. A consumer that narrows the selection further — the dashboard's KPI row follows its own account
 picker on top of the selection — summarizes the subset with the same function instead of restating the rules.
 
-`$summary.totalStaked` is the ledger's **total** — bonded plus everything still unbonding — matching what the dashboard
-showed before this aggregate existed. `redeemable` and `totalUnbonding` split the unlocking chunks against the active
-era, so they always add up to the unbonding part of that total.
+`$summary.totalStaked` is the sum of the ledgers' **active** stake — what is actually bonded and what `unbond` can take.
+Unlocking chunks are never part of it: `redeemable` and `totalUnbonding` split them against the active era, so
+`totalStaked + redeemable + totalUnbonding` is the ledger total. (It used to be the ledger total itself, which made a
+position whose whole stake was unbonding read as "10 WND staked" while the unbond flow honestly offered 0.)
 
 ## Loading and emptiness
 

--- a/src/renderer/aggregates/staking-positions/__tests__/model.test.ts
+++ b/src/renderer/aggregates/staking-positions/__tests__/model.test.ts
@@ -477,7 +477,7 @@ describe('aggregates/staking-positions', () => {
     expect(summary.activeValidatorCount).toBe(2);
 
     expect(summary.byChain[POLKADOT_AH]).toMatchObject({
-      totalStaked: '3300',
+      totalStaked: '3000',
       redeemable: '100',
       totalUnbonding: '200',
       activeValidatorCount: 1,

--- a/src/renderer/aggregates/staking-positions/__tests__/summary.test.ts
+++ b/src/renderer/aggregates/staking-positions/__tests__/summary.test.ts
@@ -57,6 +57,16 @@ describe('summarizePositions', () => {
     expect(summary.positionCount).toBe(3);
   });
 
+  test('unbonding chunks are not counted as staked', () => {
+    const position = makePosition({ chainId: POLKADOT, total: '100', totalUnbonding: '100' });
+    position.stake = { ...position.stake, active: '0', total: '100' };
+
+    const summary = summarizePositions([position]);
+
+    expect(summary.byChain[POLKADOT]?.totalStaked).toBe('0');
+    expect(summary.byChain[POLKADOT]?.totalUnbonding).toBe('100');
+  });
+
   test('the same validator on two chains counts twice', () => {
     const summary = summarizePositions([
       makePosition({ chainId: POLKADOT, activeValidators: [VAL_A, VAL_B] }),

--- a/src/renderer/aggregates/staking-positions/lib/summary.ts
+++ b/src/renderer/aggregates/staking-positions/lib/summary.ts
@@ -8,7 +8,10 @@ import { type StakingPosition } from '@/domains/staking';
 /** Totals of a single staking chain. Planck amounts are in that chain's asset. */
 export type StakingChainSummary = {
   chainId: ChainId;
-  /** Sum of `stake.total` — bonded plus everything still unbonding. */
+  /**
+   * Sum of `stake.active` — what is actually bonded; unbonding chunks live in
+   * `totalUnbonding` / `redeemable`.
+   */
   totalStaked: string;
   redeemable: string;
   totalUnbonding: string;
@@ -75,7 +78,7 @@ export function summarizePositions(positions: StakingPosition[]): StakingSummary
       validatorsByChain.set(chainId, new Set());
     }
 
-    summary.totalStaked = addPlanck(summary.totalStaked, position.stake.total);
+    summary.totalStaked = addPlanck(summary.totalStaked, position.stake.active);
     summary.redeemable = addPlanck(summary.redeemable, position.redeemable);
     summary.totalUnbonding = addPlanck(summary.totalUnbonding, position.totalUnbonding);
     summary.positionCount += 1;

--- a/src/renderer/features/dashboard-staking-kpi/README.md
+++ b/src/renderer/features/dashboard-staking-kpi/README.md
@@ -65,7 +65,8 @@ to the bottom, so a footer appearing — or a shimmer resolving — never moves 
 
 ### The four cards
 
-- **Total staked** — the fiat total, with a per-asset sub-line. Its footer merges what is still unbonding with what has
+- **Total staked** — the fiat total of the **active** stake, with a per-asset sub-line; what is unbonding is not in it,
+  so the card and its footer never count the same planck twice. The footer merges what is still unbonding with what has
   already matured, because a position whose chunks have all matured has nothing "unbonding" left yet is precisely the
   one that needs the Redeem link.
 - **Est. APY** — a **stake-weighted** blend of the per-chain network APYs, weighted by the **fiat value of the earning

--- a/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
+++ b/src/renderer/features/dashboard-staking-kpi/hooks/useStakingKpi.ts
@@ -300,8 +300,8 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
         chainName: asset.chainName,
         symbol: asset.symbol,
         precision: asset.precision,
-        staked: position.stake.total,
-        stakedFiat: toFiat(position.chainId, position.stake.total),
+        staked: position.stake.active,
+        stakedFiat: toFiat(position.chainId, position.stake.active),
         unbonding: position.unbonding,
         totalUnbonding: position.totalUnbonding,
         redeemable: position.redeemable,
@@ -324,7 +324,7 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
   const breakdownRows = useMemo(() => {
     const rows = positions.map((position, index) => {
       const asset = assets[position.chainId];
-      const fiat = toFiat(position.chainId, position.stake.total);
+      const fiat = toFiat(position.chainId, position.stake.active);
 
       return {
         key: `${position.chainId}:${position.accountId}`,
@@ -334,7 +334,7 @@ export const useStakingKpi = (accountIds: string[]): StakingKpiData => {
         symbol: asset?.symbol ?? '',
         precision: asset?.precision ?? 0,
         value: new BigNumber(fiat).toNumber(),
-        stake: position.stake.total,
+        stake: position.stake.active,
         fiat,
         color: getColorByPriceId(asset?.priceId ?? '', index),
         apy: apyByChain[position.chainId] ?? null,

--- a/src/renderer/features/dashboard-staking-kpi/lib/spread.ts
+++ b/src/renderer/features/dashboard-staking-kpi/lib/spread.ts
@@ -87,7 +87,7 @@ export function buildSpreadRows({
   eraValidatorsByChain,
   metaByChain,
 }: Params): SpreadRow[] {
-  const ordered = [...positions].sort((a, b) => comparePlanck(a.stake.total, b.stake.total));
+  const ordered = [...positions].sort((a, b) => comparePlanck(a.stake.active, b.stake.active));
   const rows: SpreadRow[] = [];
 
   for (const position of ordered) {
@@ -116,7 +116,7 @@ export function buildSpreadRows({
         precision: meta.precision,
         status,
         allocated: individual ? individual.value : status === 'active' ? null : '0',
-        positionTotal: position.stake.total,
+        positionTotal: position.stake.active,
       });
     }
 

--- a/src/renderer/features/dashboard-staking-positions/README.md
+++ b/src/renderer/features/dashboard-staking-positions/README.md
@@ -144,6 +144,9 @@ descending by default, and clearing the sort returns to that default rather than
   done with it: the multisig threshold and the count of pending drafts this very account already initiated on this very
   chain. A validator position adds a `Validator` chip here (with a tooltip) — the one glance-level marker that the rest
   of the row reads differently.
+- **Staked** — the ledger's **active** stake, the same figure the Unbond flow caps against. Chunks that are already
+  unbonding are not "staked": they show in the drawer's unbonding strip and in the KPI footer instead, and a position
+  whose whole stake is unbonding shows `0` here with its `Unbond` chip disabled.
 - **Share** — a share of what the user is _looking at_. Under the dashboard's account filter the denominator is the
   visible chain total, so the column always adds up to 100%.
 - **Status** — `Active` / `Waiting` / `Inactive` / `Bonded`, each with the reason behind it. The reason is the point:

--- a/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
+++ b/src/renderer/features/dashboard-staking-positions/hooks/usePositionRows.ts
@@ -123,7 +123,7 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
     const chainTotals = new Map<ChainId, BN>();
     for (const position of visible) {
       const current = chainTotals.get(position.chainId) ?? BN_ZERO;
-      chainTotals.set(position.chainId, current.add(new BN(position.stake.total)));
+      chainTotals.set(position.chainId, current.add(new BN(position.stake.active)));
     }
 
     const rows: PositionRow[] = [];
@@ -157,9 +157,9 @@ export const usePositionRows = (accountIds: string[]): PositionRowsResult => {
         }),
         multisig: getMultisigThreshold(account),
         status: position.status,
-        staked: position.stake.total,
+        staked: position.stake.active,
         sharePercent: calculateSharePercent(
-          position.stake.total,
+          position.stake.active,
           (chainTotals.get(position.chainId) ?? BN_ZERO).toString(),
         ),
         apy: derivePositionApy(position, chainValidators),

--- a/src/renderer/features/dashboard-staking-positions/lib/types.ts
+++ b/src/renderer/features/dashboard-staking-positions/lib/types.ts
@@ -64,7 +64,10 @@ export type PositionRow = {
   multisig: MultisigThreshold | null;
   /** Mirrors `position.status` — the table needs it as a sortable column key. */
   status: PositionStatus;
-  /** Ledger total — bonded plus everything still unbonding, in planck. */
+  /**
+   * Active stake in planck — what `unbond` can take. Unbonding chunks are
+   * counted separately.
+   */
   staked: string;
   /** Share of the chain's visible total, in percent. */
   sharePercent: number;

--- a/src/renderer/features/dashboard-staking-positions/ui/PositionDetailDrawer.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/PositionDetailDrawer.tsx
@@ -87,6 +87,14 @@ export const PositionDetailDrawer = ({ row, onClose }: Props) => {
   // cannot sign (watch-only, a multisig without a local signatory) is still a
   // local wallet — signability is the pencil glyph's business, not this badge's.
   const isContact = row !== null && row.wallet === null;
+  // `unbond` takes from the active stake only. A ledger whose whole stake is
+  // already unbonding shows a row, a status and a countdown, but has nothing
+  // left to unbond — the chip must say so instead of opening a flow at 0.
+  const unbondBlockedHint =
+    accessBlockedHint ??
+    (row !== null && new BN(row.position.stake.active).isZero()
+      ? t('dashboard.staking.positions.detail.actions.nothingToUnbond')
+      : undefined);
   // While the payout scan is in flight `unclaimed.total` is a placeholder `'0'`,
   // not an answer. Reading it as one made the drawer open with "Nothing to claim
   // on this position" over a position that turned out to have rewards.
@@ -360,7 +368,7 @@ export const PositionDetailDrawer = ({ row, onClose }: Props) => {
                 t('dashboard.staking.positions.detail.actions.unbond'),
                 () => positionActions.events.unbondRequested(actionPayload),
                 false,
-                accessBlockedHint,
+                unbondBlockedHint,
               )}
 
               {/*

--- a/src/renderer/features/dashboard-staking-positions/ui/__tests__/PositionDetailDrawer.test.tsx
+++ b/src/renderer/features/dashboard-staking-positions/ui/__tests__/PositionDetailDrawer.test.tsx
@@ -10,7 +10,7 @@ import { ThemeProvider } from '@/shared/ui-kit';
 import { type AnyAccount } from '@/domains/network';
 import { type StakingPosition } from '@/domains/staking';
 import { type PositionRow } from '../../lib';
-import { positionActions } from '../../model/position-actions';
+import { type PositionAction, positionActions } from '../../model/position-actions';
 import { PositionDetailDrawer } from '../PositionDetailDrawer';
 
 const accountId = createAccountId('stash') as AccountId;
@@ -74,8 +74,8 @@ const row: PositionRow = {
   draftCount: 0,
 };
 
-const renderDrawer = (drawerRow: PositionRow = row) => {
-  const scope = fork({ values: [[positionActions.$wiredActions, ['changeValidators']]] });
+const renderDrawer = (drawerRow: PositionRow = row, wiredActions: PositionAction[] = ['changeValidators']) => {
+  const scope = fork({ values: [[positionActions.$wiredActions, wiredActions]] });
 
   return render(
     <Provider value={scope}>
@@ -174,6 +174,28 @@ describe('features/dashboard-staking-positions/ui/PositionDetailDrawer', () => {
     expect(await screen.findByRole('button', { name: 'Change validators' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Add stake' })).toBeDisabled();
     expect(screen.getByRole('button', { name: 'Unbond' })).toBeDisabled();
+  });
+
+  test('should disable Unbond when the whole stake is already unbonding', async () => {
+    // The ledger still exists — 10 WND total, all of it in an unlocking chunk —
+    // so the row, the status and the countdown are all right, but `unbond`
+    // takes from the active stake and there is none. Opening the flow at
+    // "Staked: 0" was the symptom; the chip has to say why instead.
+    const unbondingPosition: StakingPosition = {
+      ...position,
+      stake: {
+        ...position.stake,
+        active: '0',
+        total: '1000000000000',
+        unlocking: [{ value: '1000000000000', era: '9' }],
+      },
+      totalUnbonding: '1000000000000',
+    };
+
+    renderDrawer({ ...row, position: unbondingPosition, staked: '0' }, ['changeValidators', 'addStake', 'unbond']);
+
+    expect(await screen.findByRole('button', { name: 'Unbond' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'Add stake' })).toBeEnabled();
   });
 
   test('should leave the chips alone on a position that can be signed for', async () => {

--- a/src/renderer/shared/i18n/locales/en.json
+++ b/src/renderer/shared/i18n/locales/en.json
@@ -1092,6 +1092,7 @@
             "nothingInPeriod": "No rewards attributed in this window.",
             "scanningPayouts": "Checking what is still unclaimed…",
             "nothingToClaim": "Nothing to claim on this position.",
+            "nothingToUnbond": "Nothing is bonded on this position — the whole stake is unbonding.",
             "noSigner": "None of your wallets can sign on {network}."
           },
           "blocked": {

--- a/tests/integrations/cases/staking/staking-positions.integration.test.ts
+++ b/tests/integrations/cases/staking/staking-positions.integration.test.ts
@@ -264,8 +264,8 @@ describe('Staking Positions - Integration', () => {
     expect(summary.activeValidatorCount).toBe(2);
 
     expect(summary.byChain[POLKADOT_AH]).toMatchObject({
-      // 1300 nominating + 2000 merely bonded.
-      totalStaked: '3300',
+      // 1000 active nominating + 2000 active merely bonded — unlocking chunks are not staked.
+      totalStaked: '3000',
       redeemable: '100',
       totalUnbonding: '200',
       activeValidatorCount: 1,
@@ -319,12 +319,12 @@ describe('Staking Positions - Integration', () => {
     await settle();
 
     const before = polkadot.subscribeCalls();
-    expect(env.getState(stakingPositions.$summary).byChain[POLKADOT_AH]?.totalStaked).toBe('3300');
+    expect(env.getState(stakingPositions.$summary).byChain[POLKADOT_AH]?.totalStaked).toBe('3000');
 
     polkadot.setLedger(stakingAccountB.accountId, { total: '5000', active: '5000' });
     await settle();
 
-    expect(env.getState(stakingPositions.$summary).byChain[POLKADOT_AH]?.totalStaked).toBe('6300');
+    expect(env.getState(stakingPositions.$summary).byChain[POLKADOT_AH]?.totalStaked).toBe('6000');
     expect(polkadot.subscribeCalls()).toEqual(before);
   });
 });


### PR DESCRIPTION
## Description
The staking dashboard and the Unbond flow disagreed on what "staked" means. The dashboard (positions table, drawer, KPI cards/modals, share of chain) showed the ledger `total` — active stake **plus** chunks already unbonding — while the Unbond flow correctly caps against `active`. A position whose whole stake is unbonding therefore read "10 WND · Bonded" with a live Unbond chip, and the flow opened at "Staked: 0 WND". The KPI footer was also double counting: the same planck appeared in "Total staked" and in "Unbonding".

"Staked" now means the ledger's **active** stake everywhere on the dashboard — the figure the chain will actually let you unbond — and unbonding stays a separate figure (`totalStaked + redeemable + totalUnbonding` = ledger total).

## Related Issues
—

## Changes Made
- `aggregates/staking-positions` — `$summary.totalStaked` sums `stake.active`; README/type docs updated to the new definition.
- `dashboard-staking-positions` — Staked column and chain share use `active`; the drawer's **Unbond** chip is disabled with a reason ("Nothing is bonded on this position — the whole stake is unbonding") when `active = 0`.
- `dashboard-staking-kpi` — positions modal rows, breakdown and sort use `active`; the modal's existing `hasStake` gate now hides Unbond for a fully-unbonding position.
- Tests: `summarizePositions` does not count unbonding chunks as staked; drawer disables Unbond at zero active stake (verified to fail before the fix); model test expectation updated (`3300 → 3000`).

⚠️ Product note: the **Total staked** KPI number changes — it no longer includes what is unbonding. The aggregate README had documented the old total as "matching what the dashboard showed before"; consistency with the Unbond flow and the separate Unbonding footer won.

## Screenshots/Recordings
Before: position row `10 WND · Bonded` → Unbond modal `Staked: 0 WND`.

## Test steps
1. Take an account whose full stake is unbonding (Westend Asset Hub, e.g. `5FQoRU…F1SpqB`) — KPI footer shows it under UNBONDING.
2. Dashboard → Staking: the row shows `0 WND`, the drawer's Unbond chip is disabled with a tooltip; Add stake stays enabled.
3. Total staked card: per-asset sub-line excludes the unbonding amount; Total staked drill-down shows `0` staked / full amount in Unbonding, no Unbond button on that row.
4. An account with active stake and a partial unbond: row shows only the active part; Unbond opens with the same `Staked:` figure.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [x] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines
