### PR TITLE
fix(staking): signing path heads the unbond and add stake screen

### DIFF
--- a/src/renderer/features/staking-amount-flow/README.md
+++ b/src/renderer/features/staking-amount-flow/README.md
@@ -41,16 +41,16 @@ Unbond layout verbatim, which is also what the design review asked for.
 
 The amount screen is one layout in both modes:
 
-| Element              | Unbond                                                           | Add stake                                                 |
-| -------------------- | ---------------------------------------------------------------- | --------------------------------------------------------- |
-| Title                | "Unbond"                                                         | "Add stake"                                               |
-| Chips                | Account (identicon, resolved name, short address) + network chip | same                                                      |
-| Amount label (right) | `Staked: 1.2M DOT` — the position's **active** stake             | `Available: …` — spendable balance, minus the network fee |
-| `Max`                | the whole active stake                                           | everything available after the fee                        |
-| Helper line          | `≈ $6.24M · remaining staked: 100 DOT ($520)`                    | `≈ $6.24M`                                                |
-| Warning callout      | amber, when the remainder falls below the minimum active bond    | never                                                     |
-| Info callout         | unbonding period and the projected unlock date                   | "funds start earning next era"                            |
-| Footer               | `Cancel` / `Continue`                                            | same                                                      |
+| Element              | Unbond                                                                    | Add stake                                                 |
+| -------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Title                | "Unbond"                                                                  | "Add stake"                                               |
+| Header               | Signing route (or the bare account when it signs directly) + network chip | same                                                      |
+| Amount label (right) | `Staked: 1.2M DOT` — the position's **active** stake                      | `Available: …` — spendable balance, minus the network fee |
+| `Max`                | the whole active stake                                                    | everything available after the fee                        |
+| Helper line          | `≈ $6.24M · remaining staked: 100 DOT ($520)`                             | `≈ $6.24M`                                                |
+| Warning callout      | amber, when the remainder falls below the minimum active bond             | never                                                     |
+| Info callout         | unbonding period and the projected unlock date                            | "funds start earning next era"                            |
+| Footer               | `Cancel` / `Continue`                                                     | same                                                      |
 
 **The below-minimum warning does not block `Continue`.** Leaving a stub too small to nominate is legal — merely
 suboptimal — and the user may well mean it. The callout names both figures and the two ways out ("unbond everything, or

--- a/src/renderer/features/staking-amount-flow/README.md
+++ b/src/renderer/features/staking-amount-flow/README.md
@@ -41,16 +41,16 @@ Unbond layout verbatim, which is also what the design review asked for.
 
 The amount screen is one layout in both modes:
 
-| Element              | Unbond                                                                    | Add stake                                                 |
-| -------------------- | ------------------------------------------------------------------------- | --------------------------------------------------------- |
-| Title                | "Unbond"                                                                  | "Add stake"                                               |
-| Header               | Signing route (or the bare account when it signs directly) + network chip | same                                                      |
-| Amount label (right) | `Staked: 1.2M DOT` — the position's **active** stake                      | `Available: …` — spendable balance, minus the network fee |
-| `Max`                | the whole active stake                                                    | everything available after the fee                        |
-| Helper line          | `≈ $6.24M · remaining staked: 100 DOT ($520)`                             | `≈ $6.24M`                                                |
-| Warning callout      | amber, when the remainder falls below the minimum active bond             | never                                                     |
-| Info callout         | unbonding period and the projected unlock date                            | "funds start earning next era"                            |
-| Footer               | `Cancel` / `Continue`                                                     | same                                                      |
+| Element              | Unbond                                                                                                                                                     | Add stake                                                 |
+| -------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Title                | "Unbond"                                                                                                                                                   | "Add stake"                                               |
+| Header               | Signing route (or the bare account when it signs directly) + network chip; in draft mode the network chip alone — the draft path picker follows the toggle | same                                                      |
+| Amount label (right) | `Staked: 1.2M DOT` — the position's **active** stake                                                                                                       | `Available: …` — spendable balance, minus the network fee |
+| `Max`                | the whole active stake                                                                                                                                     | everything available after the fee                        |
+| Helper line          | `≈ $6.24M · remaining staked: 100 DOT ($520)`                                                                                                              | `≈ $6.24M`                                                |
+| Warning callout      | amber, when the remainder falls below the minimum active bond                                                                                              | never                                                     |
+| Info callout         | unbonding period and the projected unlock date                                                                                                             | "funds start earning next era"                            |
+| Footer               | `Cancel` / `Continue`                                                                                                                                      | same                                                      |
 
 **The below-minimum warning does not block `Continue`.** Leaving a stub too small to nominate is legal — merely
 suboptimal — and the user may well mean it. The callout names both figures and the two ways out ("unbond everything, or

--- a/src/renderer/features/staking-amount-flow/model/amount-flow.ts
+++ b/src/renderer/features/staking-amount-flow/model/amount-flow.ts
@@ -192,6 +192,12 @@ export const createAmountFlowModel = () => {
    */
   const $routeSignatory = combine($signatoryFromPath, $initiator, (fromPath, initiator) => fromPath ?? initiator);
 
+  /**
+   * A direct signer has no route to draw — `SigningPathSection` renders nothing
+   * below two nodes — so the amount screen shows the bare account instead.
+   */
+  const $isDirectSigner = $signingPath.map((path) => path.length < 2);
+
   // --- chain constants -----------------------------------------------------
 
   type ChainConsts = { bondingDuration: number; maxUnlockingChunks: number | null };
@@ -732,6 +738,7 @@ export const createAmountFlowModel = () => {
     $signatory,
     $route,
     $signingPath,
+    $isDirectSigner,
 
     $amount: readonly($amount),
     $amountPlanck,

--- a/src/renderer/features/staking-amount-flow/ui/AmountStep.tsx
+++ b/src/renderer/features/staking-amount-flow/ui/AmountStep.tsx
@@ -32,6 +32,7 @@ export const AmountStep = () => {
   const position = useUnit(amountFlowModel.$position);
   const wallet = useUnit(amountFlowModel.$wallet);
   const isDraftMode = useUnit(amountFlowModel.$isDraftMode);
+  const signingPath = useUnit(amountFlowModel.$signingPath);
   const errors = useUnit(amountFlowModel.$errors);
   const wallets = useUnit(walletModel.$wallets);
 
@@ -41,8 +42,11 @@ export const AmountStep = () => {
     <>
       <ScrollArea>
         <div className="flex flex-col gap-4 px-5 pb-4">
+          {/* Who acts, once: the signing route when there is one to show, the
+              bare account for a direct signer, the draft path in draft mode. */}
+          {!isDraftMode && <SigningRoute />}
           <div className="flex flex-wrap items-center gap-2">
-            {initiator && (
+            {initiator && !isDraftMode && signingPath.length < 2 && (
               <div className="flex min-w-0 items-center rounded-lg border border-container-border px-2.5 py-1.5">
                 <NamedAccount accountId={initiator.accountId} chain={chain} wallet={wallet} iconSize={20} />
               </div>
@@ -82,7 +86,6 @@ export const AmountStep = () => {
               <UnlockingLimitError />
               <MinimumBondWarning />
               <ConsequenceCallout />
-              {!isDraftMode && <SigningRoute />}
             </div>
           </DraftFormBody>
         </div>

--- a/src/renderer/features/staking-amount-flow/ui/AmountStep.tsx
+++ b/src/renderer/features/staking-amount-flow/ui/AmountStep.tsx
@@ -32,7 +32,7 @@ export const AmountStep = () => {
   const position = useUnit(amountFlowModel.$position);
   const wallet = useUnit(amountFlowModel.$wallet);
   const isDraftMode = useUnit(amountFlowModel.$isDraftMode);
-  const signingPath = useUnit(amountFlowModel.$signingPath);
+  const isDirectSigner = useUnit(amountFlowModel.$isDirectSigner);
   const errors = useUnit(amountFlowModel.$errors);
   const wallets = useUnit(walletModel.$wallets);
 
@@ -42,11 +42,12 @@ export const AmountStep = () => {
     <>
       <ScrollArea>
         <div className="flex flex-col gap-4 px-5 pb-4">
-          {/* Who acts, once: the signing route when there is one to show, the
-              bare account for a direct signer, the draft path in draft mode. */}
           {!isDraftMode && <SigningRoute />}
           <div className="flex flex-wrap items-center gap-2">
-            {initiator && !isDraftMode && signingPath.length < 2 && (
+            {/* Who acts, once: the signing route above when there is one to
+                draw, this bare account for a direct signer, and in draft mode
+                the draft path picker below the toggle. */}
+            {initiator && !isDraftMode && isDirectSigner && (
               <div className="flex min-w-0 items-center rounded-lg border border-container-border px-2.5 py-1.5">
                 <NamedAccount accountId={initiator.accountId} chain={chain} wallet={wallet} iconSize={20} />
               </div>


### PR DESCRIPTION
## Description
On the Unbond / Add stake screen (`staking-amount-flow`) the signing path was rendered at the very bottom, under the amount and the callouts, while the header showed a separate account chip for the same account. For a multisig/proxied position the user saw the acting account twice and had to scroll past the amount to find who actually signs.

The signing route now heads the screen. The account chip stays only for a direct signer, where there is no path to draw (`SigningPathSection` renders nothing for a single-node path). In draft mode the draft path picker already sits at the top, so the chip is hidden there too — one "who acts" element per screen.

## Related Issues
Follow-up to the staking dashboard rework (Unbond / Add stake flow).

## Changes Made
- `AmountStep.tsx`: `SigningRoute` moved above the network chip; account chip gated on `!isDraftMode && signingPath.length < 2`; removed the bottom `SigningRoute`.
- `staking-amount-flow/README.md`: "Chips" row of the layout table updated to describe the header.

## Screenshots/Recordings
Before: account chip on top, signing path at the bottom. After: signing path (Source → Initiator) on top, no duplicate account chip.

## Test steps
1. Staking dashboard → a position owned by a **multisig or proxied** account → **Unbond**: the signing path is the first element, no account chip; the network chip is below it.
2. Same for **Add stake**.
3. A position owned by a **regular** account: the account chip + network chip are shown (no path to draw).
4. Toggle **Save as draft**: only the draft path picker is shown at the top, no account chip.

## Checklist
- [x] I have performed a self-review of my own code
- [x] I have tested the changes and verified the happy path works as expected
- [ ] I have provided screenshot of the working feature (if applicable)
- [x] I have provided description of the changes and any additional context that might help reviewers perform more accurate review
- [ ] I have added tests that cover the base logic (if applicable)
- [x] My code follows the project's coding standards and style guidelines